### PR TITLE
test: add foundational test helper utilities

### DIFF
--- a/src/__tests__/helpers/api-assertions.ts
+++ b/src/__tests__/helpers/api-assertions.ts
@@ -1,0 +1,129 @@
+import { expect } from "vitest";
+import type { NextResponse } from "next/server";
+
+/**
+ * Assert that a Response is successful and return parsed JSON data
+ * @param response - NextResponse or Response object
+ * @param expectedStatus - Expected HTTP status code (default: 200)
+ * @returns Parsed JSON data from response
+ */
+export async function expectSuccess<T = any>(
+  response: Response | NextResponse,
+  expectedStatus: number = 200
+): Promise<T> {
+  expect(response.status).toBe(expectedStatus);
+  const data = await response.json();
+  return data as T;
+}
+
+/**
+ * Assert that a Response contains an error with specific message
+ * @param response - NextResponse or Response object
+ * @param expectedError - Expected error message (can be partial match)
+ * @param expectedStatus - Expected HTTP status code (default: 400)
+ */
+export async function expectError(
+  response: Response | NextResponse,
+  expectedError: string | RegExp,
+  expectedStatus: number = 400
+): Promise<void> {
+  expect(response.status).toBe(expectedStatus);
+  const data = await response.json();
+
+  if (typeof expectedError === "string") {
+    expect(data.error).toContain(expectedError);
+  } else {
+    expect(data.error).toMatch(expectedError);
+  }
+}
+
+/**
+ * Assert that a Response contains validation errors for specific fields
+ * @param response - NextResponse or Response object
+ * @param fields - Array of field names that should have validation errors
+ */
+export async function expectValidationError(
+  response: Response | NextResponse,
+  fields?: string[]
+): Promise<void> {
+  expect(response.status).toBe(400);
+  const data = await response.json();
+
+  expect(data.error).toBe("Validation failed");
+
+  if (fields && fields.length > 0) {
+    expect(data.details).toBeDefined();
+    for (const field of fields) {
+      expect(data.details).toContain(field);
+    }
+  }
+}
+
+/**
+ * Assert that a Response is 401 Unauthorized
+ * @param response - NextResponse or Response object
+ */
+export async function expectUnauthorized(
+  response: Response | NextResponse
+): Promise<void> {
+  expect(response.status).toBe(401);
+  const data = await response.json();
+  expect(data.error).toBe("Unauthorized");
+}
+
+/**
+ * Assert that a Response is 403 Forbidden
+ * @param response - NextResponse or Response object
+ * @param expectedMessage - Optional expected error message
+ */
+export async function expectForbidden(
+  response: Response | NextResponse,
+  expectedMessage?: string
+): Promise<void> {
+  expect(response.status).toBe(403);
+  const data = await response.json();
+
+  if (expectedMessage) {
+    expect(data.error).toContain(expectedMessage);
+  } else {
+    expect(data.error).toBeDefined();
+  }
+}
+
+/**
+ * Assert that a Response is 404 Not Found
+ * @param response - NextResponse or Response object
+ * @param expectedMessage - Optional expected error message
+ */
+export async function expectNotFound(
+  response: Response | NextResponse,
+  expectedMessage?: string
+): Promise<void> {
+  expect(response.status).toBe(404);
+  const data = await response.json();
+
+  if (expectedMessage) {
+    expect(data.error).toContain(expectedMessage);
+  } else {
+    expect(data.error).toBeDefined();
+  }
+}
+
+/**
+ * Assert that a Response is 409 Conflict
+ * @param response - NextResponse or Response object
+ * @param expectedMessage - Optional expected error message
+ */
+export async function expectConflict(
+  response: Response | NextResponse,
+  expectedMessage?: string
+): Promise<void> {
+  expect(response.status).toBe(409);
+  const data = await response.json();
+
+  if (expectedMessage) {
+    expect(data.error).toContain(expectedMessage);
+  } else {
+    expect(data.error).toBeDefined();
+  }
+}

--- a/src/__tests__/helpers/auth.ts
+++ b/src/__tests__/helpers/auth.ts
@@ -1,0 +1,48 @@
+import type { User, Workspace } from "@prisma/client";
+import type { Session } from "next-auth";
+import type { WorkspaceRole } from "@/lib/auth/roles";
+
+/**
+ * Create a mock authenticated session for a user
+ * Use this to mock NextAuth's getServerSession in tests
+ */
+export function createAuthenticatedSession(user: Pick<User, "id" | "email">): Session {
+  return {
+    user: {
+      id: user.id,
+      email: user.email,
+    },
+    expires: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(), // 24 hours from now
+  };
+}
+
+/**
+ * Create a mock authenticated session with workspace context
+ * Use this when tests need both user authentication and workspace membership
+ */
+export function createWorkspaceSession(
+  user: Pick<User, "id" | "email">,
+  workspace?: Pick<Workspace, "id" | "slug">,
+  role?: WorkspaceRole
+): Session {
+  const session = createAuthenticatedSession(user);
+
+  if (workspace) {
+    // Add workspace context to session (can be extended as needed)
+    (session as any).workspace = {
+      id: workspace.id,
+      slug: workspace.slug,
+      role: role || "VIEWER",
+    };
+  }
+
+  return session;
+}
+
+/**
+ * Mock an unauthenticated session (returns null)
+ * Use this to test 401 Unauthorized cases
+ */
+export function mockUnauthenticatedSession(): null {
+  return null;
+}

--- a/src/__tests__/helpers/database-assertions.ts
+++ b/src/__tests__/helpers/database-assertions.ts
@@ -1,0 +1,140 @@
+import { expect } from "vitest";
+import { db } from "@/lib/db";
+import type { WorkspaceRole } from "@/lib/auth/roles";
+
+/**
+ * Assert that a workspace exists in the database
+ * @param workspaceId - Workspace ID to check
+ */
+export async function expectWorkspaceExists(workspaceId: string): Promise<void> {
+  const workspace = await db.workspace.findUnique({
+    where: { id: workspaceId },
+  });
+  expect(workspace).toBeTruthy();
+  expect(workspace?.deleted).toBeFalsy();
+}
+
+/**
+ * Assert that a workspace is soft-deleted
+ * @param workspaceId - Workspace ID to check
+ */
+export async function expectWorkspaceDeleted(workspaceId: string): Promise<void> {
+  const workspace = await db.workspace.findUnique({
+    where: { id: workspaceId },
+  });
+  expect(workspace).toBeTruthy();
+  expect(workspace?.deleted).toBe(true);
+  expect(workspace?.deletedAt).toBeTruthy();
+}
+
+/**
+ * Assert that a workspace does not exist in the database
+ * @param workspaceId - Workspace ID to check
+ */
+export async function expectWorkspaceNotExists(workspaceId: string): Promise<void> {
+  const workspace = await db.workspace.findUnique({
+    where: { id: workspaceId },
+  });
+  expect(workspace).toBeNull();
+}
+
+/**
+ * Assert the number of active members in a workspace
+ * @param workspaceId - Workspace ID to check
+ * @param expectedCount - Expected number of active members
+ */
+export async function expectMemberCount(
+  workspaceId: string,
+  expectedCount: number
+): Promise<void> {
+  const members = await db.workspaceMember.findMany({
+    where: { workspaceId, leftAt: null },
+  });
+  expect(members).toHaveLength(expectedCount);
+}
+
+/**
+ * Assert that a user has a specific role in a workspace
+ * @param workspaceId - Workspace ID to check
+ * @param userId - User ID to check
+ * @param expectedRole - Expected workspace role
+ */
+export async function expectMemberRole(
+  workspaceId: string,
+  userId: string,
+  expectedRole: WorkspaceRole
+): Promise<void> {
+  const member = await db.workspaceMember.findFirst({
+    where: { workspaceId, userId, leftAt: null },
+  });
+  expect(member).toBeTruthy();
+  expect(member?.role).toBe(expectedRole);
+}
+
+/**
+ * Assert that a user is not a member of a workspace
+ * @param workspaceId - Workspace ID to check
+ * @param userId - User ID to check
+ */
+export async function expectMemberNotExists(
+  workspaceId: string,
+  userId: string
+): Promise<void> {
+  const member = await db.workspaceMember.findFirst({
+    where: { workspaceId, userId, leftAt: null },
+  });
+  expect(member).toBeNull();
+}
+
+/**
+ * Assert that a user exists in a workspace (regardless of active status)
+ * @param workspaceId - Workspace ID to check
+ * @param userId - User ID to check
+ */
+export async function expectMemberExists(
+  workspaceId: string,
+  userId: string
+): Promise<void> {
+  const member = await db.workspaceMember.findFirst({
+    where: { workspaceId, userId },
+  });
+  expect(member).toBeTruthy();
+}
+
+/**
+ * Assert that a member has left a workspace (leftAt is set)
+ * @param workspaceId - Workspace ID to check
+ * @param userId - User ID to check
+ */
+export async function expectMemberLeft(
+  workspaceId: string,
+  userId: string
+): Promise<void> {
+  const member = await db.workspaceMember.findFirst({
+    where: { workspaceId, userId },
+  });
+  expect(member).toBeTruthy();
+  expect(member?.leftAt).toBeTruthy();
+}
+
+/**
+ * Assert that a user exists in the database
+ * @param userId - User ID to check
+ */
+export async function expectUserExists(userId: string): Promise<void> {
+  const user = await db.user.findUnique({
+    where: { id: userId },
+  });
+  expect(user).toBeTruthy();
+}
+
+/**
+ * Assert that a user does not exist in the database
+ * @param userId - User ID to check
+ */
+export async function expectUserNotExists(userId: string): Promise<void> {
+  const user = await db.user.findUnique({
+    where: { id: userId },
+  });
+  expect(user).toBeNull();
+}

--- a/src/__tests__/helpers/ids.ts
+++ b/src/__tests__/helpers/ids.ts
@@ -1,0 +1,48 @@
+/**
+ * Generate a unique ID using timestamp + random string
+ * This prevents collisions during parallel test execution
+ * @param prefix - Optional prefix for the ID
+ * @returns Unique ID string
+ */
+export function generateUniqueId(prefix?: string): string {
+  const timestamp = Date.now();
+  const random = Math.random().toString(36).substring(2, 15);
+  const uniqueId = `${timestamp}-${random}`;
+  return prefix ? `${prefix}-${uniqueId}` : uniqueId;
+}
+
+/**
+ * Generate a unique slug for workspace/entity testing
+ * @param prefix - Optional prefix for the slug (default: "test")
+ * @returns Unique slug string
+ */
+export function generateUniqueSlug(prefix: string = "test"): string {
+  return `${prefix}-${generateUniqueId()}`;
+}
+
+/**
+ * Generate a unique email address for user testing
+ * @param prefix - Optional prefix for the email (default: "test")
+ * @returns Unique email string
+ */
+export function generateUniqueEmail(prefix: string = "test"): string {
+  return `${prefix}-${generateUniqueId()}@example.com`;
+}
+
+/**
+ * Generate a unique username for testing
+ * @param prefix - Optional prefix for the username (default: "user")
+ * @returns Unique username string
+ */
+export function generateUniqueUsername(prefix: string = "user"): string {
+  return `${prefix}-${generateUniqueId()}`;
+}
+
+/**
+ * Generate a unique name for testing
+ * @param prefix - Optional prefix for the name (default: "Test")
+ * @returns Unique name string
+ */
+export function generateUniqueName(prefix: string = "Test"): string {
+  return `${prefix} ${generateUniqueId()}`;
+}

--- a/src/__tests__/helpers/index.ts
+++ b/src/__tests__/helpers/index.ts
@@ -1,0 +1,11 @@
+// Auth helpers
+export * from "./auth";
+
+// API assertion helpers
+export * from "./api-assertions";
+
+// Database assertion helpers
+export * from "./database-assertions";
+
+// ID generator helpers
+export * from "./ids";


### PR DESCRIPTION
- Add auth helpers for mocking NextAuth sessions
- Add API assertion helpers (expectSuccess, expectError, etc.)
- Add database assertion helpers (expectWorkspaceExists, etc.)
- Add ID generators (generateUniqueSlug, generateUniqueEmail, etc.)
- Create index export for single import point

These utilities reduce test boilerplate and improve consistency across the test suite.