### PR TITLE
Fix Stakgraph workspace data persistence issues

### DIFF
--- a/src/utils/request-manager.ts
+++ b/src/utils/request-manager.ts
@@ -1,0 +1,42 @@
+export class RequestManager {
+  private controller: AbortController | null = null;
+
+  abort(): void {
+    if (this.controller) {
+      this.controller.abort();
+      this.controller = null;
+    }
+  }
+
+  getSignal(): AbortSignal {
+    this.abort();
+    this.controller = new AbortController();
+    return this.controller.signal;
+  }
+
+  isAborted(): boolean {
+    return this.controller?.signal.aborted ?? false;
+  }
+
+  reset(): void {
+    this.abort();
+    this.controller = null;
+  }
+
+  getCurrentSignal(): AbortSignal | null {
+    return this.controller?.signal ?? null;
+  }
+
+  hasActiveRequest(): boolean {
+    return this.controller !== null && !this.isAborted();
+  }
+}
+
+export function createRequestManager(): RequestManager {
+  return new RequestManager();
+}
+
+
+export function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}


### PR DESCRIPTION
## Problem
When switching between workspaces, the Stakgraph form would briefly show data from the previous workspace before loading the new workspace data, or sometimes mix data between workspaces.

## Changes:
- Added workspace tracking with `currentSlug` to identify when switching between workspaces
- Implemented AbortController to cancel pending API requests when switching workspaces
- Reset the form state completely when changing workspaces
- Added validation to ensure responses for old workspaces are ignored
- Prevented race conditions by enforcing proper request cancellation

## Closed: #116

## Testing
1. Create a new workspace with some Stakgraph configuration
2. Create another workspace with different configuration
3. Switch between workspaces multiple times
4. Verify that no stale data appears when switching workspaces
5. Confirm that only the correct workspace data is displayed after loading completes

This fix ensures users only see data belonging to their current workspace, improving UX and preventing confusion or data errors.

## Demo:

https://www.loom.com/share/74cf0f48aae942c2b6e633ff0de4ca7a