### PR TITLE
refactor: simplify janitor workflow configuration with dedicated workflow ID

### DIFF
--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -24,6 +24,7 @@ export const optionalEnvVars = {
   STAKWORK_BASE_URL:
     process.env.STAKWORK_BASE_URL || "https://api.stakwork.com/api/v1",
   STAKWORK_WORKFLOW_ID: process.env.STAKWORK_WORKFLOW_ID,
+  STAKWORK_JANITOR_WORKFLOW_ID: process.env.STAKWORK_JANITOR_WORKFLOW_ID,
   POOL_MANAGER_BASE_URL:
     process.env.POOL_MANAGER_BASE_URL || "https://workspaces.sphinx.chat/api",
   API_TIMEOUT: parseInt(process.env.API_TIMEOUT || "10000"),

--- a/src/services/janitor.ts
+++ b/src/services/janitor.ts
@@ -406,7 +406,9 @@ export async function acceptJanitorRecommendation(
     priority: recommendation.priority,
     sourceType: "JANITOR",
     userId: userId,
-    initialMessage: message
+    initialMessage: message,
+    useJanitorWorkflow: true,
+    janitorType: recommendation.janitorRun.janitorType
   });
 
   return { 


### PR DESCRIPTION
## Summary

This PR simplifies the janitor workflow configuration by replacing the complex mode-based workflow selection logic with a dedicated environment variable and boolean flag system.

- Replace `JANITOR_WORKFLOW_ID` with `STAKWORK_JANITOR_WORKFLOW_ID` environment variable
- Remove complex mode-based workflow selection logic from task-workflow service  
- Add `useJanitorWorkflow` flag to enable janitor-specific workflow selection
- Pass `janitorType` enum from Prisma to Stakwork workflow via `set_var`
- Update janitor service to use dedicated workflow for recommendation acceptance

## Changes Made

### Environment Configuration
- Added `STAKWORK_JANITOR_WORKFLOW_ID` to environment variables in `src/lib/env.ts`

### Task Workflow Service (`src/services/task-workflow.ts`)
- Added `useJanitorWorkflow?: boolean` and `janitorType?: string` parameters to workflow functions
- Replaced complex mode-based workflow ID selection with simple boolean logic:
  ```typescript
  const workflowId = useJanitorWorkflow ? config.STAKWORK_JANITOR_WORKFLOW_ID : config.STAKWORK_WORKFLOW_ID;
  ```
- Removed `taskMode` from vars object and added conditional `janitorType`

### Janitor Service (`src/services/janitor.ts`)  
- Updated `acceptJanitorRecommendation()` to pass `useJanitorWorkflow: true` and `janitorType: recommendation.janitorRun.janitorType`

## Benefits
- **Simplified Logic**: Clear boolean-based workflow selection instead of complex mode indexing
- **Environment Separation**: Dedicated workflow ID for janitor tasks
- **Type Safety**: Passes actual Prisma enum values to Stakwork
- **Maintainability**: Easier to understand and extend

## Test Plan
- [ ] Verify janitor recommendation acceptance uses correct workflow ID
- [ ] Confirm janitorType is passed to Stakwork workflow
- [ ] Test that regular tasks still use standard workflow ID
- [ ] Validate environment variable configuration works