### PR TITLE
fix: prevent repo URL persistence across workspace creations

### DIFF
--- a/src/app/onboarding/workspace/wizard/wizard-steps/project-name-setup/index.tsx
+++ b/src/app/onboarding/workspace/wizard/wizard-steps/project-name-setup/index.tsx
@@ -143,6 +143,11 @@ export function ProjectNameSetupStep() {
       if (data?.workspace?.slug && data?.workspace?.id) {
         await refreshWorkspaces();
 
+        // Persist repo URL specifically for this workspace so setup can complete after redirect
+        if (repositoryUrlDraft) {
+          localStorage.setItem(`repoUrl:${data.workspace.id}`, repositoryUrlDraft);
+        }
+
         // 2. Check GitHub App status for this workspace/repository
         const statusResponse = await fetch(`/api/github/app/status?workspaceSlug=${data.workspace.slug}&repositoryUrl=${encodeURIComponent(repositoryUrlDraft)}`);
         const statusData = await statusResponse.json();

--- a/src/app/w/[slug]/page.tsx
+++ b/src/app/w/[slug]/page.tsx
@@ -163,7 +163,16 @@ export default function DashboardPage() {
 
     try {
       // Get repository URL from localStorage if available
-      const repositoryUrl = localStorage.getItem("repoUrl");
+      const repoStorageKeys = workspaceId ? [`repoUrl:${workspaceId}`, "repoUrl"] : ["repoUrl"];
+      let repositoryUrl: string | null = null;
+
+      for (const key of repoStorageKeys) {
+        const storedUrl = localStorage.getItem(key);
+        if (storedUrl) {
+          repositoryUrl = storedUrl;
+          break;
+        }
+      }
 
       if (!repositoryUrl) {
         console.error("No repository URL found for setup");
@@ -291,6 +300,9 @@ export default function DashboardPage() {
 
       const servicesData = await servicesRes.json();
       console.log('services', servicesData);
+
+      // Repo URL no longer needed after successful setup; remove cached values
+      repoStorageKeys.forEach((key) => localStorage.removeItem(key));
 
       toast({
         title: "Workspace Setup Complete",


### PR DESCRIPTION
Store repo URL under workspace-specific key to prevent bleeding into future workspace creation flows. Clear cached values after successful setup completion.

Fixes #869