### PR TITLE
fix: dev mode setup after authentication

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,11 +6,13 @@ import { redirect } from "next/navigation";
 export default async function HomePage() {
   const session = await getServerSession(authOptions);
 
-
   if (session?.user) {
     await handleWorkspaceRedirect(session);
     return null;
   } else {
+    if (process.env.POD_URL) {
+      redirect("/auth/signin");
+    }
     redirect("/onboarding/workspace");
   }
 }

--- a/src/lib/auth/nextauth.ts
+++ b/src/lib/auth/nextauth.ts
@@ -5,13 +5,8 @@ import { PrismaAdapter } from "@auth/prisma-adapter";
 import { db } from "@/lib/db";
 import axios from "axios";
 import { EncryptionService } from "@/lib/encryption";
-import {
-  SwarmStatus,
-  SwarmWizardStep,
-  StepStatus,
-  RepositoryStatus,
-} from "@prisma/client";
 import { getDefaultWorkspaceForUser } from "@/services/workspace";
+import { ensureMockWorkspaceForUser } from "@/utils/mockSetup";
 
 const encryptionService: EncryptionService = EncryptionService.getInstance();
 
@@ -121,86 +116,7 @@ export const authOptions: NextAuthOptions = {
             user.id = existingUser.id;
           }
 
-          // Seed a minimal, completed workspace + swarm so onboarding is skipped
-          const ownerId = user.id as string;
-          const hasWorkspace = await db.workspace.findFirst({
-            where: { ownerId, deleted: false },
-            select: { id: true },
-          });
-
-          if (!hasWorkspace) {
-            const baseSlug = "mock-stakgraph";
-            let slugCandidate = baseSlug;
-            let suffix = 1;
-            while (
-              await db.workspace.findUnique({ where: { slug: slugCandidate } })
-            ) {
-              slugCandidate = `${baseSlug}-${++suffix}`;
-            }
-
-            const workspace = await db.workspace.create({
-              data: {
-                name: "Mock Stakgraph Workspace",
-                description: "Development workspace (mock)",
-                slug: slugCandidate,
-                ownerId,
-              },
-              select: { id: true },
-            });
-
-            // Optional mock repo to satisfy UIs that expect a repository
-            await db.repository.create({
-              data: {
-                name: "stakgraph",
-                repositoryUrl: "https://github.com/mock/stakgraph",
-                branch: "main",
-                status: RepositoryStatus.SYNCED,
-                workspaceId: workspace.id,
-              },
-            });
-
-            // Completed swarm pointing to local dev services
-            const slugify = (s: string) =>
-              s
-                .toLowerCase()
-                .replace(/[^a-z0-9]+/g, "-")
-                .replace(/^-+|-+$/g, "")
-                .replace(/-{2,}/g, "-");
-
-            await db.swarm.create({
-              data: {
-                name: slugify(`${slugCandidate}-swarm`),
-                status: SwarmStatus.ACTIVE,
-                instanceType: "XL",
-                repositoryName: "stakgraph",
-                repositoryUrl: "https://github.com/mock/stakgraph",
-                defaultBranch: "main",
-                environmentVariables: [
-                  { name: "NODE_ENV", value: "development" },
-                ],
-                services: [
-                  {
-                    name: "stakgraph",
-                    port: 7799,
-                    scripts: { start: "start" },
-                  },
-                  {
-                    name: "repo2graph",
-                    port: 3355,
-                    scripts: { start: "start" },
-                  },
-                ],
-                wizardStep: SwarmWizardStep.COMPLETION,
-                stepStatus: StepStatus.COMPLETED,
-                wizardData: {
-                  seeded: true,
-                  seededAt: new Date().toISOString(),
-                },
-                workspaceId: workspace.id,
-                swarmUrl: "http://localhost/api",
-              },
-            });
-          }
+          await ensureMockWorkspaceForUser(user.id as string);
         } catch (error) {
           console.error("Error handling mock authentication:", error);
           return false;

--- a/src/lib/auth/workspace-resolver.ts
+++ b/src/lib/auth/workspace-resolver.ts
@@ -19,13 +19,19 @@ export interface WorkspaceResolutionResult {
 export async function resolveUserWorkspaceRedirect(
   session: Session,
 ): Promise<WorkspaceResolutionResult> {
-
-
   const userId = (session.user as { id: string }).id;
 
   try {
     // Get all workspaces the user has access to
     const userWorkspaces = await getUserWorkspaces(userId);
+
+    if (process.env.POD_URL && userWorkspaces.length === 0) {
+      return {
+        shouldRedirect: true,
+        redirectUrl: "/auth/signin",
+        workspaceCount: 0,
+      };
+    }
 
     if (userWorkspaces.length === 0) {
       // User has no workspaces - redirect to onboarding
@@ -83,9 +89,7 @@ export async function resolveUserWorkspaceRedirect(
  * Handles workspace redirection for server components
  * This is a convenience function that calls resolveUserWorkspaceRedirect and performs the redirect
  */
-export async function handleWorkspaceRedirect(
-  session: Session,
-): Promise<void> {
+export async function handleWorkspaceRedirect(session: Session): Promise<void> {
   const result = await resolveUserWorkspaceRedirect(session);
 
   if (result.shouldRedirect && result.redirectUrl) {

--- a/src/utils/mockSetup.ts
+++ b/src/utils/mockSetup.ts
@@ -1,0 +1,81 @@
+import { db } from "@/lib/db";
+import {
+  RepositoryStatus,
+  SwarmStatus,
+  SwarmWizardStep,
+  StepStatus,
+} from "@prisma/client";
+
+function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+}
+
+/**
+ * Ensures a mock workspace and a completed swarm exist for a given user.
+ * Returns the workspace slug.
+ */
+export async function ensureMockWorkspaceForUser(
+  userId: string,
+): Promise<string> {
+  const existing = await db.workspace.findFirst({
+    where: { ownerId: userId, deleted: false },
+    select: { id: true, slug: true },
+  });
+
+  if (existing?.slug) return existing.slug;
+
+  const baseSlug = "mock-stakgraph";
+  let slugCandidate = baseSlug;
+  let suffix = 1;
+  while (await db.workspace.findUnique({ where: { slug: slugCandidate } })) {
+    slugCandidate = `${baseSlug}-${++suffix}`;
+  }
+
+  const workspace = await db.workspace.create({
+    data: {
+      name: "Mock Stakgraph Workspace",
+      description: "Development workspace (mock)",
+      slug: slugCandidate,
+      ownerId: userId,
+    },
+    select: { id: true, slug: true },
+  });
+
+  // Optional repository seed to satisfy UIs expecting a repository
+  await db.repository.create({
+    data: {
+      name: "stakgraph",
+      repositoryUrl: "https://github.com/mock/stakgraph",
+      branch: "main",
+      status: RepositoryStatus.SYNCED,
+      workspaceId: workspace.id,
+    },
+  });
+
+  await db.swarm.create({
+    data: {
+      name: slugify(`${workspace.slug}-swarm`),
+      status: SwarmStatus.ACTIVE,
+      instanceType: "XL",
+      repositoryName: "stakgraph",
+      repositoryUrl: "https://github.com/mock/stakgraph",
+      defaultBranch: "main",
+      environmentVariables: [{ name: "NODE_ENV", value: "development" }],
+      services: [
+        { name: "stakgraph", port: 7799, scripts: { start: "start" } },
+        { name: "repo2graph", port: 3355, scripts: { start: "start" } },
+      ],
+      wizardStep: SwarmWizardStep.COMPLETION,
+      stepStatus: StepStatus.COMPLETED,
+      wizardData: { seeded: true, seededAt: new Date().toISOString() },
+      workspaceId: workspace.id,
+      swarmUrl: "http://localhost",
+    },
+  });
+
+  return workspace.slug;
+}


### PR DESCRIPTION
Closes: #46 

Used Github Auth because it's needed for some functions and easy to setup. But acomplished the following to make setup easy: 
- Created and seeded the Db with mock data immediately after setup to make development easier. 
- Need to turn on `DEVELOPMENT="true"` to have your workspace seeded with Mock Data. 
- Can be easily opted out of. 
https://www.loom.com/share/2d4767604b0748f7a100ee8a8d60f5c7?sid=52940ff0-ec62-41f2-8b94-dcbcce594d8a


@Evanfeenstra @tomsmith8 please what do you think about this workflow? 