### PR TITLE
Fix workspace limit environment variable for client-side usage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,7 @@ Required environment variables:
 - `NEXTAUTH_SECRET` - Session encryption secret
 - `GITHUB_CLIENT_ID` - GitHub OAuth client ID
 - `GITHUB_CLIENT_SECRET` - GitHub OAuth client secret
+- `NEXT_PUBLIC_MAX_WORKSPACES_PER_USER` - Maximum workspaces per user (default: 3)
 
 ### Code Style
 - Uses ESLint with Next.js configuration

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -118,7 +118,7 @@ export const WORKSPACE_PERMISSION_LEVELS: Record<WorkspaceRole, number> = {
 
 // Workspace limits
 export const WORKSPACE_LIMITS = {
-  MAX_WORKSPACES_PER_USER: parseInt(process.env.MAX_WORKSPACES_PER_USER || "3", 10),
+  MAX_WORKSPACES_PER_USER: parseInt(process.env.NEXT_PUBLIC_MAX_WORKSPACES_PER_USER || "3", 10),
 } as const;
 
 // Error messages


### PR DESCRIPTION
- Change MAX_WORKSPACES_PER_USER to NEXT_PUBLIC_MAX_WORKSPACES_PER_USER
- Required for the limit to be accessible in client components
- Fixes issue where changing the limit in production didn't affect UI