### PR TITLE
fix: ensure stakwork create-customer route always returns a Response

### DIFF
--- a/src/app/api/stakwork/create-customer/route.ts
+++ b/src/app/api/stakwork/create-customer/route.ts
@@ -92,6 +92,12 @@ export async function POST(request: NextRequest) {
 
       return NextResponse.json({ token }, { status: 201 });
     }
+    
+    // If we don't have a valid token in the response
+    return NextResponse.json(
+      { error: "Invalid response from Stakwork API" },
+      { status: 500 }
+    );
   } catch (error) {
     console.error("Error creating Stakwork customer:", error);
 


### PR DESCRIPTION
Fix local builds.

The POST function had a code path that could return undefined when the token was not present in the response, causing TypeScript build errors. Now returns a proper error response in all cases.