### PR TITLE
feat(chat): retry UX on failed/error workflows + realtime status emits (#236)

### DIFF
--- a/src/app/api/mock/responses.ts
+++ b/src/app/api/mock/responses.ts
@@ -136,10 +136,17 @@ export function generateLongformResponse() {
   ]);
 }
 
+// Toggle this flag to simulate failure or success
+const MOCK_FAIL = true; // Set to true to simulate failure, false for normal behavior
+
 export function generateResponseBasedOnMessage(
   message: string,
   baseUrl: string,
 ) {
+  if (MOCK_FAIL) {
+    return null;
+  }
+
   const messageText = message.toLowerCase();
 
   if (messageText.includes("browser")) {

--- a/src/app/api/mock/route.ts
+++ b/src/app/api/mock/route.ts
@@ -1,6 +1,9 @@
 import axios from "axios";
 import { generateResponseBasedOnMessage } from "./responses";
 import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { WorkflowStatus } from "@prisma/client";
+import { emitWorkflowStatus } from "@/lib/emitWorkflowStatus";
 
 export const fetchCache = "force-no-store";
 
@@ -15,6 +18,48 @@ export async function POST(req: NextRequest) {
 
       const mockResponse = generateResponseBasedOnMessage(message, baseUrl);
 
+      if (!mockResponse) {
+        try {
+          await axios.post(`${baseUrl}/api/chat/response`, {
+            taskId,
+            message: "⚠️ Response failed. Please try again.",
+            contextTags: [],
+            sourceWebsocketID: null,
+            artifacts: [],
+          });
+        } catch (broadcastErr) {
+          console.error(
+            "Failed to broadcast mock failure message:",
+            broadcastErr,
+          );
+        }
+
+        try {
+          const updated = await db.task.update({
+            where: { id: taskId },
+            data: {
+              workflowStatus: WorkflowStatus.FAILED,
+              workflowCompletedAt: new Date(),
+            },
+          });
+          await emitWorkflowStatus({
+            taskId,
+            workflowStatus: WorkflowStatus.FAILED,
+            workflowStartedAt: updated.workflowStartedAt,
+            workflowCompletedAt: updated.workflowCompletedAt,
+          });
+        } catch (statusErr) {
+          console.error("Failed to set FAILED status for mock:", statusErr);
+        }
+        return NextResponse.json(
+          {
+            success: false,
+            error: "Mock generation failed",
+          },
+          { status: 500 },
+        );
+      }
+
       const responsePayload = {
         taskId: taskId,
         message: mockResponse.message,
@@ -27,6 +72,24 @@ export async function POST(req: NextRequest) {
       };
 
       await axios.post(`${baseUrl}/api/chat/response`, responsePayload);
+
+      try {
+        const updated = await db.task.update({
+          where: { id: taskId },
+          data: {
+            workflowStatus: WorkflowStatus.COMPLETED,
+            workflowCompletedAt: new Date(),
+          },
+        });
+        await emitWorkflowStatus({
+          taskId,
+          workflowStatus: WorkflowStatus.COMPLETED,
+          workflowStartedAt: updated.workflowStartedAt,
+          workflowCompletedAt: updated.workflowCompletedAt,
+        });
+      } catch (statusErr) {
+        console.error("Failed to set COMPLETED status for mock:", statusErr);
+      }
     } catch (error) {
       console.error("❌ Mock error sending response:", error);
     }

--- a/src/app/w/[slug]/task/[...taskParams]/components/ChatArea.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/components/ChatArea.tsx
@@ -2,7 +2,11 @@
 
 import { useRef, useEffect } from "react";
 import { motion } from "framer-motion";
-import { ChatMessage as ChatMessageType, Option, WorkflowStatus } from "@/lib/chat";
+import {
+  ChatMessage as ChatMessageType,
+  Option,
+  WorkflowStatus,
+} from "@/lib/chat";
 import { ChatMessage } from "./ChatMessage";
 import { ChatInput } from "./ChatInput";
 import { getAgentIcon } from "@/lib/icons";
@@ -21,6 +25,7 @@ interface ChatAreaProps {
   isChainVisible?: boolean;
   lastLogLine?: string;
   workflowStatus?: WorkflowStatus | null;
+  onRetry?: () => void;
 }
 
 export function ChatArea({
@@ -33,6 +38,7 @@ export function ChatArea({
   isChainVisible = false,
   lastLogLine = "",
   workflowStatus,
+  onRetry,
 }: ChatAreaProps) {
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
@@ -55,16 +61,18 @@ export function ChatArea({
       <div className="flex-1 overflow-y-auto px-4 py-6 space-y-4 bg-muted/40">
         {messages
           .filter((msg) => !msg.replyId) // Hide messages that are replies
-          .map((msg) => {
-            // Find if this message has been replied to
+          .map((msg, idx, arr) => {
             const replyMessage = messages.find((m) => m.replyId === msg.id);
-
+            const isLast = idx === arr.length - 1;
             return (
               <ChatMessage
                 key={msg.id}
                 message={msg}
                 replyMessage={replyMessage}
                 onArtifactAction={onArtifactAction}
+                isLast={isLast}
+                workflowStatus={workflowStatus}
+                onRetry={onRetry}
               />
             );
           })}
@@ -113,6 +121,7 @@ export function ChatArea({
         disabled={inputDisabled}
         isLoading={isLoading}
         workflowStatus={workflowStatus}
+        onRetry={onRetry}
       />
     </motion.div>
   );

--- a/src/app/w/[slug]/task/[...taskParams]/components/ChatMessage.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/components/ChatMessage.tsx
@@ -7,10 +7,13 @@ import {
   ChatMessage as ChatMessageType,
   Option,
   FormContent,
+  WorkflowStatus,
 } from "@/lib/chat";
 import { FormArtifact, LongformArtifactPanel } from "../artifacts";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
 import { WorkflowUrlLink } from "./WorkflowUrlLink";
+import { Button } from "@/components/ui/button";
+import { RotateCcw } from "lucide-react";
 
 interface ChatMessageProps {
   message: ChatMessageType;
@@ -20,14 +23,27 @@ interface ChatMessageProps {
     action: Option,
     webhook: string,
   ) => Promise<void>;
+  isLast?: boolean;
+  workflowStatus?: WorkflowStatus | null;
+  onRetry?: () => void;
 }
 
 export function ChatMessage({
   message,
   replyMessage,
   onArtifactAction,
+  isLast = false,
+  workflowStatus,
+  onRetry,
 }: ChatMessageProps) {
   const [isHovered, setIsHovered] = useState(false);
+
+  const showRetry =
+    isLast &&
+    message.role !== "USER" &&
+    (workflowStatus === WorkflowStatus.ERROR ||
+      workflowStatus === WorkflowStatus.FAILED) &&
+    typeof onRetry === "function";
 
   return (
     <motion.div
@@ -57,13 +73,28 @@ export function ChatMessage({
             >
               {message.message}
             </MarkdownRenderer>
-            
+
             {/* Workflow URL Link for message bubble */}
             {message.workflowUrl && (
-              <WorkflowUrlLink 
+              <WorkflowUrlLink
                 workflowUrl={message.workflowUrl}
                 className={isHovered ? "opacity-100" : "opacity-0"}
               />
+            )}
+            {showRetry && (
+              <div className="mt-3 flex justify-end">
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="group h-7 px-2 gap-1 rounded-full border border-destructive/30 bg-destructive/10 hover:bg-destructive/20 text-destructive relative overflow-hidden"
+                  type="button"
+                  onClick={onRetry}
+                >
+                  <span className="absolute inset-0 bg-gradient-to-r from-destructive/0 via-destructive/10 to-destructive/0 opacity-0 group-hover:opacity-100 transition-opacity" />
+                  <RotateCcw className="h-4 w-4 group-hover:rotate-[-180deg] transition-transform duration-300" />
+                  <span className="text-xs font-medium">Retry</span>
+                </Button>
+              </div>
             )}
           </div>
         )}
@@ -119,8 +150,8 @@ export function ChatMessage({
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: 0.2 }}
               >
-                <LongformArtifactPanel 
-                  artifacts={[artifact]} 
+                <LongformArtifactPanel
+                  artifacts={[artifact]}
                   workflowUrl={message.workflowUrl ?? undefined}
                 />
               </motion.div>

--- a/src/lib/emitWorkflowStatus.ts
+++ b/src/lib/emitWorkflowStatus.ts
@@ -1,0 +1,33 @@
+import { pusherServer, getTaskChannelName, PUSHER_EVENTS } from "./pusher";
+import { WorkflowStatus } from "@prisma/client";
+
+export type EmitWorkflowStatusArgs = {
+  taskId: string;
+  workflowStatus: WorkflowStatus;
+  workflowStartedAt?: Date | null;
+  workflowCompletedAt?: Date | null;
+};
+
+export async function emitWorkflowStatus({
+  taskId,
+  workflowStatus,
+  workflowStartedAt,
+  workflowCompletedAt,
+}: EmitWorkflowStatusArgs) {
+  try {
+    const channelName = getTaskChannelName(taskId);
+    await pusherServer.trigger(
+      channelName,
+      PUSHER_EVENTS.WORKFLOW_STATUS_UPDATE,
+      {
+        taskId,
+        workflowStatus,
+        workflowStartedAt: workflowStartedAt ?? null,
+        workflowCompletedAt: workflowCompletedAt ?? null,
+        timestamp: new Date(),
+      },
+    );
+  } catch (err) {
+    console.error("emitWorkflowStatus error", err);
+  }
+}


### PR DESCRIPTION
## Summary

Adds **user-facing retry capability** when a workflow run fails or errors, with live status updates and clearer failure signaling.

---

## Key Changes

- **New utility:** `emitWorkflowStatus`  
  - Centralizes `Pusher` `WORKFLOW_STATUS_UPDATE` emits.
- **Status transition emits:**  
  - `chat/message` route now emits `IN_PROGRESS` / `FAILED` status updates.
- **Refactor:**  
  - Stakwork webhook now uses `emitWorkflowStatus` utility.
- **Mock route updates:**  
  - Sets `FAILED` on generation failure, `COMPLETED` on success, and emits both.
- **Retry UI changes:**  
  - Added a retry button on failed chat bubble.
- **Workflow timestamp reset:**  
  - Clears `workflowCompletedAt` (sets `null`) on new run start to avoid stale completion times.
- **Testing flag:** Added optional `MOCK_FAIL` in mock responses for deterministic failure testing.

---

## Loom Video
https://www.loom.com/share/bc44012df5e2455dbefc4244b3d85f67?sid=d94be5d4-18ff-4b40-8514-eb4008262cc1

## MOCK_FAIL Flag (IMPORTANT for reviewers)

**File:** `responses.ts`  
**Toggle:**  
```ts
const MOCK_FAIL = true | false;
