### PR TITLE
Add E2E tests for workspace member management

### DIFF
--- a/src/__tests__/e2e/specs/workspace/workspace-membership.spec.ts
+++ b/src/__tests__/e2e/specs/workspace/workspace-membership.spec.ts
@@ -1,0 +1,66 @@
+import { test } from '@/__tests__/e2e/support/fixtures/test-hooks';
+import { AuthPage, DashboardPage, WorkspaceSettingsPage } from '@/__tests__/e2e/support/page-objects';
+import { createInvitableUser } from '@/__tests__/e2e/support/fixtures/e2e-scenarios';
+import { WorkspaceRole } from '@/lib/auth/roles';
+
+/**
+ * Workspace member management journey tests.
+ * Covers inviting a member, updating their role, and removing them.
+ */
+test.describe('Workspace Member Management', () => {
+  let authPage: AuthPage;
+  let dashboardPage: DashboardPage;
+  let settingsPage: WorkspaceSettingsPage;
+  let workspaceSlug: string;
+  let inviteeUsername: string;
+
+  test.beforeEach(async ({ page }) => {
+    inviteeUsername = `e2e-member-${Date.now()}`;
+    await createInvitableUser({ githubUsername: inviteeUsername });
+
+    authPage = new AuthPage(page);
+    dashboardPage = new DashboardPage(page);
+    settingsPage = new WorkspaceSettingsPage(page);
+
+    await authPage.goto();
+    await authPage.signInWithMock();
+    await dashboardPage.waitForLoad();
+    workspaceSlug = authPage.getCurrentWorkspaceSlug();
+    await settingsPage.goto(workspaceSlug);
+    await settingsPage.waitForLoad();
+  });
+
+  test('owner can invite, update, and remove workspace members', async ({ page }) => {
+    await test.step('invite a new member as PM', async () => {
+      await settingsPage.inviteMember({
+        githubUsername: inviteeUsername,
+        role: WorkspaceRole.PM,
+      });
+
+      await settingsPage.expectMemberVisible(inviteeUsername);
+      await settingsPage.expectMemberRole(inviteeUsername, WorkspaceRole.PM);
+    });
+
+    await test.step('update the member role to Admin', async () => {
+      await settingsPage.changeMemberRole(inviteeUsername, WorkspaceRole.ADMIN);
+      await settingsPage.expectMemberRole(inviteeUsername, WorkspaceRole.ADMIN);
+    });
+
+    await test.step('downgrade the member role to Viewer', async () => {
+      await settingsPage.changeMemberRole(inviteeUsername, WorkspaceRole.VIEWER);
+      await settingsPage.expectMemberRole(inviteeUsername, WorkspaceRole.VIEWER);
+    });
+
+    await test.step('persist member visibility after page reload', async () => {
+      await page.reload();
+      await settingsPage.waitForLoad();
+      await settingsPage.expectMemberVisible(inviteeUsername);
+      await settingsPage.expectMemberRole(inviteeUsername, WorkspaceRole.VIEWER);
+    });
+
+    await test.step('remove the member and verify list updates', async () => {
+      await settingsPage.removeMember(inviteeUsername);
+      await settingsPage.expectMemberAbsent(inviteeUsername);
+    });
+  });
+});

--- a/src/__tests__/e2e/support/fixtures/e2e-scenarios.ts
+++ b/src/__tests__/e2e/support/fixtures/e2e-scenarios.ts
@@ -8,6 +8,8 @@
 import {
   createTestWorkspaceScenario,
   createTestTask,
+  createTestUser,
+  type CreateTestUserOptions,
   type TestWorkspaceScenarioResult,
 } from "./database";
 
@@ -87,5 +89,15 @@ export async function createWorkspaceWithMembersScenario() {
       { role: "DEVELOPER", withGitHubAuth: true, githubUsername: "e2e-dev" },
       { role: "VIEWER", withGitHubAuth: true, githubUsername: "e2e-viewer" },
     ],
+  });
+}
+
+/**
+ * Create a Hive user with GitHub auth for invitation flows.
+ */
+export async function createInvitableUser(options: Partial<CreateTestUserOptions> = {}) {
+  return createTestUser({
+    withGitHubAuth: true,
+    ...options,
   });
 }

--- a/src/__tests__/e2e/support/fixtures/selectors.ts
+++ b/src/__tests__/e2e/support/fixtures/selectors.ts
@@ -46,6 +46,40 @@ export const selectors = {
     createButton: 'button:has-text("Create")',
   },
 
+  workspaceMembers: {
+    card: '[data-testid="workspace-members-card"]',
+    addButton: '[data-testid="add-member-button"]',
+    emptyState: '[data-testid="members-empty-state"]',
+    ownerRow: '[data-testid="workspace-owner-row"]',
+    memberRow: '[data-testid="workspace-member-row"]',
+    roleBadge: '[data-testid="member-role-badge"]',
+    actionsButton: '[data-testid="member-actions-button"]',
+    actionMakeAdmin: '[data-testid="member-action-make-admin"]',
+    actionMakePM: '[data-testid="member-action-make-pm"]',
+    actionMakeDeveloper: '[data-testid="member-action-make-developer"]',
+    actionMakeViewer: '[data-testid="member-action-make-viewer"]',
+    actionRemove: '[data-testid="member-action-remove"]',
+  },
+
+  addMemberModal: {
+    modal: '[data-testid="add-member-modal"]',
+    form: '[data-testid="add-member-form"]',
+    githubInput: '[data-testid="add-member-github-input"]',
+    roleTrigger: '[data-testid="add-member-role-trigger"]',
+    roleOptionViewer: '[data-testid="role-option-viewer"]',
+    roleOptionDeveloper: '[data-testid="role-option-developer"]',
+    roleOptionPm: '[data-testid="role-option-pm"]',
+    roleOptionAdmin: '[data-testid="role-option-admin"]',
+    submit: '[data-testid="add-member-submit"]',
+    cancel: '[data-testid="add-member-cancel"]',
+  },
+
+  dialogs: {
+    confirm: '[data-testid="remove-member-dialog"]',
+    confirmButton: '[data-testid="remove-member-dialog-confirm"]',
+    cancelButton: '[data-testid="remove-member-dialog-cancel"]',
+  },
+
   // Tasks
   tasks: {
     newTaskButton: 'button:has-text("New Task")',
@@ -135,4 +169,10 @@ export const dynamicSelectors = {
    */
   linkByText: (text: string) =>
     `a:has-text("${text}")`,
+
+  workspaceMemberRowByUsername: (username: string) =>
+    `[data-testid="workspace-member-row"][data-member-username="${username}"]`,
+
+  workspaceMemberRoleBadgeByUsername: (username: string) =>
+    `[data-testid="workspace-member-row"][data-member-username="${username}"] [data-testid="member-role-badge"]`,
 };

--- a/src/__tests__/e2e/support/fixtures/workspace.ts
+++ b/src/__tests__/e2e/support/fixtures/workspace.ts
@@ -1,17 +1,17 @@
 import { Page, expect } from '@playwright/test';
+import { selectors } from './selectors';
 
 /**
  * Navigate to workspace settings page
  */
 export async function navigateToSettings(page: Page): Promise<void> {
-  const settingsButton = page.locator('button:has-text("Settings")');
+  const settingsButton = page.locator(selectors.navigation.settingsButton);
   await settingsButton.waitFor({ state: 'visible' });
   await settingsButton.click();
 
   // Verify we've landed on the settings page
-  const pageTitle = page.locator('h1.text-3xl.font-bold.text-foreground');
+  const pageTitle = page.locator(selectors.pageTitle.settings);
   await expect(pageTitle).toBeVisible();
-  await expect(pageTitle).toContainText('Workspace Settings');
 }
 
 /**
@@ -21,7 +21,7 @@ export async function navigateToTasks(page: Page, workspaceSlug: string): Promis
   await page.goto(`http://localhost:3000/w/${workspaceSlug}/tasks`);
 
   // Wait for tasks page to load
-  const pageTitle = page.locator('h1:has-text("Tasks")');
+  const pageTitle = page.locator(selectors.pageTitle.tasks);
   await expect(pageTitle).toBeVisible({ timeout: 10000 });
 }
 
@@ -32,7 +32,7 @@ export async function navigateToInsights(page: Page, workspaceSlug: string): Pro
   await page.goto(`http://localhost:3000/w/${workspaceSlug}/insights`);
 
   // Wait for insights page to load
-  const pageTitle = page.locator('h1:has-text("Insights")');
+  const pageTitle = page.locator(selectors.pageTitle.insights);
   await expect(pageTitle).toBeVisible({ timeout: 10000 });
 }
 
@@ -43,7 +43,7 @@ export async function navigateToDashboard(page: Page, workspaceSlug: string): Pr
   await page.goto(`http://localhost:3000/w/${workspaceSlug}`);
 
   // Wait for dashboard to load
-  const pageTitle = page.locator('h1:has-text("Dashboard")');
+  const pageTitle = page.locator(selectors.pageTitle.dashboard);
   await expect(pageTitle).toBeVisible({ timeout: 10000 });
 }
 

--- a/src/__tests__/e2e/support/page-objects/WorkspaceSettingsPage.ts
+++ b/src/__tests__/e2e/support/page-objects/WorkspaceSettingsPage.ts
@@ -1,0 +1,106 @@
+import { Page, expect } from '@playwright/test';
+import { selectors, dynamicSelectors } from '../fixtures/selectors';
+import { WorkspaceRole } from '@/lib/auth/roles';
+
+const roleSelectors: Record<WorkspaceRole, string | undefined> = {
+  OWNER: undefined,
+  ADMIN: selectors.addMemberModal.roleOptionAdmin,
+  PM: selectors.addMemberModal.roleOptionPm,
+  DEVELOPER: selectors.addMemberModal.roleOptionDeveloper,
+  STAKEHOLDER: undefined,
+  VIEWER: selectors.addMemberModal.roleOptionViewer,
+};
+
+/**
+ * Page Object Model for workspace settings and membership management.
+ */
+export class WorkspaceSettingsPage {
+  constructor(private page: Page) {}
+
+  async goto(workspaceSlug: string): Promise<void> {
+    await this.page.goto(`http://localhost:3000/w/${workspaceSlug}/settings`);
+    await this.waitForLoad();
+  }
+
+  async waitForLoad(): Promise<void> {
+    await expect(this.page.locator(selectors.pageTitle.settings)).toBeVisible({ timeout: 10000 });
+  }
+
+  async openAddMemberModal(): Promise<void> {
+    await this.page.locator(selectors.workspaceMembers.addButton).click();
+    await expect(this.page.locator(selectors.addMemberModal.modal)).toBeVisible({ timeout: 10000 });
+  }
+
+  async inviteMember(options: { githubUsername: string; role?: WorkspaceRole }): Promise<void> {
+    const { githubUsername, role = WorkspaceRole.DEVELOPER } = options;
+
+    const modal = this.page.locator(selectors.addMemberModal.modal);
+    if (!(await modal.isVisible())) {
+      await this.openAddMemberModal();
+    }
+
+    await modal.locator(selectors.addMemberModal.githubInput).fill(githubUsername);
+
+    const roleSelector = roleSelectors[role];
+    if (roleSelector && role !== WorkspaceRole.DEVELOPER) {
+      await modal.locator(selectors.addMemberModal.roleTrigger).click();
+      await this.page.locator(roleSelector).click();
+    }
+
+    await modal.locator(selectors.addMemberModal.submit).click();
+    await expect(modal).toBeHidden({ timeout: 10000 });
+  }
+
+  async expectMemberVisible(username: string): Promise<void> {
+    const memberRow = this.page.locator(dynamicSelectors.workspaceMemberRowByUsername(username));
+    await expect(memberRow).toBeVisible({ timeout: 10000 });
+  }
+
+  async expectMemberRole(username: string, role: WorkspaceRole): Promise<void> {
+    const roleBadge = this.page.locator(dynamicSelectors.workspaceMemberRoleBadgeByUsername(username));
+    await expect(roleBadge).toHaveText(role, { timeout: 10000 });
+  }
+
+  async changeMemberRole(username: string, role: WorkspaceRole): Promise<void> {
+    const action = this.getRoleActionSelector(role);
+    if (!action) {
+      throw new Error(`Role ${role} is not supported by the UI`);
+    }
+
+    const row = this.page.locator(dynamicSelectors.workspaceMemberRowByUsername(username));
+    await row.locator(selectors.workspaceMembers.actionsButton).click();
+    await this.page.locator(action).click();
+    await this.expectMemberRole(username, role);
+  }
+
+  async removeMember(username: string): Promise<void> {
+    const row = this.page.locator(dynamicSelectors.workspaceMemberRowByUsername(username));
+    await row.locator(selectors.workspaceMembers.actionsButton).click();
+    await this.page.locator(selectors.workspaceMembers.actionRemove).click();
+
+    const dialog = this.page.locator(selectors.dialogs.confirm);
+    await expect(dialog).toBeVisible({ timeout: 10000 });
+    await this.page.locator(selectors.dialogs.confirmButton).click();
+    await expect(row).toHaveCount(0, { timeout: 10000 });
+  }
+
+  async expectMemberAbsent(username: string): Promise<void> {
+    const row = this.page.locator(dynamicSelectors.workspaceMemberRowByUsername(username));
+    await expect(row).toHaveCount(0, { timeout: 10000 });
+  }
+
+  private getRoleActionSelector(role: WorkspaceRole): string | undefined {
+    switch (role) {
+      case WorkspaceRole.ADMIN:
+        return selectors.workspaceMembers.actionMakeAdmin;
+      case WorkspaceRole.PM:
+        return selectors.workspaceMembers.actionMakePM;
+      case WorkspaceRole.DEVELOPER:
+        return selectors.workspaceMembers.actionMakeDeveloper;
+      case WorkspaceRole.VIEWER:
+        return selectors.workspaceMembers.actionMakeViewer;
+      default:
+        return undefined;
+    }
+  }
+}

--- a/src/__tests__/e2e/support/page-objects/index.ts
+++ b/src/__tests__/e2e/support/page-objects/index.ts
@@ -6,3 +6,4 @@
 export { AuthPage } from './AuthPage';
 export { DashboardPage } from './DashboardPage';
 export { TasksPage } from './TasksPage';
+export { WorkspaceSettingsPage } from './WorkspaceSettingsPage';

--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -20,6 +20,7 @@ interface ConfirmDialogProps {
   cancelText?: string;
   variant?: "default" | "destructive";
   onConfirm: () => void;
+  testId?: string;
 }
 
 export function ConfirmDialog({
@@ -31,6 +32,7 @@ export function ConfirmDialog({
   cancelText = "Cancel",
   variant = "default",
   onConfirm,
+  testId,
 }: ConfirmDialogProps) {
   const handleConfirm = () => {
     onConfirm();
@@ -39,13 +41,16 @@ export function ConfirmDialog({
 
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
-      <AlertDialogContent>
+      <AlertDialogContent data-testid={testId}>
         <AlertDialogHeader>
           <AlertDialogTitle>{title}</AlertDialogTitle>
           <AlertDialogDescription>{description}</AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel onClick={() => onOpenChange(false)}>
+          <AlertDialogCancel
+            onClick={() => onOpenChange(false)}
+            data-testid={testId ? `${testId}-cancel` : undefined}
+          >
             {cancelText}
           </AlertDialogCancel>
           <AlertDialogAction
@@ -55,6 +60,7 @@ export function ConfirmDialog({
                 ? "bg-destructive text-destructive-foreground hover:bg-destructive/90"
                 : undefined
             }
+            data-testid={testId ? `${testId}-confirm` : undefined}
           >
             {confirmText}
           </AlertDialogAction>

--- a/src/components/workspace/AddMemberModal.tsx
+++ b/src/components/workspace/AddMemberModal.tsx
@@ -158,7 +158,7 @@ export function AddMemberModal({ open, onOpenChange, workspaceSlug, onMemberAdde
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="sm:max-w-md" data-testid="add-member-modal">
         <DialogHeader>
           <DialogTitle>Add Member</DialogTitle>
           <DialogDescription>
@@ -167,7 +167,11 @@ export function AddMemberModal({ open, onOpenChange, workspaceSlug, onMemberAdde
         </DialogHeader>
 
         <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <form
+            onSubmit={form.handleSubmit(onSubmit)}
+            className="space-y-4"
+            data-testid="add-member-form"
+          >
             <FormField
               control={form.control}
               name="githubUsername"
@@ -187,6 +191,7 @@ export function AddMemberModal({ open, onOpenChange, workspaceSlug, onMemberAdde
                           field.onChange(e.target.value);
                           setSelectedUser(null);
                         }}
+                        data-testid="add-member-github-input"
                       />
                     </div>
                   </FormControl>
@@ -274,15 +279,35 @@ export function AddMemberModal({ open, onOpenChange, workspaceSlug, onMemberAdde
                   <FormLabel>Role</FormLabel>
                   <Select onValueChange={field.onChange} defaultValue={field.value}>
                     <FormControl>
-                      <SelectTrigger>
+                      <SelectTrigger data-testid="add-member-role-trigger">
                         <SelectValue placeholder="Select a role" />
                       </SelectTrigger>
                     </FormControl>
                     <SelectContent>
-                      <SelectItem value={WorkspaceRole.VIEWER}>{RoleLabels[WorkspaceRole.VIEWER]}</SelectItem>
-                      <SelectItem value={WorkspaceRole.DEVELOPER}>{RoleLabels[WorkspaceRole.DEVELOPER]}</SelectItem>
-                      <SelectItem value={WorkspaceRole.PM}>{RoleLabels[WorkspaceRole.PM]}</SelectItem>
-                      <SelectItem value={WorkspaceRole.ADMIN}>{RoleLabels[WorkspaceRole.ADMIN]}</SelectItem>
+                      <SelectItem
+                        value={WorkspaceRole.VIEWER}
+                        data-testid="role-option-viewer"
+                      >
+                        {RoleLabels[WorkspaceRole.VIEWER]}
+                      </SelectItem>
+                      <SelectItem
+                        value={WorkspaceRole.DEVELOPER}
+                        data-testid="role-option-developer"
+                      >
+                        {RoleLabels[WorkspaceRole.DEVELOPER]}
+                      </SelectItem>
+                      <SelectItem
+                        value={WorkspaceRole.PM}
+                        data-testid="role-option-pm"
+                      >
+                        {RoleLabels[WorkspaceRole.PM]}
+                      </SelectItem>
+                      <SelectItem
+                        value={WorkspaceRole.ADMIN}
+                        data-testid="role-option-admin"
+                      >
+                        {RoleLabels[WorkspaceRole.ADMIN]}
+                      </SelectItem>
                     </SelectContent>
                   </Select>
                   <FormDescription>
@@ -300,12 +325,18 @@ export function AddMemberModal({ open, onOpenChange, workspaceSlug, onMemberAdde
             )}
 
             <div className="flex justify-end space-x-2">
-              <Button type="button" variant="outline" onClick={handleClose}>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleClose}
+                data-testid="add-member-cancel"
+              >
                 Cancel
               </Button>
               <Button 
                 type="submit" 
                 disabled={isSubmitting || !form.watch("githubUsername")}
+                data-testid="add-member-submit"
               >
                 {isSubmitting ? "Adding..." : "Add Member"}
               </Button>

--- a/src/components/workspace/WorkspaceMembers.tsx
+++ b/src/components/workspace/WorkspaceMembers.tsx
@@ -134,7 +134,7 @@ export function WorkspaceMembers({ canAdmin }: WorkspaceMembersProps) {
 
   return (
     <>
-      <Card>
+      <Card data-testid="workspace-members-card">
         <CardHeader>
           <div className="flex items-center justify-between">
             <div>
@@ -147,7 +147,7 @@ export function WorkspaceMembers({ canAdmin }: WorkspaceMembersProps) {
               </CardDescription>
             </div>
             {canAdmin && (
-              <Button onClick={() => setShowAddModal(true)}>
+              <Button onClick={() => setShowAddModal(true)} data-testid="add-member-button">
                 <Plus className="w-4 h-4 mr-2" />
                 Add Member
               </Button>
@@ -169,14 +169,22 @@ export function WorkspaceMembers({ canAdmin }: WorkspaceMembersProps) {
               ))}
             </div>
           ) : (members.length === 0 && !owner) ? (
-            <div className="text-center py-6 text-muted-foreground">
+            <div
+              className="text-center py-6 text-muted-foreground"
+              data-testid="members-empty-state"
+            >
               No members found
             </div>
           ) : (
             <div className="space-y-3">
               {/* Render owner first if present */}
               {owner && (
-                <div key={`owner-${owner.id}`} className="flex items-center justify-between p-3 rounded-lg border bg-muted/30">
+                <div
+                  key={`owner-${owner.id}`}
+                  className="flex items-center justify-between p-3 rounded-lg border bg-muted/30"
+                  data-testid="workspace-owner-row"
+                  data-owner-id={owner.userId}
+                >
                   <div className="flex items-center space-x-3">
                     <Avatar className="w-10 h-10">
                       <AvatarImage 
@@ -213,7 +221,13 @@ export function WorkspaceMembers({ canAdmin }: WorkspaceMembersProps) {
               
               {/* Render regular members */}
               {members.map((member) => (
-                <div key={member.id} className="flex items-center justify-between p-3 rounded-lg border">
+                <div
+                  key={member.id}
+                  className="flex items-center justify-between p-3 rounded-lg border"
+                  data-testid="workspace-member-row"
+                  data-member-id={member.userId}
+                  data-member-username={member.user.github?.username || member.user.email || ""}
+                >
                   <div className="flex items-center space-x-3">
                     <Avatar className="w-10 h-10">
                       <AvatarImage 
@@ -241,34 +255,53 @@ export function WorkspaceMembers({ canAdmin }: WorkspaceMembersProps) {
                     </div>
                   </div>
                   <div className="flex items-center gap-2">
-                    <Badge variant={getRoleBadgeVariant(member.role)}>
+                    <Badge
+                      variant={getRoleBadgeVariant(member.role)}
+                      data-testid="member-role-badge"
+                    >
                       {member.role}
                     </Badge>
                     {canAdmin && (
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild>
-                          <Button variant="ghost" size="sm">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            data-testid="member-actions-button"
+                          >
                             <MoreHorizontal className="w-4 h-4" />
                           </Button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
                           {member.role !== "ADMIN" && (
-                            <DropdownMenuItem onClick={() => handleUpdateRole(member.userId, "ADMIN")}>
+                            <DropdownMenuItem
+                              onClick={() => handleUpdateRole(member.userId, "ADMIN")}
+                              data-testid="member-action-make-admin"
+                            >
                               Make Admin
                             </DropdownMenuItem>
                           )}
                           {member.role !== "PM" && (
-                            <DropdownMenuItem onClick={() => handleUpdateRole(member.userId, "PM")}>
+                            <DropdownMenuItem
+                              onClick={() => handleUpdateRole(member.userId, "PM")}
+                              data-testid="member-action-make-pm"
+                            >
                               Make PM
                             </DropdownMenuItem>
                           )}
                           {member.role !== "DEVELOPER" && (
-                            <DropdownMenuItem onClick={() => handleUpdateRole(member.userId, "DEVELOPER")}>
+                            <DropdownMenuItem
+                              onClick={() => handleUpdateRole(member.userId, "DEVELOPER")}
+                              data-testid="member-action-make-developer"
+                            >
                               Make Developer
                             </DropdownMenuItem>
                           )}
                           {member.role !== "VIEWER" && (
-                            <DropdownMenuItem onClick={() => handleUpdateRole(member.userId, "VIEWER")}>
+                            <DropdownMenuItem
+                              onClick={() => handleUpdateRole(member.userId, "VIEWER")}
+                              data-testid="member-action-make-viewer"
+                            >
                               Make Viewer
                             </DropdownMenuItem>
                           )}
@@ -278,6 +311,7 @@ export function WorkspaceMembers({ canAdmin }: WorkspaceMembersProps) {
                               member.user.name || member.user.github?.username || "this member"
                             )}
                             className="text-destructive"
+                            data-testid="member-action-remove"
                           >
                             <Trash2 className="w-4 h-4 mr-2" />
                             Remove
@@ -311,6 +345,7 @@ export function WorkspaceMembers({ canAdmin }: WorkspaceMembersProps) {
         cancelText="Cancel"
         variant="destructive"
         onConfirm={confirmRemoveMember}
+        testId="remove-member-dialog"
       />
     </>
   );


### PR DESCRIPTION
Implements comprehensive E2E test coverage for the complete workspace member lifecycle including invite, role updates, persistence verification, and removal.

- Add WorkspaceSettingsPage Page Object with member management methods
- Add workspace membership E2E spec with multi-step user journey test
- Add data-testid attributes to workspace member components for reliable selection
- Add createInvitableUser scenario helper for test data setup
- Extend selectors.ts with workspace members and modal selectors
- Add confirm-dialog data-testid for removal confirmation