### PR TITLE
Add SECURITY_REVIEW janitor type

### DIFF
--- a/prisma/migrations/20250906015917_add_security_review_janitor/migration.sql
+++ b/prisma/migrations/20250906015917_add_security_review_janitor/migration.sql
@@ -1,0 +1,5 @@
+-- AlterEnum
+ALTER TYPE "JanitorType" ADD VALUE 'SECURITY_REVIEW';
+
+-- AlterTable
+ALTER TABLE "janitor_configs" ADD COLUMN     "security_review_enabled" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -636,6 +636,7 @@ model JanitorConfig {
   unitTestsEnabled        Boolean @default(false) @map("unit_tests_enabled")
   integrationTestsEnabled Boolean @default(false) @map("integration_tests_enabled")
   e2eTestsEnabled         Boolean @default(false) @map("e2e_tests_enabled")
+  securityReviewEnabled   Boolean @default(false) @map("security_review_enabled")
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
@@ -832,6 +833,7 @@ enum JanitorType {
   UNIT_TESTS
   INTEGRATION_TESTS
   E2E_TESTS
+  SECURITY_REVIEW
 }
 
 enum JanitorStatus {

--- a/src/app/api/workspaces/[slug]/janitors/config/route.ts
+++ b/src/app/api/workspaces/[slug]/janitors/config/route.ts
@@ -8,6 +8,7 @@ const updateJanitorConfigSchema = z.object({
   unitTestsEnabled: z.boolean().optional(),
   integrationTestsEnabled: z.boolean().optional(),
   e2eTestsEnabled: z.boolean().optional(),
+  securityReviewEnabled: z.boolean().optional(),
 });
 
 export async function GET(

--- a/src/app/w/[slug]/insights/page.tsx
+++ b/src/app/w/[slug]/insights/page.tsx
@@ -15,11 +15,13 @@ import { BarChart3, BookOpen, GitPullRequest, Package, Shield, TestTube, Type, W
 import { redirect } from "next/navigation";
 import { useEffect, useCallback } from "react";
 
-// Testing janitors - real data from centralized constants plus PR reviews
+// Get all janitor items and separate them by category
+const allJanitors = getAllJanitorItems();
 const testingJanitors: JanitorItem[] = [
-  ...getAllJanitorItems(),
+  ...allJanitors.filter(j => j.id !== "SECURITY_REVIEW"),
   { id: "pr-reviews", name: "PR Reviews", icon: GitPullRequest, description: "Enable automatic PR reviews.", comingSoon: true },
 ];
+const securityReviewJanitor = allJanitors.find(j => j.id === "SECURITY_REVIEW");
 
 // Maintainability janitors - coming soon
 const maintainabilityJanitors: JanitorItem[] = [
@@ -28,10 +30,10 @@ const maintainabilityJanitors: JanitorItem[] = [
   { id: "documentation", name: "Documentation", icon: BookOpen, description: "Generate missing documentation." },
 ];
 
-// Security janitors - coming soon  
+// Security janitors
 const securityJanitors: JanitorItem[] = [
-  { id: "security", name: "Security Scan", icon: Shield, description: "Scan for vulnerabilities." },
-  { id: "supply-chain", name: "Supply Chain", icon: Package, description: "Check dependencies risk." },
+  ...(securityReviewJanitor ? [securityReviewJanitor] : []),
+  { id: "supply-chain", name: "Supply Chain", icon: Package, description: "Check dependencies risk.", comingSoon: true },
 ];
 
 export default function InsightsPage() {
@@ -124,7 +126,6 @@ export default function InsightsPage() {
         description="Security scanning and vulnerability detection"
         icon={<Shield className="h-5 w-5 text-red-500" />}
         janitors={securityJanitors}
-        comingSoon={true}
       />
       </div>{/* End content container */}
     </div>

--- a/src/lib/constants/janitor.ts
+++ b/src/lib/constants/janitor.ts
@@ -1,5 +1,5 @@
 import { JanitorType, Priority } from "@prisma/client";
-import { FlaskConical, Zap, Monitor, LucideIcon } from "lucide-react";
+import { FlaskConical, Zap, Monitor, Shield, LucideIcon } from "lucide-react";
 
 /**
  * Janitor system error messages
@@ -25,6 +25,7 @@ export interface JanitorConfigFields {
   unitTestsEnabled: boolean;
   integrationTestsEnabled: boolean;
   e2eTestsEnabled: boolean;
+  securityReviewEnabled: boolean;
 }
 
 /**
@@ -53,6 +54,12 @@ export const JANITOR_CONFIG: Record<JanitorType, {
     description: "Identify missing end-to-end tests.",
     icon: Monitor,
     enabledField: "e2eTestsEnabled",
+  },
+  SECURITY_REVIEW: {
+    name: "Security Review",
+    description: "Scan for security vulnerabilities and best practices.",
+    icon: Shield,
+    enabledField: "securityReviewEnabled",
   },
 } as const;
 

--- a/src/services/janitor-cron.ts
+++ b/src/services/janitor-cron.ts
@@ -31,6 +31,7 @@ export async function getWorkspacesWithEnabledJanitors(): Promise<Array<{
     unitTestsEnabled: boolean;
     integrationTestsEnabled: boolean;
     e2eTestsEnabled: boolean;
+    securityReviewEnabled: boolean;
   } | null;
 }>> {
   return await db.workspace.findMany({
@@ -51,6 +52,7 @@ export async function getWorkspacesWithEnabledJanitors(): Promise<Array<{
           unitTestsEnabled: true,
           integrationTestsEnabled: true,
           e2eTestsEnabled: true,
+          securityReviewEnabled: true,
         }
       }
     }

--- a/src/types/janitor.ts
+++ b/src/types/janitor.ts
@@ -11,6 +11,7 @@ export interface JanitorConfigUpdate {
   unitTestsEnabled?: boolean;
   integrationTestsEnabled?: boolean;
   e2eTestsEnabled?: boolean;
+  securityReviewEnabled?: boolean;
 }
 
 export interface AcceptRecommendationRequest {


### PR DESCRIPTION
- Add SECURITY_REVIEW to JanitorType enum in Prisma schema
- Add securityReviewEnabled field to JanitorConfig model
- Update backend constants with Security Review configuration
- Update API endpoints to handle new security review field
- Update insights page to display Security Review janitor (no longer coming soon)
- Create database migration for schema changes