### PR TITLE
using a slim image to keep container alive

### DIFF
--- a/src/utils/devContainerUtils.ts
+++ b/src/utils/devContainerUtils.ts
@@ -172,17 +172,8 @@ networks:
     driver: bridge
 services:
   app:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    volumes:
-      - ../..:/workspaces:cached
+    image: alpine:latest
     command: sleep infinity
-    networks:
-      - app_network
-    extra_hosts:
-      - "localhost:172.17.0.1"
-      - "host.docker.internal:host-gateway"
 `;
 }
 


### PR DESCRIPTION
This will allow the container to spin up a tiny bit faster because it doesn't have to create a docker image of the source code, it just runs a slim alpine image sleeping indefinitely.