### PR TITLE
Enhance WorkspaceSwitcher to handle navigation based on current path

### DIFF
--- a/src/components/WorkspaceSwitcher.tsx
+++ b/src/components/WorkspaceSwitcher.tsx
@@ -43,6 +43,19 @@ export function WorkspaceSwitcher({
 
       // Call optional callback for backward compatibility
       onWorkspaceChange?.(targetWorkspace);
+
+      // Get the current path
+      const currentPath = window.location.pathname;
+
+      // Check if the current path includes "/task/"
+      if (currentPath.includes("/task/")) {
+        // Navigate to the main task page (without task ID)
+        router.push(`/w/${targetWorkspace.slug}/tasks`);
+      } else {
+        // Preserve the current path, replacing the workspace slug
+        const newPath = currentPath.replace(/\/w\/[^/]+/, `/w/${targetWorkspace.slug}`);
+        router.push(newPath);
+      }
     } catch (error) {
       console.error("Failed to switch workspace:", error);
     }


### PR DESCRIPTION
#282

- Implement logic to navigate to the main task page if the current path includes "/task/"
- Preserve the current path while replacing the workspace slug for other cases

https://www.loom.com/share/c6b7e903b72c41e7844eb016c693be15?sid=a1b2cc02-4bce-4373-84d4-28b3f2bdde08