### PR TITLE
Add Dashboard navigation item to Sidebar component

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
-import { CheckSquare, Menu, Network, Settings } from "lucide-react";
+import { CheckSquare, HomeIcon, Menu, Network, Settings } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
 import { useState } from "react";
 
@@ -25,6 +25,7 @@ interface SidebarProps {
 }
 
 const navigationItems = [
+  {icon: HomeIcon, label: "Dashboard", href: '/'},
   { icon: CheckSquare, label: "Tasks", href: "/tasks" },
   // { icon: Map, label: "Roadmap", href: "/roadmap" },
   { icon: Network, label: "Stakgraph", href: "/stakgraph" },


### PR DESCRIPTION
I'm not sure if this was omitted intentionally but when user initially logs in they land on the Dashboard page. If they navigate away, there's no way to get back to that page. So I've added a NavItem for Dashboard 

<img width="2254" height="1407" alt="image" src="https://github.com/user-attachments/assets/bb4c57a5-362c-42b7-aa81-72df05b111e5" />
 