### PR TITLE
feature: add longform artefact in chat

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -469,6 +469,7 @@ enum ArtifactType {
   IDE
   MEDIA
   STREAM
+  LONGFORM
 }
 
 // =============================================

--- a/src/app/w/[slug]/tasks/new/artifacts.tsx
+++ b/src/app/w/[slug]/tasks/new/artifacts.tsx
@@ -19,6 +19,7 @@ import {
   CodeContent,
   BrowserContent,
   Option,
+  LongformContent,
 } from "@/lib/chat";
 import Prism from "prismjs";
 import "prismjs/components/prism-javascript";
@@ -307,6 +308,32 @@ export function BrowserArtifactPanel({ artifacts }: { artifacts: Artifact[] }) {
           );
         })}
       </div>
+    </div>
+  );
+}
+
+export function LongformArtifactPanel({
+  artifacts,
+}: {
+  artifacts: Artifact[];
+}) {
+  if (artifacts.length === 0) return null;
+
+  return (
+    <div className="h-full flex flex-col">
+      {artifacts.map((artifact) => {
+        const content = artifact.content as LongformContent;
+        return (
+          <div key={artifact.id} className="p-4">
+            {content.title && (
+              <div className="font-semibold text-lg mb-2">{content.title}</div>
+            )}
+            <div className="bg-background/50 border rounded-lg p-4 max-h-80 overflow-auto text-sm whitespace-pre-wrap">
+              {content.text}
+            </div>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/app/w/[slug]/tasks/new/mockmsgs.ts
+++ b/src/app/w/[slug]/tasks/new/mockmsgs.ts
@@ -8,6 +8,7 @@ import {
   FormContent,
   createChatMessage,
   createArtifact,
+  LongformContent,
 } from "@/lib/chat";
 
 export function codeMessage(): ChatMessage {
@@ -168,6 +169,64 @@ export function assistantMessage(): ChatMessage {
             },
           ],
         } as FormContent,
+      }),
+    ],
+  };
+}
+
+export function longformMessage(): ChatMessage {
+  const baseMessage = createChatMessage({
+    id: (Date.now() + 3).toString(),
+    message: "Project Hive's repomap on Display",
+    role: ChatRole.ASSISTANT,
+    status: ChatStatus.SENT,
+  });
+
+  return {
+    ...baseMessage,
+    artifacts: [
+      createArtifact({
+        id: "longform-1",
+        messageId: baseMessage.id,
+        type: ArtifactType.LONGFORM,
+        content: {
+          title: "Repomap: Project Hive RepoMap",
+          text: `
+<pre>
+Repository: fayekelmith/demo-repo
+├─┬ Directory: frontend
+│ ├─┬ Directory: public
+│ │ └── File: index.html (118)
+│ ├─┬ Directory: src
+│ │ ├─┬ Directory: components
+│ │ │ ├── File: NewPerson.tsx (592)
+│ │ │ ├── File: People.tsx (185)
+│ │ │ └── File: Person.tsx (20)
+│ │ ├── File: api.ts (15)
+│ │ ├── File: App.css (169)
+│ │ ├── File: App.tsx (133)
+│ │ └── File: index.tsx (54)
+│ ├── File: .gitignore (7)
+│ ├── File: package.json (405)
+│ ├── File: tsconfig.json (162)
+│ └── File: yarn.lock (220266)
+├── File: .env (16)
+├── File: .gitignore (6)
+├── File: alpha.go (16)
+├── File: beta.go (22)
+├─┬ File: db.go (436)
+│ └── Instance: DB (3)
+├── File: delta.go (22)
+├── File: docker-compose.yaml (85)
+├── File: go.mod (88)
+├── File: go.sum (4982)
+├── File: main.go (159)
+├── File: routes.go (660)
+└── File: utils.go (47)
+
+</pre>
+          `,
+        } as LongformContent,
       }),
     ],
   };

--- a/src/app/w/[slug]/tasks/new/page.tsx
+++ b/src/app/w/[slug]/tasks/new/page.tsx
@@ -19,11 +19,12 @@ import {
   createChatMessage,
   ArtifactType,
 } from "@/lib/chat";
-import { assistantMessage, codeMessage } from "./mockmsgs";
+import { assistantMessage, codeMessage, longformMessage } from "./mockmsgs";
 import {
   FormArtifact,
   CodeArtifactPanel,
   BrowserArtifactPanel,
+  LongformArtifactPanel,
 } from "./artifacts";
 
 function TaskStartInput({ onStart }: { onStart: (task: string) => void }) {
@@ -185,7 +186,7 @@ export default function TaskChatPage() {
     // Auto-reply after a short delay
     setTimeout(() => {
       const msg = assistantMessage();
-      setMessages((prev) => [...prev, msg]);
+      setMessages((prev) => [...prev, msg, longformMessage()]);
     }, 1000);
   };
 
@@ -311,6 +312,25 @@ export default function TaskChatPage() {
                               artifact={artifact}
                               onAction={handleArtifactAction}
                             />
+                          </motion.div>
+                        </div>
+                      </div>
+                    ))}
+                  {/* Only Longform Artifacts in Chat */}
+                  {msg.artifacts
+                    ?.filter((a) => a.type === "LONGFORM")
+                    .map((artifact) => (
+                      <div
+                        key={artifact.id}
+                        className={`flex ${msg.role === "USER" ? "justify-end" : "justify-start"}`}
+                      >
+                        <div className="max-w-md w-full">
+                          <motion.div
+                            initial={{ opacity: 0, y: 10 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            transition={{ delay: 0.2 }}
+                          >
+                            <LongformArtifactPanel artifacts={[artifact]} />
                           </motion.div>
                         </div>
                       </div>

--- a/src/lib/chat.ts
+++ b/src/lib/chat.ts
@@ -42,9 +42,13 @@ export interface FormContent {
   options: Option[];
 }
 
+export interface LongformContent {
+  text: string;
+  title?: string;
+}
 // Client-side types that extend Prisma types with proper JSON field typing
 export interface Artifact extends Omit<PrismaArtifact, "content"> {
-  content?: FormContent | CodeContent | BrowserContent;
+  content?: FormContent | CodeContent | BrowserContent | LongformContent;
 }
 
 export interface ChatMessage
@@ -83,7 +87,7 @@ export function createArtifact(data: {
   id: string;
   messageId: string;
   type: ArtifactType;
-  content?: FormContent | CodeContent | BrowserContent;
+  content?: FormContent | CodeContent | BrowserContent | LongformContent;
 }): Artifact {
   return {
     id: data.id,


### PR DESCRIPTION
Issue: #104 

GOAL:
- To add a `LONGFORM` artifact to the chat right after the messages. 
- Make the artifact scrollable. 

Proof of work 
https://www.loom.com/share/db15dc0314da40cabf9925f7aa45fe49?sid=460c7531-d5b3-4599-8bc7-2d70161acfab


Screenshot: 
<img width="1142" height="888" alt="Screenshot 2025-08-01 at 5 53 57 AM" src="https://github.com/user-attachments/assets/dfd015b6-4839-44a0-8607-52964a04a63b" />


@Evanfeenstra, please review this PR. 