### PR TITLE
Remove floating burger menu from task pages

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -162,25 +162,23 @@ export function Sidebar({ user }: SidebarProps) {
 
   return (
     <>
-      {/* Mobile Sidebar */}
-      <Sheet open={isOpen} onOpenChange={setIsOpen}>
-        <SheetTrigger asChild>
-          <Button
-            variant="outline"
-            size="icon"
-            className={
-              isTaskPage
-                ? "flex items-center justify-center absolute left-3 top-2 z-50"
-                : "md:hidden"
-            }
-          >
-            <Menu className="h-4 w-4" />
-          </Button>
-        </SheetTrigger>
-        <SheetContent side="left" className="w-80 p-0">
-          <SidebarContent />
-        </SheetContent>
-      </Sheet>
+      {/* Mobile Sidebar - Hidden on task pages since we have a back button */}
+      {!isTaskPage && (
+        <Sheet open={isOpen} onOpenChange={setIsOpen}>
+          <SheetTrigger asChild>
+            <Button
+              variant="outline"
+              size="icon"
+              className="md:hidden"
+            >
+              <Menu className="h-4 w-4" />
+            </Button>
+          </SheetTrigger>
+          <SheetContent side="left" className="w-80 p-0">
+            <SidebarContent />
+          </SheetContent>
+        </Sheet>
+      )}
       {/* Desktop Sidebar */}
       <div
         className={`${isTaskPage ? "hidden" : "hidden md:flex"} md:w-80 md:flex-col md:fixed md:inset-y-0 md:z-50`}


### PR DESCRIPTION
The floating burger menu in the top left corner is no longer needed on task pages since we now have a dedicated back button in the task chat view.

- Hide mobile sidebar Sheet component on task pages
- Users can navigate back using the back button in ChatArea component