### PR TITLE
Fix thinking logs disappearing after first artifact

### DIFF
--- a/src/app/w/[slug]/task/[...taskParams]/page.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/page.tsx
@@ -64,13 +64,15 @@ export default function TaskChatPage() {
     (message: ChatMessage) => {
       setMessages((prev) => [...prev, message]);
 
-      // Clear logs when we get a new message (similar to old implementation)
-      if (message.artifacts?.length === 0) {
-        clearLogs();
+      // Only hide chain visibility when we receive a final assistant response (not a reply)
+      // This allows thinking logs to continue showing during artifact creation
+      if (message.role === ChatRole.ASSISTANT && !message.replyId) {
+        // This is a main response from the assistant, hide thinking logs after a delay
+        setTimeout(() => {
+          setIsChainVisible(false);
+          clearLogs();
+        }, 1500); // Short delay to let users see the final thinking status
       }
-
-      // Hide chain visibility when message processing is complete
-      setIsChainVisible(false);
     },
     [clearLogs],
   );


### PR DESCRIPTION
The thinking logs were disappearing after the first artifact was received because setIsChainVisible(false) was called on every incoming message.

Changes:
- Only hide chain visibility when receiving final assistant response
- Allow thinking logs to persist during artifact creation
- Add delay before hiding to let users see final thinking status