### PR TITLE
feat: add GitHub username to Stakwork user journey data

### DIFF
--- a/src/app/api/stakwork/user-journey/route.ts
+++ b/src/app/api/stakwork/user-journey/route.ts
@@ -6,7 +6,7 @@ import { db } from "@/lib/db";
 import { getWorkspaceById } from "@/services/workspace";
 import { type StakworkWorkflowPayload } from "@/app/api/chat/message/route";
 import { transformSwarmUrlToRepo2Graph } from "@/lib/utils/swarm";
-import { getOAuthProfile } from "@/lib/auth/utils";
+import { getGithubUsernameAndPAT } from "@/lib/auth/nextauth";
 
 export const runtime = "nodejs";
 
@@ -132,7 +132,9 @@ export async function POST(request: NextRequest) {
     }
 
     // Get user's GitHub profile (access token and username)
-    const { accessToken, username } = await getOAuthProfile(userId, "github");
+    const githubProfile = await getGithubUsernameAndPAT(userId);
+    const accessToken = githubProfile?.pat || null;
+    const username = githubProfile?.username || null;
 
     // Find the swarm associated with this workspace
     const swarm = await db.swarm.findUnique({

--- a/src/app/api/stakwork/user-journey/route.ts
+++ b/src/app/api/stakwork/user-journey/route.ts
@@ -6,7 +6,7 @@ import { db } from "@/lib/db";
 import { getWorkspaceById } from "@/services/workspace";
 import { type StakworkWorkflowPayload } from "@/app/api/chat/message/route";
 import { transformSwarmUrlToRepo2Graph } from "@/lib/utils/swarm";
-import { getGitHubAccessToken } from "@/lib/auth/utils";
+import { getOAuthProfile } from "@/lib/auth/utils";
 
 export const runtime = "nodejs";
 
@@ -20,6 +20,7 @@ async function callStakwork(
   poolName: string | null,
   repo2GraphUrl: string,
   accessToken: string | null,
+  username: string | null,
 ) {
   try {
     // Validate that all required Stakwork environment variables are set
@@ -36,6 +37,7 @@ async function callStakwork(
     const vars = {
       message,
       accessToken,
+      username,
       swarmUrl,
       swarmSecretAlias,
       poolName,
@@ -129,8 +131,8 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Get user's GitHub access token
-    const accessToken = await getGitHubAccessToken(userId);
+    // Get user's GitHub profile (access token and username)
+    const { accessToken, username } = await getOAuthProfile(userId, "github");
 
     // Find the swarm associated with this workspace
     const swarm = await db.swarm.findUnique({
@@ -167,6 +169,7 @@ export async function POST(request: NextRequest) {
       poolName,
       repo2GraphUrl,
       accessToken,
+      username,
     );
 
     return NextResponse.json(

--- a/src/lib/auth/utils.ts
+++ b/src/lib/auth/utils.ts
@@ -49,54 +49,6 @@ export async function getOAuthAccessToken(
   return null;
 }
 
-/**
- * Get the user's OAuth profile data (access token and username) for a specific provider
- */
-export async function getOAuthProfile(
-  userId: string, 
-  provider: string = "github"
-): Promise<{ accessToken: string | null; username: string | null }> {
-  const user = await db.user.findUnique({
-    where: { id: userId },
-    select: {
-      accounts: {
-        where: { provider },
-        select: {
-          access_token: true,
-        },
-      },
-      gitHubAuth: provider === "github" ? {
-        select: {
-          githubUsername: true,
-        },
-      } : undefined,
-    },
-  });
-
-  if (!user) {
-    return { accessToken: null, username: null };
-  }
-
-  let accessToken: string | null = null;
-  const accountWithToken = user.accounts[0];
-
-  if (accountWithToken?.access_token) {
-    try {
-      accessToken = encryptionService.decryptField(
-        "access_token",
-        accountWithToken.access_token,
-      );
-    } catch (error) {
-      console.error("Failed to decrypt access_token:", error);
-      // Fallback to unencrypted token if decryption fails
-      accessToken = accountWithToken.access_token;
-    }
-  }
-
-  const username = provider === "github" ? user.gitHubAuth?.githubUsername || null : null;
-
-  return { accessToken, username };
-}
 
 /**
  * Get the user's GitHub access token (convenience function)

--- a/src/lib/auth/utils.ts
+++ b/src/lib/auth/utils.ts
@@ -50,6 +50,55 @@ export async function getOAuthAccessToken(
 }
 
 /**
+ * Get the user's OAuth profile data (access token and username) for a specific provider
+ */
+export async function getOAuthProfile(
+  userId: string, 
+  provider: string = "github"
+): Promise<{ accessToken: string | null; username: string | null }> {
+  const user = await db.user.findUnique({
+    where: { id: userId },
+    select: {
+      accounts: {
+        where: { provider },
+        select: {
+          access_token: true,
+        },
+      },
+      gitHubAuth: provider === "github" ? {
+        select: {
+          githubUsername: true,
+        },
+      } : undefined,
+    },
+  });
+
+  if (!user) {
+    return { accessToken: null, username: null };
+  }
+
+  let accessToken: string | null = null;
+  const accountWithToken = user.accounts[0];
+
+  if (accountWithToken?.access_token) {
+    try {
+      accessToken = encryptionService.decryptField(
+        "access_token",
+        accountWithToken.access_token,
+      );
+    } catch (error) {
+      console.error("Failed to decrypt access_token:", error);
+      // Fallback to unencrypted token if decryption fails
+      accessToken = accountWithToken.access_token;
+    }
+  }
+
+  const username = provider === "github" ? user.gitHubAuth?.githubUsername || null : null;
+
+  return { accessToken, username };
+}
+
+/**
  * Get the user's GitHub access token (convenience function)
  */
 export async function getGitHubAccessToken(userId: string): Promise<string | null> {


### PR DESCRIPTION
- Add getOAuthProfile helper to fetch both access token and username in one call
- Update user journey API to send GitHub username along with access token
- Optimize database queries from 2 calls to 1 for better performance