### PR TITLE
Fix infinite retry loop on GET ingest endpoint for invalid ingestRefId

### DIFF
--- a/src/services/swarm/db.ts
+++ b/src/services/swarm/db.ts
@@ -40,7 +40,7 @@ interface SaveOrUpdateSwarmParams {
   services?: ServiceConfig[]; // Use ServiceConfig[]
   swarmId?: string;
   swarmSecretAlias?: string;
-  ingestRefId?: string;
+  ingestRefId?: string | null;
   containerFiles?: Record<string, string>;
   defaultBranch?: string;
   githubInstallationId?: string;


### PR DESCRIPTION
## Problem

The GET ingest endpoint was causing infinite retry loops when receiving 404 errors due to invalid `ingestRefId` values. This happened when:

- An `ingestRefId` becomes stale/invalid on the stakgraph API
- The frontend polling logic would retry forever without cleanup
- Users experienced endless network requests and poor UX
- No mechanism existed to clear bad references automatically

## Closed: #849 

## Solution

Added intelligent retry limiting with automatic cleanup:

- **Retry Limit**: Max 5 attempts before giving up
- **404 Detection**: Handles both API route 404s and nested stakgraph API 404s
- **Auto Cleanup**: New PATCH endpoint clears invalid `ingestRefId` from database
- **User Feedback**: Proper notifications for different failure scenarios
- **DRY Refactor**: Eliminated duplicate 404 handling logic

## Changes Made

### Backend (`src/app/api/swarm/stakgraph/ingest/route.ts`)
- ✅ Added `PATCH` endpoint with `clearIngestRefId` action
- ✅ Updated `SaveOrUpdateSwarmParams` to accept `string | null` for `ingestRefId`

### Frontend (`src/app/w/[slug]/page.tsx`)
- ✅ Added retry counter with 5-attempt limit
- ✅ Enhanced 404 error detection (API + stakgraph levels)
- ✅ Auto-cleanup via PATCH call after max attempts
- ✅ Refactored duplicate logic into reusable `handle404Error` function
- ✅ Improved user notifications and error messages

### Type Safety (`src/services/swarm/db.ts`)
- ✅ Updated interface to properly handle `null` ingestRefId values