### PR TITLE
Remove user/assistant avatar bubbles and add agent icons to thinking …

### DIFF
--- a/src/app/w/[slug]/task/[...taskParams]/artifacts/longform.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/artifacts/longform.tsx
@@ -2,17 +2,7 @@ import { MarkdownRenderer } from "@/components/MarkdownRenderer";
 import { LongformContent, Artifact } from "@/lib/chat";
 import { useRef, useState, useEffect } from "react";
 import { WorkflowUrlLink } from "../components/WorkflowUrlLink";
-import { Code, Bot, Phone, MessageSquare } from "lucide-react";
-
-const getArtifactIcon = (iconType: string) => {
-  const icons = {
-    code: <Code className="h-5 w-5 flex-shrink-0" />,
-    agent: <Bot className="h-5 w-5 flex-shrink-0" />,
-    call: <Phone className="h-5 w-5 flex-shrink-0" />,
-    message: <MessageSquare className="h-5 w-5 flex-shrink-0" />
-  };
-  return icons[iconType?.toLowerCase() as keyof typeof icons] || null;
-};
+import { getArtifactIcon } from "@/lib/icons";
 
 export function LongformArtifactPanel({
   artifacts,

--- a/src/app/w/[slug]/task/[...taskParams]/components/ChatArea.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/components/ChatArea.tsx
@@ -5,6 +5,7 @@ import { motion } from "framer-motion";
 import { ChatMessage as ChatMessageType, Option, WorkflowStatus } from "@/lib/chat";
 import { ChatMessage } from "./ChatMessage";
 import { ChatInput } from "./ChatInput";
+import { getAgentIcon } from "@/lib/icons";
 
 interface ChatAreaProps {
   messages: ChatMessageType[];
@@ -76,7 +77,8 @@ export function ChatArea({
             className="flex justify-start"
           >
             <div className="max-w-[85%] bg-muted rounded-2xl px-4 py-3 shadow-sm">
-              <div className="font-medium text-sm text-muted-foreground mb-1">
+              <div className="font-medium text-sm text-muted-foreground mb-1 flex items-center gap-2">
+                {getAgentIcon()}
                 Hive
               </div>
               <div className="text-sm">

--- a/src/app/w/[slug]/task/[...taskParams]/components/ChatMessage.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/components/ChatMessage.tsx
@@ -40,21 +40,14 @@ export function ChatMessage({
       onMouseLeave={() => setIsHovered(false)}
     >
       <div
-        className={`flex items-end gap-3 ${message.role === "USER" ? "justify-end ml-12" : "justify-start"}`}
+        className={`flex items-end gap-3 ${message.role === "USER" ? "justify-end" : "justify-start"}`}
       >
-        {message.role === "ASSISTANT" && (
-          <Avatar>
-            <AvatarImage src="" alt="Assistant" />
-            <AvatarFallback>A</AvatarFallback>
-          </Avatar>
-        )}
-
         {message.message && (
           <div
             className={`px-4 py-1 rounded-md max-w-full shadow-sm relative ${
               message.role === "USER"
-                ? "bg-primary text-primary-foreground rounded-br-none"
-                : "bg-background text-foreground rounded-bl-none border"
+                ? "bg-primary text-primary-foreground rounded-br-md"
+                : "bg-background text-foreground rounded-bl-md border"
             }`}
             onMouseEnter={() => setIsHovered(true)}
             onMouseLeave={() => setIsHovered(false)}
@@ -73,12 +66,6 @@ export function ChatMessage({
               />
             )}
           </div>
-        )}
-        {message.role === "USER" && (
-          <Avatar>
-            <AvatarImage src="" alt="You" />
-            <AvatarFallback>Y</AvatarFallback>
-          </Avatar>
         )}
       </div>
 

--- a/src/lib/icons.tsx
+++ b/src/lib/icons.tsx
@@ -1,0 +1,19 @@
+import { Code, Bot, Phone, MessageSquare } from "lucide-react";
+
+export const getIcon = (iconType: string, className = "h-4 w-4") => {
+  const icons = {
+    code: <Code className={className} />,
+    agent: <Bot className={className} />,
+    call: <Phone className={className} />,
+    message: <MessageSquare className={className} />
+  };
+  return icons[iconType?.toLowerCase() as keyof typeof icons] || null;
+};
+
+export const getArtifactIcon = (iconType: string) => {
+  return getIcon(iconType, "h-5 w-5 flex-shrink-0");
+};
+
+export const getAgentIcon = (className = "h-4 w-4 flex-shrink-0") => {
+  return <Bot className={className} />;
+};


### PR DESCRIPTION
…logs

- Remove Y and A avatar fallbacks from chat messages
- Clean up message layout by removing avatar components entirely
- Add agent icon next to "Hive" in thinking logs section
- Create global icon utility library for consistent icon usage
- Refactor artifact icons to use centralized icon system