### PR TITLE
fix: show zero percent coverage on null test coverage response

### DIFF
--- a/src/app/w/[slug]/page.tsx
+++ b/src/app/w/[slug]/page.tsx
@@ -160,13 +160,13 @@ export default function DashboardPage() {
                 <div className="flex items-center justify-between">
                   <span className="text-xs text-muted-foreground">Integration</span>
                   <span className="text-sm font-medium">
-                    {testCoverage.integration_tests.percent.toFixed(1)}%
+                    {testCoverage.integration_tests?.percent.toFixed(1) || 0}%
                   </span>
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-xs text-muted-foreground">E2E</span>
                   <span className="text-sm font-medium">
-                    {testCoverage.e2e_tests.percent.toFixed(1)}%
+                    {testCoverage.e2e_tests?.percent.toFixed(1) || 0}%
                   </span>
                 </div>
               </div>


### PR DESCRIPTION
I had the integration test and e2e tests returning null which was causing an error for me. I just set the value to 0% if the api returns null

![Screenshot 2025-09-02 at 9 40 07 AM](https://github.com/user-attachments/assets/162d10f1-ca88-4b90-a8a9-18b0b336c54c)
