### PR TITLE
Add skeleton loading states to key components

### DIFF
--- a/src/app/w/[slug]/learn/components/LearnSidebar.tsx
+++ b/src/app/w/[slug]/learn/components/LearnSidebar.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import { MessageCircle, Lightbulb, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import type { Learnings } from "@/types/learn";
 
 interface LearnSidebarProps {
@@ -81,7 +82,7 @@ export function LearnSidebar({ workspaceSlug, onPromptClick, currentQuestion }: 
         </div>
         <div className="space-y-2">
           {Array.from({ length: 3 }).map((_, i) => (
-            <div key={i} className="h-8 bg-muted rounded-lg animate-pulse" />
+            <Skeleton key={i} className="h-16 w-full" />
           ))}
         </div>
       </div>

--- a/src/components/WorkspaceSwitcher.tsx
+++ b/src/components/WorkspaceSwitcher.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import type { WorkspaceWithRole } from "@/types/workspace";
 import { Building2, ChevronsUpDown, Plus, Lock } from "lucide-react";
@@ -68,13 +69,10 @@ export function WorkspaceSwitcher({
   if (loading) {
     return (
       <div className="p-4 border-b">
-        <div className="flex items-center gap-3 p-3 border rounded-lg bg-muted/50">
-          <div className="flex items-center justify-center w-8 h-8 rounded-lg bg-muted animate-pulse">
-            <Building2 className="w-4 h-4 text-muted-foreground" />
-          </div>
-          <div className="text-left flex-1">
-            <div className="h-4 bg-muted rounded animate-pulse mb-1"></div>
-            <div className="h-3 bg-muted rounded animate-pulse w-20"></div>
+        <div className="flex items-center gap-3 p-3 border rounded-lg">
+          <Skeleton className="w-8 h-8 rounded-lg" />
+          <div className="text-left flex-1 space-y-1">
+            <Skeleton className="h-4 w-32" />
           </div>
           <ChevronsUpDown className="w-4 h-4 ml-2 opacity-30" />
         </div>

--- a/src/components/dashboard/test-coverage-card/index.tsx
+++ b/src/components/dashboard/test-coverage-card/index.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { TestCoverageData } from "@/types";
-import { Clock, TestTube } from "lucide-react";
+import { TestTube } from "lucide-react";
 import { useEffect, useState } from "react";
 
 export function TestCoverageCard() {
@@ -47,9 +48,19 @@ export function TestCoverageCard() {
       </CardHeader>
       <CardContent>
         {coverageLoading ? (
-          <div className="flex items-center gap-2">
-            <Clock className="w-4 h-4 animate-spin" />
-            <span className="text-sm text-muted-foreground">Loading...</span>
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <Skeleton className="h-3 w-12" />
+              <Skeleton className="h-4 w-10" />
+            </div>
+            <div className="flex items-center justify-between">
+              <Skeleton className="h-3 w-16" />
+              <Skeleton className="h-4 w-10" />
+            </div>
+            <div className="flex items-center justify-between">
+              <Skeleton className="h-3 w-10" />
+              <Skeleton className="h-4 w-10" />
+            </div>
           </div>
         ) : testCoverage?.unit_tests !== null && testCoverage?.integration_tests !== null && testCoverage?.e2e_tests !== null ? (
           <div className="space-y-2">

--- a/src/components/insights/CoverageInsights.tsx
+++ b/src/components/insights/CoverageInsights.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Loader2, SlidersHorizontal } from "lucide-react";
 import { useMemo } from "react";
 import type { CoverageNodeConcise } from "@/types/stakgraph";
@@ -115,16 +116,26 @@ export function CoverageInsights() {
         {loading && !filterLoading ? (
           <div className="space-y-3">
             <div className="rounded-md border overflow-hidden">
-              <div className="p-4 space-y-2">
-                {Array.from({ length: 6 }).map((_, i) => (
-                  <div key={i} className="grid grid-cols-12 gap-4">
-                    <div className="col-span-4 h-4 rounded-md bg-muted animate-pulse" />
-                    <div className="col-span-5 h-4 rounded-md bg-muted animate-pulse" />
-                    <div className="col-span-1 h-4 rounded-md bg-muted animate-pulse" />
-                    <div className="col-span-2 h-4 rounded-md bg-muted animate-pulse" />
-                  </div>
-                ))}
-              </div>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-[35%]">Name</TableHead>
+                    <TableHead className="w-[40%]">File</TableHead>
+                    <TableHead className="w-[10%] text-right">Coverage</TableHead>
+                    <TableHead className="w-[15%] text-right">Status</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {Array.from({ length: 6 }).map((_, i) => (
+                    <TableRow key={i}>
+                      <TableCell><Skeleton className="h-4 w-32" /></TableCell>
+                      <TableCell><Skeleton className="h-4 w-48" /></TableCell>
+                      <TableCell className="text-right"><Skeleton className="h-4 w-8 ml-auto" /></TableCell>
+                      <TableCell className="text-right"><Skeleton className="h-5 w-16 ml-auto" /></TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
             </div>
           </div>
         ) : error ? (

--- a/src/components/insights/TestCoverageCard.tsx
+++ b/src/components/insights/TestCoverageCard.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect, useCallback } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { TestTube, FunctionSquare, Globe, Loader2, Target } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { TestTube, FunctionSquare, Globe, Target } from "lucide-react";
 import { TestCoverageData } from "@/types";
 import { useWorkspace } from "@/hooks/useWorkspace";
 
@@ -69,8 +70,23 @@ export function TestCoverageCard() {
           <CardDescription>Code coverage analysis from your test suite</CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="flex items-center justify-center py-8">
-            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          <div className="space-y-6">
+            {[...Array(3)].map((_, i) => (
+              <div key={i} className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center space-x-2">
+                    <Skeleton className="h-4 w-4" />
+                    <Skeleton className="h-4 w-24" />
+                  </div>
+                  <Skeleton className="h-5 w-12 rounded-full" />
+                </div>
+                <Skeleton className="h-2 w-full rounded-full" />
+                <div className="flex justify-between">
+                  <Skeleton className="h-3 w-16" />
+                  <Skeleton className="h-3 w-16" />
+                </div>
+              </div>
+            ))}
           </div>
         </CardContent>
       </Card>

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-primary/10", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }


### PR DESCRIPTION
- Install shadcn skeleton component
- Add skeleton to dashboard test coverage card
- Add skeleton to workspace switcher loading state
- Add skeleton to learn sidebar loading state
- Add skeleton to insights test coverage card (3 metrics)
- Standardize CoverageInsights table to use skeleton rows

Skeleton is used only for components with predictable data structures that always load content, improving UX by showing the expected layout while loading.