### PR TITLE
fix: improve Learn chat message contrast in light mode (#709)

### DIFF
--- a/src/app/w/[slug]/learn/components/LearnChatMessage.tsx
+++ b/src/app/w/[slug]/learn/components/LearnChatMessage.tsx
@@ -36,13 +36,11 @@ export function LearnChatMessage({ message }: LearnChatMessageProps) {
             <User className="w-4 h-4" />
           </div>
         )}
-        <div className={`text-sm ${
-          isUser ? "text-primary-foreground" : "text-foreground"
-        }`}>
+        <div className={`text-sm ${isUser ? "text-primary-foreground" : ""}`}>
           {isUser ? (
             <div className="whitespace-pre-wrap">{message.content}</div>
           ) : (
-            <div className="prose prose-sm max-w-none dark:prose-invert">
+            <div className="prose prose-sm max-w-none dark:prose-invert prose-gray [&>*]:!text-foreground [&_*]:!text-foreground">
               <ReactMarkdown>
                 {message.content}
               </ReactMarkdown>


### PR DESCRIPTION
- Force prose content to use theme foreground color
- Override Tailwind's default prose styling that was causing poor contrast
- Ensures chat messages are readable in light mode

Before:
<img width="1014" height="575" alt="image" src="https://github.com/user-attachments/assets/964cd6ca-7fb1-4621-b38e-f05e5f8e9069" />
After:
<img width="869" height="548" alt="Screenshot 2025-09-18 at 11 52 52" src="https://github.com/user-attachments/assets/e4d8cd19-9e16-440e-a64c-62902465ed0b" />
