### PR TITLE
fix: update metric-display color thresholds to match reverted values

### DIFF
--- a/src/components/ui/metric-display.tsx
+++ b/src/components/ui/metric-display.tsx
@@ -11,14 +11,14 @@ interface MetricDisplayProps {
 
 export function MetricDisplay({ label, percent, covered, total, icon }: MetricDisplayProps) {
   const getPercentageColor = (percent: number) => {
-    if (percent >= 20) return "text-green-600 border-green-200 bg-green-50";
-    if (percent >= 10) return "text-yellow-600 border-yellow-200 bg-yellow-50";
+    if (percent >= 70) return "text-green-600 border-green-200 bg-green-50";
+    if (percent >= 15) return "text-yellow-600 border-yellow-200 bg-yellow-50";
     return "text-red-600 border-red-200 bg-red-50";
   };
 
   const getProgressColor = (percent: number) => {
-    if (percent >= 20) return "bg-green-500";
-    if (percent >= 10) return "bg-yellow-500";
+    if (percent >= 70) return "bg-green-500";
+    if (percent >= 15) return "bg-yellow-500";
     return "bg-red-500";
   };
 


### PR DESCRIPTION
The MetricDisplay component still had the old thresholds (20%/10%) while TestCoverageCard was reverted to (70%/15%). This caused 21% coverage to show as green instead of orange.

Updated MetricDisplay thresholds to:
- Green: >= 70%
- Orange: >= 15%
- Red: < 15%