### PR TITLE
fix: display swarmApiKey and swarmSecretAlias as separate fields in stakgraph form

### DIFF
--- a/src/app/api/workspaces/[slug]/stakgraph/route.ts
+++ b/src/app/api/workspaces/[slug]/stakgraph/route.ts
@@ -134,6 +134,17 @@ export async function GET(
 
     const environmentVariables = swarm?.environmentVariables;
 
+    // Decrypt swarmApiKey if it exists
+    let decryptedSwarmApiKey = "";
+    if (swarm.swarmApiKey) {
+      try {
+        const parsedKey = JSON.parse(swarm.swarmApiKey as string);
+        decryptedSwarmApiKey = encryptionService.decryptField("swarmApiKey", parsedKey);
+      } catch (error) {
+        console.error("Failed to decrypt swarmApiKey:", error);
+      }
+    }
+
     return NextResponse.json({
       success: true,
       message: "Stakgraph settings retrieved successfully",
@@ -142,6 +153,7 @@ export async function GET(
         description: swarm.repositoryDescription || "",
         repositoryUrl: swarm.repositoryUrl || "",
         swarmUrl: swarm.swarmUrl || "",
+        swarmApiKey: decryptedSwarmApiKey,
         swarmSecretAlias: swarm.swarmSecretAlias || "",
         poolName: swarm.id || "",
         environmentVariables:

--- a/src/components/stakgraph/forms/SwarmForm.tsx
+++ b/src/components/stakgraph/forms/SwarmForm.tsx
@@ -2,8 +2,8 @@ import { useState } from "react";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Eye, EyeOff } from "lucide-react";
 import { SwarmData, FormSectionProps } from "../types";
-import { Key } from "lucide-react";
 
 export default function SwarmForm({
   data,
@@ -12,31 +12,10 @@ export default function SwarmForm({
   onChange,
 }: FormSectionProps<SwarmData>) {
   const [showApiKey, setShowApiKey] = useState(false);
-  const [apiKeyTouched, setApiKeyTouched] = useState(false);
 
   const handleInputChange = (field: keyof SwarmData, value: string) => {
     onChange({ [field]: value });
-    if (field === "swarmApiKey") {
-      setApiKeyTouched(true);
-    }
   };
-
-  const toggleKeyView = () => {
-    setShowApiKey(!showApiKey);
-    if (!showApiKey) {
-      setApiKeyTouched(false); // Reset when switching to API key view
-    }
-  };
-
-  const handleApiKeyFocus = () => {
-    if (showApiKey) {
-      setApiKeyTouched(true);
-    }
-  };
-
-  // Show visual dots if we're in API key mode, field hasn't been touched, and there's no actual value
-  const showVisualDots = showApiKey && !apiKeyTouched && (!data.swarmApiKey || data.swarmApiKey === "");
-  const displayValue = showVisualDots ? "••••••••••••••••" : (showApiKey ? (data.swarmApiKey || "") : (data.swarmSecretAlias || ""));
 
   return (
     <div className="space-y-2">
@@ -62,53 +41,55 @@ export default function SwarmForm({
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor={showApiKey ? "swarmApiKey" : "swarmSecretAlias"}>
-          {showApiKey ? "Swarm Api Key" : "Swarm Secret Alias"}
-        </Label>
+        <Label htmlFor="swarmApiKey">Swarm API Key</Label>
         <div className="relative">
           <Input
-            key={showApiKey ? "swarmApiKey" : "swarmSecretAlias"}
-            id={showApiKey ? "swarmApiKey" : "swarmSecretAlias"}
-            type={showApiKey ? "password" : "text"}
-            placeholder={
-              showApiKey
-                ? "Enter your actual API key to update"
-                : "e.g. {{SWARM_123456_API_KEY}}"
-            }
-            value={displayValue}
-            onChange={(e) =>
-              handleInputChange(
-                showApiKey ? "swarmApiKey" : "swarmSecretAlias",
-                e.target.value
-              )
-            }
-            onFocus={showApiKey ? handleApiKeyFocus : undefined}
-            className={
-              errors.swarmSecretAlias || errors.swarmApiKey
-                ? "border-destructive pr-10"
-                : "pr-10"
-            }
+            id="swarmApiKey"
+            type={showApiKey ? "text" : "password"}
+            placeholder="Enter your Swarm API key"
+            value={data.swarmApiKey || ""}
+            onChange={(e) => handleInputChange("swarmApiKey", e.target.value)}
+            className={errors.swarmApiKey ? "border-destructive pr-10" : "pr-10"}
             disabled={loading}
           />
           <Button
             type="button"
             variant="ghost"
             size="sm"
-            className="absolute right-1 top-1/2 -translate-y-1/2 h-8 w-8 p-0"
-            onClick={toggleKeyView}
+            className="absolute right-2 top-1/2 -translate-y-1/2 h-7 w-7 p-0"
+            onClick={() => setShowApiKey(!showApiKey)}
           >
-            <Key className="h-4 w-4" />
+            {showApiKey ? (
+              <EyeOff className="h-4 w-4" />
+            ) : (
+              <Eye className="h-4 w-4" />
+            )}
           </Button>
         </div>
-        {(errors.swarmSecretAlias || errors.swarmApiKey) && (
-          <p className="text-sm text-destructive">
-            {showApiKey ? errors.swarmApiKey : errors.swarmSecretAlias}
-          </p>
+        {errors.swarmApiKey && (
+          <p className="text-sm text-destructive">{errors.swarmApiKey}</p>
         )}
         <p className="text-xs text-muted-foreground">
-          {showApiKey
-            ? "Your actual API key for authenticating with the Swarm service (write-only)"
-            : "The secret alias reference for your Swarm API key"}
+          Your actual API key for authenticating with the Swarm service
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="swarmSecretAlias">Swarm Secret Alias</Label>
+        <Input
+          id="swarmSecretAlias"
+          type="text"
+          placeholder="e.g. {{SWARM_123456_API_KEY}}"
+          value={data.swarmSecretAlias || ""}
+          onChange={(e) => handleInputChange("swarmSecretAlias", e.target.value)}
+          className={errors.swarmSecretAlias ? "border-destructive" : ""}
+          disabled={loading}
+        />
+        {errors.swarmSecretAlias && (
+          <p className="text-sm text-destructive">{errors.swarmSecretAlias}</p>
+        )}
+        <p className="text-xs text-muted-foreground">
+          The secret alias reference for your Swarm API key (used in environment variables)
         </p>
       </div>
     </div>


### PR DESCRIPTION
- Remove toggle between fields, show both independently
- Add show/hide toggle for API key field with eye icon on right
- Return decrypted swarmApiKey in GET endpoint for form display
- Both fields now properly managed separately as per data model