### PR TITLE
fix: replace null toast message with meaningful GitHub connection message

### DIFF
--- a/src/app/w/[slug]/page.tsx
+++ b/src/app/w/[slug]/page.tsx
@@ -143,8 +143,8 @@ export default function DashboardPage() {
           variant = "destructive";
           break;
         default:
-          title = "GitHub App Action";
-          description = `GitHub App ${setupAction} completed`;
+          title = "GitHub App Connected";
+          description = "Successfully connected to GitHub";
       }
 
       toast({


### PR DESCRIPTION
Addresses issue #674 where toast notification displayed "null" when successfully linking GitHub. Updated default case to show clear success message instead of interpolating undefined setupAction value.