### PR TITLE
Move Settings to bottom of sidebar above user profile

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -32,7 +32,6 @@ const baseNavigationItems = [
   // { icon: Map, label: "Roadmap", href: "/roadmap" },
   { icon: Network, label: "Stakgraph", href: "/stakgraph" },
   { icon: BarChart3, label: "Insights", href: "/insights" },
-  { icon: Settings, label: "Settings", href: "/settings" },
 ];
 
 export function Sidebar({ user }: SidebarProps) {
@@ -70,8 +69,8 @@ export function Sidebar({ user }: SidebarProps) {
       <WorkspaceSwitcher
         onWorkspaceChange={() => null}
       />
-      {/* Navigation */}
-      <nav className="flex-1 p-4">
+      {/* Main Navigation */}
+      <nav className="p-4">
         <ul className="space-y-2">
           {navigationItems.map((item) => (
             <li key={item.href}>
@@ -87,6 +86,19 @@ export function Sidebar({ user }: SidebarProps) {
           ))}
         </ul>
       </nav>
+      {/* Spacer to push bottom content down */}
+      <div className="flex-1" />
+      {/* Settings */}
+      <div className="p-4 pb-2">
+        <Button
+          variant="ghost"
+          className="w-full justify-start"
+          onClick={() => handleNavigate("/settings")}
+        >
+          <Settings className="w-4 h-4 mr-2" />
+          Settings
+        </Button>
+      </div>
       <Separator />
       {/* User Popover */}
       <div className="p-4">

--- a/src/components/WorkspaceSwitcher.tsx
+++ b/src/components/WorkspaceSwitcher.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import type { WorkspaceWithRole } from "@/types/workspace";
-import { Building2, ChevronsUpDown, Plus, Settings } from "lucide-react";
+import { Building2, ChevronsUpDown, Plus } from "lucide-react";
 import { useRouter } from "next/navigation";
 
 interface WorkspaceSwitcherProps {

--- a/src/components/WorkspaceSwitcher.tsx
+++ b/src/components/WorkspaceSwitcher.tsx
@@ -144,7 +144,6 @@ export function WorkspaceSwitcher({
             <div className="w-2 h-2 rounded-full bg-primary" />
           </DropdownMenuItem>
 
-
           {/* Other Workspaces */}
           {workspaces.filter((ws) => ws.id !== activeWorkspace.id).length >
             0 && (
@@ -186,7 +185,6 @@ export function WorkspaceSwitcher({
               Create new workspace
             </div>
           </DropdownMenuItem>
-
         </DropdownMenuContent>
       </DropdownMenu>
     </div>

--- a/src/components/WorkspaceSwitcher.tsx
+++ b/src/components/WorkspaceSwitcher.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import type { WorkspaceWithRole } from "@/types/workspace";
-import { Building2, ChevronsUpDown, Plus } from "lucide-react";
+import { Building2, ChevronsUpDown, Plus, Settings } from "lucide-react";
 import { useRouter } from "next/navigation";
 
 interface WorkspaceSwitcherProps {
@@ -144,6 +144,7 @@ export function WorkspaceSwitcher({
             <div className="w-2 h-2 rounded-full bg-primary" />
           </DropdownMenuItem>
 
+
           {/* Other Workspaces */}
           {workspaces.filter((ws) => ws.id !== activeWorkspace.id).length >
             0 && (
@@ -185,6 +186,7 @@ export function WorkspaceSwitcher({
               Create new workspace
             </div>
           </DropdownMenuItem>
+
         </DropdownMenuContent>
       </DropdownMenu>
     </div>


### PR DESCRIPTION
- Position Settings at bottom of sidebar with spacer
- Maintain visual separation with separator above user profile