### PR TITLE
feat: rename VM Configuration to Pool Status

### DIFF
--- a/src/app/w/[slug]/page.tsx
+++ b/src/app/w/[slug]/page.tsx
@@ -6,7 +6,7 @@ import { EmptyState, TaskCard } from "@/components/tasks";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { PageHeader } from "@/components/ui/page-header";
 import { useToast } from "@/components/ui/use-toast";
-import { VMConfigSection } from "@/components/vm-config";
+import { VMConfigSection } from "@/components/pool-status";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { useWorkspaceTasks } from "@/hooks/useWorkspaceTasks";
 import { useSearchParams } from "next/navigation";

--- a/src/app/w/[slug]/settings/page.tsx
+++ b/src/app/w/[slug]/settings/page.tsx
@@ -3,7 +3,7 @@ import { authOptions } from "@/lib/auth/nextauth";
 import { DeleteWorkspace } from "@/components/DeleteWorkspace";
 import { WorkspaceMembers } from "@/components/workspace/WorkspaceMembers";
 import { WorkspaceSettings } from "@/components/WorkspaceSettings";
-import { VMConfigSection } from "@/components/vm-config";
+import { VMConfigSection } from "@/components/pool-status";
 import { PageHeader } from "@/components/ui/page-header";
 import { getWorkspaceBySlug } from "@/services/workspace";
 import { notFound } from "next/navigation";

--- a/src/app/w/[slug]/stakgraph/page.tsx
+++ b/src/app/w/[slug]/stakgraph/page.tsx
@@ -153,13 +153,13 @@ export default function StakgraphPage() {
         </Button>
       </div>
       <PageHeader
-        title="VM Configuration"
-        description="Configure your virtual machine settings for development environment"
+        title="Pool Status"
+        description="Configure your pool settings for development environment"
       />
 
       <Card className="max-w-2xl">
         <CardHeader className="flex flex-row items-center justify-between">
-          <CardTitle>VM Settings</CardTitle>
+          <CardTitle>Pool Settings</CardTitle>
           <div className="flex gap-2">
             {!formData.webhookEnsured && formData.repositoryUrl ? (
               <Button type="button" variant="default" onClick={handleEnsureWebhooks}>

--- a/src/components/pool-status/index.tsx
+++ b/src/components/pool-status/index.tsx
@@ -92,7 +92,7 @@ export function VMConfigSection() {
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <Server className="w-5 h-5" />
-          VM Configuration
+          Pool Status
         </CardTitle>
         <CardDescription>
           {vmState.description}
@@ -133,7 +133,7 @@ export function VMConfigSection() {
                   <Zap className="w-6 h-6" />
                 </div>
                 <div className="flex flex-col">
-                  <span className="text-sm font-medium">Set up VMs</span>
+                  <span className="text-sm font-medium">Set up Pool</span>
                   <span className="text-xs text-muted-foreground">Get started now</span>
                 </div>
               </div>


### PR DESCRIPTION
- Renamed all "VM Configuration" references to "Pool Status"
- Renamed "VM Settings" to "Pool Settings"
- Renamed component directory from vm-config to pool-status
- Updated imports in dashboard and settings pages
- Changed "Set up VMs" to "Set up Pool" in UI

Fixes #871