### PR TITLE
fix: experimental auth workflow

### DIFF
--- a/src/lib/auth/workspace-resolver.ts
+++ b/src/lib/auth/workspace-resolver.ts
@@ -2,6 +2,7 @@ import {
   getDefaultWorkspaceForUser,
   getUserWorkspaces,
 } from "@/services/workspace";
+import { ensureMockWorkspaceForUser } from "@/utils/mockSetup";
 import { Session } from "next-auth";
 import { redirect } from "next/navigation";
 
@@ -25,11 +26,16 @@ export async function resolveUserWorkspaceRedirect(
     // Get all workspaces the user has access to
     const userWorkspaces = await getUserWorkspaces(userId);
 
-    if (process.env.POD_URL && userWorkspaces.length === 0) {
+    if (
+      (process.env.POD_URL || process.env.DEVELOPMENT === "true") &&
+      userWorkspaces.length === 0
+    ) {
+      const slug = await ensureMockWorkspaceForUser(userId);
       return {
         shouldRedirect: true,
-        redirectUrl: "/auth/signin",
-        workspaceCount: 0,
+        redirectUrl: `/w/${slug}/tasks`,
+        workspaceCount: 1,
+        defaultWorkspaceSlug: slug,
       };
     }
 


### PR DESCRIPTION
Auto seeds workspace data in dev mode after github sign up: 
https://www.loom.com/share/9f4533e098314810ad801ce8494c7e17?sid=a03826c4-ab35-441c-9d94-f67437141e74

@tomsmith8 @Evanfeenstra, would this workflow be useful for getting directly to the dashboard more easily (while using a GitHub account). 