### PR TITLE
Improve pool status display clarity

### DIFF
--- a/src/components/pool-status/index.tsx
+++ b/src/components/pool-status/index.tsx
@@ -101,24 +101,35 @@ export function VMConfigSection() {
               <Skeleton className="h-4 w-32" />
             </div>
           ) : poolStatus ? (
-            <div className="flex flex-col gap-1">
+            <div className="flex flex-col gap-2">
               <div className="flex items-center gap-2 text-sm font-medium">
-                <span className={poolStatus.status.runningVms > 0 ? "text-green-600" : "text-muted-foreground"}>
-                  {poolStatus.status.runningVms} running
+                <span className="text-green-600">
+                  {poolStatus.status.usedVms} in use
                 </span>
                 <span className="text-muted-foreground">•</span>
-                <span className={poolStatus.status.pendingVms > 0 ? "text-orange-600" : "text-muted-foreground"}>
-                  {poolStatus.status.pendingVms} pending
+                <span className="text-muted-foreground">
+                  {poolStatus.status.unusedVms} available
                 </span>
-                {poolStatus.status.failedVms > 0 && (
-                  <>
-                    <span className="text-muted-foreground">•</span>
+              </div>
+
+              {(poolStatus.status.pendingVms > 0 || poolStatus.status.failedVms > 0) && (
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  {poolStatus.status.pendingVms > 0 && (
+                    <>
+                      <span className="text-orange-600">
+                        {poolStatus.status.pendingVms} pending
+                      </span>
+                      {poolStatus.status.failedVms > 0 && <span>•</span>}
+                    </>
+                  )}
+                  {poolStatus.status.failedVms > 0 && (
                     <span className="text-red-600">
                       {poolStatus.status.failedVms} failed
                     </span>
-                  </>
-                )}
-              </div>
+                  )}
+                </div>
+              )}
+
               {poolStatus.status.lastCheck && (
                 <div className="text-xs text-muted-foreground">
                   Updated {formatRelativeTime(poolStatus.status.lastCheck.endsWith('Z')

--- a/src/services/pool-manager/PoolManagerService.ts
+++ b/src/services/pool-manager/PoolManagerService.ts
@@ -102,6 +102,8 @@ export class PoolManagerService extends BaseServiceClass implements IPoolManager
           runningVms: data.status.running_vms,
           pendingVms: data.status.pending_vms,
           failedVms: data.status.failed_vms,
+          usedVms: data.status.used_vms,
+          unusedVms: data.status.unused_vms,
           lastCheck: data.status.last_check,
         },
       };

--- a/src/types/pool-manager.ts
+++ b/src/types/pool-manager.ts
@@ -124,6 +124,8 @@ export interface PoolStatus {
   runningVms: number;
   pendingVms: number;
   failedVms: number;
+  usedVms: number;
+  unusedVms: number;
   lastCheck: string;
 }
 


### PR DESCRIPTION
Replace redundant "running" metric with "in use" and "available" breakdown. Move pending/failed to separate line with muted styling when present.

Changes:
- Primary line: "{n} in use" (green) • "{n} available" (muted)
- Secondary line: "{n} pending" (orange) • "{n} failed" (red) - only shown if > 0
- Remove "running" count (redundant: running = used + unused)