### PR TITLE
Fix Stakwork logs not resubscribing after page refresh

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -399,6 +399,9 @@ model Task {
   workflowStartedAt  DateTime?       @map("workflow_started_at")
   workflowCompletedAt DateTime?      @map("workflow_completed_at")
   
+  // Stakwork project ID for log subscription
+  stakworkProjectId Int?            @map("stakwork_project_id")
+  
   // Audit fields
   createdById   String      @map("created_by_id")
   createdBy     User        @relation("TaskCreator", fields: [createdById], references: [id])

--- a/src/app/api/chat/message/route.ts
+++ b/src/app/api/chat/message/route.ts
@@ -375,12 +375,23 @@ export async function POST(request: NextRequest) {
       
       // Update workflow status based on Stakwork call result
       if (stakworkData.success) {
+        const updateData: {
+          workflowStatus: WorkflowStatus;
+          workflowStartedAt: Date;
+          stakworkProjectId?: number;
+        } = {
+          workflowStatus: WorkflowStatus.IN_PROGRESS,
+          workflowStartedAt: new Date(),
+        };
+        
+        // Store the Stakwork project ID if available
+        if (stakworkData.data?.project_id) {
+          updateData.stakworkProjectId = stakworkData.data.project_id;
+        }
+        
         await db.task.update({
           where: { id: taskId },
-          data: {
-            workflowStatus: WorkflowStatus.IN_PROGRESS,
-            workflowStartedAt: new Date(),
-          },
+          data: updateData,
         });
       } else {
         await db.task.update({

--- a/src/app/api/tasks/[taskId]/messages/route.ts
+++ b/src/app/api/tasks/[taskId]/messages/route.ts
@@ -45,6 +45,7 @@ export async function GET(
         title: true,
         workspaceId: true,
         workflowStatus: true,
+        stakworkProjectId: true,
         workspace: {
           select: {
             id: true,
@@ -111,6 +112,7 @@ export async function GET(
             title: task.title,
             workspaceId: task.workspaceId,
             workflowStatus: task.workflowStatus,
+            stakworkProjectId: task.stakworkProjectId,
           },
           messages: clientMessages,
           count: clientMessages.length,

--- a/src/app/w/[slug]/task/[...taskParams]/page.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/page.tsx
@@ -126,6 +126,12 @@ export default function TaskChatPage() {
         if (result.data.task?.workflowStatus) {
           setWorkflowStatus(result.data.task.workflowStatus);
         }
+        
+        // Set project ID for log subscription if available
+        if (result.data.task?.stakworkProjectId) {
+          console.log("Setting project ID from task data:", result.data.task.stakworkProjectId);
+          setProjectId(result.data.task.stakworkProjectId.toString());
+        }
       }
     } catch (error) {
       console.error("Error loading task messages:", error);


### PR DESCRIPTION
- Add stakworkProjectId field to Task model to persist Stakwork project ID
- Store project_id from Stakwork API response in database when sending messages
- Return stakworkProjectId in task messages API response
- Auto-subscribe to logs on page load using stored project ID

Fixes issue where thinking logs wouldn't render after refresh/navigation.