### PR TITLE
feat: add copy/paste and drag & drop support for environment variables

### DIFF
--- a/src/components/stakgraph/forms/EnvironmentForm.tsx
+++ b/src/components/stakgraph/forms/EnvironmentForm.tsx
@@ -2,10 +2,13 @@ import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Eye, EyeOff } from "lucide-react";
+import { Eye, EyeOff, Clipboard, AlertCircle } from "lucide-react";
 import { EnvironmentData, FormSectionProps } from "../types";
 import { useEnvironmentVars } from "@/hooks/useEnvironmentVars";
-import { useEffect } from "react";
+import { FileDropZone } from "@/components/ui/file-drop-zone";
+import { parseEnv } from "@/lib/env-parser";
+import { useToast } from "@/components/ui/use-toast";
+import { useEffect, useState } from "react";
 
 interface EnvironmentFormProps extends FormSectionProps<EnvironmentData> {
   onEnvVarsChange: (
@@ -26,7 +29,10 @@ export default function EnvironmentForm({
     handleAddEnv,
     handleRemoveEnv,
     setEnvVars,
+    bulkAddEnvVars,
   } = useEnvironmentVars();
+  const { toast } = useToast();
+  const [showImportSection, setShowImportSection] = useState(false);
 
   // Sync environment variables when data changes
   useEffect(() => {
@@ -56,6 +62,64 @@ export default function EnvironmentForm({
 
   const handlePoolMemoryChange = (value: string) => {
     onChange({ poolMemory: value });
+  };
+
+  const handlePasteEnv = async () => {
+    try {
+      const text = await navigator.clipboard.readText();
+      const parsed = parseEnv(text);
+
+      const count = Object.keys(parsed).length;
+      if (count === 0) {
+        toast({
+          title: "No variables found",
+          description: "The clipboard content doesn't contain valid environment variables.",
+          variant: "destructive",
+        });
+        return;
+      }
+
+      bulkAddEnvVars(parsed);
+      toast({
+        title: "Variables imported",
+        description: `Successfully imported ${count} environment variable${count > 1 ? 's' : ''}.`,
+      });
+    } catch (err) {
+      toast({
+        title: "Paste failed",
+        description: "Unable to read from clipboard. Please try again.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleFileContent = (content: string, fileName: string) => {
+    try {
+      const parsed = parseEnv(content);
+
+      const count = Object.keys(parsed).length;
+      if (count === 0) {
+        toast({
+          title: "No variables found",
+          description: `The file "${fileName}" doesn't contain valid environment variables.`,
+          variant: "destructive",
+        });
+        return;
+      }
+
+      bulkAddEnvVars(parsed);
+      toast({
+        title: "Variables imported",
+        description: `Successfully imported ${count} environment variable${count > 1 ? 's' : ''} from ${fileName}.`,
+      });
+      setShowImportSection(false);
+    } catch (err) {
+      toast({
+        title: "Import failed",
+        description: "Failed to parse the file. Please check the format.",
+        variant: "destructive",
+      });
+    }
   };
 
   return (
@@ -134,12 +198,54 @@ export default function EnvironmentForm({
         </div>
       </div>
 
-      <div className="space-y-3">
-        <h4 className="text-md font-medium">Environment Variables</h4>
-        <p className="text-xs text-muted-foreground">
-          Add any ENV variables your Stakgraph integration needs. These will be
-          included in your configuration.
-        </p>
+      <div className="space-y-4">
+        <div>
+          <h4 className="text-md font-medium">Environment Variables</h4>
+          <p className="text-xs text-muted-foreground mt-1">
+            Add any ENV variables your Stakgraph integration needs. These will be
+            included in your configuration.
+          </p>
+        </div>
+
+        {/* Import section */}
+        <div className="bg-muted/30 rounded-lg p-3">
+          <div className="flex items-center gap-3 text-sm">
+            <span className="text-muted-foreground">Quick import:</span>
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={handlePasteEnv}
+              disabled={loading}
+              className="h-7"
+            >
+              <Clipboard className="w-3.5 h-3.5 mr-1.5" />
+              Paste ENVs
+            </Button>
+            <span className="text-muted-foreground">or</span>
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={() => setShowImportSection(!showImportSection)}
+              disabled={loading}
+              className="h-7"
+            >
+              File import
+            </Button>
+          </div>
+
+          {showImportSection && (
+            <div className="mt-3 animate-in fade-in-0 slide-in-from-top-2 duration-200">
+              <FileDropZone
+                onFileContent={handleFileContent}
+                disabled={loading}
+                className="max-w-full"
+              />
+            </div>
+          )}
+        </div>
+
         <div className="space-y-2">
           {envVars.map((pair, idx) => (
             <div key={idx} className="flex gap-2 items-center">

--- a/src/components/ui/file-drop-zone.tsx
+++ b/src/components/ui/file-drop-zone.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState, useRef, DragEvent, ChangeEvent } from "react";
+import { Upload, FileText } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface FileDropZoneProps {
+  onFileContent: (content: string, fileName: string) => void;
+  accept?: string;
+  className?: string;
+  disabled?: boolean;
+}
+
+export function FileDropZone({
+  onFileContent,
+  accept = ".env,.txt,text/plain",
+  className,
+  disabled = false
+}: FileDropZoneProps) {
+  const [isDragging, setIsDragging] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleDragEnter = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!disabled) {
+      setIsDragging(true);
+    }
+  };
+
+  const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!disabled) {
+      setIsDragging(true);
+    }
+  };
+
+  const handleDragLeave = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    // Check if we're leaving the drop zone entirely
+    const rect = e.currentTarget.getBoundingClientRect();
+    const x = e.clientX;
+    const y = e.clientY;
+
+    if (x < rect.left || x >= rect.right || y < rect.top || y >= rect.bottom) {
+      setIsDragging(false);
+    }
+  };
+
+  const handleDrop = async (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(false);
+
+    if (disabled) return;
+
+    const files = Array.from(e.dataTransfer.files);
+    const file = files[0];
+
+    if (file) {
+      // Accept .env files, text files, or files with no extension
+      const isEnvFile = file.name.endsWith('.env');
+      const isTextFile = file.type === "text/plain" || file.type === "";
+      const isTxtFile = file.name.endsWith('.txt');
+
+      if (isEnvFile || isTextFile || isTxtFile) {
+        try {
+          const content = await file.text();
+          onFileContent(content, file.name);
+        } catch (error) {
+          console.error("Error reading file:", error);
+        }
+      }
+    }
+  };
+
+  const handleFileSelect = async (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      const content = await file.text();
+      onFileContent(content, file.name);
+    }
+    // Reset input
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  return (
+    <div
+      onDragEnter={handleDragEnter}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+      className={cn(
+        "relative border-2 border-dashed rounded-lg p-4 text-center transition-all",
+        isDragging && !disabled
+          ? "border-primary bg-primary/5"
+          : "border-muted-foreground/25 hover:border-muted-foreground/50",
+        disabled && "opacity-50 cursor-not-allowed",
+        !disabled && "cursor-pointer",
+        className
+      )}
+      onClick={() => !disabled && fileInputRef.current?.click()}
+    >
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={accept}
+        onChange={handleFileSelect}
+        className="hidden"
+        disabled={disabled}
+      />
+
+      <div className="flex items-center justify-center gap-3">
+        {isDragging ? (
+          <FileText className="w-6 h-6 text-primary animate-pulse" />
+        ) : (
+          <Upload className="w-5 h-5 text-muted-foreground" />
+        )}
+
+        <div className="text-left">
+          <p className="text-sm font-medium">
+            {isDragging ? "Drop your file here" : "Drop .env file or click to browse"}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Supports .env and .txt files
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useEnvironmentVars.ts
+++ b/src/hooks/useEnvironmentVars.ts
@@ -1,5 +1,7 @@
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { EnvironmentVariable } from "@/types/wizard";
+
+type MergeStrategy = "replace" | "skip" | "merge";
 
 interface UseEnvironmentVarsReturn {
   envVars: EnvironmentVariable[];
@@ -11,6 +13,10 @@ interface UseEnvironmentVarsReturn {
   handleAddEnv: () => void;
   handleRemoveEnv: (index: number) => void;
   setEnvVars: (vars: EnvironmentVariable[]) => void;
+  bulkAddEnvVars: (
+    vars: Record<string, string>,
+    strategy?: MergeStrategy
+  ) => void;
 }
 
 export function useEnvironmentVars(
@@ -38,11 +44,51 @@ export function useEnvironmentVars(
     setEnvVars((prev) => prev.filter((_, i) => i !== index));
   };
 
+  const bulkAddEnvVars = useCallback(
+    (vars: Record<string, string>, strategy: MergeStrategy = "merge") => {
+      setEnvVars((prev) => {
+        const existingKeys = new Set(prev.map((v) => v.name).filter(Boolean));
+        const newVars: EnvironmentVariable[] = [];
+
+        Object.entries(vars).forEach(([key, value]) => {
+          if (!key) return;
+
+          if (existingKeys.has(key)) {
+            if (strategy === "replace") {
+              // Update existing variable
+              const index = prev.findIndex((v) => v.name === key);
+              if (index !== -1) {
+                prev[index].value = value;
+              }
+            }
+            // For "skip" strategy, do nothing for existing keys
+          } else {
+            // Add new variable
+            newVars.push({ name: key, value, show: false });
+          }
+        });
+
+        // Remove empty placeholder if it exists
+        const filtered = prev.filter((v) => v.name || v.value);
+
+        if (strategy === "replace") {
+          return [...filtered, ...newVars];
+        }
+
+        return [...filtered, ...newVars].length > 0
+          ? [...filtered, ...newVars]
+          : [{ name: "", value: "", show: false }];
+      });
+    },
+    []
+  );
+
   return {
     envVars,
     handleEnvChange,
     handleAddEnv,
     handleRemoveEnv,
     setEnvVars,
+    bulkAddEnvVars,
   };
 }

--- a/src/lib/env-parser.ts
+++ b/src/lib/env-parser.ts
@@ -1,0 +1,52 @@
+export function parseEnv(envContent: string): Record<string, string> {
+  const result: Record<string, string> = {};
+
+  const lines = envContent.split('\n');
+
+  for (const line of lines) {
+    // Skip empty lines and comments
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue;
+    }
+
+    // Find the first = sign
+    const equalIndex = trimmed.indexOf('=');
+    if (equalIndex === -1) {
+      continue; // Skip lines without =
+    }
+
+    const key = trimmed.slice(0, equalIndex).trim();
+    let value = trimmed.slice(equalIndex + 1).trim();
+
+    // Handle quoted values
+    if ((value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+
+    if (key) {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}
+
+export function validateEnvKey(key: string): boolean {
+  // ENV keys should start with a letter or underscore,
+  // and contain only letters, numbers, and underscores
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(key);
+}
+
+export function formatEnvForExport(vars: Record<string, string>): string {
+  return Object.entries(vars)
+    .map(([key, value]) => {
+      // Quote values that contain spaces or special characters
+      if (value.includes(' ') || value.includes('\n') || value.includes('"')) {
+        return `${key}="${value.replace(/"/g, '\\"')}"`;
+      }
+      return `${key}=${value}`;
+    })
+    .join('\n');
+}


### PR DESCRIPTION
- Add ENV parser utility for parsing .env file format
- Create reusable FileDropZone component for drag & drop
- Add bulk import functionality to useEnvironmentVars hook
- Update EnvironmentForm with paste and file import buttons
- Add same functionality to wizard environment setup step
- Support KEY=VALUE format with quoted values and comments

Closes #701