### PR TITLE
fix: improve destructive alert text visibility and remove signup requ…

### DIFF
--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils";
 const alertVariants = {
   default: "bg-muted text-foreground border border-border",
   destructive:
-    "bg-red-100/50 dark:bg-red-900/20 text-red-800 dark:text-red-200 border border-red-300 dark:border-red-800",
+    "bg-destructive/10 text-destructive border border-destructive/20",
 };
 
 export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -35,7 +35,7 @@ const AlertDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <p
     ref={ref}
-    className={cn("text-sm leading-relaxed", className)}
+    className={cn("text-sm leading-relaxed text-inherit", className)}
     {...props}
   />
 ));

--- a/src/components/workspace/AddMemberModal.tsx
+++ b/src/components/workspace/AddMemberModal.tsx
@@ -166,14 +166,6 @@ export function AddMemberModal({ open, onOpenChange, workspaceSlug, onMemberAdde
           </DialogDescription>
         </DialogHeader>
 
-        <Alert>
-          <InfoIcon className="h-4 w-4" />
-          <AlertDescription>
-            Only users who have already signed up to Hive can be added as members.
-            If they haven't signed up yet, ask them to create an account first.
-          </AlertDescription>
-        </Alert>
-
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
             <FormField


### PR DESCRIPTION
…irement notice

- Update Alert destructive variant to use semantic theme colors (bg-destructive/10, text-destructive, border-destructive/20)
- Add text-inherit to AlertDescription to properly inherit parent text colors
- Remove "Only users who have already signed up" notice from AddMemberModal

This ensures destructive alerts are properly visible in both light and dark themes.