### PR TITLE
Fix test coverage API to use swarm URL instead of name

### DIFF
--- a/src/app/api/tests/coverage/route.ts
+++ b/src/app/api/tests/coverage/route.ts
@@ -50,7 +50,8 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const stakgraphUrl = `https://${swarm.name}:7799`;
+    const swarmUrlObj = new URL(swarm.swarmUrl);
+    const stakgraphUrl = `https://${swarmUrlObj.hostname}:7799`;
 
     // Proxy to stakgraph microservice
     const apiResult = await swarmApiRequest({


### PR DESCRIPTION
Changed stakgraph URL construction to properly parse swarm.swarmUrl and extract hostname instead of using swarm.name directly.