### PR TITLE
Standardize workspace page headers with PageHeader component

### DIFF
--- a/src/app/w/[slug]/insights/page.tsx
+++ b/src/app/w/[slug]/insights/page.tsx
@@ -55,12 +55,13 @@ export default function InsightsPage() {
 
 
   return (
-    <div className="container mx-auto p-6 space-y-8 max-w-4xl">
+    <div className="space-y-6">
       <PageHeader
         title="Insights"
         description="Automated codebase analysis and recommendations"
-        icon={BarChart3}
       />
+      
+      <div className="max-w-4xl space-y-6">{/* Content container */}
 
       <TestCoverageCard />
 
@@ -88,6 +89,7 @@ export default function InsightsPage() {
         janitors={securityJanitors}
         comingSoon={true}
       />
+      </div>{/* End content container */}
     </div>
   );
 }

--- a/src/app/w/[slug]/page.tsx
+++ b/src/app/w/[slug]/page.tsx
@@ -17,21 +17,17 @@ import {
 } from "lucide-react";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { ConnectRepository } from "@/components/ConnectRepository";
+import { PageHeader } from "@/components/ui/page-header";
 
 export default function DashboardPage() {
   const { workspace, slug } = useWorkspace();
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex justify-between items-start">
-        <div>
-          <h1 className="text-3xl font-bold text-foreground">Dashboard</h1>
-          <p className="text-muted-foreground mt-2">
-            Welcome to your development workspace.
-          </p>
-        </div>
-      </div>
+      <PageHeader 
+        title="Dashboard"
+        description="Welcome to your development workspace."
+      />
 
       {/* Onboarding Card - Only show if CodeGraph is not set up */}
       {workspace && !workspace.isCodeGraphSetup && (

--- a/src/app/w/[slug]/settings/page.tsx
+++ b/src/app/w/[slug]/settings/page.tsx
@@ -3,6 +3,7 @@ import { authOptions } from "@/lib/auth/nextauth";
 import { DeleteWorkspace } from "@/components/DeleteWorkspace";
 import { WorkspaceMembers } from "@/components/workspace/WorkspaceMembers";
 import { WorkspaceSettings } from "@/components/WorkspaceSettings";
+import { PageHeader } from "@/components/ui/page-header";
 import { getWorkspaceBySlug } from "@/services/workspace";
 import { notFound } from "next/navigation";
 
@@ -32,22 +33,22 @@ export default async function SettingsPage({
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold text-foreground">Workspace Settings</h1>
-        <p className="text-muted-foreground mt-2">
-          Manage workspace configuration, members, and settings.
-        </p>
-      </div>
+      <PageHeader 
+        title="Workspace Settings"
+        description="Manage workspace configuration, members, and settings."
+      />
 
-      <div className="max-w-2xl space-y-6">
-        <WorkspaceSettings />
+      <div className="max-w-2xl">
+        <div className="space-y-6">
+          <WorkspaceSettings />
 
-        <WorkspaceMembers canAdmin={workspace.userRole === "OWNER" || workspace.userRole === "ADMIN"} />
+          <WorkspaceMembers canAdmin={workspace.userRole === "OWNER" || workspace.userRole === "ADMIN"} />
 
-        <DeleteWorkspace
-          workspaceSlug={workspace.slug}
-          workspaceName={workspace.name}
-        />
+          <DeleteWorkspace
+            workspaceSlug={workspace.slug}
+            workspaceName={workspace.name}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/app/w/[slug]/stakgraph/page.tsx
+++ b/src/app/w/[slug]/stakgraph/page.tsx
@@ -11,6 +11,7 @@ import { FileTabs } from "@/components/stakgraph/forms/EditFilesForm";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useToast } from "@/components/ui/use-toast";
+import { PageHeader } from "@/components/ui/page-header";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { useStakgraphStore } from "@/stores/useStakgraphStore";
 import { AnimatePresence, motion } from "framer-motion";
@@ -103,15 +104,10 @@ export default function StakgraphPage() {
   if (initialLoading) {
     return (
       <div className="space-y-6">
-        <div className="flex items-center gap-3">
-          {/* <Network className="w-8 h-8 text-primary" /> */}
-          <div>
-            <h1 className="text-3xl font-bold">Stakgraph Configuration</h1>
-            <p className="text-muted-foreground">
-              Configure your settings for Stakgraph integration
-            </p>
-          </div>
-        </div>
+        <PageHeader 
+          title="Stakgraph Configuration"
+          description="Configure your settings for Stakgraph integration"
+        />
         <Card className="max-w-2xl">
           <CardContent className="flex items-center justify-center py-8">
             <div className="flex items-center gap-2">
@@ -126,16 +122,10 @@ export default function StakgraphPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-3">
-        {/* <Network className="w-8 h-8 text-primary" /> */}
-        <div>
-          <h1 className="text-3xl font-bold">Stakgraph Configuration</h1>
-          <p className="text-muted-foreground">
-            Configure your settings for Stakgraph integration
-          </p>
-          {/* Removed Swarm Status and Last updated */}
-        </div>
-      </div>
+      <PageHeader 
+        title="Stakgraph Configuration"
+        description="Configure your settings for Stakgraph integration"
+      />
 
       {/* Subtle: Create Stakgraph section (only if all fields are empty, with smooth animation) */}
       <AnimatePresence>

--- a/src/app/w/[slug]/tasks/page.tsx
+++ b/src/app/w/[slug]/tasks/page.tsx
@@ -6,27 +6,23 @@ import { useRouter } from "next/navigation";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { ConnectRepository } from "@/components/ConnectRepository";
 import { TasksList } from "@/components/tasks";
+import { PageHeader } from "@/components/ui/page-header";
 
 export default function TasksPage() {
   const router = useRouter();
   const { workspace, slug, id: workspaceId } = useWorkspace();
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex justify-between items-start">
-        <div>
-          <h1 className="text-3xl font-bold text-foreground">Tasks</h1>
-          <p className="text-muted-foreground mt-2">
-            Manage and track your development tasks and issues.
-          </p>
-        </div>
-        {workspace?.isCodeGraphSetup && (
+      <PageHeader 
+        title="Tasks"
+        description="Manage and track your development tasks and issues."
+        actions={workspace?.isCodeGraphSetup && (
           <Button onClick={() => router.push(`/w/${slug}/task/new`)}>
             <Plus className="w-4 h-4 mr-2" />
             New Task
           </Button>
         )}
-      </div>
+      />
 
       {/* Connect Repository Card - Only show if CodeGraph is not set up */}
       {workspace && !workspace.isCodeGraphSetup ? (

--- a/src/components/ui/page-header.tsx
+++ b/src/components/ui/page-header.tsx
@@ -8,6 +8,7 @@ interface PageHeaderProps {
   iconClassName?: string;
   actions?: ReactNode;
   className?: string;
+  spacing?: string;
 }
 
 export function PageHeader({
@@ -16,16 +17,19 @@ export function PageHeader({
   icon: Icon,
   iconClassName = "h-8 w-8 text-blue-600",
   actions,
-  className = "flex items-center justify-between"
+  className,
+  spacing = "mb-6"
 }: PageHeaderProps) {
+  const defaultClassName = actions ? "flex justify-between items-start" : "";
+  
   return (
-    <div className={className}>
+    <div className={`${className || defaultClassName} ${spacing}`}>
       <div className="flex items-center space-x-3">
         {Icon && <Icon className={iconClassName} />}
         <div>
-          <h1 className="text-3xl font-bold">{title}</h1>
+          <h1 className="text-3xl font-bold text-foreground">{title}</h1>
           {description && (
-            <p className="text-muted-foreground">{description}</p>
+            <p className="text-muted-foreground mt-2">{description}</p>
           )}
         </div>
       </div>


### PR DESCRIPTION
- Update PageHeader component with configurable spacing prop (defaults to mb-6)
- Replace manual headers with PageHeader across all workspace pages
- Standardize all pages to use consistent space-y-6 spacing
- Fix insights page header positioning and component spacing
- Remove icon from insights page for consistency
- Ensure proper separation between header and content sections