### PR TITLE
fix: add missing PM role option to workspace member dropdown

### DIFF
--- a/src/components/workspace/WorkspaceMembers.tsx
+++ b/src/components/workspace/WorkspaceMembers.tsx
@@ -120,8 +120,12 @@ export function WorkspaceMembers({ canAdmin }: WorkspaceMembersProps) {
       case "ADMIN":
         return "secondary";
       case "PM":
-        return "outline";
+        return "destructive";
       case "DEVELOPER":
+        return "outline";
+      case "STAKEHOLDER":
+        return "outline";
+      case "VIEWER":
         return "outline";
       default:
         return "outline";
@@ -251,6 +255,11 @@ export function WorkspaceMembers({ canAdmin }: WorkspaceMembersProps) {
                           {member.role !== "ADMIN" && (
                             <DropdownMenuItem onClick={() => handleUpdateRole(member.userId, "ADMIN")}>
                               Make Admin
+                            </DropdownMenuItem>
+                          )}
+                          {member.role !== "PM" && (
+                            <DropdownMenuItem onClick={() => handleUpdateRole(member.userId, "PM")}>
+                              Make PM
                             </DropdownMenuItem>
                           )}
                           {member.role !== "DEVELOPER" && (


### PR DESCRIPTION
- Add PM role option to member role management dropdown
- Update badge variant styling for all role types including STAKEHOLDER and VIEWER
- Role dropdown now shows all assignable roles (ADMIN, PM, DEVELOPER, VIEWER)
- Current role is correctly excluded from dropdown options