### PR TITLE
Refactor: Rename GitHubAuth model to GitHubProfile for better semantics

### DIFF
--- a/prisma/migrations/20250806093446_rename_github_auth_to_profile/migration.sql
+++ b/prisma/migrations/20250806093446_rename_github_auth_to_profile/migration.sql
@@ -1,0 +1,13 @@
+-- Rename the github_auth table to github_profiles instead of dropping and recreating it
+-- This preserves all existing data
+
+ALTER TABLE "github_auth" DROP CONSTRAINT "github_auth_user_id_fkey";
+
+ALTER TABLE "github_auth" RENAME TO "github_profiles";
+
+ALTER INDEX "github_auth_user_id_key" RENAME TO "github_profiles_user_id_key";
+ALTER INDEX "github_auth_github_user_id_idx" RENAME TO "github_profiles_github_user_id_idx";
+ALTER INDEX "github_auth_github_username_idx" RENAME TO "github_profiles_github_username_idx";
+ALTER TABLE "github_profiles" RENAME CONSTRAINT "github_auth_pkey" TO "github_profiles_pkey";
+
+ALTER TABLE "github_profiles" ADD CONSTRAINT "github_profiles_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,7 +61,7 @@ model User {
   // Authentication relationships
   accounts      Account[]
   sessions      Session[]
-  githubAuth    GitHubAuth?
+  githubProfile GitHubProfile?
 
   // Pool api key
   poolApiKey            String? @map("pool_api_key") // NEW: Pool API Key for Pool Manager
@@ -99,7 +99,7 @@ model VerificationToken {
   @@map("verification_tokens")
 }
 
-model GitHubAuth {
+model GitHubProfile {
   id                String    @id @default(cuid())
   userId            String    @unique @map("user_id")
   githubUserId      String    @map("github_user_id")
@@ -126,7 +126,7 @@ model GitHubAuth {
 
   @@index([githubUserId])
   @@index([githubUsername])
-  @@map("github_auth")
+  @@map("github_profiles")
 }
 
 // =============================================

--- a/scripts/cleanup-test-db.js
+++ b/scripts/cleanup-test-db.js
@@ -50,9 +50,9 @@ async function cleanupTestDatabase() {
     }
 
     try {
-      await prisma.gitHubAuth.deleteMany();
+      await prisma.gitHubProfile.deleteMany();
     } catch (error) {
-      console.log("⚠️  GitHubAuth table does not exist, skipping...");
+      console.log("⚠️  GitHubProfile table does not exist, skipping...");
     }
 
     try {

--- a/scripts/setup-test-db.js
+++ b/scripts/setup-test-db.js
@@ -39,7 +39,7 @@ async function setupTestDatabase() {
     await prisma.verificationToken.deleteMany();
     await prisma.session.deleteMany();
     await prisma.account.deleteMany();
-    await prisma.gitHubAuth.deleteMany();
+    await prisma.gitHubProfile.deleteMany();
     await prisma.user.deleteMany();
 
     // Create some test users for integration tests

--- a/src/__tests__/setup-integration.ts
+++ b/src/__tests__/setup-integration.ts
@@ -52,7 +52,7 @@ async function cleanDatabase() {
       'swarm', 
       'workspaceMember',
       'workspace',
-      'githubAuth',
+      'gitHubProfile',
       'user'
     ];
 

--- a/src/app/api/auth/revoke-github/route.ts
+++ b/src/app/api/auth/revoke-github/route.ts
@@ -67,8 +67,8 @@ export async function POST() {
       },
     });
 
-    // Also delete the GitHub auth data
-    await db.gitHubAuth.deleteMany({
+    // Also delete the GitHub profile data
+    await db.gitHubProfile.deleteMany({
       where: {
         userId: userId,
       },

--- a/src/app/api/chat/message/route.ts
+++ b/src/app/api/chat/message/route.ts
@@ -324,7 +324,9 @@ export async function POST(request: NextRequest) {
       })) as Artifact[],
     };
 
-    const githubAuth = await db.gitHubAuth.findUnique({ where: { userId } });
+    const githubProfile = await db.gitHubProfile.findUnique({
+      where: { userId },
+    });
 
     // Check if Stakwork environment variables are defined
     const useStakwork =
@@ -333,7 +335,7 @@ export async function POST(request: NextRequest) {
       config.STAKWORK_WORKFLOW_ID;
 
     // Extract data for Stakwork payload
-    const userName = githubAuth?.githubUsername || null;
+    const userName = githubProfile?.githubUsername || null;
     const accessToken =
       user.accounts.find((account) => account.access_token)?.access_token ||
       null;


### PR DESCRIPTION
## Overview
This PR renames the `GitHubAuth` model to `GitHubProfile` along with the corresponding database table from `github_auth` to `github_profiles`. All references throughout the codebase have been updated to use the new model name.

## Motivation
Functionally, the GitHubAuth table is the user's cached GitHub profile data, not authentication data. This renaming better reflects its purpose and aligns with a future architecture where we might have similar profile tables for other providers (GitLabProfile, BitbucketProfile, GoogleProfile, etc.).

The change also better separates concerns:
- User = person/identity
- Account = "OAuth credentials & linkage"; one row per provider per user
- {Provider}Profile = provider-specific, slow-changing profile data

## Changes
- Renamed model in schema from `GitHubAuth` to `GitHubProfile`
- Updated database table mapping from `github_auth` to `github_profiles`
- Updated all references in the codebase, including:
  - nextauth.ts
  - revoke-github/route.ts
  - chat/message/route.ts
  - test setup and cleanup scripts

## Closed: #126

## Testing
Database migration has been tested with the schema change. All affected functionality (GitHub authentication, profile data retrieval) continues to work as expected.

## Migration
This PR includes a SQL migration to rename the database table. When deploying, ensure the migration runs before the application starts with the updated model names.

## Demo:

https://www.loom.com/share/959b41235e044091b972995aa14a34ab