### PR TITLE
Fix webhook URL bug in callStakworkAPI

### DIFF
--- a/src/app/api/chat/message/route.ts
+++ b/src/app/api/chat/message/route.ts
@@ -14,6 +14,7 @@ import {
 import { WorkflowStatus } from "@prisma/client";
 import { EncryptionService } from "@/lib/encryption";
 import { getS3Service } from "@/services/s3";
+import { getBaseUrl } from "@/lib/utils";
 
 export const runtime = "nodejs";
 
@@ -47,13 +48,6 @@ interface StakworkWorkflowPayload {
   };
 }
 
-function getBaseUrl(request?: NextRequest): string {
-  // Use the request host or fallback to localhost
-  const host = request?.headers.get("host") || "localhost:3000";
-  const protocol = host.includes("localhost") ? "http" : "https";
-  const baseUrl = `${protocol}://${host}`;
-  return baseUrl;
-}
 
 async function callMock(
   taskId: string,
@@ -62,7 +56,7 @@ async function callMock(
   artifacts: ArtifactRequest[],
   request?: NextRequest,
 ) {
-  const baseUrl = getBaseUrl(request);
+  const baseUrl = getBaseUrl(request?.headers.get("host"));
 
   try {
     const response = await fetch(`${baseUrl}/api/mock`, {
@@ -119,7 +113,7 @@ async function callStakwork(
       );
     }
 
-    const baseUrl = getBaseUrl(request);
+    const baseUrl = getBaseUrl(request?.headers.get("host"));
     let webhookUrl = `${baseUrl}/api/chat/response`;
     if (process.env.CUSTOM_WEBHOOK_URL) {
       webhookUrl = process.env.CUSTOM_WEBHOOK_URL;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -25,3 +25,19 @@ export function formatRelativeTime(date: string | Date): string {
     return targetDate.toLocaleDateString();
   }
 }
+
+export function getBaseUrl(hostHeader?: string | null): string {
+  // Use the provided host header, NEXTAUTH_URL, or fallback to localhost
+  if (hostHeader) {
+    const protocol = hostHeader.includes("localhost") ? "http" : "https";
+    return `${protocol}://${hostHeader}`;
+  }
+  
+  // If NEXTAUTH_URL is provided, use it directly
+  if (process.env.NEXTAUTH_URL) {
+    return process.env.NEXTAUTH_URL;
+  }
+  
+  // Fallback to localhost
+  return "http://localhost:3000";
+}

--- a/src/services/task-workflow.ts
+++ b/src/services/task-workflow.ts
@@ -2,6 +2,7 @@ import { db } from "@/lib/db";
 import { Priority, TaskStatus, TaskSourceType } from "@prisma/client";
 import { config } from "@/lib/env";
 import { EncryptionService } from "@/lib/encryption";
+import { getBaseUrl } from "@/lib/utils";
 
 const encryptionService: EncryptionService = EncryptionService.getInstance();
 
@@ -332,9 +333,9 @@ async function callStakworkAPI(params: {
   }
 
   // Build webhook URLs (replicating the webhook URL logic)
-  const baseUrl = config.STAKWORK_BASE_URL;
-  const webhookUrl = `${baseUrl}/api/chat/response`;
-  const workflowWebhookUrl = `${baseUrl}/api/stakwork/webhook?task_id=${taskId}`;
+  const appBaseUrl = getBaseUrl();
+  const webhookUrl = `${appBaseUrl}/api/chat/response`;
+  const workflowWebhookUrl = `${appBaseUrl}/api/stakwork/webhook?task_id=${taskId}`;
 
   // Build vars object (replicating the vars structure from chat/message route)
   const vars = {


### PR DESCRIPTION
The callStakworkAPI function was incorrectly using STAKWORK_BASE_URL instead of the application's base URL for webhook callbacks. This caused webhook URLs to point to the Stakwork API instead of the application.

Changes:
- Extract getBaseUrl utility to shared location in lib/utils.ts
- Update callStakworkAPI to use getBaseUrl() for webhook URLs
- Refactor message route to use shared getBaseUrl function
- Ensure webhook URLs correctly point to application endpoints

The fix ensures webhook URLs (webhookUrl and workflowWebhookUrl) now properly use the application's base URL, matching the behavior in the existing callStakwork function.