### PR TITLE
feat: add test setup tracking flags to Repository model

### DIFF
--- a/prisma/migrations/20250919131339_add_test_setup_flags_to_repository/migration.sql
+++ b/prisma/migrations/20250919131339_add_test_setup_flags_to_repository/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "repositories" ADD COLUMN     "playwright_setup" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "testing_framework_setup" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -260,6 +260,10 @@ model Repository {
   githubWebhookId     String? @map("github_webhook_id")
   githubWebhookSecret String? @map("github_webhook_secret")
 
+  // Test setup flags
+  testingFrameworkSetup Boolean @default(false) @map("testing_framework_setup")
+  playwrightSetup       Boolean @default(false) @map("playwright_setup")
+
   // Repository belongs to workspace
   workspaceId String    @map("workspace_id")
   workspace   Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
- Add testingFrameworkSetup flag to track if any testing framework is configured
- Add playwrightSetup flag to track Playwright installation for user journey recording
- These flags will enable recommendations for test framework setup when missing