### PR TITLE
Fix websocket subscription after task execution

### DIFF
--- a/src/app/w/[slug]/task/[...taskParams]/page.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/page.tsx
@@ -247,9 +247,9 @@ export default function TaskChatPage() {
         throw new Error(result.error || "Failed to send message");
       }
 
-      if (result.data?.project_id) {
-        console.log("Project ID:", result.data.project_id);
-        setProjectId(result.data.project_id);
+      if (result.workflow?.project_id) {
+        console.log("Project ID:", result.workflow.project_id);
+        setProjectId(result.workflow.project_id);
         setIsChainVisible(true);
         clearLogs();
       }


### PR DESCRIPTION
The frontend was looking for project_id in result.data.project_id but the API returns it in result.workflow.project_id. This caused thinking logs to not appear after executing tasks without a page refresh.

Changes:
- Update project_id path from result.data.project_id to result.workflow.project_id
- Enables automatic websocket subscription when tasks are executed
- Eliminates need for hard refresh to see thinking logs