### PR TITLE
fix: show accurate running tasks counter across all pages

### DIFF
--- a/src/app/api/tasks/stats/route.ts
+++ b/src/app/api/tasks/stats/route.ts
@@ -1,0 +1,124 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/lib/auth/nextauth";
+import { db } from "@/lib/db";
+import { WorkflowStatus } from "@/lib/chat";
+
+export async function GET(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const userId = (session.user as { id?: string })?.id;
+    if (!userId) {
+      return NextResponse.json(
+        { error: "Invalid user session" },
+        { status: 401 },
+      );
+    }
+
+    const { searchParams } = new URL(request.url);
+    const workspaceId = searchParams.get("workspaceId");
+
+    if (!workspaceId) {
+      return NextResponse.json(
+        { error: "workspaceId query parameter is required" },
+        { status: 400 },
+      );
+    }
+
+    // Verify workspace exists and user has access
+    const workspace = await db.workspace.findFirst({
+      where: {
+        id: workspaceId,
+        deleted: false,
+      },
+      select: {
+        id: true,
+        ownerId: true,
+        members: {
+          where: {
+            userId: userId,
+          },
+          select: {
+            role: true,
+          },
+        },
+      },
+    });
+
+    if (!workspace) {
+      return NextResponse.json(
+        { error: "Workspace not found" },
+        { status: 404 },
+      );
+    }
+
+    // Check if user is workspace owner or member
+    const isOwner = workspace.ownerId === userId;
+    const isMember = workspace.members.length > 0;
+
+    if (!isOwner && !isMember) {
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
+    }
+
+    // Get task statistics
+    const [
+      totalCount,
+      inProgressCount,
+      waitingForInputCount,
+    ] = await Promise.all([
+      // Total tasks
+      db.task.count({
+        where: {
+          workspaceId,
+          deleted: false,
+        },
+      }),
+      // Tasks with IN_PROGRESS workflow status
+      db.task.count({
+        where: {
+          workspaceId,
+          deleted: false,
+          workflowStatus: WorkflowStatus.IN_PROGRESS,
+        },
+      }),
+      // Tasks waiting for input (have FORM artifacts in latest message)
+      db.task.count({
+        where: {
+          workspaceId,
+          deleted: false,
+          chatMessages: {
+            some: {
+              artifacts: {
+                some: {
+                  type: "FORM",
+                },
+              },
+            },
+          },
+        },
+      }),
+    ]);
+
+    return NextResponse.json(
+      {
+        success: true,
+        data: {
+          total: totalCount,
+          inProgress: inProgressCount,
+          waitingForInput: waitingForInputCount,
+        },
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    console.error("Error fetching task statistics:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch task statistics" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/tasks/TasksList.tsx
+++ b/src/components/tasks/TasksList.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { FileText, Play } from "lucide-react";
 import { useWorkspaceTasks } from "@/hooks/useWorkspaceTasks";
+import { useTaskStats } from "@/hooks/useTaskStats";
 import { TaskCard } from "./TaskCard";
 import { EmptyState } from "./empty-state";
 import { LoadingState } from "./LoadingState";
@@ -21,8 +22,7 @@ interface TasksListProps {
 
 export function TasksList({ workspaceId, workspaceSlug }: TasksListProps) {
   const { tasks, loading, error, pagination, loadMore } = useWorkspaceTasks(workspaceId, workspaceSlug, true);
-  
-  const runningTasksCount = tasks.filter(task => task.workflowStatus === "IN_PROGRESS").length;
+  const { stats } = useTaskStats(workspaceId);
 
   if (loading && tasks.length === 0) {
     return <LoadingState />;
@@ -52,14 +52,14 @@ export function TasksList({ workspaceId, workspaceSlug }: TasksListProps) {
             Recent Tasks
           </div>
           <div className="flex items-center gap-4 text-sm">
-            {runningTasksCount > 0 && (
+            {stats?.inProgress && stats.inProgress > 0 && (
               <span className="flex items-center gap-1 font-normal text-green-600">
                 <Play className="h-4 w-4" />
-                {runningTasksCount} running
+                {stats.inProgress} running
               </span>
             )}
             <span className="font-normal text-muted-foreground">
-              {pagination?.totalCount || tasks.length} task{(pagination?.totalCount || tasks.length) !== 1 ? 's' : ''}
+              {stats?.total ?? pagination?.totalCount ?? tasks.length} task{(stats?.total ?? pagination?.totalCount ?? tasks.length) !== 1 ? 's' : ''}
             </span>
           </div>
         </CardTitle>

--- a/src/hooks/useTaskStats.ts
+++ b/src/hooks/useTaskStats.ts
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useSession } from "next-auth/react";
+
+export interface TaskStats {
+  total: number;
+  inProgress: number;
+  waitingForInput: number;
+}
+
+interface UseTaskStatsResult {
+  stats: TaskStats | null;
+  loading: boolean;
+  error: string | null;
+  refetch: () => Promise<void>;
+}
+
+export function useTaskStats(workspaceId: string | null): UseTaskStatsResult {
+  const { data: session } = useSession();
+  const [stats, setStats] = useState<TaskStats | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchStats = useCallback(async () => {
+    if (!workspaceId || !session?.user) {
+      setStats(null);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/tasks/stats?workspaceId=${workspaceId}`, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch task statistics: ${response.statusText}`);
+      }
+
+      const result = await response.json();
+      
+      if (result.success && result.data) {
+        setStats(result.data);
+      } else {
+        throw new Error("Invalid response format");
+      }
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : "Failed to fetch task statistics";
+      setError(errorMessage);
+      console.error("Error fetching task statistics:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, [workspaceId, session?.user]);
+
+  useEffect(() => {
+    fetchStats();
+  }, [fetchStats]);
+
+  return {
+    stats,
+    loading,
+    error,
+    refetch: fetchStats,
+  };
+}


### PR DESCRIPTION
- Add /api/tasks/stats endpoint for efficient task statistics queries
- Create useTaskStats hook for fetching workspace task counts
- Update TasksList to use statistics API instead of filtering paginated results
- Fix counter showing only paginated results instead of total running tasks
- Counter now displays all IN_PROGRESS tasks regardless of pagination

Resolves issue where running tasks counter only showed tasks from current page (max 5) instead of the actual total count across all workspace tasks.