### PR TITLE
Add toast notifications for all recorded actions

### DIFF
--- a/public/js/playwright-generator.js
+++ b/public/js/playwright-generator.js
@@ -1,414 +1,462 @@
-// src/playwright-generator.ts
-function convertToPlaywrightSelector(clickDetail) {
-  const { selectors } = clickDetail;
-  if (selectors.primary.includes("[data-testid=")) {
-    return selectors.primary;
-  }
-  if (selectors.primary.startsWith("#")) {
-    return selectors.primary;
-  }
-  if (selectors.text && (selectors.tagName === "button" || selectors.tagName === "a" || selectors.role === "button")) {
-    const cleanText = selectors.text.trim();
-    if (cleanText.length > 0 && cleanText.length <= 50) {
-      if (selectors.tagName === "button") {
-        return `button:has-text("${escapeTextForAssertion(cleanText)}")`;
+"use strict";
+(() => {
+  var __defProp = Object.defineProperty;
+  var __defProps = Object.defineProperties;
+  var __getOwnPropDescs = Object.getOwnPropertyDescriptors;
+  var __getOwnPropSymbols = Object.getOwnPropertySymbols;
+  var __hasOwnProp = Object.prototype.hasOwnProperty;
+  var __propIsEnum = Object.prototype.propertyIsEnumerable;
+  var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+  var __spreadValues = (a, b) => {
+    for (var prop in b || (b = {}))
+      if (__hasOwnProp.call(b, prop))
+        __defNormalProp(a, prop, b[prop]);
+    if (__getOwnPropSymbols)
+      for (var prop of __getOwnPropSymbols(b)) {
+        if (__propIsEnum.call(b, prop))
+          __defNormalProp(a, prop, b[prop]);
       }
-      if (selectors.tagName === "a") {
-        return `a:has-text("${escapeTextForAssertion(cleanText)}")`;
-      }
-      if (selectors.role === "button") {
-        return `[role="button"]:has-text("${escapeTextForAssertion(cleanText)}")`;
-      }
-    }
-  }
-  if (selectors.ariaLabel) {
-    return `[aria-label="${escapeTextForAssertion(selectors.ariaLabel)}"]`;
-  }
-  for (const fallback of selectors.fallbacks) {
-    if (isValidCSSSelector(fallback)) {
-      return fallback;
-    }
-  }
-  if (isValidCSSSelector(selectors.primary)) {
-    return selectors.primary;
-  }
-  if (selectors.role) {
-    return `[role="${selectors.role}"]`;
-  }
-  if (selectors.tagName === "input") {
-    const type = clickDetail.elementInfo.attributes.type;
-    const name = clickDetail.elementInfo.attributes.name;
-    if (type)
-      return `input[type="${type}"]`;
-    if (name)
-      return `input[name="${name}"]`;
-  }
-  if (selectors.xpath) {
-    return `xpath=${selectors.xpath}`;
-  }
-  return selectors.tagName;
-}
-function isValidCSSSelector(selector) {
-  if (!selector || selector.trim() === "")
-    return false;
-  try {
-    if (typeof document !== "undefined") {
-      document.querySelector(selector);
-    }
-    return true;
-  } catch (e) {
-    return false;
-  }
-}
-function generatePlaywrightTest(url, trackingData) {
-  var _a;
-  if (!trackingData)
-    return generateEmptyTest(url);
-  const { clicks, inputChanges, assertions, userInfo, formElementChanges } = trackingData;
-  if (!((_a = clicks == null ? void 0 : clicks.clickDetails) == null ? void 0 : _a.length) && !(inputChanges == null ? void 0 : inputChanges.length) && !(assertions == null ? void 0 : assertions.length) && !(formElementChanges == null ? void 0 : formElementChanges.length)) {
-    return generateEmptyTest(url);
-  }
-  return `import { test, expect } from '@playwright/test';
-    
-  test('User interaction replay', async ({ page }) => {
-    // Navigate to the page
-    await page.goto('${url}');
-    
-    // Wait for page to load
-    await page.waitForLoadState('networkidle');
-    
-    // Set viewport size to match recorded session
-    await page.setViewportSize({ 
-      width: ${userInfo.windowSize[0]}, 
-      height: ${userInfo.windowSize[1]} 
-    });
-  
-  ${generateUserInteractions(
-    clicks,
-    inputChanges,
-    trackingData.focusChanges,
-    assertions,
-    formElementChanges
-  )}
-  
-    await page.waitForTimeout(432);
-  });`;
-}
-function generateEmptyTest(url) {
-  return `import { test, expect } from '@playwright/test';
-  
-  test('Empty test template', async ({ page }) => {
-    // Navigate to the page
-    await page.goto('${url}');
-    
-    // Wait for page to load
-    await page.waitForLoadState('networkidle');
-    
-    // No interactions were recorded
-    console.log('No user interactions to replay');
-  });`;
-}
-function generateUserInteractions(clicks, inputChanges, focusChanges, assertions = [], formElementChanges = []) {
-  var _a;
-  const allEvents = [];
-  const processedSelectors = /* @__PURE__ */ new Set();
-  const formElementTimestamps = {};
-  if (formElementChanges == null ? void 0 : formElementChanges.length) {
-    const formElementsBySelector = {};
-    formElementChanges.forEach((change) => {
-      const selector = change.elementSelector;
-      if (!formElementsBySelector[selector]) {
-        formElementsBySelector[selector] = [];
-      }
-      formElementsBySelector[selector].push(change);
-    });
-    Object.entries(formElementsBySelector).forEach(([selector, changes]) => {
-      changes.sort((a, b) => a.timestamp - b.timestamp);
-      if (changes[0].type === "checkbox" || changes[0].type === "radio") {
-        const latestChange = changes[changes.length - 1];
-        allEvents.push({
-          type: "form",
-          formType: latestChange.type,
-          selector: latestChange.elementSelector,
-          value: latestChange.value,
-          checked: latestChange.checked,
-          timestamp: latestChange.timestamp,
-          isUserAction: true
-        });
-        formElementTimestamps[selector] = latestChange.timestamp;
-      } else if (changes[0].type === "select") {
-        let lastValue = null;
-        changes.forEach((change) => {
-          if (change.value !== lastValue) {
-            allEvents.push({
-              type: "form",
-              formType: change.type,
-              selector: change.elementSelector,
-              value: change.value,
-              text: change.text,
-              timestamp: change.timestamp,
-              isUserAction: true
-            });
-            formElementTimestamps[selector] = change.timestamp;
-            lastValue = change.value;
-          }
-        });
-      }
-      processedSelectors.add(selector);
-    });
-  }
-  if ((_a = clicks == null ? void 0 : clicks.clickDetails) == null ? void 0 : _a.length) {
-    clicks.clickDetails.forEach((clickDetail) => {
-      const selector = convertToPlaywrightSelector(clickDetail);
-      if (!selector || selector.trim() === "") {
-        console.warn(
-          `Skipping click with invalid selector for element: ${clickDetail.selectors.tagName}`
-        );
-        return;
-      }
-      const shouldSkip = processedSelectors.has(clickDetail.selectors.primary) || processedSelectors.has(selector) || Object.entries(formElementTimestamps).some(
-        ([formSelector, formTimestamp]) => {
-          const isRelatedToForm = clickDetail.selectors.primary.includes(formSelector) || formSelector.includes(clickDetail.selectors.primary) || selector.includes(formSelector) || clickDetail.selectors.fallbacks.some(
-            (f) => f.includes(formSelector) || formSelector.includes(f)
-          );
-          return isRelatedToForm && Math.abs(clickDetail.timestamp - formTimestamp) < 500;
-        }
-      );
-      if (!shouldSkip) {
-        allEvents.push({
-          type: "click",
-          x: clickDetail.x,
-          y: clickDetail.y,
-          selector,
-          timestamp: clickDetail.timestamp,
-          isUserAction: true,
-          text: clickDetail.selectors.text,
-          clickDetail
-          // Store for better debugging
-        });
-      }
-    });
-  }
-  if (inputChanges == null ? void 0 : inputChanges.length) {
-    const completedInputs = inputChanges.filter(
-      (change) => change.action === "complete" || !change.action
-    );
-    completedInputs.forEach((change) => {
-      const isFormElement = change.elementSelector.includes('type="checkbox"') || change.elementSelector.includes('type="radio"');
-      if (!processedSelectors.has(change.elementSelector) && !isFormElement) {
-        allEvents.push({
-          type: "input",
-          selector: change.elementSelector,
-          value: change.value,
-          timestamp: change.timestamp,
-          isUserAction: true
-        });
-      }
-    });
-  }
-  if (assertions == null ? void 0 : assertions.length) {
-    assertions.forEach((assertion) => {
-      const text = assertion.value || "";
-      const isShortText = text.length < 4;
-      const hasValidText = text.trim().length > 0;
-      if (!isShortText && hasValidText) {
-        allEvents.push({
-          type: "assertion",
-          assertionType: assertion.type,
-          selector: assertion.selector,
-          value: assertion.value,
-          timestamp: assertion.timestamp,
-          isUserAction: false
-        });
-      }
-    });
-  }
-  allEvents.sort((a, b) => a.timestamp - b.timestamp);
-  const uniqueEvents = [];
-  const processedFormActions = /* @__PURE__ */ new Set();
-  allEvents.forEach((event) => {
-    if (event.type === "form") {
-      const eventKey = `${event.formType}-${event.selector}-${event.checked !== void 0 ? event.checked : event.value}`;
-      if (!processedFormActions.has(eventKey)) {
-        uniqueEvents.push(event);
-        processedFormActions.add(eventKey);
-      }
-    } else {
-      uniqueEvents.push(event);
-    }
-  });
-  let code = "";
-  let lastUserActionTimestamp = null;
-  uniqueEvents.forEach((event, index) => {
-    if (index > 0) {
-      const prevEvent = uniqueEvents[index - 1];
-      if (event.isUserAction) {
-        let waitTime = 0;
-        if (lastUserActionTimestamp) {
-          waitTime = event.timestamp - lastUserActionTimestamp;
-        } else if (prevEvent.isUserAction) {
-          waitTime = event.timestamp - prevEvent.timestamp;
-        }
-        waitTime = Math.max(100, Math.min(5e3, waitTime));
-        if (waitTime > 100) {
-          code += `  await page.waitForTimeout(${waitTime});
-
-`;
-        }
-      }
-    }
-    switch (event.type) {
-      case "click":
-        code += generateClickCode(event);
-        lastUserActionTimestamp = event.timestamp;
-        break;
-      case "input":
-        code += generateInputCode(event);
-        lastUserActionTimestamp = event.timestamp;
-        break;
-      case "form":
-        code += generateFormCode(event);
-        lastUserActionTimestamp = event.timestamp;
-        break;
-      case "assertion":
-        code += generateAssertionCode(event);
-        break;
-    }
-  });
-  return code;
-}
-function generateClickCode(event) {
-  const selectorComment = event.clickDetail ? `${event.clickDetail.selectors.tagName}${event.clickDetail.selectors.text ? ` "${event.clickDetail.selectors.text}"` : ""}` : event.selector;
-  let code = `  // Click on ${selectorComment}
-`;
-  code += `  await page.click('${event.selector}');
-
-`;
-  return code;
-}
-function generateInputCode(event) {
-  const escapedValue = escapeTextForAssertion(event.value);
-  let code = `  // Fill input: ${event.selector}
-`;
-  code += `  await page.fill('${event.selector}', '${escapedValue}');
-
-`;
-  return code;
-}
-function generateFormCode(event) {
-  let code = "";
-  if (event.formType === "checkbox" || event.formType === "radio") {
-    if (event.checked) {
-      code += `  // Check ${event.formType}: ${event.selector}
-`;
-      code += `  await page.check('${event.selector}');
-
-`;
-    } else {
-      code += `  // Uncheck ${event.formType}: ${event.selector}
-`;
-      code += `  await page.uncheck('${event.selector}');
-
-`;
-    }
-  } else if (event.formType === "select") {
-    const escapedValue = escapeTextForAssertion(event.value);
-    code += `  // Select option: ${event.text || event.value} in ${event.selector}
-`;
-    code += `  await page.selectOption('${event.selector}', '${escapedValue}');
-
-`;
-  }
-  return code;
-}
-function generateAssertionCode(event) {
-  let code = "";
-  switch (event.assertionType) {
-    case "isVisible":
-      code += `  // Assert element is visible: ${event.selector}
-`;
-      code += `  await expect(page.locator('${event.selector}')).toBeVisible();
-
-`;
-      break;
-    case "hasText":
-      const genericSelectors = [
-        "div",
-        "p",
-        "span",
-        "h1",
-        "h2",
-        "h3",
-        "h4",
-        "h5",
-        "h6"
-      ];
-      const isGenericSelector = genericSelectors.includes(event.selector);
-      if (isGenericSelector) {
-        const cleanedText = cleanTextForGetByText(event.value);
-        const isShortText = cleanedText.length < 10 || cleanedText.split(" ").length <= 2;
-        code += `  // Assert element contains text: ${event.selector}
-`;
-        if (isShortText) {
-          code += `  await expect(page.locator('${event.selector}').filter({ hasText: '${cleanedText}' })).toBeVisible();
-
-`;
-        } else {
-          code += `  await expect(page.getByText('${cleanedText}', { exact: false })).toBeVisible();
-
-`;
-        }
-      } else {
-        const escapedText = escapeTextForAssertion(event.value);
-        code += `  // Assert element contains text: ${event.selector}
-`;
-        code += `  await expect(page.locator('${event.selector}')).toContainText('${escapedText}');
-
-`;
-      }
-      break;
-    case "isChecked":
-      code += `  // Assert checkbox/radio is checked: ${event.selector}
-`;
-      code += `  await expect(page.locator('${event.selector}')).toBeChecked();
-
-`;
-      break;
-    case "isNotChecked":
-      code += `  // Assert checkbox/radio is not checked: ${event.selector}
-`;
-      code += `  await expect(page.locator('${event.selector}')).not.toBeChecked();
-
-`;
-      break;
-  }
-  return code;
-}
-function escapeTextForAssertion(text) {
-  if (!text)
-    return "";
-  return text.replace(/\\/g, "\\\\").replace(/'/g, "\\'").replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t").trim();
-}
-function cleanTextForGetByText(text) {
-  if (!text)
-    return "";
-  return text.replace(/\s+/g, " ").replace(/\n+/g, " ").trim();
-}
-function isTextAmbiguous(text) {
-  if (!text)
-    return true;
-  if (text.length < 6)
-    return true;
-  if (text.split(/\s+/).length <= 2)
-    return true;
-  return false;
-}
-if (typeof window !== "undefined") {
-  window.PlaywrightGenerator = {
-    generatePlaywrightTest,
-    convertToPlaywrightSelector,
-    escapeTextForAssertion,
-    cleanTextForGetByText,
-    isTextAmbiguous
+    return a;
   };
-}
+  var __spreadProps = (a, b) => __defProps(a, __getOwnPropDescs(b));
+
+  // src/actionModel.ts
+  function resultsToActions(results) {
+    var _a;
+    const actions = [];
+    const navigations = (results.pageNavigation || []).slice().sort((a, b) => a.timestamp - b.timestamp);
+    const normalize = (u) => {
+      var _a2;
+      try {
+        const url = new URL(u, ((_a2 = results.userInfo) == null ? void 0 : _a2.url) || "http://localhost");
+        return url.origin + url.pathname.replace(/\/$/, "");
+      } catch (e) {
+        return u.replace(/[?#].*$/, "").replace(/\/$/, "");
+      }
+    };
+    for (const nav of navigations) {
+      actions.push({ kind: "nav", timestamp: nav.timestamp, url: nav.url, normalizedUrl: normalize(nav.url) });
+    }
+    const clicks = ((_a = results.clicks) == null ? void 0 : _a.clickDetails) || [];
+    for (let i = 0; i < clicks.length; i++) {
+      const cd = clicks[i];
+      actions.push({
+        kind: "click",
+        timestamp: cd.timestamp,
+        locator: {
+          primary: cd.selectors.stabilizedPrimary || cd.selectors.primary,
+          fallbacks: cd.selectors.fallbacks || [],
+          role: cd.selectors.role,
+          text: cd.selectors.text,
+          tagName: cd.selectors.tagName,
+          stableSelector: cd.selectors.stabilizedPrimary || cd.selectors.primary,
+          candidates: cd.selectors.scores || void 0
+        }
+      });
+      const nav = navigations.find((n) => n.timestamp > cd.timestamp && n.timestamp - cd.timestamp < 1800);
+      if (nav) {
+        actions.push({
+          kind: "waitForUrl",
+          timestamp: nav.timestamp - 1,
+          // ensure ordering between click and nav
+          expectedUrl: nav.url,
+          normalizedUrl: normalize(nav.url),
+          navRefTimestamp: nav.timestamp
+        });
+      }
+    }
+    if (results.inputChanges) {
+      for (const input of results.inputChanges) {
+        if (input.action === "complete" || !input.action) {
+          actions.push({
+            kind: "input",
+            timestamp: input.timestamp,
+            locator: { primary: input.elementSelector, fallbacks: [] },
+            value: input.value
+          });
+        }
+      }
+    }
+    if (results.formElementChanges) {
+      for (const fe of results.formElementChanges) {
+        actions.push({
+          kind: "form",
+          timestamp: fe.timestamp,
+          locator: { primary: fe.elementSelector, fallbacks: [] },
+          formType: fe.type,
+          value: fe.value,
+          checked: fe.checked
+        });
+      }
+    }
+    if (results.assertions) {
+      for (const asrt of results.assertions) {
+        actions.push({
+          kind: "assertion",
+          timestamp: asrt.timestamp,
+          locator: { primary: asrt.selector, fallbacks: [] },
+          value: asrt.value
+        });
+      }
+    }
+    actions.sort((a, b) => a.timestamp - b.timestamp || weightOrder(a.kind) - weightOrder(b.kind));
+    refineLocators(actions);
+    for (let i = actions.length - 1; i > 0; i--) {
+      const current = actions[i];
+      const previous = actions[i - 1];
+      if (current.kind === "waitForUrl" && previous.kind === "waitForUrl" && current.normalizedUrl === previous.normalizedUrl) {
+        actions.splice(i, 1);
+      }
+    }
+    return actions;
+  }
+  function weightOrder(kind) {
+    switch (kind) {
+      case "click":
+        return 1;
+      case "waitForUrl":
+        return 2;
+      case "nav":
+        return 3;
+      default:
+        return 4;
+    }
+  }
+  function refineLocators(actions) {
+    if (typeof document === "undefined")
+      return;
+    const seen = /* @__PURE__ */ new Set();
+    for (const a of actions) {
+      if (!a.locator)
+        continue;
+      const { primary, fallbacks } = a.locator;
+      const validated = [];
+      if (isUnique(primary))
+        validated.push(primary);
+      for (const fb of fallbacks) {
+        if (validated.length >= 3)
+          break;
+        if (isUnique(fb))
+          validated.push(fb);
+      }
+      if (validated.length === 0)
+        continue;
+      a.locator.primary = validated[0];
+      a.locator.fallbacks = validated.slice(1);
+      const key = a.locator.primary + "::" + a.kind;
+      if (seen.has(key) && a.locator.fallbacks.length > 0) {
+        a.locator.primary = a.locator.fallbacks[0];
+        a.locator.fallbacks = a.locator.fallbacks.slice(1);
+      }
+      seen.add(a.locator.primary + "::" + a.kind);
+    }
+  }
+  function isUnique(sel) {
+    if (!sel || /^(html|body|div|span|p|button|input)$/i.test(sel))
+      return false;
+    try {
+      const nodes = document.querySelectorAll(sel);
+      return nodes.length === 1;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  // src/playwright-generator.ts
+  var RecordingManager = class {
+    constructor() {
+      this.trackingData = {
+        pageNavigation: [],
+        clicks: { clickCount: 0, clickDetails: [] },
+        inputChanges: [],
+        formElementChanges: [],
+        assertions: [],
+        keyboardActivities: [],
+        mouseMovement: [],
+        mouseScroll: [],
+        focusChanges: [],
+        visibilitychanges: [],
+        windowSizes: [],
+        touchEvents: [],
+        audioVideoInteractions: []
+      };
+      this.capturedActions = [];
+      this.actionIdCounter = 0;
+    }
+    /**
+     * Handle an event from the iframe and store it
+     */
+    handleEvent(eventType, eventData) {
+      switch (eventType) {
+        case "click":
+          this.trackingData.clicks.clickDetails.push(eventData);
+          this.trackingData.clicks.clickCount++;
+          break;
+        case "nav":
+        case "navigation":
+          this.trackingData.pageNavigation.push({
+            type: "navigation",
+            url: eventData.url,
+            timestamp: eventData.timestamp
+          });
+          break;
+        case "input":
+          this.trackingData.inputChanges.push({
+            elementSelector: eventData.selector || "",
+            value: eventData.value,
+            timestamp: eventData.timestamp,
+            action: "complete"
+          });
+          break;
+        case "form":
+          this.trackingData.formElementChanges.push({
+            elementSelector: eventData.selector || "",
+            type: eventData.formType || "input",
+            checked: eventData.checked,
+            value: eventData.value || "",
+            text: eventData.text,
+            timestamp: eventData.timestamp
+          });
+          break;
+        case "assertion":
+          this.trackingData.assertions.push({
+            id: eventData.id,
+            type: eventData.type || "hasText",
+            selector: eventData.selector,
+            value: eventData.value || "",
+            timestamp: eventData.timestamp
+          });
+          break;
+        default:
+          return null;
+      }
+      const action = this.createAction(eventType, eventData);
+      if (action) {
+        this.capturedActions.push(action);
+      }
+      return action;
+    }
+    createAction(eventType, eventData) {
+      const id = `${Date.now()}_${this.actionIdCounter++}`;
+      const baseAction = {
+        id,
+        timestamp: eventData.timestamp || Date.now()
+      };
+      switch (eventType) {
+        case "click":
+          return __spreadProps(__spreadValues({}, baseAction), {
+            kind: "click",
+            locator: eventData.selectors || eventData.locator,
+            elementInfo: eventData.elementInfo
+          });
+        case "nav":
+        case "navigation":
+          return __spreadProps(__spreadValues({}, baseAction), {
+            kind: "nav",
+            url: eventData.url
+          });
+        case "input":
+          return __spreadProps(__spreadValues({}, baseAction), {
+            kind: "input",
+            value: eventData.value,
+            locator: eventData.locator || { primary: eventData.selector }
+          });
+        case "form":
+          return __spreadProps(__spreadValues({}, baseAction), {
+            kind: "form",
+            formType: eventData.formType,
+            checked: eventData.checked,
+            value: eventData.value,
+            locator: eventData.locator || { primary: eventData.selector }
+          });
+        case "assertion":
+          return __spreadProps(__spreadValues({}, baseAction), {
+            kind: "assertion",
+            value: eventData.value,
+            locator: { primary: eventData.selector, fallbacks: [] }
+          });
+        default:
+          return __spreadProps(__spreadValues({}, baseAction), {
+            kind: eventType
+          });
+      }
+    }
+    /**
+     * Remove an action by ID
+     */
+    removeAction(actionId) {
+      const action = this.capturedActions.find((a) => a.id === actionId);
+      if (!action)
+        return false;
+      this.capturedActions = this.capturedActions.filter((a) => a.id !== actionId);
+      this.removeFromTrackingData(action);
+      return true;
+    }
+    removeFromTrackingData(action) {
+      const timestamp = action.timestamp;
+      switch (action.kind) {
+        case "click":
+          this.trackingData.clicks.clickDetails = this.trackingData.clicks.clickDetails.filter(
+            (c) => c.timestamp !== timestamp
+          );
+          this.trackingData.clicks.clickCount = this.trackingData.clicks.clickDetails.length;
+          break;
+        case "nav":
+          this.trackingData.pageNavigation = this.trackingData.pageNavigation.filter(
+            (n) => n.timestamp !== timestamp
+          );
+          break;
+        case "input":
+          this.trackingData.inputChanges = this.trackingData.inputChanges.filter(
+            (i) => i.timestamp !== timestamp
+          );
+          break;
+        case "form":
+          this.trackingData.formElementChanges = this.trackingData.formElementChanges.filter(
+            (f) => f.timestamp !== timestamp
+          );
+          break;
+        case "assertion":
+          this.trackingData.assertions = this.trackingData.assertions.filter(
+            (a) => a.timestamp !== timestamp
+          );
+          const clickBeforeAssertion = this.trackingData.clicks.clickDetails.filter((c) => c.timestamp < timestamp).sort((a, b) => b.timestamp - a.timestamp)[0];
+          if (clickBeforeAssertion && timestamp - clickBeforeAssertion.timestamp < 1e3) {
+            this.trackingData.clicks.clickDetails = this.trackingData.clicks.clickDetails.filter(
+              (c) => c.timestamp !== clickBeforeAssertion.timestamp
+            );
+            this.trackingData.clicks.clickCount = this.trackingData.clicks.clickDetails.length;
+          }
+          break;
+      }
+    }
+    /**
+     * Generate Playwright test from current data
+     */
+    generateTest(url, options) {
+      const actions = resultsToActions(this.trackingData);
+      return generatePlaywrightTestFromActions(actions, __spreadValues({
+        baseUrl: url
+      }, options));
+    }
+    /**
+     * Get current actions for UI display
+     */
+    getActions() {
+      return [...this.capturedActions];
+    }
+    /**
+     * Get tracking data (for compatibility)
+     */
+    getTrackingData() {
+      return this.trackingData;
+    }
+    /**
+     * Clear all recorded data
+     */
+    clear() {
+      this.trackingData = {
+        pageNavigation: [],
+        clicks: { clickCount: 0, clickDetails: [] },
+        inputChanges: [],
+        formElementChanges: [],
+        assertions: [],
+        keyboardActivities: [],
+        mouseMovement: [],
+        mouseScroll: [],
+        focusChanges: [],
+        visibilitychanges: [],
+        windowSizes: [],
+        touchEvents: [],
+        audioVideoInteractions: []
+      };
+      this.capturedActions = [];
+      this.actionIdCounter = 0;
+    }
+    /**
+     * Clear all actions (but keep recording)
+     */
+    clearAllActions() {
+      this.clear();
+    }
+  };
+  function escapeTextForAssertion(text) {
+    if (!text)
+      return "";
+    return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  }
+  function generatePlaywrightTestFromActions(actions, options = {}) {
+    const { baseUrl = "" } = options;
+    const body = actions.map((action) => {
+      var _a, _b, _c, _d, _e;
+      switch (action.kind) {
+        case "nav":
+          return `  await page.goto('${action.url || baseUrl}');`;
+        case "waitForUrl":
+          if (action.normalizedUrl) {
+            return `  await page.waitForURL('${action.normalizedUrl}');`;
+          }
+          return "";
+        case "click": {
+          const selector = ((_a = action.locator) == null ? void 0 : _a.stableSelector) || ((_b = action.locator) == null ? void 0 : _b.primary);
+          if (!selector)
+            return "";
+          return `  await page.click('${selector}');`;
+        }
+        case "input": {
+          const selector = (_c = action.locator) == null ? void 0 : _c.primary;
+          if (!selector || action.value === void 0)
+            return "";
+          const value = action.value.replace(/'/g, "\\'");
+          return `  await page.fill('${selector}', '${value}');`;
+        }
+        case "form": {
+          const selector = (_d = action.locator) == null ? void 0 : _d.primary;
+          if (!selector)
+            return "";
+          if (action.formType === "checkbox" || action.formType === "radio") {
+            if (action.checked) {
+              return `  await page.check('${selector}');`;
+            } else {
+              return `  await page.uncheck('${selector}');`;
+            }
+          } else if (action.formType === "select" && action.value) {
+            return `  await page.selectOption('${selector}', '${action.value}');`;
+          }
+          return "";
+        }
+        case "assertion": {
+          const selector = (_e = action.locator) == null ? void 0 : _e.primary;
+          if (!selector || action.value === void 0)
+            return "";
+          const escapedValue = escapeTextForAssertion(action.value);
+          return `  await expect(page.locator('${selector}')).toContainText('${escapedValue}');`;
+        }
+        default:
+          return "";
+      }
+    }).filter((line) => line !== "").join("\n");
+    if (!body)
+      return "";
+    return `import { test, expect } from '@playwright/test';
+
+test('Recorded test', async ({ page }) => {
+${body.split("\n").filter((l) => l.trim()).map((l) => l).join("\n")}
+});`;
+  }
+  if (typeof window !== "undefined") {
+    const existing = window.PlaywrightGenerator || {};
+    existing.RecordingManager = RecordingManager;
+    existing.generatePlaywrightTestFromActions = generatePlaywrightTestFromActions;
+    existing.generatePlaywrightTest = (url, trackingData) => {
+      try {
+        const actions = resultsToActions(trackingData);
+        return generatePlaywrightTestFromActions(actions, { baseUrl: url });
+      } catch (error) {
+        console.error("Error generating Playwright test:", error);
+        return "";
+      }
+    };
+    window.PlaywrightGenerator = existing;
+  }
+})();

--- a/src/app/w/[slug]/task/[...taskParams]/artifacts/browser.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/artifacts/browser.tsx
@@ -25,18 +25,18 @@ export function BrowserArtifactPanel({
 }) {
   const [activeTab, setActiveTab] = useState(0);
   const [refreshKey, setRefreshKey] = useState(0);
-  const [assertionToast, setAssertionToast] = useState<{ text: string; id: number } | null>(null);
+  const [actionToast, setActionToast] = useState<{ type: string; text: string; id: number } | null>(null);
 
   // Get the current artifact and its content
   const activeArtifact = artifacts[activeTab];
   const activeContent = activeArtifact?.content as BrowserContent;
 
-  // Local toast handler
-  const showAssertionToast = useCallback((text: string) => {
+  // Local toast handler for all action types
+  const showActionToast = useCallback((type: string, text: string) => {
     const id = Date.now();
-    setAssertionToast({ text, id });
+    setActionToast({ type, text, id });
     setTimeout(() => {
-      setAssertionToast(null);
+      setActionToast(null);
     }, 3000);
   }, []);
 
@@ -61,7 +61,7 @@ export function BrowserArtifactPanel({
   } = useStaktrak(activeContent?.url, () => {
     // Open modal when test is generated
     setIsTestModalOpen(true);
-  }, showAssertionToast);
+  }, showActionToast);
 
   // Use playwright replay hook
   const { isPlaywrightReplaying, startPlaywrightReplay, stopPlaywrightReplay } = usePlaywrightReplay(iframeRef);
@@ -341,17 +341,17 @@ export function BrowserArtifactPanel({
                     onDebugSelection={handleDebugSelection}
                   />
                 )}
-                {/* Assertion toast - only active for the current tab */}
-                {isActive && assertionToast && (
+                {/* Action toast - only active for the current tab */}
+                {isActive && actionToast && (
                   <div className="absolute top-4 right-4 z-50 pointer-events-none animate-in fade-in slide-in-from-top-2 duration-300">
                     <div className="pointer-events-auto flex items-start gap-3 rounded-lg border border-border bg-background/95 backdrop-blur-sm p-4 shadow-lg">
                       <CheckCircle2 className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
                       <div className="flex flex-col gap-1">
                         <div className="font-semibold text-sm text-foreground">
-                          Assertion captured
+                          {actionToast.type}
                         </div>
                         <div className="text-sm text-muted-foreground">
-                          "{assertionToast.text}"
+                          {actionToast.text}
                         </div>
                       </div>
                     </div>

--- a/src/app/w/[slug]/task/[...taskParams]/artifacts/browser.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/artifacts/browser.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { useState } from "react";
-import { Monitor, RefreshCw, ExternalLink, Circle, Square, Target, FlaskConical, Bug, Play, Pause } from "lucide-react";
+import { Monitor, RefreshCw, ExternalLink, Circle, Square, Target, FlaskConical, Bug, Play, Pause, ChevronUp, ChevronDown } from "lucide-react";
 import { Artifact, BrowserContent } from "@/lib/chat";
 import { useStaktrak } from "@/hooks/useStaktrak";
 import { usePlaywrightReplay } from "@/hooks/useStaktrakReplay";
@@ -10,6 +10,7 @@ import { TestManagerModal } from "./TestManagerModal";
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { DebugOverlay } from "@/components/DebugOverlay";
 import { useDebugSelection } from "@/hooks/useDebugSelection";
+import { ActionsList } from "@/components/ActionsList";
 
 export function BrowserArtifactPanel({
   artifacts,
@@ -42,6 +43,11 @@ export function BrowserArtifactPanel({
     disableAssertionMode,
     generatedPlaywrightTest,
     setGeneratedPlaywrightTest,
+    capturedActions,
+    showActions,
+    removeAction,
+    clearAllActions,
+    toggleActionsView,
   } = useStaktrak(activeContent?.url, () => {
     // Open modal when test is generated
     setIsTestModalOpen(true);
@@ -172,6 +178,25 @@ export function BrowserArtifactPanel({
                         </Tooltip>
                       </TooltipProvider>
                     )}
+                    {isSetup && isRecording && (
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={toggleActionsView}
+                              className="h-8 w-8 p-0"
+                            >
+                              {showActions ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom">
+                            {showActions ? "Hide" : "Show"} Actions ({capturedActions.length})
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    )}
                     {generatedPlaywrightTest && (
                       <TooltipProvider>
                         <Tooltip>
@@ -281,6 +306,14 @@ export function BrowserArtifactPanel({
                     </TooltipProvider>
                   </div>
                 </div>
+              )}
+              {showActions && (
+                <ActionsList
+                  actions={capturedActions}
+                  onRemoveAction={removeAction}
+                  onClearAll={clearAllActions}
+                  isRecording={isRecording}
+                />
               )}
               <div className="flex-1 overflow-hidden min-h-0 min-w-0 relative">
                 <iframe

--- a/src/app/w/[slug]/task/[...taskParams]/artifacts/browser.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/artifacts/browser.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { useState } from "react";
-import { Monitor, RefreshCw, ExternalLink, Circle, Square, Target, FlaskConical, Bug, Play, Pause, ChevronUp, ChevronDown } from "lucide-react";
+import { useState, useCallback } from "react";
+import { Monitor, RefreshCw, ExternalLink, Circle, Square, Target, FlaskConical, Bug, Play, Pause, ChevronUp, ChevronDown, CheckCircle2 } from "lucide-react";
 import { Artifact, BrowserContent } from "@/lib/chat";
 import { useStaktrak } from "@/hooks/useStaktrak";
 import { usePlaywrightReplay } from "@/hooks/useStaktrakReplay";
@@ -25,10 +25,20 @@ export function BrowserArtifactPanel({
 }) {
   const [activeTab, setActiveTab] = useState(0);
   const [refreshKey, setRefreshKey] = useState(0);
+  const [assertionToast, setAssertionToast] = useState<{ text: string; id: number } | null>(null);
 
   // Get the current artifact and its content
   const activeArtifact = artifacts[activeTab];
   const activeContent = activeArtifact?.content as BrowserContent;
+
+  // Local toast handler
+  const showAssertionToast = useCallback((text: string) => {
+    const id = Date.now();
+    setAssertionToast({ text, id });
+    setTimeout(() => {
+      setAssertionToast(null);
+    }, 3000);
+  }, []);
 
   // Use staktrak hook with all the functions
   const {
@@ -51,7 +61,7 @@ export function BrowserArtifactPanel({
   } = useStaktrak(activeContent?.url, () => {
     // Open modal when test is generated
     setIsTestModalOpen(true);
-  });
+  }, showAssertionToast);
 
   // Use playwright replay hook
   const { isPlaywrightReplaying, startPlaywrightReplay, stopPlaywrightReplay } = usePlaywrightReplay(iframeRef);
@@ -330,6 +340,22 @@ export function BrowserArtifactPanel({
                     isSubmitting={isSubmittingDebug}
                     onDebugSelection={handleDebugSelection}
                   />
+                )}
+                {/* Assertion toast - only active for the current tab */}
+                {isActive && assertionToast && (
+                  <div className="absolute top-4 right-4 z-50 pointer-events-none animate-in fade-in slide-in-from-top-2 duration-300">
+                    <div className="pointer-events-auto flex items-start gap-3 rounded-lg border border-border bg-background/95 backdrop-blur-sm p-4 shadow-lg">
+                      <CheckCircle2 className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
+                      <div className="flex flex-col gap-1">
+                        <div className="font-semibold text-sm text-foreground">
+                          Assertion captured
+                        </div>
+                        <div className="text-sm text-muted-foreground">
+                          "{assertionToast.text}"
+                        </div>
+                      </div>
+                    </div>
+                  </div>
                 )}
               </div>
             </div>

--- a/src/app/w/[slug]/task/[...taskParams]/artifacts/browser.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/artifacts/browser.tsx
@@ -42,7 +42,10 @@ export function BrowserArtifactPanel({
     disableAssertionMode,
     generatedPlaywrightTest,
     setGeneratedPlaywrightTest,
-  } = useStaktrak(activeContent?.url);
+  } = useStaktrak(activeContent?.url, () => {
+    // Open modal when test is generated
+    setIsTestModalOpen(true);
+  });
 
   // Use playwright replay hook
   const { isPlaywrightReplaying, startPlaywrightReplay, stopPlaywrightReplay } = usePlaywrightReplay(iframeRef);
@@ -71,7 +74,7 @@ export function BrowserArtifactPanel({
   const handleRecordToggle = () => {
     if (isRecording) {
       stopRecording();
-      setIsTestModalOpen(true);
+      // Modal will open automatically when test is generated (via callback)
     } else {
       startRecording();
     }

--- a/src/components/ActionsList.tsx
+++ b/src/components/ActionsList.tsx
@@ -1,0 +1,202 @@
+import { Button } from "@/components/ui/button";
+import { X } from "lucide-react";
+
+interface Action {
+  id: string;
+  kind: string;
+  timestamp: number;
+  locator?: {
+    primary: string;
+    text?: string;
+  };
+  value?: string;
+  url?: string;
+  expectedUrl?: string;
+  formType?: string;
+  checked?: boolean;
+}
+
+interface ActionsListProps {
+  actions: Action[];
+  onRemoveAction: (action: Action) => void;
+  onClearAll: () => void;
+  isRecording: boolean;
+}
+
+// Helper function to extract the most descriptive element identifier
+function getElementDescription(action: Action): string {
+  const selector = action.locator?.primary;
+  if (!selector) return "element";
+
+  // Extract ID (highest priority)
+  if (selector.includes("#")) {
+    const idMatch = selector.match(/#([^.\s[]+)/);
+    if (idMatch) return `#${idMatch[1]}`;
+  }
+
+  // Extract class (medium priority, limit to first class)
+  if (selector.includes(".") && !selector.startsWith("text=")) {
+    const classMatch = selector.match(/\.([^.\s[#]+)/);
+    if (classMatch) return `.${classMatch[1]}`;
+  }
+
+  // Extract attribute selectors like [name="email"]
+  if (selector.includes("[")) {
+    const attrMatch = selector.match(/\[([^=\]]+)=?"?([^"\]]*)"?\]/);
+    if (attrMatch) {
+      const attrName = attrMatch[1];
+      const attrValue = attrMatch[2];
+      if (attrValue) {
+        return `[${attrName}="${attrValue}"]`;
+      }
+      return `[${attrName}]`;
+    }
+  }
+
+  // Use selector as fallback (truncate if too long)
+  if (selector.length > 25) {
+    return selector.substring(0, 22) + "...";
+  }
+
+  return selector;
+}
+
+function getActionDisplay(action: Action): React.ReactNode {
+  switch (action.kind) {
+    case "nav":
+      return (
+        <>
+          Navigate to <span className="text-primary">{action.url || "/"}</span>
+        </>
+      );
+    case "click":
+      if (action.locator?.text) {
+        const elementDesc = getElementDescription(action);
+        return (
+          <>
+            Click <span className="text-primary">"{action.locator.text}"</span>
+            {elementDesc !== "element" && <span className="text-muted-foreground"> ({elementDesc})</span>}
+          </>
+        );
+      }
+      const clickDesc = getElementDescription(action);
+      return (
+        <>
+          Click <span className="text-primary">{clickDesc}</span>
+        </>
+      );
+    case "input":
+      const inputValue = action.value && action.value.length > 30 ? action.value.substring(0, 30) + "..." : action.value;
+      const inputDesc = getElementDescription(action);
+      return (
+        <>
+          Type <span className="text-primary">"{inputValue}"</span>
+          {inputDesc !== "element" && <span className="text-muted-foreground"> in {inputDesc}</span>}
+        </>
+      );
+    case "form":
+      const formDesc = getElementDescription(action);
+      if (action.formType === "checkbox" || action.formType === "radio") {
+        return (
+          <>
+            {action.checked ? "Check" : "Uncheck"}{" "}
+            <span className="text-primary">{formDesc !== "element" ? formDesc : action.formType}</span>
+          </>
+        );
+      } else if (action.formType === "select") {
+        return (
+          <>
+            Select <span className="text-primary">"{action.value}"</span>
+            {formDesc !== "element" && <span className="text-muted-foreground"> from {formDesc}</span>}
+          </>
+        );
+      }
+      return (
+        <>
+          Form: <span className="text-primary">{action.value}</span>
+          {formDesc !== "element" && <span className="text-muted-foreground"> in {formDesc}</span>}
+        </>
+      );
+    case "assertion":
+      const assertText = action.value && action.value.length > 30 ? action.value.substring(0, 30) + "..." : action.value;
+      const assertDesc = getElementDescription(action);
+      return (
+        <>
+          Assert <span className="text-primary">"{assertText}"</span>
+          {assertDesc !== "element" && <span className="text-muted-foreground"> in {assertDesc}</span>}
+        </>
+      );
+    case "waitForUrl":
+      return (
+        <>
+          Wait for <span className="text-primary">{action.expectedUrl || "navigation"}</span>
+        </>
+      );
+    default:
+      return <span className="text-primary">{action.kind}</span>;
+  }
+}
+
+// Get border color class for action type
+function getActionBorderColor(kind: string): string {
+  switch (kind) {
+    case "nav":
+      return "border-l-blue-500";
+    case "click":
+      return "border-l-green-500";
+    case "input":
+      return "border-l-amber-500";
+    case "form":
+      return "border-l-purple-500";
+    case "assertion":
+      return "border-l-red-500";
+    case "waitForUrl":
+      return "border-l-muted-foreground";
+    default:
+      return "border-l-border";
+  }
+}
+
+export function ActionsList({ actions, onRemoveAction, onClearAll, isRecording }: ActionsListProps) {
+  return (
+    <div className="mx-4 my-3 rounded-lg border bg-card shadow-sm">
+      <div className="flex items-center justify-between p-3 border-b">
+        <h3 className="text-sm font-semibold">Test Actions ({actions.length})</h3>
+        <Button variant="destructive" size="sm" onClick={onClearAll} disabled={!isRecording || actions.length === 0}>
+          Clear All
+        </Button>
+      </div>
+
+      <div className="max-h-96 overflow-y-auto">
+        {actions.length === 0 ? (
+          <div className="p-6 text-center text-sm text-muted-foreground">No actions recorded yet</div>
+        ) : (
+          <div className="flex flex-col gap-1 p-2">
+            {actions.map((action) => (
+              <div
+                key={action.id}
+                className={`flex items-center justify-between rounded border-l-4 ${getActionBorderColor(
+                  action.kind
+                )} bg-muted/50 p-2 transition-colors hover:bg-muted`}
+              >
+                <div className="flex-1 text-sm overflow-hidden text-ellipsis whitespace-nowrap">
+                  {getActionDisplay(action)}
+                </div>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => onRemoveAction(action)}
+                  disabled={!isRecording}
+                  className="h-6 w-6 p-0 hover:bg-destructive/10 hover:text-destructive"
+                  title="Remove this action"
+                >
+                  <X className="h-3 w-3" />
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useStaktrak.ts
+++ b/src/hooks/useStaktrak.ts
@@ -53,7 +53,7 @@ declare global {
 export const useStaktrak = (
   initialUrl?: string,
   onTestGenerated?: (test: string) => void,
-  onAssertionCaptured?: (text: string) => void
+  onActionCaptured?: (type: string, text: string) => void
 ) => {
   const [currentUrl, setCurrentUrl] = useState<string | null>(initialUrl || null);
   const [isSetup, setIsSetup] = useState(false);
@@ -67,13 +67,13 @@ export const useStaktrak = (
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const recorderRef = useRef<RecordingManager | null>(null);
   const onTestGeneratedRef = useRef(onTestGenerated);
-  const onAssertionCapturedRef = useRef(onAssertionCaptured);
+  const onActionCapturedRef = useRef(onActionCaptured);
 
   // Keep callback refs up to date
   useEffect(() => {
     onTestGeneratedRef.current = onTestGenerated;
-    onAssertionCapturedRef.current = onAssertionCaptured;
-  }, [onTestGenerated, onAssertionCaptured]);
+    onActionCapturedRef.current = onActionCaptured;
+  }, [onTestGenerated, onActionCaptured]);
 
   const startRecording = () => {
     // Lazy initialize RecordingManager on first recording
@@ -157,11 +157,54 @@ export const useStaktrak = (
                 // Update captured actions in real-time
                 setCapturedActions(recorderRef.current.getActions());
 
-                // Show notification for assertions
-                if (staktrakEvent.data.eventType === "assertion" && onAssertionCapturedRef.current) {
-                  const assertionData = staktrakEvent.data.data as any;
-                  const assertionText = assertionData.value || "Element";
-                  onAssertionCapturedRef.current(assertionText);
+                // Show notification for all action types
+                if (onActionCapturedRef.current) {
+                  const eventType = staktrakEvent.data.eventType;
+                  const eventData = staktrakEvent.data.data as any;
+
+                  let toastType = "";
+                  let toastText = "";
+
+                  switch (eventType) {
+                    case "click":
+                      toastType = "Click captured";
+                      toastText = eventData.selectors?.text || eventData.selectors?.tagName || "Element";
+                      break;
+
+                    case "input":
+                      toastType = "Input captured";
+                      toastText = eventData.value || "Input field";
+                      break;
+
+                    case "form":
+                      toastType = "Form change captured";
+                      const formType = eventData.formType || "input";
+                      if (formType === "checkbox" || formType === "radio") {
+                        toastText = `${formType} ${eventData.checked ? "checked" : "unchecked"}`;
+                      } else if (formType === "select") {
+                        toastText = `Selected: ${eventData.text || eventData.value || "option"}`;
+                      } else {
+                        toastText = formType;
+                      }
+                      break;
+
+                    case "nav":
+                    case "navigation":
+                      toastType = "Navigation captured";
+                      toastText = eventData.url || "Page navigation";
+                      break;
+
+                    case "assertion":
+                      toastType = "Assertion captured";
+                      toastText = `"${eventData.value || "Element"}"`;
+                      break;
+
+                    default:
+                      toastType = `${eventType} captured`;
+                      toastText = "Action recorded";
+                  }
+
+                  onActionCapturedRef.current(toastType, toastText);
                 }
               } catch (error) {
                 console.error("Error handling staktrak event:", error);

--- a/src/hooks/useStaktrak.ts
+++ b/src/hooks/useStaktrak.ts
@@ -157,15 +157,10 @@ export const useStaktrak = (initialUrl?: string, onTestGenerated?: (test: string
             break;
 
           case "staktrak-results":
-            // Generate test using bulk data from staktrak-results
-            // Don't use RecordingManager.generateTest() because events aren't sent incrementally
-            if (window.PlaywrightGenerator?.generatePlaywrightTest && initialUrl && staktrakEvent.data.data) {
+            // Generate test from RecordingManager to respect removed actions
+            if (recorderRef.current && initialUrl) {
               try {
-                const bulkData = staktrakEvent.data.data;
-                const test = window.PlaywrightGenerator.generatePlaywrightTest(
-                  cleanInitialUrl(initialUrl),
-                  bulkData
-                );
+                const test = recorderRef.current.generateTest(cleanInitialUrl(initialUrl));
                 setGeneratedPlaywrightTest(test);
                 // Call the callback if provided
                 if (onTestGeneratedRef.current) {


### PR DESCRIPTION
Extends toast notification system from PR #1004 to show feedback for all action types during test recording.

## Changes

- Updated `useStaktrak` hook to handle toast notifications for all action types (not just assertions)
- Modified `browser.tsx` to display dynamic action toast with type and text
- Toast notifications now show for:
  - **Click**: Shows element text or tag name
  - **Input**: Shows the typed value
  - **Form**: Shows checkbox/radio/select changes
  - **Navigation**: Shows the URL
  - **Assertion**: Shows assertion text (existing)

## Implementation

Followed the same pattern as assertion toasts from PR #1004:
- Frosted glass styling
- 3-second auto-dismiss
- Top-right position
- Same CheckCircle2 icon

Closes #1038