### PR TITLE
fix: prevent workspace members from setting their current role

### DIFF
--- a/src/__tests__/unit/services/workspace.test.ts
+++ b/src/__tests__/unit/services/workspace.test.ts
@@ -957,6 +957,18 @@ describe("Workspace Service - Unit Tests", () => {
           updateWorkspaceMemberRole("workspace1", "user1", "DEVELOPER")
         ).rejects.toThrow("Member not found");
       });
+
+      test("should throw error if trying to set same role", async () => {
+        const memberWithAdminRole = {
+          ...mockMember,
+          role: "ADMIN",
+        };
+        mockedFindActiveMember.mockResolvedValue(memberWithAdminRole);
+
+        await expect(
+          updateWorkspaceMemberRole("workspace1", "user1", "ADMIN")
+        ).rejects.toThrow("Member already has this role");
+      });
     });
 
     describe("removeWorkspaceMember", () => {

--- a/src/components/workspace/WorkspaceMembers.tsx
+++ b/src/components/workspace/WorkspaceMembers.tsx
@@ -23,6 +23,7 @@ import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import type { WorkspaceMember } from "@/types/workspace";
 import type { WorkspaceRole } from "@/lib/auth/roles";
+import { useSession } from "next-auth/react";
 
 interface WorkspaceMembersProps {
   canAdmin: boolean;
@@ -33,13 +34,14 @@ export function WorkspaceMembers({ canAdmin }: WorkspaceMembersProps) {
   const [members, setMembers] = useState<WorkspaceMember[]>([]);
   const [owner, setOwner] = useState<WorkspaceMember | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [, setError] = useState<string | null>(null);
   const [confirmRemove, setConfirmRemove] = useState<{
     open: boolean;
     userId: string;
     userName: string;
   }>({ open: false, userId: "", userName: "" });
   const { slug } = useWorkspace();
+  const { data: session } = useSession();
 
   // Fetch workspace members
   const fetchMembers = async () => {
@@ -246,15 +248,21 @@ export function WorkspaceMembers({ canAdmin }: WorkspaceMembersProps) {
                           </Button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
-                          <DropdownMenuItem onClick={() => handleUpdateRole(member.userId, "ADMIN")}>
-                            Make Admin
-                          </DropdownMenuItem>
-                          <DropdownMenuItem onClick={() => handleUpdateRole(member.userId, "DEVELOPER")}>
-                            Make Developer
-                          </DropdownMenuItem>
-                          <DropdownMenuItem onClick={() => handleUpdateRole(member.userId, "VIEWER")}>
-                            Make Viewer
-                          </DropdownMenuItem>
+                          {member.role !== "ADMIN" && (
+                            <DropdownMenuItem onClick={() => handleUpdateRole(member.userId, "ADMIN")}>
+                              Make Admin
+                            </DropdownMenuItem>
+                          )}
+                          {member.role !== "DEVELOPER" && (
+                            <DropdownMenuItem onClick={() => handleUpdateRole(member.userId, "DEVELOPER")}>
+                              Make Developer
+                            </DropdownMenuItem>
+                          )}
+                          {member.role !== "VIEWER" && (
+                            <DropdownMenuItem onClick={() => handleUpdateRole(member.userId, "VIEWER")}>
+                              Make Viewer
+                            </DropdownMenuItem>
+                          )}
                           <DropdownMenuItem 
                             onClick={() => handleRemoveMember(
                               member.userId, 

--- a/src/services/workspace.ts
+++ b/src/services/workspace.ts
@@ -514,6 +514,11 @@ export async function updateWorkspaceMemberRole(
   if (!member) {
     throw new Error("Member not found");
   }
+  
+  // Check if the new role is the same as current role
+  if (member.role === newRole) {
+    throw new Error("Member already has this role");
+  }
 
   const updatedMember = await updateMemberRole(member.id, newRole);
   return mapWorkspaceMember(updatedMember);


### PR DESCRIPTION
- Add frontend validation to hide current role options in dropdown
- Add backend validation to prevent API calls with same role
- Add unit test coverage for same role validation
- Improve UX by preventing confusing role assignment options