### PR TITLE
fix: task header workflow link now appears immediately

### DIFF
--- a/src/app/w/[slug]/task/[...taskParams]/page.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/page.tsx
@@ -263,6 +263,7 @@ export default function TaskChatPage() {
       if (result.workflow?.project_id) {
         console.log("Project ID:", result.workflow.project_id);
         setProjectId(result.workflow.project_id);
+        setStakworkProjectId(result.workflow.project_id);
         setIsChainVisible(true);
         clearLogs();
       }


### PR DESCRIPTION
Previously, the workflow link in the task header required a hard refresh to appear after starting a task. This was because the stakworkProjectId wasn't being set when receiving the project ID from the API response.

Now sets stakworkProjectId immediately when the workflow starts, ensuring the link appears without needing a page refresh.

Fixes #574