### PR TITLE
feat: display real e2e tests from swarm graph nodes

### DIFF
--- a/src/app/api/workspaces/[slug]/graph/nodes/route.ts
+++ b/src/app/api/workspaces/[slug]/graph/nodes/route.ts
@@ -1,0 +1,116 @@
+import { authOptions } from "@/lib/auth/nextauth";
+import { db } from "@/lib/db";
+import { swarmApiRequestAuth } from "@/services/swarm/api/swarm";
+import { EncryptionService } from "@/lib/encryption";
+import { getWorkspaceBySlug } from "@/services/workspace";
+import { getServerSession } from "next-auth/next";
+import { NextRequest, NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+
+const encryptionService: EncryptionService = EncryptionService.getInstance();
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  try {
+    const session = await getServerSession(authOptions);
+    const { slug } = await params;
+
+    if (!session?.user) {
+      return NextResponse.json(
+        { success: false, message: "Unauthorized" },
+        { status: 401 },
+      );
+    }
+
+    const userId = (session.user as { id?: string })?.id;
+    if (!userId) {
+      return NextResponse.json(
+        { success: false, message: "Invalid user session" },
+        { status: 401 },
+      );
+    }
+
+    // Get workspace and verify user has access
+    const workspace = await getWorkspaceBySlug(slug, userId);
+    if (!workspace) {
+      return NextResponse.json(
+        { success: false, message: "Workspace not found or access denied" },
+        { status: 404 },
+      );
+    }
+
+    const { searchParams } = new URL(request.url);
+    const nodeType = searchParams.get("node_type");
+    const output = searchParams.get("output") || "json";
+
+    if (!nodeType) {
+      return NextResponse.json(
+        { success: false, message: "Missing required parameter: node_type" },
+        { status: 400 },
+      );
+    }
+
+    // Get swarm for this workspace
+    const swarm = await db.swarm.findUnique({
+      where: { workspaceId: workspace.id },
+    });
+
+    if (!swarm) {
+      return NextResponse.json(
+        { success: false, message: "Swarm not found for this workspace" },
+        { status: 404 },
+      );
+    }
+
+    if (!swarm.swarmUrl || !swarm.swarmApiKey) {
+      return NextResponse.json(
+        { success: false, message: "Swarm configuration is incomplete" },
+        { status: 400 },
+      );
+    }
+
+    // Extract hostname from swarm URL and construct graph endpoint
+    const swarmUrlObj = new URL(swarm.swarmUrl);
+    const graphUrl = `https://${swarmUrlObj.hostname}:3355`;
+
+    // Proxy to graph microservice
+    const apiResult = await swarmApiRequestAuth({
+      swarmUrl: graphUrl,
+      endpoint: "/nodes",
+      method: "GET",
+      apiKey: encryptionService.decryptField("swarmApiKey", swarm.swarmApiKey),
+      params: {
+        node_type: nodeType,
+        output: output,
+      },
+    });
+
+    if (!apiResult.ok) {
+      return NextResponse.json(
+        { 
+          success: false, 
+          message: "Failed to fetch graph nodes",
+          details: apiResult.data 
+        },
+        { status: apiResult.status },
+      );
+    }
+
+    return NextResponse.json(
+      {
+        success: true,
+        data: apiResult.data,
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    console.error("Error fetching graph nodes:", error);
+    return NextResponse.json(
+      { success: false, message: "Failed to fetch graph nodes" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,120 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn("w-full caption-bottom text-sm", className)}
+      {...props}
+    />
+  </div>
+))
+Table.displayName = "Table"
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+))
+TableHeader.displayName = "TableHeader"
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
+))
+TableBody.displayName = "TableBody"
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn(
+      "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+      className
+    )}
+    {...props}
+  />
+))
+TableFooter.displayName = "TableFooter"
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      className
+    )}
+    {...props}
+  />
+))
+TableRow.displayName = "TableRow"
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      className
+    )}
+    {...props}
+  />
+))
+TableHead.displayName = "TableHead"
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn(
+      "p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      className
+    )}
+    {...props}
+  />
+))
+TableCell.displayName = "TableCell"
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn("mt-4 text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+TableCaption.displayName = "TableCaption"
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}


### PR DESCRIPTION
- Add generic /api/workspaces/[slug]/graph/nodes endpoint for fetching any node type
- Install shadcn table component for clean UI
- Update UserJourneys component to fetch and display real e2e tests
- Add GitHub link button next to file paths for easy navigation
- Follow workspace-scoped API pattern for proper authorization