### PR TITLE
Fix stakwork decryption field type and variable naming

### DIFF
--- a/src/app/api/stakwork/create-customer/route.ts
+++ b/src/app/api/stakwork/create-customer/route.ts
@@ -61,15 +61,15 @@ export async function POST(request: NextRequest) {
         /{{(.*?)}}/g,
         "$1",
       );
-      const decryptedStakworkApiKey = encryptionService.decryptField(
-        "stakworkApiKey",
+      const decryptedSwarmApiKey = encryptionService.decryptField(
+        "swarmApiKey",
         swarm?.swarmApiKey || "",
       );
 
       if (sanitizedSecretAlias && swarm?.swarmApiKey && token) {
         await stakworkService().createSecret(
           sanitizedSecretAlias,
-          decryptedStakworkApiKey,
+          decryptedSwarmApiKey,
           token,
         );
       }


### PR DESCRIPTION
- Change decryptField() call to use correct field type 'swarmApiKey' instead of 'stakworkApiKey'
- Rename variable from decryptedStakworkApiKey to decryptedSwarmApiKey for clarity
- Resolves issue where encrypted object was returned instead of decrypted key string