### PR TITLE
feat: add task notification badge to sidebar

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -16,7 +16,7 @@ import { useState } from "react";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { useFeatureFlag } from "@/hooks/useFeatureFlag";
 import { useWorkspace } from "@/hooks/useWorkspace";
-import { useWorkspaceTasks } from "@/hooks/useWorkspaceTasks";
+import { useTasksStore } from "@/stores/useTasksStore";
 import { FEATURE_FLAGS } from "@/lib/feature-flags";
 import { NavUser } from "./NavUser";
 import { WorkspaceSwitcher } from "./WorkspaceSwitcher";
@@ -67,7 +67,9 @@ const baseNavigationItems = [
 export function Sidebar({ user }: SidebarProps) {
   const router = useRouter();
   const { slug: workspaceSlug, workspace } = useWorkspace();
-  const { waitingForInputCount: tasksWaitingForInputCount } = useWorkspaceTasks(workspace?.id || null, true);
+  const tasksWaitingForInputCount = useTasksStore(state => 
+    workspace?.id ? state.getWaitingForInputCount(workspace.id) : 0
+  );
 
   const canAccessInsights = useFeatureFlag(
     FEATURE_FLAGS.CODEBASE_RECOMMENDATION,

--- a/src/hooks/useWorkspaceTasks.ts
+++ b/src/hooks/useWorkspaceTasks.ts
@@ -7,6 +7,7 @@ import {
   usePusherConnection,
   TaskTitleUpdateEvent,
 } from "@/hooks/usePusherConnection";
+import { updateWaitingForInputCount } from "@/stores/useTasksStore";
 
 export interface TaskData {
   id: string;
@@ -153,6 +154,13 @@ export function useWorkspaceTasks(
   const waitingForInputCount = includeNotifications 
     ? tasks.filter(task => task.hasActionArtifact).length 
     : 0;
+
+  // Update store when count changes (only when notifications are enabled)
+  useEffect(() => {
+    if (includeNotifications && workspaceId) {
+      updateWaitingForInputCount(workspaceId, waitingForInputCount);
+    }
+  }, [includeNotifications, workspaceId, waitingForInputCount]);
 
   return {
     tasks,

--- a/src/stores/useTasksStore.ts
+++ b/src/stores/useTasksStore.ts
@@ -1,0 +1,37 @@
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+
+interface TasksStore {
+  // Simple notification count by workspace
+  waitingForInputCountByWorkspace: Record<string, number>;
+  
+  // Actions
+  setWaitingForInputCount: (workspaceId: string, count: number) => void;
+  getWaitingForInputCount: (workspaceId: string) => number;
+}
+
+export const useTasksStore = create<TasksStore>()(
+  devtools(
+    (set, get) => ({
+      waitingForInputCountByWorkspace: {},
+
+      setWaitingForInputCount: (workspaceId, count) =>
+        set((state) => ({
+          waitingForInputCountByWorkspace: {
+            ...state.waitingForInputCountByWorkspace,
+            [workspaceId]: count,
+          },
+        })),
+
+      getWaitingForInputCount: (workspaceId) => {
+        return get().waitingForInputCountByWorkspace[workspaceId] || 0;
+      },
+    }),
+    { name: "tasks-store" }
+  )
+);
+
+// Simple utility to update count from anywhere
+export const updateWaitingForInputCount = (workspaceId: string, count: number) => {
+  useTasksStore.getState().setWaitingForInputCount(workspaceId, count);
+};


### PR DESCRIPTION
Add amber notification badge next to Tasks navigation item to show count of tasks waiting for user input.

The notification badge matches existing "Waiting for input" styling on task cards and provides users with immediate visibility of tasks requiring their attention.