### PR TITLE
Stale workspace form context

### DIFF
--- a/src/stores/useStakgraphStore.ts
+++ b/src/stores/useStakgraphStore.ts
@@ -138,11 +138,17 @@ export const useStakgraphStore = create<StakgraphStore>()(
         } else if (response.status === 404) {
           // No swarm found - this is expected for workspaces without swarms
           console.log("No swarm found for this workspace yet");
+          // Reset form data to initial state for workspaces without swarms
+          set({ formData: initialFormData, envVars: [] });
         } else {
           console.error("Failed to load stakgraph settings");
+          // Reset form data on error to prevent stale data
+          set({ formData: initialFormData, envVars: [] });
         }
       } catch (error) {
         console.error("Error loading stakgraph settings:", error);
+        // Reset form data on error to prevent stale data
+        set({ formData: initialFormData, envVars: [] });
       } finally {
         set({ initialLoading: false });
       }


### PR DESCRIPTION
#116 

The issue was in hive/src/stores/useStakgraphStore.ts:138-151.

The useStakgraphStore Zustand store wasn't resetting form data when switching to workspaces that don't have stakgraph configurations.

Problem: When loadSettings() received a 404 response (no swarm found), it only logged a message but didn't reset the form data, causing previous workspace data to persist.

  Solution: Added form data reset to initial state in three scenarios:
  1. When API returns 404 (no swarm found for workspace)
  2. When API returns other error responses
  3. When network/fetch errors occur

This ensures form data is always workspace-specific and doesn't carry over between workspace switches.