### PR TITLE
Fix auth race condition by tracking session and workspace loading sep…

### DIFF
--- a/src/__tests__/unit/config/services.test.ts
+++ b/src/__tests__/unit/config/services.test.ts
@@ -79,7 +79,7 @@ describe("getServiceConfig", () => {
         timeout: expect.any(Number),
         headers: expect.any(Object),
       });
-      expect(config.baseURL).toBe(process.env.SWARM_SUPER_ADMIN_URL || "");
+      expect(config.baseURL).toBe("");
       expect(config.apiKey).toBe(""); // Added under x-user-token
       expect(config.timeout).toBe(120000); // 2 minutes timeout
       expect(config.headers).toHaveProperty("Content-Type", "application/json");


### PR DESCRIPTION
…arately

Prevents premature 'access denied' errors during page refresh by:
- Tracking both session loading and workspace loading states independently
- Maintaining loading state while auth session is resolving
- Only showing access errors after both auth and workspace have finished loading
- Adding abort controller to properly handle concurrent fetch requests
- Preventing race conditions when switching between workspaces rapidly