### PR TITLE
Rename 'Project' links to 'Workflow' in task components

### DIFF
--- a/src/app/w/[slug]/task/[...taskParams]/components/ChatArea.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/components/ChatArea.tsx
@@ -128,7 +128,7 @@ export function ChatArea({
                   rel="noopener noreferrer"
                   className="inline-flex items-center gap-1 px-2 py-1 text-xs text-blue-600 hover:text-blue-800 hover:underline transition-colors flex-shrink-0"
                 >
-                  Project
+                  Workflow
                   <ExternalLink className="w-3 h-3" />
                 </Link>
               )}

--- a/src/components/tasks/TaskCard.tsx
+++ b/src/components/tasks/TaskCard.tsx
@@ -66,7 +66,7 @@ export function TaskCard({ task, workspaceSlug }: TaskCardProps) {
               onClick={(e) => e.stopPropagation()}
               className="inline-flex items-center gap-1 px-2 py-1 text-xs text-blue-600 hover:text-blue-800 hover:underline transition-colors"
             >
-              Project
+              Workflow
               <ExternalLink className="w-3 h-3" />
             </Link>
           )}


### PR DESCRIPTION
Updated external link text from 'Project' to 'Workflow' in both TaskCard and ChatArea components for consistency with terminology.