### PR TITLE
feat: restrict delete workspace to owner only

### DIFF
--- a/src/app/w/[slug]/settings/page.tsx
+++ b/src/app/w/[slug]/settings/page.tsx
@@ -44,10 +44,12 @@ export default async function SettingsPage({
 
         <WorkspaceMembers canAdmin={workspace.userRole === "OWNER" || workspace.userRole === "ADMIN"} />
 
-        <DeleteWorkspace
-          workspaceSlug={workspace.slug}
-          workspaceName={workspace.name}
-        />
+        {workspace.userRole === "OWNER" && (
+          <DeleteWorkspace
+            workspaceSlug={workspace.slug}
+            workspaceName={workspace.name}
+          />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Only workspace owners can now see and access the delete workspace option in settings.