### PR TITLE
fix: use workspace owner relation instead of WorkspaceMember query

### DIFF
--- a/src/services/task-coordinator-cron.ts
+++ b/src/services/task-coordinator-cron.ts
@@ -35,7 +35,14 @@ export async function executeTaskCoordinatorRuns(): Promise<TaskCoordinatorExecu
       },
       include: {
         janitorConfig: true,
-        swarm: true
+        swarm: true,
+        owner: {
+          select: {
+            id: true,
+            name: true,
+            email: true
+          }
+        }
       }
     });
 
@@ -111,26 +118,10 @@ export async function executeTaskCoordinatorRuns(): Promise<TaskCoordinatorExecu
             // Use the existing acceptJanitorRecommendation service
             const { acceptJanitorRecommendation } = await import("@/services/janitor");
 
-            // Get the workspace owner to use as the accepting user
-            const workspaceOwner = await db.workspaceMember.findFirst({
-              where: {
-                workspaceId: workspace.id,
-                role: "OWNER"
-              },
-              include: {
-                user: true
-              }
-            });
-
-            if (!workspaceOwner) {
-              console.error(`[TaskCoordinator] No owner found for workspace ${workspace.slug}, skipping recommendation ${recommendation.id}`);
-              continue;
-            }
-
             // Accept the recommendation - this will create a task with sourceType: JANITOR
             await acceptJanitorRecommendation(
               recommendation.id,
-              workspaceOwner.userId, // Use workspace owner as the accepting user
+              workspace.owner.id, // Use workspace owner as the accepting user
               {} // No specific assignee or repository
             );
 


### PR DESCRIPTION
The Task Coordinator was querying WorkspaceMember table for role OWNER, but workspace owners are tracked via workspace.ownerId field, not as WorkspaceMember records. This caused all auto-accept operations to fail with 'No owner found for workspace' error.

Changes:
- Include owner relation in initial workspace query for efficiency
- Use workspace.owner.id directly instead of separate DB lookup
- Aligns with existing architecture patterns in getWorkspaceBySlug