### PR TITLE
refactor: reorganize VM configuration and workspace settings

### DIFF
--- a/src/app/w/[slug]/stakgraph/page.tsx
+++ b/src/app/w/[slug]/stakgraph/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { EnvironmentForm, ProjectInfoForm, RepositoryForm, ServicesForm, SwarmForm } from "@/components/stakgraph";
+import { EnvironmentForm, ServicesForm } from "@/components/stakgraph";
 import { FileTabs } from "@/components/stakgraph/forms/EditFilesForm";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -8,13 +8,12 @@ import { useToast } from "@/components/ui/use-toast";
 import { PageHeader } from "@/components/ui/page-header";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { useStakgraphStore } from "@/stores/useStakgraphStore";
-import { useGitVisualizer } from "@/hooks/useGitVisualizer";
-import { Webhook, Loader2, Save, ArrowLeft } from "lucide-react";
+import { Loader2, Save, ArrowLeft } from "lucide-react";
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 
 export default function StakgraphPage() {
-  const { slug, id, refreshCurrentWorkspace } = useWorkspace();
+  const { slug, refreshCurrentWorkspace } = useWorkspace();
   const router = useRouter();
 
   const {
@@ -25,9 +24,6 @@ export default function StakgraphPage() {
     saved,
     loadSettings,
     saveSettings,
-    handleProjectInfoChange,
-    handleRepositoryChange,
-    handleSwarmChange,
     handleEnvironmentChange,
     handleEnvVarsChange,
     handleServicesChange,
@@ -35,13 +31,6 @@ export default function StakgraphPage() {
   } = useStakgraphStore();
 
   const { toast } = useToast();
-
-  // Initialize GitVisualizer
-  useGitVisualizer({
-    workspaceId: id,
-    repositoryUrl: formData.repositoryUrl,
-    swarmUrl: formData.swarmUrl,
-  });
 
   // Load existing settings on component mount
   useEffect(() => {
@@ -59,69 +48,6 @@ export default function StakgraphPage() {
     refreshCurrentWorkspace();
   };
 
-  const handleEnsureWebhooks = async () => {
-    try {
-      if (!id) {
-        toast({
-          title: "Error",
-          description: "Workspace not ready",
-          variant: "destructive",
-        });
-        return;
-      }
-      const res = await fetch("/api/github/webhook/ensure", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          workspaceId: id,
-          repositoryUrl: formData.repositoryUrl,
-        }),
-      });
-
-      const data = await res.json();
-
-      if (!res.ok) {
-        if (data.error === "INSUFFICIENT_PERMISSIONS") {
-          toast({
-            title: "Permission Required",
-            description: data.message || "Admin access required to manage webhooks on this repository",
-            variant: "destructive",
-          });
-        } else {
-          toast({
-            title: "Error",
-            description: data.message || "Failed to add webhooks",
-            variant: "destructive",
-          });
-        }
-        return;
-      }
-
-      toast({
-        title: "Webhooks added",
-        description: "GitHub webhooks have been ensured",
-      });
-      await loadSettings(slug!);
-    } catch (error) {
-      console.error("Failed to ensure webhooks", error);
-      toast({
-        title: "Error",
-        description: "Failed to add webhooks",
-        variant: "destructive",
-      });
-    }
-  };
-
-  // const allFieldsFilled =
-  //   formData.name &&
-  //     formData.repositoryUrl &&
-  //     formData.swarmUrl &&
-  //     formData.swarmSecretAlias &&
-  //     formData.poolName
-  //     ? true
-  //     : false;
-
-  // console.log("allFieldsFilled", allFieldsFilled);
 
   if (initialLoading) {
     return (
@@ -154,20 +80,12 @@ export default function StakgraphPage() {
       </div>
       <PageHeader
         title="VM Configuration"
-        description="Configure your virtual machine settings for development environment"
+        description="Configure your virtual machine environment, services, and container files"
       />
 
       <Card className="max-w-2xl">
-        <CardHeader className="flex flex-row items-center justify-between">
-          <CardTitle>VM Settings</CardTitle>
-          <div className="flex gap-2">
-            {!formData.webhookEnsured && formData.repositoryUrl ? (
-              <Button type="button" variant="default" onClick={handleEnsureWebhooks}>
-                <Webhook className="mr-2 h-4 w-4" />
-                Add Github Webhooks
-              </Button>
-            ) : null}
-          </div>
+        <CardHeader>
+          <CardTitle>VM Environment Settings</CardTitle>
         </CardHeader>
         <CardContent>
           <form onSubmit={handleSubmit} className="space-y-6">
@@ -184,34 +102,6 @@ export default function StakgraphPage() {
             )}
 
             <div className="space-y-6">
-              <ProjectInfoForm
-                data={{
-                  name: formData.name,
-                  description: formData.description,
-                }}
-                errors={errors}
-                loading={loading}
-                onChange={handleProjectInfoChange}
-              />
-
-              <RepositoryForm
-                data={{ repositoryUrl: formData.repositoryUrl }}
-                errors={errors}
-                loading={loading}
-                onChange={handleRepositoryChange}
-              />
-
-              <SwarmForm
-                data={{
-                  swarmUrl: formData.swarmUrl,
-                  swarmApiKey: formData.swarmApiKey || "",
-                  swarmSecretAlias: formData.swarmSecretAlias,
-                }}
-                errors={errors}
-                loading={loading}
-                onChange={handleSwarmChange}
-              />
-
               <EnvironmentForm
                 data={{
                   poolName: formData.poolName,
@@ -243,18 +133,11 @@ export default function StakgraphPage() {
               ) : (
                 <>
                   <Save className="mr-2 h-4 w-4" />
-                  Save
+                  Save VM Configuration
                 </>
               )}
             </Button>
           </form>
-        </CardContent>
-      </Card>
-
-      {/* Gitsee section */}
-      <Card className="max-w-2xl">
-        <CardContent>
-          <svg width="500" height="500" id="vizzy" style={{ width: "100%", height: "100%" }}></svg>
         </CardContent>
       </Card>
     </div>

--- a/src/components/WorkspaceSettings.tsx
+++ b/src/components/WorkspaceSettings.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
-import { Edit3, Loader2 } from "lucide-react";
+import { Edit3, Loader2, GitBranch, Server, Key } from "lucide-react";
 
 import {
   Card,
@@ -25,18 +25,39 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { useWorkspaceAccess } from "@/hooks/useWorkspaceAccess";
 import { updateWorkspaceSchema, UpdateWorkspaceInput } from "@/lib/schemas/workspace";
 import { useToast } from "@/components/ui/use-toast";
+import { useStakgraphStore } from "@/stores/useStakgraphStore";
 
 export function WorkspaceSettings() {
   const { workspace, refreshCurrentWorkspace } = useWorkspace();
   const { canAdmin } = useWorkspaceAccess();
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [activeTab, setActiveTab] = useState("general");
   const { toast } = useToast();
+
+  // Stakgraph store for repository and infrastructure data
+  const {
+    formData: stakgraphData,
+    loadSettings,
+    handleRepositoryChange,
+    handleSwarmChange,
+    errors: stakgraphErrors,
+    loading: stakgraphLoading,
+    initialLoading: stakgraphInitialLoading,
+  } = useStakgraphStore();
+
+  // Load stakgraph settings when workspace changes
+  useEffect(() => {
+    if (workspace?.slug) {
+      loadSettings(workspace.slug);
+    }
+  }, [workspace?.slug, loadSettings]);
 
   const form = useForm<UpdateWorkspaceInput>({
     resolver: zodResolver(updateWorkspaceSchema),
@@ -46,6 +67,27 @@ export function WorkspaceSettings() {
       description: workspace?.description || "",
     },
   });
+
+  // Repository form
+  const [repositoryUrl, setRepositoryUrl] = useState(stakgraphData.repositoryUrl || "");
+
+  // Infrastructure form
+  const [swarmUrl, setSwarmUrl] = useState(stakgraphData.swarmUrl || "");
+  const [swarmSecretAlias, setSwarmSecretAlias] = useState(stakgraphData.swarmSecretAlias || "");
+  const [swarmApiKey, setSwarmApiKey] = useState(stakgraphData.swarmApiKey || "");
+  const [showApiKey, setShowApiKey] = useState(false);
+  const [apiKeyTouched, setApiKeyTouched] = useState(false);
+
+  // Update local state when stakgraph data loads
+  useEffect(() => {
+    setRepositoryUrl(stakgraphData.repositoryUrl || "");
+    setSwarmUrl(stakgraphData.swarmUrl || "");
+    setSwarmSecretAlias(stakgraphData.swarmSecretAlias || "");
+    // Don't set API key from stakgraph data as it's write-only
+    if (!swarmApiKey) {
+      setSwarmApiKey("");
+    }
+  }, [stakgraphData]);
 
   const onSubmit = async (data: UpdateWorkspaceInput) => {
     if (!workspace) return;
@@ -90,96 +132,379 @@ export function WorkspaceSettings() {
     }
   };
 
+  const saveRepository = async () => {
+    if (!workspace) return;
+    setIsSubmitting(true);
+
+    try {
+      // Update stakgraph store state
+      handleRepositoryChange({ repositoryUrl });
+
+      // Prepare minimal payload for repository update
+      const payload = {
+        name: stakgraphData.name || workspace.name, // Use workspace name as fallback
+        description: stakgraphData.description || workspace.description || "",
+        repositoryUrl: repositoryUrl.trim(),
+        // Preserve existing swarm settings
+        swarmUrl: stakgraphData.swarmUrl || "",
+        swarmSecretAlias: stakgraphData.swarmSecretAlias || "",
+        swarmApiKey: stakgraphData.swarmApiKey || "",
+        // Preserve VM settings
+        poolName: stakgraphData.poolName || "",
+        poolCpu: stakgraphData.poolCpu || "2",
+        poolMemory: stakgraphData.poolMemory || "4Gi",
+        environmentVariables: stakgraphData.environmentVariables || [],
+        services: stakgraphData.services || [],
+        containerFiles: stakgraphData.containerFiles || {},
+      };
+
+      // Save to backend
+      const response = await fetch(`/api/workspaces/${workspace.slug}/stakgraph`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const result = await response.json();
+
+      if (!response.ok) {
+        throw new Error(result.error || "Failed to update repository");
+      }
+
+      toast({
+        title: "Success",
+        description: "Repository settings updated successfully",
+      });
+
+      // Reload settings to get updated data
+      await loadSettings(workspace.slug);
+    } catch (error) {
+      console.error("Error updating repository:", error);
+      toast({
+        variant: "destructive",
+        title: "Error",
+        description: error instanceof Error ? error.message : "Failed to update repository",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const saveInfrastructure = async () => {
+    if (!workspace) return;
+    setIsSubmitting(true);
+
+    try {
+      // Update stakgraph store state
+      handleSwarmChange({ swarmUrl, swarmSecretAlias, swarmApiKey });
+
+      // Prepare minimal payload for infrastructure update
+      const payload = {
+        name: stakgraphData.name || workspace.name, // Use workspace name as fallback
+        description: stakgraphData.description || workspace.description || "",
+        // Preserve repository setting
+        repositoryUrl: stakgraphData.repositoryUrl || "",
+        // Update swarm settings
+        swarmUrl: swarmUrl.trim(),
+        swarmSecretAlias: swarmSecretAlias.trim(),
+        swarmApiKey: swarmApiKey ? swarmApiKey.trim() : "",
+        // Preserve VM settings
+        poolName: stakgraphData.poolName || "",
+        poolCpu: stakgraphData.poolCpu || "2",
+        poolMemory: stakgraphData.poolMemory || "4Gi",
+        environmentVariables: stakgraphData.environmentVariables || [],
+        services: stakgraphData.services || [],
+        containerFiles: stakgraphData.containerFiles || {},
+      };
+
+      // Save to backend
+      const response = await fetch(`/api/workspaces/${workspace.slug}/stakgraph`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const result = await response.json();
+
+      if (!response.ok) {
+        throw new Error(result.error || "Failed to update infrastructure");
+      }
+
+      toast({
+        title: "Success",
+        description: "Infrastructure settings updated successfully",
+      });
+
+      // Reload settings to get updated data
+      await loadSettings(workspace.slug);
+    } catch (error) {
+      console.error("Error updating infrastructure:", error);
+      toast({
+        variant: "destructive",
+        title: "Error",
+        description: error instanceof Error ? error.message : "Failed to update infrastructure",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
   if (!workspace || !canAdmin) {
     return null;
   }
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <Edit3 className="w-5 h-5" />
-          Workspace Details
-        </CardTitle>
-        <CardDescription>
-          Update your workspace name, URL, and description
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-            <FormField
-              control={form.control}
-              name="name"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Workspace Name</FormLabel>
-                  <FormControl>
-                    <Input 
-                      placeholder="The display name for your workspace" 
-                      {...field} 
-                      disabled={isSubmitting}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+    <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-4">
+      <TabsList className="grid w-full grid-cols-3">
+        <TabsTrigger value="general" className="flex items-center gap-2">
+          <Edit3 className="w-4 h-4" />
+          General
+        </TabsTrigger>
+        <TabsTrigger value="repository" className="flex items-center gap-2">
+          <GitBranch className="w-4 h-4" />
+          Repository
+        </TabsTrigger>
+        <TabsTrigger value="infrastructure" className="flex items-center gap-2">
+          <Server className="w-4 h-4" />
+          Graph DB
+        </TabsTrigger>
+      </TabsList>
 
-            <FormField
-              control={form.control}
-              name="slug"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Workspace URL</FormLabel>
-                  <FormControl>
-                    <div className="flex items-center">
-                      <span className="text-sm text-muted-foreground mr-1">
-                        /w/
-                      </span>
-                      <Input 
-                        placeholder="lowercase, use hyphens for spaces" 
-                        {...field} 
-                        disabled={isSubmitting}
-                      />
-                    </div>
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+      <TabsContent value="general">
+        <Card>
+          <CardHeader>
+            <CardTitle>Workspace Details</CardTitle>
+            <CardDescription>
+              Update your workspace name, URL, and description
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Form {...form}>
+              <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+                <FormField
+                  control={form.control}
+                  name="name"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Workspace Name</FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="The display name for your workspace"
+                          {...field}
+                          disabled={isSubmitting}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
 
-            <FormField
-              control={form.control}
-              name="description"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Description (Optional)</FormLabel>
-                  <FormControl>
-                    <Textarea 
-                      placeholder="A brief description of your workspace"
-                      className="resize-none"
-                      {...field} 
-                      disabled={isSubmitting}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
+                <FormField
+                  control={form.control}
+                  name="slug"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Workspace URL</FormLabel>
+                      <FormControl>
+                        <div className="flex items-center">
+                          <span className="text-sm text-muted-foreground mr-1">
+                            /w/
+                          </span>
+                          <Input
+                            placeholder="lowercase, use hyphens for spaces"
+                            {...field}
+                            disabled={isSubmitting}
+                          />
+                        </div>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="description"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Description (Optional)</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          placeholder="A brief description of your workspace"
+                          className="resize-none"
+                          {...field}
+                          disabled={isSubmitting}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <div className="flex justify-end">
+                  <Button
+                    type="submit"
+                    disabled={isSubmitting || !form.formState.isDirty}
+                  >
+                    {isSubmitting && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+                    {isSubmitting ? "Updating..." : "Update Workspace"}
+                  </Button>
+                </div>
+              </form>
+            </Form>
+          </CardContent>
+        </Card>
+      </TabsContent>
+
+      <TabsContent value="repository">
+        <Card>
+          <CardHeader>
+            <CardTitle>Repository Configuration</CardTitle>
+            <CardDescription>
+              Configure the GitHub repository for this workspace
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Repository URL</label>
+              <Input
+                placeholder="https://github.com/owner/repository"
+                value={repositoryUrl}
+                onChange={(e) => setRepositoryUrl(e.target.value)}
+                disabled={isSubmitting || stakgraphLoading}
+              />
+              {stakgraphErrors.repositoryUrl && (
+                <p className="text-sm text-destructive">{stakgraphErrors.repositoryUrl}</p>
               )}
-            />
+              <p className="text-sm text-muted-foreground">
+                The GitHub repository URL for your project
+              </p>
+            </div>
 
             <div className="flex justify-end">
-              <Button 
-                type="submit" 
-                disabled={isSubmitting || !form.formState.isDirty}
+              <Button
+                onClick={saveRepository}
+                disabled={isSubmitting || stakgraphLoading || repositoryUrl === stakgraphData.repositoryUrl}
               >
                 {isSubmitting && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
-                {isSubmitting ? "Updating..." : "Update Workspace"}
+                {isSubmitting ? "Updating..." : "Update Repository"}
               </Button>
             </div>
-          </form>
-        </Form>
-      </CardContent>
-    </Card>
+          </CardContent>
+        </Card>
+      </TabsContent>
+
+      <TabsContent value="infrastructure">
+        <Card>
+          <CardHeader>
+            <CardTitle>Graph Database Configuration</CardTitle>
+            <CardDescription>
+              Configure Swarm connection for your Graph database infrastructure
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Swarm URL</label>
+              <Input
+                placeholder="https://your-swarm-domain.com"
+                value={swarmUrl}
+                onChange={(e) => setSwarmUrl(e.target.value)}
+                disabled={isSubmitting || stakgraphLoading}
+              />
+              {stakgraphErrors.swarmUrl && (
+                <p className="text-sm text-destructive">{stakgraphErrors.swarmUrl}</p>
+              )}
+              <p className="text-xs text-muted-foreground">
+                The base URL of your Swarm instance
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor={showApiKey ? "swarmApiKey" : "swarmSecretAlias"}>
+                {showApiKey ? "Swarm Api Key" : "Swarm Secret Alias"}
+              </label>
+              <div className="relative">
+                <Input
+                  key={showApiKey ? "swarmApiKey" : "swarmSecretAlias"}
+                  id={showApiKey ? "swarmApiKey" : "swarmSecretAlias"}
+                  type={showApiKey ? "password" : "text"}
+                  placeholder={
+                    showApiKey
+                      ? "Enter your actual API key to update"
+                      : "e.g. {{SWARM_123456_API_KEY}}"
+                  }
+                  value={
+                    (() => {
+                      const showVisualDots = showApiKey && !apiKeyTouched && (!swarmApiKey || swarmApiKey === "");
+                      return showVisualDots ? "••••••••••••••••" : (showApiKey ? (swarmApiKey || "") : (swarmSecretAlias || ""));
+                    })()
+                  }
+                  onChange={(e) => {
+                    if (showApiKey) {
+                      setSwarmApiKey(e.target.value);
+                      setApiKeyTouched(true);
+                    } else {
+                      setSwarmSecretAlias(e.target.value);
+                    }
+                  }}
+                  onFocus={() => {
+                    if (showApiKey) {
+                      setApiKeyTouched(true);
+                    }
+                  }}
+                  disabled={isSubmitting || stakgraphLoading}
+                  className={
+                    stakgraphErrors.swarmSecretAlias || stakgraphErrors.swarmApiKey
+                      ? "border-destructive pr-10"
+                      : "pr-10"
+                  }
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="absolute right-1 top-1/2 -translate-y-1/2 h-8 w-8 p-0"
+                  onClick={() => {
+                    setShowApiKey(!showApiKey);
+                    if (!showApiKey) {
+                      setApiKeyTouched(false);
+                    }
+                  }}
+                >
+                  <Key className="h-4 w-4" />
+                </Button>
+              </div>
+              {(stakgraphErrors.swarmSecretAlias || stakgraphErrors.swarmApiKey) && (
+                <p className="text-sm text-destructive">
+                  {showApiKey ? stakgraphErrors.swarmApiKey : stakgraphErrors.swarmSecretAlias}
+                </p>
+              )}
+              <p className="text-xs text-muted-foreground">
+                {showApiKey
+                  ? "Your actual API key for authenticating with the Swarm service (write-only)"
+                  : "The secret alias reference for your Swarm API key"}
+              </p>
+            </div>
+
+            <div className="flex justify-end">
+              <Button
+                onClick={saveInfrastructure}
+                disabled={isSubmitting || stakgraphLoading ||
+                  (swarmUrl === stakgraphData.swarmUrl &&
+                   swarmSecretAlias === stakgraphData.swarmSecretAlias &&
+                   swarmApiKey === stakgraphData.swarmApiKey)}
+              >
+                {isSubmitting && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+                {isSubmitting ? "Updating..." : "Update Infrastructure"}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </TabsContent>
+    </Tabs>
   );
 }

--- a/src/components/vm-config/index.tsx
+++ b/src/components/vm-config/index.tsx
@@ -40,7 +40,7 @@ export function VMConfigSection() {
             icon: CheckCircle,
             className: "bg-green-100 text-green-800 border-green-200"
           },
-          description: "Manage environment variables and services any time."
+          description: "Configure your VM environment, services, and container files."
         };
       case "PENDING":
         return {
@@ -82,7 +82,7 @@ export function VMConfigSection() {
               <DropdownMenuItem asChild>
                 <Link href={`/w/${slug}/stakgraph`} className="cursor-pointer">
                   <Settings className="w-4 h-4 mr-2" />
-                  Edit Configuration
+                  VM Environment Settings
                 </Link>
               </DropdownMenuItem>
             </DropdownMenuContent>

--- a/src/stores/useStakgraphStore.ts
+++ b/src/stores/useStakgraphStore.ts
@@ -203,28 +203,20 @@ export const useStakgraphStore = create<StakgraphStore>()(
       // Reset previous states
       set({ errors: {}, saved: false });
 
-      // Validation
+      // Validation - only validate fields that are on the VM config page
       const newErrors: Record<string, string> = {};
 
-      if (!state.formData.name.trim()) {
-        newErrors.name = "Name is required";
-      }
-      if (!state.formData.repositoryUrl.trim()) {
-        newErrors.repositoryUrl = "Repository URL is required";
-      } else if (!isValidUrl(state.formData.repositoryUrl.trim())) {
+      // Repository and Swarm settings are now in Settings page
+      // Only validate if they are present (for backward compatibility)
+      if (state.formData.repositoryUrl && !isValidUrl(state.formData.repositoryUrl.trim())) {
         newErrors.repositoryUrl = "Please enter a valid URL";
       }
 
-      if (!state.formData.swarmUrl.trim()) {
-        newErrors.swarmUrl = "Swarm URL is required";
-      } else if (!isValidUrl(state.formData.swarmUrl.trim())) {
+      if (state.formData.swarmUrl && !isValidUrl(state.formData.swarmUrl.trim())) {
         newErrors.swarmUrl = "Please enter a valid URL";
       }
 
-      if (!state.formData.swarmSecretAlias.trim()) {
-        newErrors.swarmSecretAlias = "Swarm API Key is required";
-      }
-
+      // VM-specific validations
       if (!state.formData.poolName.trim()) {
         newErrors.poolName = "Pool Name is required";
       }
@@ -266,11 +258,14 @@ export const useStakgraphStore = create<StakgraphStore>()(
         );
 
         const payload: Partial<StakgraphSettings> = {
-          name: state.formData.name.trim(),
-          description: state.formData.description.trim(),
-          repositoryUrl: state.formData.repositoryUrl.trim(),
-          swarmUrl: state.formData.swarmUrl.trim(),
-          swarmSecretAlias: state.formData.swarmSecretAlias.trim(),
+          // Include name and description if they exist (backward compatibility)
+          ...(state.formData.name && { name: state.formData.name.trim() }),
+          ...(state.formData.description && { description: state.formData.description.trim() }),
+          // Include repository and swarm settings if they exist
+          ...(state.formData.repositoryUrl && { repositoryUrl: state.formData.repositoryUrl.trim() }),
+          ...(state.formData.swarmUrl && { swarmUrl: state.formData.swarmUrl.trim() }),
+          ...(state.formData.swarmSecretAlias && { swarmSecretAlias: state.formData.swarmSecretAlias.trim() }),
+          // VM-specific settings
           poolName: state.formData.poolName.trim(),
           poolCpu: state.formData.poolCpu,
           poolMemory: state.formData.poolMemory,


### PR DESCRIPTION
- Move Project Info, Repository, and Infrastructure sections from VM Config to Settings page
- Add tabbed interface in Settings: General, Repository, Graph DB
- Implement proper API key UI with write-only functionality and key icon toggle
- Simplify VM Configuration page to focus only on environment, services, and files
- Remove GitSee animation and related code from stakgraph page
- Update validation logic to handle optional fields in stakgraph store
- Maintain backward compatibility with existing API endpoints