### PR TITLE
fix: more webhook organization level management

### DIFF
--- a/src/app/w/[slug]/stakgraph/page.tsx
+++ b/src/app/w/[slug]/stakgraph/page.tsx
@@ -75,7 +75,28 @@ export default function StakgraphPage() {
           repositoryUrl: formData.repositoryUrl,
         }),
       });
-      if (!res.ok) throw new Error("Failed to ensure webhooks");
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        if (data.error === "INSUFFICIENT_PERMISSIONS") {
+          toast({
+            title: "Permission Required",
+            description:
+              data.message ||
+              "Admin access required to manage webhooks on this repository",
+            variant: "destructive",
+          });
+        } else {
+          toast({
+            title: "Error",
+            description: data.message || "Failed to add webhooks",
+            variant: "destructive",
+          });
+        }
+        return;
+      }
+
       toast({
         title: "Webhooks added",
         description: "GitHub webhooks have been ensured",

--- a/src/lib/auth/nextauth.ts
+++ b/src/lib/auth/nextauth.ts
@@ -43,7 +43,8 @@ const getProviders = () => {
         clientSecret: process.env.GITHUB_CLIENT_SECRET!,
         authorization: {
           params: {
-            scope: "read:user user:email read:org repo admin:repo_hook",
+            scope:
+              "read:user user:email read:org repo admin:repo_hook admin:org_hook",
           },
         },
       }),

--- a/src/services/github/WebhookService.ts
+++ b/src/services/github/WebhookService.ts
@@ -104,6 +104,12 @@ export class WebhookService extends BaseServiceClass {
         const repoInfo = (await response.json()) as { default_branch?: string };
         return repoInfo.default_branch || null;
       }
+      if (!response.ok) {
+        if (response.status === 403) {
+          throw new Error("INSUFFICIENT_PERMISSIONS");
+        }
+        throw new Error("WEBHOOK_CREATION_FAILED");
+      }
     } catch (error) {
       console.error("Failed to detect repository default branch:", error);
     }
@@ -248,7 +254,12 @@ export class WebhookService extends BaseServiceClass {
         },
       },
     );
-    if (!res.ok) throw new Error(`Failed to list webhooks: ${res.status}`);
+    if (!res.ok) {
+      if (res.status === 403) {
+        throw new Error("INSUFFICIENT_PERMISSIONS");
+      }
+      throw new Error("WEBHOOK_CREATION_FAILED");
+    }
     return (await res.json()) as Array<{
       id: number;
       config?: { url?: string };
@@ -287,10 +298,12 @@ export class WebhookService extends BaseServiceClass {
       },
     );
     const data = await res.json();
+
     if (!res.ok) {
-      throw new Error(
-        `Failed to create webhook: ${res.status} ${JSON.stringify(data)}`,
-      );
+      if (res.status === 403) {
+        throw new Error("INSUFFICIENT_PERMISSIONS");
+      }
+      throw new Error("WEBHOOK_CREATION_FAILED");
     }
     return { id: data.id as number };
   }
@@ -319,8 +332,10 @@ export class WebhookService extends BaseServiceClass {
       },
     );
     if (!res.ok) {
-      const err = await res.text();
-      throw new Error(`Failed to update webhook: ${res.status} ${err}`);
+      if (res.status === 403) {
+        throw new Error("INSUFFICIENT_PERMISSIONS");
+      }
+      throw new Error("WEBHOOK_CREATION_FAILED");
     }
   }
 
@@ -341,8 +356,10 @@ export class WebhookService extends BaseServiceClass {
       },
     );
     if (!res.ok) {
-      const err = await res.text();
-      throw new Error(`Failed to delete webhook: ${res.status} ${err}`);
+      if (res.status === 403) {
+        throw new Error("INSUFFICIENT_PERMISSIONS");
+      }
+      throw new Error("WEBHOOK_CREATION_FAILED");
     }
   }
 }

--- a/src/stores/useStakgraphStore.ts
+++ b/src/stores/useStakgraphStore.ts
@@ -312,6 +312,14 @@ export const useStakgraphStore = create<StakgraphStore>()(
           // Handle validation errors
           if (result.error === "VALIDATION_ERROR" && result.details) {
             set({ errors: result.details });
+          } else if (result.error === "INSUFFICIENT_PERMISSIONS") {
+            set({
+              errors: {
+                general:
+                  result.message ||
+                  "Admin access required to manage webhooks on this repository",
+              },
+            });
           } else {
             set({
               errors: {
@@ -323,7 +331,10 @@ export const useStakgraphStore = create<StakgraphStore>()(
           }
 
           toast({
-            title: "Error",
+            title:
+              result.error === "INSUFFICIENT_PERMISSIONS"
+                ? "Permission Required"
+                : "Error",
             description: result.message || "Failed to save configuration",
             variant: "destructive",
           });


### PR DESCRIPTION
Added more permissions for webhook management. 

Testing on Organization private repo:
https://www.loom.com/share/6eb880ea0e8144b78ba554560be7a53e?sid=eb1ccb62-a1fc-4f80-862d-46b0302095ff

- Renders correct error when permissions are not met to create webhook (admin-level access required). 
- With admin-level access, successfully creates a webhook. 