### PR TITLE
Add back button and Stakwork link to task chat view

### DIFF
--- a/src/app/w/[slug]/task/[...taskParams]/components/ChatArea.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/components/ChatArea.tsx
@@ -2,6 +2,9 @@
 
 import { useRef, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
+import { ArrowLeft, ExternalLink } from "lucide-react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
 import {
   ChatMessage as ChatMessageType,
   Option,
@@ -12,6 +15,7 @@ import { ChatMessage } from "./ChatMessage";
 import { ChatInput } from "./ChatInput";
 import { getAgentIcon } from "@/lib/icons";
 import { LogEntry } from "@/hooks/useProjectLogWebSocket";
+import { Button } from "@/components/ui/button";
 
 interface ChatAreaProps {
   messages: ChatMessageType[];
@@ -31,6 +35,8 @@ interface ChatAreaProps {
   onRemoveDebugAttachment?: () => void;
   workflowStatus?: WorkflowStatus | null;
   taskTitle?: string | null;
+  stakworkProjectId?: number | null;
+  workspaceSlug?: string;
 }
 
 export function ChatArea({
@@ -47,12 +53,23 @@ export function ChatArea({
   onRemoveDebugAttachment,
   workflowStatus,
   taskTitle,
+  stakworkProjectId,
+  workspaceSlug,
 }: ChatAreaProps) {
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const router = useRouter();
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
+
+  const handleBackToTasks = () => {
+    if (workspaceSlug) {
+      router.push(`/w/${workspaceSlug}/tasks`);
+    } else {
+      router.back();
+    }
+  };
 
   return (
     <motion.div
@@ -75,19 +92,47 @@ export function ChatArea({
             transition={{ duration: 0.2 }}
             className="px-4 py-3 border-b bg-muted/20"
           >
-            <AnimatePresence mode="wait">
-              <motion.h2
-                key={taskTitle} // This will trigger re-animation when title changes
-                initial={{ opacity: 0, scale: 0.98 }}
-                animate={{ opacity: 1, scale: 1 }}
-                exit={{ opacity: 0, scale: 0.98 }}
-                transition={{ duration: 0.3, ease: "easeInOut" }}
-                className="text-lg font-semibold text-foreground truncate"
-                title={taskTitle}
-              >
-                {taskTitle.length > 80 ? `${taskTitle.slice(0, 80)}...` : taskTitle}
-              </motion.h2>
-            </AnimatePresence>
+            <div className="flex items-center justify-between gap-4">
+              <div className="flex items-center gap-3 flex-1 min-w-0">
+                {/* Back Button */}
+                <Button 
+                  variant="ghost" 
+                  size="sm" 
+                  onClick={handleBackToTasks}
+                  className="flex-shrink-0"
+                >
+                  <ArrowLeft className="w-4 h-4" />
+                </Button>
+                
+                {/* Task Title */}
+                <AnimatePresence mode="wait">
+                  <motion.h2
+                    key={taskTitle} // This will trigger re-animation when title changes
+                    initial={{ opacity: 0, scale: 0.98 }}
+                    animate={{ opacity: 1, scale: 1 }}
+                    exit={{ opacity: 0, scale: 0.98 }}
+                    transition={{ duration: 0.3, ease: "easeInOut" }}
+                    className="text-lg font-semibold text-foreground truncate flex-1"
+                    title={taskTitle}
+                  >
+                    {taskTitle.length > 60 ? `${taskTitle.slice(0, 60)}...` : taskTitle}
+                  </motion.h2>
+                </AnimatePresence>
+              </div>
+              
+              {/* Stakwork Project Link */}
+              {stakworkProjectId && (
+                <Link
+                  href={`https://jobs.stakwork.com/admin/projects/${stakworkProjectId}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 px-2 py-1 text-xs text-blue-600 hover:text-blue-800 hover:underline transition-colors flex-shrink-0"
+                >
+                  Project
+                  <ExternalLink className="w-3 h-3" />
+                </Link>
+              )}
+            </div>
           </motion.div>
         )}
       </AnimatePresence>

--- a/src/app/w/[slug]/task/[...taskParams]/page.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/page.tsx
@@ -58,6 +58,7 @@ export default function TaskChatPage() {
     taskIdFromUrl,
   );
   const [taskTitle, setTaskTitle] = useState<string | null>(null);
+  const [stakworkProjectId, setStakworkProjectId] = useState<number | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [isChainVisible, setIsChainVisible] = useState(false);
   const [workflowStatus, setWorkflowStatus] = useState<WorkflowStatus | null>(
@@ -157,6 +158,7 @@ export default function TaskChatPage() {
             result.data.task.stakworkProjectId,
           );
           setProjectId(result.data.task.stakworkProjectId.toString());
+          setStakworkProjectId(result.data.task.stakworkProjectId);
         }
 
         // Set task title from API response
@@ -426,6 +428,8 @@ export default function TaskChatPage() {
                     }
                     workflowStatus={workflowStatus}
                     taskTitle={taskTitle}
+                    stakworkProjectId={stakworkProjectId}
+                    workspaceSlug={slug}
                   />
                 </div>
               </ResizablePanel>
@@ -455,6 +459,8 @@ export default function TaskChatPage() {
                 onRemoveDebugAttachment={() => setPendingDebugAttachment(null)}
                 workflowStatus={workflowStatus}
                 taskTitle={taskTitle}
+                stakworkProjectId={stakworkProjectId}
+                workspaceSlug={slug}
               />
             </div>
           )}


### PR DESCRIPTION
- Add back button (arrow only) that navigates to tasks list
- Add Stakwork project link in chat header when available
- Update navigation to go to /w/{slug}/tasks instead of dashboard

Fixes #496 and #499