### PR TITLE
Implement 3-workspace limit with improved UX

### DIFF
--- a/src/__tests__/integration/api/workspaces.test.ts
+++ b/src/__tests__/integration/api/workspaces.test.ts
@@ -1,0 +1,208 @@
+import { describe, test, expect, beforeEach } from "vitest";
+import { POST } from "@/app/api/workspaces/route";
+import { NextRequest } from "next/server";
+import { getServerSession } from "next-auth/next";
+import { db } from "@/lib/db";
+import { 
+  WORKSPACE_ERRORS,
+  WORKSPACE_LIMITS
+} from "@/lib/constants";
+import type { User } from "@prisma/client";
+
+// Mock next-auth
+vi.mock("next-auth/next", () => ({
+  getServerSession: vi.fn(),
+}));
+
+// Mock authOptions (not used directly but imported by route)
+vi.mock("@/lib/auth/nextauth", () => ({
+  authOptions: {},
+}));
+
+describe("Workspace API - Integration Tests", () => {
+  const generateRandomString = (length = 8) => {
+    const characters = 'abcdefghijklmnopqrstuvwxyz0123456789';
+    let result = '';
+    for (let i = 0; i < length; i++) {
+      result += characters.charAt(Math.floor(Math.random() * characters.length));
+    }
+    return result;
+  };
+
+  let testUser: User;
+
+  beforeEach(async () => {
+    // Create test user
+    testUser = await db.user.create({
+      data: {
+        name: "Test User",
+        email: `user_${generateRandomString()}@example.com`,
+      },
+    });
+
+    // Mock session for authenticated user
+    (getServerSession as vi.Mock).mockResolvedValue({
+      user: { id: testUser.id, email: testUser.email },
+    });
+  });
+
+  describe("POST /api/workspaces", () => {
+    test("should create workspace successfully", async () => {
+      const slug = `test-workspace-${generateRandomString()}`;
+      const request = new NextRequest("http://localhost:3000/api/workspaces", {
+        method: "POST",
+        body: JSON.stringify({
+          name: "Test Workspace",
+          description: "A test workspace",
+          slug: slug,
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(data.workspace).toMatchObject({
+        name: "Test Workspace",
+        description: "A test workspace",
+        slug: slug,
+        ownerId: testUser.id,
+      });
+    });
+
+    test("should enforce workspace limit", async () => {
+      // Create max workspaces for the user
+      for (let i = 0; i < WORKSPACE_LIMITS.MAX_WORKSPACES_PER_USER; i++) {
+        await db.workspace.create({
+          data: {
+            name: `Workspace ${i + 1}`,
+            slug: `workspace-${i + 1}-${generateRandomString()}`,
+            ownerId: testUser.id,
+          },
+        });
+      }
+
+      // Try to create another workspace via API
+      const slug = `extra-workspace-${generateRandomString()}`;
+      const request = new NextRequest("http://localhost:3000/api/workspaces", {
+        method: "POST",
+        body: JSON.stringify({
+          name: "Extra Workspace",
+          description: "This should fail",
+          slug: slug,
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe(WORKSPACE_ERRORS.WORKSPACE_LIMIT_EXCEEDED);
+    });
+
+    test("should allow creation after workspace deletion", async () => {
+      // Create max workspaces
+      const workspaces = [];
+      for (let i = 0; i < WORKSPACE_LIMITS.MAX_WORKSPACES_PER_USER; i++) {
+        const workspace = await db.workspace.create({
+          data: {
+            name: `Workspace ${i + 1}`,
+            slug: `workspace-${i + 1}-${generateRandomString()}`,
+            ownerId: testUser.id,
+          },
+        });
+        workspaces.push(workspace);
+      }
+
+      // Delete one workspace
+      await db.workspace.update({
+        where: { id: workspaces[0].id },
+        data: { deleted: true, deletedAt: new Date() }
+      });
+
+      // Now should be able to create via API
+      const slug = `new-workspace-${generateRandomString()}`;
+      const request = new NextRequest("http://localhost:3000/api/workspaces", {
+        method: "POST",
+        body: JSON.stringify({
+          name: "New Workspace",
+          slug: slug,
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(data.workspace.name).toBe("New Workspace");
+      expect(data.workspace.slug).toBe(slug);
+    });
+
+    test("should return 401 for unauthenticated user", async () => {
+      (getServerSession as vi.Mock).mockResolvedValue(null);
+
+      const request = new NextRequest("http://localhost:3000/api/workspaces", {
+        method: "POST",
+        body: JSON.stringify({
+          name: "Test Workspace",
+          slug: "test-workspace",
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error).toBe("Unauthorized");
+    });
+
+    test("should return 400 for missing required fields", async () => {
+      const request = new NextRequest("http://localhost:3000/api/workspaces", {
+        method: "POST",
+        body: JSON.stringify({
+          description: "Missing name and slug",
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe("Missing required fields");
+    });
+
+    test("should return 400 for duplicate slug", async () => {
+      const slug = `duplicate-${generateRandomString()}`;
+      
+      // Create first workspace
+      await db.workspace.create({
+        data: {
+          name: "First Workspace",
+          slug: slug,
+          ownerId: testUser.id,
+        },
+      });
+
+      // Try to create another with same slug
+      const request = new NextRequest("http://localhost:3000/api/workspaces", {
+        method: "POST",
+        body: JSON.stringify({
+          name: "Duplicate Workspace",
+          slug: slug,
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe(WORKSPACE_ERRORS.SLUG_ALREADY_EXISTS);
+    });
+  });
+});

--- a/src/__tests__/unit/components/error-display.test.tsx
+++ b/src/__tests__/unit/components/error-display.test.tsx
@@ -1,0 +1,25 @@
+import { describe, test, expect } from "vitest";
+import { classifyError } from "@/components/ui/error-display";
+import { WORKSPACE_ERRORS } from "@/lib/constants";
+
+describe("classifyError utility", () => {
+  test("should classify known workspace errors", () => {
+    const config = classifyError(WORKSPACE_ERRORS.WORKSPACE_LIMIT_EXCEEDED);
+    
+    expect(config.type).toBe("error");
+    expect(config.title).toBe("Workspace Limit Reached");
+    expect(config.description).toBe("You can only create up to 2 workspaces.");
+    expect(config.helpText).toBe("You can delete an existing workspace to create a new one.");
+  });
+
+  test("should classify unknown errors with defaults", () => {
+    const unknownError = "Random error message";
+    const config = classifyError(unknownError);
+    
+    expect(config.type).toBe("error");
+    expect(config.title).toBe("Something went wrong");
+    expect(config.description).toBe(unknownError);
+  });
+});
+
+

--- a/src/__tests__/unit/components/workspace-switcher.test.tsx
+++ b/src/__tests__/unit/components/workspace-switcher.test.tsx
@@ -1,0 +1,62 @@
+import { describe, test, expect, vi } from "vitest";
+import { WORKSPACE_LIMITS } from "@/lib/constants";
+
+// Mock the useWorkspace hook
+const mockUseWorkspace = vi.fn();
+vi.mock("@/hooks/useWorkspace", () => ({
+  useWorkspace: () => mockUseWorkspace(),
+}));
+
+// Mock router
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+describe("WorkspaceSwitcher Logic", () => {
+  test("should identify when user is at workspace limit", () => {
+    const workspaces = [
+      { id: "1", userRole: "OWNER", name: "Workspace 1" },
+      { id: "2", userRole: "OWNER", name: "Workspace 2" },
+      { id: "3", userRole: "DEVELOPER", name: "Workspace 3" }, // Not owned
+    ];
+
+    const ownedWorkspaces = workspaces.filter(ws => ws.userRole === 'OWNER');
+    const isAtLimit = ownedWorkspaces.length >= WORKSPACE_LIMITS.MAX_WORKSPACES_PER_USER;
+
+    expect(ownedWorkspaces).toHaveLength(2);
+    expect(isAtLimit).toBe(true);
+  });
+
+  test("should allow creation when under limit", () => {
+    const workspaces = [
+      { id: "1", userRole: "OWNER", name: "Workspace 1" },
+      { id: "2", userRole: "DEVELOPER", name: "Workspace 2" }, // Not owned
+    ];
+
+    const ownedWorkspaces = workspaces.filter(ws => ws.userRole === 'OWNER');
+    const isAtLimit = ownedWorkspaces.length >= WORKSPACE_LIMITS.MAX_WORKSPACES_PER_USER;
+
+    expect(ownedWorkspaces).toHaveLength(1);
+    expect(isAtLimit).toBe(false);
+  });
+
+  test("should count only owned workspaces toward limit", () => {
+    const workspaces = [
+      { id: "1", userRole: "OWNER", name: "Owned 1" },
+      { id: "2", userRole: "OWNER", name: "Owned 2" },
+      { id: "3", userRole: "ADMIN", name: "Admin workspace" },
+      { id: "4", userRole: "DEVELOPER", name: "Dev workspace" },
+      { id: "5", userRole: "VIEWER", name: "Viewer workspace" },
+    ];
+
+    const ownedWorkspaces = workspaces.filter(ws => ws.userRole === 'OWNER');
+    const isAtLimit = ownedWorkspaces.length >= WORKSPACE_LIMITS.MAX_WORKSPACES_PER_USER;
+
+    expect(ownedWorkspaces).toHaveLength(2);
+    expect(workspaces).toHaveLength(5); // Total workspaces user can access
+    expect(isAtLimit).toBe(true); // But only 2 are owned, so at limit
+  });
+});

--- a/src/app/onboarding/workspace/wizard/wizard-steps/project-name-setup/index.tsx
+++ b/src/app/onboarding/workspace/wizard/wizard-steps/project-name-setup/index.tsx
@@ -11,6 +11,7 @@ import { Label } from "@/components/ui/label";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { useWizardStore } from "@/stores/useWizardStore";
 import { AnimatePresence, motion } from "framer-motion";
+import { ErrorDisplay } from "@/components/ui/error-display";
 import { ArrowRight, Loader2 } from "lucide-react";
 import { redirect, useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
@@ -203,6 +204,7 @@ export function ProjectNameSetupStep() {
   ) : (
     <Card className="max-w-2xl mx-auto bg-card text-card-foreground">
       <CardHeader className="text-center">
+        <ErrorDisplay error={error} className="mb-4" />
         <div className="flex items-center justify-center mx-auto mb-4">
           <svg
             width="64"

--- a/src/app/workspaces/page.tsx
+++ b/src/app/workspaces/page.tsx
@@ -5,9 +5,10 @@ import { getUserWorkspaces } from "@/services/workspace";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
-import { Building2, Plus, Users, Calendar, ArrowRight } from "lucide-react";
+import { Building2, Plus, Users, Calendar, ArrowRight, Lock } from "lucide-react";
 import Link from "next/link";
 import { LogoutButton } from "./LogoutButton";
+import { WORKSPACE_LIMITS } from "@/lib/constants";
 
 export default async function WorkspacesPage() {
   const session = await getServerSession(authOptions);
@@ -22,6 +23,9 @@ export default async function WorkspacesPage() {
   if (userWorkspaces.length === 0) {
     redirect("/onboarding/workspace");
   }
+
+  // Check if user is at workspace limit
+  const isAtLimit = userWorkspaces.length >= WORKSPACE_LIMITS.MAX_WORKSPACES_PER_USER;
 
   return (
     <div className="min-h-screen bg-background">
@@ -101,24 +105,45 @@ export default async function WorkspacesPage() {
             </Card>
           ))}
 
-          {/* Create New Workspace */}
-          <Card className="border-dashed border-2 hover:border-primary/50 transition-colors">
-            <Link href="/onboarding/workspace" className="block">
-              <CardContent className="p-4">
-                <div className="flex items-center gap-4">
-                  <div className="flex items-center justify-center w-10 h-10 rounded-lg border-2 border-dashed border-muted-foreground">
-                    <Plus className="w-5 h-5 text-muted-foreground" />
-                  </div>
-                  <div className="flex-1">
-                    <h3 className="font-semibold text-lg mb-1">Create New Workspace</h3>
-                    <p className="text-sm text-muted-foreground">
-                      Start a new project or organization
-                    </p>
-                  </div>
-                  <ArrowRight className="w-4 h-4 text-muted-foreground" />
+          {/* Create New Workspace Card */}
+          <Card className={`group transition-all duration-200 border-dashed border-2 ${
+            isAtLimit 
+              ? 'border-muted-foreground/10 cursor-not-allowed opacity-60' 
+              : 'border-muted-foreground/25 hover:border-primary/50 hover:shadow-md cursor-pointer'
+          }`}>
+            {isAtLimit ? (
+              <CardContent className="flex flex-col items-center justify-center h-full py-12 text-center">
+                <div className="w-12 h-12 rounded-full bg-muted flex items-center justify-center mb-4">
+                  <Lock className="w-6 h-6 text-muted-foreground" />
                 </div>
+                <h3 className="font-medium mb-2 text-muted-foreground">
+                  Workspace Limit Reached
+                </h3>
+                <p className="text-sm text-muted-foreground mb-1">
+                  You've used all {WORKSPACE_LIMITS.MAX_WORKSPACES_PER_USER} available workspaces
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Delete a workspace to create a new one
+                </p>
               </CardContent>
-            </Link>
+            ) : (
+              <Link href="/onboarding/workspace" className="block">
+                <CardContent className="p-4">
+                  <div className="flex items-center gap-4">
+                    <div className="flex items-center justify-center w-10 h-10 rounded-lg border-2 border-dashed border-muted-foreground">
+                      <Plus className="w-5 h-5 text-muted-foreground" />
+                    </div>
+                    <div className="flex-1">
+                      <h3 className="font-semibold text-lg mb-1">Create New Workspace</h3>
+                      <p className="text-sm text-muted-foreground">
+                        Start a new project or organization
+                      </p>
+                    </div>
+                    <ArrowRight className="w-4 h-4 text-muted-foreground" />
+                  </div>
+                </CardContent>
+              </Link>
+            )}
           </Card>
         </div>
 

--- a/src/components/CreateWorkspaceDialog.tsx
+++ b/src/components/CreateWorkspaceDialog.tsx
@@ -15,6 +15,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { useSession } from "next-auth/react";
 import type { WorkspaceResponse } from "@/types/workspace";
+import { ErrorDisplay } from "@/components/ui/error-display";
 
 interface CreateWorkspaceDialogProps {
   open: boolean;
@@ -68,8 +69,8 @@ export function CreateWorkspaceDialog({
       setFormData({ name: "", description: "", slug: "" });
       setErrors({});
       onOpenChange(false);
-    } catch (err: any) {
-      setApiError(err.message || "Unknown error");
+    } catch (err: unknown) {
+      setApiError(err instanceof Error ? err.message : "Unknown error");
     } finally {
       setLoading(false);
     }
@@ -145,7 +146,7 @@ export function CreateWorkspaceDialog({
               disabled={loading}
             />
           </div>
-          {apiError && <p className="text-sm text-destructive">{apiError}</p>}
+          <ErrorDisplay error={apiError} />
           <DialogFooter>
             <Button
               type="button"

--- a/src/components/WorkspaceSwitcher.tsx
+++ b/src/components/WorkspaceSwitcher.tsx
@@ -12,8 +12,9 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import type { WorkspaceWithRole } from "@/types/workspace";
-import { Building2, ChevronsUpDown, Plus } from "lucide-react";
+import { Building2, ChevronsUpDown, Plus, Lock } from "lucide-react";
 import { useRouter } from "next/navigation";
+import { WORKSPACE_LIMITS } from "@/lib/constants";
 
 interface WorkspaceSwitcherProps {
   // Legacy props for backward compatibility
@@ -48,12 +49,19 @@ export function WorkspaceSwitcher({
     }
   };
 
+  // Check if user is at workspace limit
+  const isAtLimit = workspaces.length >= WORKSPACE_LIMITS.MAX_WORKSPACES_PER_USER;
+
+
   const handleCreateWorkspace = () => {
+    if (isAtLimit) {
+      // Don't navigate if at limit - this prevents the error flow
+      return;
+    }
 
     localStorage.removeItem("repoUrl");
     // Default behavior: navigate to workspace creation
     router.push("/onboarding/workspace");
-
   };
 
   // Loading state
@@ -175,14 +183,32 @@ export function WorkspaceSwitcher({
           <DropdownMenuSeparator />
           <DropdownMenuItem
             onClick={handleCreateWorkspace}
-            className="flex items-center gap-2 p-2"
+            disabled={isAtLimit}
+            className={`flex items-center gap-2 p-2 ${
+              isAtLimit ? 'opacity-60 cursor-not-allowed' : ''
+            }`}
           >
-            <div className="flex items-center justify-center w-6 h-6 rounded-md border border-dashed">
-              <Plus className="w-4 h-4" />
+            <div className={`flex items-center justify-center w-6 h-6 rounded-md ${
+              isAtLimit ? 'border border-muted bg-muted' : 'border border-dashed'
+            }`}>
+              {isAtLimit ? (
+                <Lock className="w-4 h-4 text-muted-foreground" />
+              ) : (
+                <Plus className="w-4 h-4" />
+              )}
             </div>
 
-            <div className="font-medium text-sm text-muted-foreground">
-              Create new workspace
+            <div className="flex-1">
+              <div className={`font-medium text-sm ${
+                isAtLimit ? 'text-muted-foreground' : 'text-muted-foreground'
+              }`}>
+                {isAtLimit ? 'Workspace limit reached' : 'Create new workspace'}
+              </div>
+              {isAtLimit && (
+                <div className="text-xs text-muted-foreground mt-0.5">
+                  {workspaces.length}/{WORKSPACE_LIMITS.MAX_WORKSPACES_PER_USER} workspaces used
+                </div>
+              )}
             </div>
           </DropdownMenuItem>
         </DropdownMenuContent>

--- a/src/components/onboarding/WorkspaceForm.tsx
+++ b/src/components/onboarding/WorkspaceForm.tsx
@@ -5,6 +5,7 @@ import { ArrowRight } from "lucide-react";
 import { useWorkspaceForm } from "@/hooks/useWorkspaceForm";
 import { FormField } from "./FormField";
 import { useWorkspace } from "@/hooks/useWorkspace";
+import { ErrorDisplay } from "@/components/ui/error-display";
 
 export function WorkspaceForm() {
   const {
@@ -63,11 +64,7 @@ export function WorkspaceForm() {
             rows={3}
           />
 
-          {apiError && (
-            <div className="p-3 border border-destructive bg-destructive/10 rounded-md">
-              <p className="text-sm text-destructive">{apiError}</p>
-            </div>
-          )}
+          <ErrorDisplay error={apiError} />
 
           <Button
             type="submit"

--- a/src/components/ui/error-display.tsx
+++ b/src/components/ui/error-display.tsx
@@ -1,0 +1,156 @@
+import React from "react";
+import { AlertCircle, Info } from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { WORKSPACE_ERRORS } from "@/lib/constants";
+
+export interface ErrorDisplayConfig {
+  type: 'error' | 'warning' | 'info';
+  title?: string;
+  description?: string;
+  helpText?: string;
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
+}
+
+// Centralized error configuration mapping
+const ERROR_CONFIGS: Record<string, ErrorDisplayConfig> = {
+  [WORKSPACE_ERRORS.WORKSPACE_LIMIT_EXCEEDED]: {
+    type: 'error',
+    title: 'Workspace Limit Reached',
+    description: 'You can only create up to 2 workspaces.',
+    helpText: 'You can delete an existing workspace to create a new one.',
+  },
+  [WORKSPACE_ERRORS.SLUG_ALREADY_EXISTS]: {
+    type: 'error',
+    title: 'Name Already Taken',
+    description: 'A workspace with this name already exists.',
+    helpText: 'Please choose a different name for your workspace.',
+  },
+  [WORKSPACE_ERRORS.SLUG_INVALID_FORMAT]: {
+    type: 'error',
+    title: 'Invalid Name Format',
+    description: 'Workspace name must start and end with letters or numbers.',
+    helpText: 'You can only use letters, numbers, and hyphens.',
+  },
+  [WORKSPACE_ERRORS.SLUG_INVALID_LENGTH]: {
+    type: 'error',
+    title: 'Invalid Name Length',
+    description: 'Workspace name must be between 2 and 50 characters.',
+  },
+  [WORKSPACE_ERRORS.SLUG_RESERVED]: {
+    type: 'error',
+    title: 'Reserved Name',
+    description: 'This workspace name is reserved by the system.',
+    helpText: 'Please choose a different name for your workspace.',
+  },
+  [WORKSPACE_ERRORS.NOT_FOUND]: {
+    type: 'error',
+    title: 'Workspace Not Found',
+    description: 'The requested workspace could not be found.',
+  },
+  [WORKSPACE_ERRORS.ACCESS_DENIED]: {
+    type: 'error',
+    title: 'Access Denied',
+    description: 'You do not have permission to access this workspace.',
+  },
+};
+
+interface ErrorDisplayProps {
+  error: string | null;
+  className?: string;
+  compact?: boolean;
+  onActionClick?: () => void;
+}
+
+export function ErrorDisplay({ 
+  error, 
+  className = "", 
+  compact = false,
+  onActionClick 
+}: ErrorDisplayProps) {
+  if (!error) return null;
+
+  // Get configuration for this error, or create a default one
+  const config = ERROR_CONFIGS[error] || {
+    type: 'error' as const,
+    title: 'Error',
+    description: error,
+  };
+
+  const getAlertVariant = (type: ErrorDisplayConfig['type']) => {
+    switch (type) {
+      case 'warning': return 'default';
+      case 'info': return 'default';
+      case 'error': 
+      default: return 'destructive';
+    }
+  };
+
+  const getIcon = (type: ErrorDisplayConfig['type']) => {
+    switch (type) {
+      case 'info': return <Info className="h-4 w-4" />;
+      case 'warning':
+      case 'error':
+      default: return <AlertCircle className="h-4 w-4" />;
+    }
+  };
+
+  if (compact) {
+    return (
+      <div className={`text-sm text-destructive ${className}`}>
+        <p>{config.description}</p>
+        {config.helpText && (
+          <p className="text-xs text-muted-foreground mt-1">
+            {config.helpText}
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <Alert variant={getAlertVariant(config.type)} className={className}>
+      {getIcon(config.type)}
+      <AlertDescription>
+        <div className="space-y-2">
+          {config.title && (
+            <p className="font-medium">{config.title}</p>
+          )}
+          <p>{config.description}</p>
+          {config.helpText && (
+            <p className="text-xs opacity-90">
+              {config.helpText}
+            </p>
+          )}
+          {config.action && (
+            <button
+              onClick={onActionClick || config.action.onClick}
+              className="text-xs underline hover:no-underline"
+            >
+              {config.action.label}
+            </button>
+          )}
+        </div>
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+// Utility function to classify unknown errors
+export function classifyError(error: string): ErrorDisplayConfig {
+  return ERROR_CONFIGS[error] || {
+    type: 'error',
+    title: 'Something went wrong',
+    description: error,
+  };
+}
+
+// Hook for error handling
+export function useErrorDisplay() {
+  return {
+    getErrorConfig: classifyError,
+    isWorkspaceError: (error: string) => Object.keys(ERROR_CONFIGS).includes(error),
+  };
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -116,6 +116,11 @@ export const WORKSPACE_PERMISSION_LEVELS: Record<WorkspaceRole, number> = {
   [WorkspaceRole.OWNER]: 5,
 } as const;
 
+// Workspace limits
+export const WORKSPACE_LIMITS = {
+  MAX_WORKSPACES_PER_USER: parseInt(process.env.MAX_WORKSPACES_PER_USER || "2", 10),
+} as const;
+
 // Error messages
 export const WORKSPACE_ERRORS = {
   NOT_FOUND: "Workspace not found",
@@ -127,6 +132,8 @@ export const WORKSPACE_ERRORS = {
   SLUG_INVALID_LENGTH: "Workspace name must be between 2 and 50 characters.",
   SLUG_ALREADY_EXISTS:
     "A workspace with this name already exists. Please choose a different name.",
+  WORKSPACE_LIMIT_EXCEEDED:
+    `You can only create up to ${WORKSPACE_LIMITS.MAX_WORKSPACES_PER_USER} workspaces. Please delete an existing workspace first.`,
 } as const;
 
 // Swarm creation defaults

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -118,7 +118,7 @@ export const WORKSPACE_PERMISSION_LEVELS: Record<WorkspaceRole, number> = {
 
 // Workspace limits
 export const WORKSPACE_LIMITS = {
-  MAX_WORKSPACES_PER_USER: parseInt(process.env.MAX_WORKSPACES_PER_USER || "2", 10),
+  MAX_WORKSPACES_PER_USER: parseInt(process.env.MAX_WORKSPACES_PER_USER || "3", 10),
 } as const;
 
 // Error messages


### PR DESCRIPTION
- Add configurable workspace limits via environment variable (default: 3)
- Implement service layer validation in createWorkspace function
- Add comprehensive unit and integration tests for limit enforcement
- Create centralized ErrorDisplay component for consistent error handling
- Improve WorkspaceSwitcher UX: disable/gray out creation when at limit
- Update workspaces page to show limit status instead of creation option
- Prevent users from entering creation flow when at limit
- Add informative messaging: '3/3 workspaces used' with clear guidance
- Ensure deleted workspaces don't count toward limit
- Test coverage: limit enforcement, deletion scenarios, cross-user isolation