### PR TITLE
Add single feature API endpoints

### DIFF
--- a/src/__tests__/integration/api/features-featureId.test.ts
+++ b/src/__tests__/integration/api/features-featureId.test.ts
@@ -1,0 +1,641 @@
+import { describe, test, expect, beforeEach, vi } from "vitest";
+import { GET, PATCH } from "@/app/api/features/[featureId]/route";
+import { db } from "@/lib/db";
+import { FeatureStatus, FeaturePriority } from "@prisma/client";
+import {
+  createTestUser,
+  createTestWorkspace,
+} from "@/__tests__/support/fixtures";
+import {
+  createAuthenticatedSession,
+  mockUnauthenticatedSession,
+  getMockedSession,
+  expectSuccess,
+  expectUnauthorized,
+  expectError,
+  createGetRequest,
+  createPatchRequest,
+} from "@/__tests__/support/helpers";
+
+describe("Single Feature API - Integration Tests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("GET /api/features/[featureId]", () => {
+    test("returns feature with user stories for workspace member", async () => {
+      // Setup
+      const user = await createTestUser();
+      const workspace = await createTestWorkspace({
+        ownerId: user.id,
+        name: "Test Workspace",
+        slug: "test-workspace",
+      });
+
+      const feature = await db.feature.create({
+        data: {
+          title: "Test Feature",
+          workspaceId: workspace.id,
+          status: FeatureStatus.IN_PROGRESS,
+          priority: FeaturePriority.HIGH,
+          createdById: user.id,
+          updatedById: user.id,
+        },
+      });
+
+      // Create user stories
+      await db.userStory.create({
+        data: {
+          featureId: feature.id,
+          title: "User Story 1",
+          order: 1,
+          completed: false,
+          createdById: user.id,
+          updatedById: user.id,
+        },
+      });
+
+      await db.userStory.create({
+        data: {
+          featureId: feature.id,
+          title: "User Story 2",
+          order: 2,
+          completed: true,
+          createdById: user.id,
+          updatedById: user.id,
+        },
+      });
+
+      getMockedSession().mockResolvedValue(createAuthenticatedSession(user));
+
+      const request = createGetRequest(
+        `http://localhost:3000/api/features/${feature.id}`
+      );
+
+      // Execute
+      const response = await GET(request, {
+        params: Promise.resolve({ featureId: feature.id }),
+      });
+
+      // Assert
+      const data = await expectSuccess(response, 200);
+      expect(data.data).toMatchObject({
+        id: feature.id,
+        title: "Test Feature",
+        status: FeatureStatus.IN_PROGRESS,
+        priority: FeaturePriority.HIGH,
+      });
+      expect(data.data.userStories).toHaveLength(2);
+      expect(data.data.userStories[0].title).toBe("User Story 1");
+      expect(data.data.userStories[0].order).toBe(1);
+      expect(data.data.userStories[1].title).toBe("User Story 2");
+      expect(data.data.userStories[1].completed).toBe(true);
+    });
+
+    test("includes workspace, assignee, and audit information", async () => {
+      // Setup
+      const creator = await createTestUser({ name: "Creator User" });
+      const assignee = await createTestUser({ name: "Assignee User" });
+      const workspace = await createTestWorkspace({
+        ownerId: creator.id,
+        name: "Test Workspace",
+        slug: "test-workspace",
+      });
+
+      const feature = await db.feature.create({
+        data: {
+          title: "Test Feature",
+          workspaceId: workspace.id,
+          assigneeId: assignee.id,
+          createdById: creator.id,
+          updatedById: creator.id,
+        },
+      });
+
+      getMockedSession().mockResolvedValue(createAuthenticatedSession(creator));
+
+      const request = createGetRequest(
+        `http://localhost:3000/api/features/${feature.id}`
+      );
+
+      // Execute
+      const response = await GET(request, {
+        params: Promise.resolve({ featureId: feature.id }),
+      });
+
+      // Assert
+      const data = await expectSuccess(response, 200);
+      expect(data.data.workspace).toMatchObject({
+        id: workspace.id,
+        name: "Test Workspace",
+        slug: "test-workspace",
+      });
+      expect(data.data.assignee).toMatchObject({
+        id: assignee.id,
+        name: "Assignee User",
+      });
+      expect(data.data.createdBy).toMatchObject({
+        id: creator.id,
+        name: "Creator User",
+      });
+    });
+
+    test("requires authentication", async () => {
+      getMockedSession().mockResolvedValue(mockUnauthenticatedSession());
+
+      const request = createGetRequest(
+        "http://localhost:3000/api/features/test-feature-id"
+      );
+
+      const response = await GET(request, {
+        params: Promise.resolve({ featureId: "test-feature-id" }),
+      });
+
+      await expectUnauthorized(response);
+    });
+
+    test("returns 404 for non-existent feature", async () => {
+      const user = await createTestUser();
+      getMockedSession().mockResolvedValue(createAuthenticatedSession(user));
+
+      const request = createGetRequest(
+        "http://localhost:3000/api/features/non-existent-id"
+      );
+
+      const response = await GET(request, {
+        params: Promise.resolve({ featureId: "non-existent-id" }),
+      });
+
+      await expectError(response, "Feature not found", 404);
+    });
+
+    test("denies access to non-workspace members", async () => {
+      // Setup
+      const owner = await createTestUser();
+      const nonMember = await createTestUser();
+      const workspace = await createTestWorkspace({
+        ownerId: owner.id,
+        name: "Test Workspace",
+        slug: "test-workspace",
+      });
+
+      const feature = await db.feature.create({
+        data: {
+          title: "Test Feature",
+          workspaceId: workspace.id,
+          createdById: owner.id,
+          updatedById: owner.id,
+        },
+      });
+
+      getMockedSession().mockResolvedValue(createAuthenticatedSession(nonMember));
+
+      const request = createGetRequest(
+        `http://localhost:3000/api/features/${feature.id}`
+      );
+
+      // Execute
+      const response = await GET(request, {
+        params: Promise.resolve({ featureId: feature.id }),
+      });
+
+      // Assert
+      await expectError(response, "Access denied", 403);
+    });
+  });
+
+  describe("PATCH /api/features/[featureId]", () => {
+    test("updates feature title", async () => {
+      // Setup
+      const user = await createTestUser();
+      const workspace = await createTestWorkspace({
+        ownerId: user.id,
+        name: "Test Workspace",
+        slug: "test-workspace",
+      });
+
+      const feature = await db.feature.create({
+        data: {
+          title: "Original Title",
+          workspaceId: workspace.id,
+          createdById: user.id,
+          updatedById: user.id,
+        },
+      });
+
+      getMockedSession().mockResolvedValue(createAuthenticatedSession(user));
+
+      const request = createPatchRequest(
+        `http://localhost:3000/api/features/${feature.id}`,
+        { title: "Updated Title" }
+      );
+
+      // Execute
+      const response = await PATCH(request, {
+        params: Promise.resolve({ featureId: feature.id }),
+      });
+
+      // Assert
+      const data = await expectSuccess(response, 200);
+      expect(data.data.title).toBe("Updated Title");
+      expect(data.data.updatedById).toBe(user.id);
+    });
+
+    test("updates feature status", async () => {
+      // Setup
+      const user = await createTestUser();
+      const workspace = await createTestWorkspace({
+        ownerId: user.id,
+        name: "Test Workspace",
+        slug: "test-workspace",
+      });
+
+      const feature = await db.feature.create({
+        data: {
+          title: "Test Feature",
+          workspaceId: workspace.id,
+          status: FeatureStatus.BACKLOG,
+          createdById: user.id,
+          updatedById: user.id,
+        },
+      });
+
+      getMockedSession().mockResolvedValue(createAuthenticatedSession(user));
+
+      const request = createPatchRequest(
+        `http://localhost:3000/api/features/${feature.id}`,
+        { status: FeatureStatus.IN_PROGRESS }
+      );
+
+      // Execute
+      const response = await PATCH(request, {
+        params: Promise.resolve({ featureId: feature.id }),
+      });
+
+      // Assert
+      const data = await expectSuccess(response, 200);
+      expect(data.data.status).toBe(FeatureStatus.IN_PROGRESS);
+    });
+
+    test("updates feature priority", async () => {
+      // Setup
+      const user = await createTestUser();
+      const workspace = await createTestWorkspace({
+        ownerId: user.id,
+        name: "Test Workspace",
+        slug: "test-workspace",
+      });
+
+      const feature = await db.feature.create({
+        data: {
+          title: "Test Feature",
+          workspaceId: workspace.id,
+          priority: FeaturePriority.LOW,
+          createdById: user.id,
+          updatedById: user.id,
+        },
+      });
+
+      getMockedSession().mockResolvedValue(createAuthenticatedSession(user));
+
+      const request = createPatchRequest(
+        `http://localhost:3000/api/features/${feature.id}`,
+        { priority: FeaturePriority.URGENT }
+      );
+
+      // Execute
+      const response = await PATCH(request, {
+        params: Promise.resolve({ featureId: feature.id }),
+      });
+
+      // Assert
+      const data = await expectSuccess(response, 200);
+      expect(data.data.priority).toBe(FeaturePriority.URGENT);
+    });
+
+    test("updates feature assignee", async () => {
+      // Setup
+      const owner = await createTestUser();
+      const assignee = await createTestUser({ name: "New Assignee" });
+      const workspace = await createTestWorkspace({
+        ownerId: owner.id,
+        name: "Test Workspace",
+        slug: "test-workspace",
+      });
+
+      const feature = await db.feature.create({
+        data: {
+          title: "Test Feature",
+          workspaceId: workspace.id,
+          createdById: owner.id,
+          updatedById: owner.id,
+        },
+      });
+
+      getMockedSession().mockResolvedValue(createAuthenticatedSession(owner));
+
+      const request = createPatchRequest(
+        `http://localhost:3000/api/features/${feature.id}`,
+        { assigneeId: assignee.id }
+      );
+
+      // Execute
+      const response = await PATCH(request, {
+        params: Promise.resolve({ featureId: feature.id }),
+      });
+
+      // Assert
+      const data = await expectSuccess(response, 200);
+      expect(data.data.assignee).toMatchObject({
+        id: assignee.id,
+        name: "New Assignee",
+      });
+    });
+
+    test("can unassign feature by setting assigneeId to null", async () => {
+      // Setup
+      const owner = await createTestUser();
+      const assignee = await createTestUser();
+      const workspace = await createTestWorkspace({
+        ownerId: owner.id,
+        name: "Test Workspace",
+        slug: "test-workspace",
+      });
+
+      const feature = await db.feature.create({
+        data: {
+          title: "Test Feature",
+          workspaceId: workspace.id,
+          assigneeId: assignee.id,
+          createdById: owner.id,
+          updatedById: owner.id,
+        },
+      });
+
+      getMockedSession().mockResolvedValue(createAuthenticatedSession(owner));
+
+      const request = createPatchRequest(
+        `http://localhost:3000/api/features/${feature.id}`,
+        { assigneeId: null }
+      );
+
+      // Execute
+      const response = await PATCH(request, {
+        params: Promise.resolve({ featureId: feature.id }),
+      });
+
+      // Assert
+      const data = await expectSuccess(response, 200);
+      expect(data.data.assigneeId).toBeNull();
+      expect(data.data.assignee).toBeNull();
+    });
+
+    test("updates multiple fields at once", async () => {
+      // Setup
+      const user = await createTestUser();
+      const workspace = await createTestWorkspace({
+        ownerId: user.id,
+        name: "Test Workspace",
+        slug: "test-workspace",
+      });
+
+      const feature = await db.feature.create({
+        data: {
+          title: "Original Title",
+          workspaceId: workspace.id,
+          status: FeatureStatus.BACKLOG,
+          priority: FeaturePriority.LOW,
+          createdById: user.id,
+          updatedById: user.id,
+        },
+      });
+
+      getMockedSession().mockResolvedValue(createAuthenticatedSession(user));
+
+      const request = createPatchRequest(
+        `http://localhost:3000/api/features/${feature.id}`,
+        {
+          title: "New Title",
+          status: FeatureStatus.COMPLETED,
+          priority: FeaturePriority.HIGH,
+        }
+      );
+
+      // Execute
+      const response = await PATCH(request, {
+        params: Promise.resolve({ featureId: feature.id }),
+      });
+
+      // Assert
+      const data = await expectSuccess(response, 200);
+      expect(data.data).toMatchObject({
+        title: "New Title",
+        status: FeatureStatus.COMPLETED,
+        priority: FeaturePriority.HIGH,
+      });
+    });
+
+    test("trims whitespace from title", async () => {
+      // Setup
+      const user = await createTestUser();
+      const workspace = await createTestWorkspace({
+        ownerId: user.id,
+        name: "Test Workspace",
+        slug: "test-workspace",
+      });
+
+      const feature = await db.feature.create({
+        data: {
+          title: "Original Title",
+          workspaceId: workspace.id,
+          createdById: user.id,
+          updatedById: user.id,
+        },
+      });
+
+      getMockedSession().mockResolvedValue(createAuthenticatedSession(user));
+
+      const request = createPatchRequest(
+        `http://localhost:3000/api/features/${feature.id}`,
+        { title: "  Trimmed Title  " }
+      );
+
+      // Execute
+      const response = await PATCH(request, {
+        params: Promise.resolve({ featureId: feature.id }),
+      });
+
+      // Assert
+      const data = await expectSuccess(response, 200);
+      expect(data.data.title).toBe("Trimmed Title");
+    });
+
+    test("requires authentication", async () => {
+      getMockedSession().mockResolvedValue(mockUnauthenticatedSession());
+
+      const request = createPatchRequest(
+        "http://localhost:3000/api/features/test-feature-id",
+        { title: "New Title" }
+      );
+
+      const response = await PATCH(request, {
+        params: Promise.resolve({ featureId: "test-feature-id" }),
+      });
+
+      await expectUnauthorized(response);
+    });
+
+    test("returns 404 for non-existent feature", async () => {
+      const user = await createTestUser();
+      getMockedSession().mockResolvedValue(createAuthenticatedSession(user));
+
+      const request = createPatchRequest(
+        "http://localhost:3000/api/features/non-existent-id",
+        { title: "New Title" }
+      );
+
+      const response = await PATCH(request, {
+        params: Promise.resolve({ featureId: "non-existent-id" }),
+      });
+
+      await expectError(response, "Feature not found", 404);
+    });
+
+    test("denies access to non-workspace members", async () => {
+      // Setup
+      const owner = await createTestUser();
+      const nonMember = await createTestUser();
+      const workspace = await createTestWorkspace({
+        ownerId: owner.id,
+        name: "Test Workspace",
+        slug: "test-workspace",
+      });
+
+      const feature = await db.feature.create({
+        data: {
+          title: "Test Feature",
+          workspaceId: workspace.id,
+          createdById: owner.id,
+          updatedById: owner.id,
+        },
+      });
+
+      getMockedSession().mockResolvedValue(createAuthenticatedSession(nonMember));
+
+      const request = createPatchRequest(
+        `http://localhost:3000/api/features/${feature.id}`,
+        { title: "Updated Title" }
+      );
+
+      // Execute
+      const response = await PATCH(request, {
+        params: Promise.resolve({ featureId: feature.id }),
+      });
+
+      // Assert
+      await expectError(response, "Access denied", 403);
+    });
+
+    test("validates status enum", async () => {
+      // Setup
+      const user = await createTestUser();
+      const workspace = await createTestWorkspace({
+        ownerId: user.id,
+        name: "Test Workspace",
+        slug: "test-workspace",
+      });
+
+      const feature = await db.feature.create({
+        data: {
+          title: "Test Feature",
+          workspaceId: workspace.id,
+          createdById: user.id,
+          updatedById: user.id,
+        },
+      });
+
+      getMockedSession().mockResolvedValue(createAuthenticatedSession(user));
+
+      const request = createPatchRequest(
+        `http://localhost:3000/api/features/${feature.id}`,
+        { status: "INVALID_STATUS" }
+      );
+
+      // Execute
+      const response = await PATCH(request, {
+        params: Promise.resolve({ featureId: feature.id }),
+      });
+
+      // Assert
+      await expectError(response, "Invalid status", 400);
+    });
+
+    test("validates priority enum", async () => {
+      // Setup
+      const user = await createTestUser();
+      const workspace = await createTestWorkspace({
+        ownerId: user.id,
+        name: "Test Workspace",
+        slug: "test-workspace",
+      });
+
+      const feature = await db.feature.create({
+        data: {
+          title: "Test Feature",
+          workspaceId: workspace.id,
+          createdById: user.id,
+          updatedById: user.id,
+        },
+      });
+
+      getMockedSession().mockResolvedValue(createAuthenticatedSession(user));
+
+      const request = createPatchRequest(
+        `http://localhost:3000/api/features/${feature.id}`,
+        { priority: "INVALID_PRIORITY" }
+      );
+
+      // Execute
+      const response = await PATCH(request, {
+        params: Promise.resolve({ featureId: feature.id }),
+      });
+
+      // Assert
+      await expectError(response, "Invalid priority", 400);
+    });
+
+    test("validates assignee exists", async () => {
+      // Setup
+      const user = await createTestUser();
+      const workspace = await createTestWorkspace({
+        ownerId: user.id,
+        name: "Test Workspace",
+        slug: "test-workspace",
+      });
+
+      const feature = await db.feature.create({
+        data: {
+          title: "Test Feature",
+          workspaceId: workspace.id,
+          createdById: user.id,
+          updatedById: user.id,
+        },
+      });
+
+      getMockedSession().mockResolvedValue(createAuthenticatedSession(user));
+
+      const request = createPatchRequest(
+        `http://localhost:3000/api/features/${feature.id}`,
+        { assigneeId: "non-existent-user-id" }
+      );
+
+      // Execute
+      const response = await PATCH(request, {
+        params: Promise.resolve({ featureId: feature.id }),
+      });
+
+      // Assert
+      await expectError(response, "Assignee not found", 400);
+    });
+  });
+});

--- a/src/app/api/features/[featureId]/route.ts
+++ b/src/app/api/features/[featureId]/route.ts
@@ -1,0 +1,308 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/lib/auth/nextauth";
+import { db } from "@/lib/db";
+import { FeatureStatus, FeaturePriority } from "@prisma/client";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ featureId: string }> }
+) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const userId = (session.user as { id?: string })?.id;
+    if (!userId) {
+      return NextResponse.json(
+        { error: "Invalid user session" },
+        { status: 401 }
+      );
+    }
+
+    const { featureId } = await params;
+
+    const feature = await db.feature.findUnique({
+      where: {
+        id: featureId,
+      },
+      include: {
+        workspace: {
+          select: {
+            id: true,
+            name: true,
+            slug: true,
+            ownerId: true,
+            members: {
+              where: {
+                userId: userId,
+              },
+              select: {
+                role: true,
+              },
+            },
+          },
+        },
+        assignee: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            image: true,
+          },
+        },
+        createdBy: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            image: true,
+          },
+        },
+        updatedBy: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            image: true,
+          },
+        },
+        userStories: {
+          orderBy: {
+            order: "asc",
+          },
+          include: {
+            createdBy: {
+              select: {
+                id: true,
+                name: true,
+                email: true,
+              },
+            },
+            updatedBy: {
+              select: {
+                id: true,
+                name: true,
+                email: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!feature) {
+      return NextResponse.json(
+        { error: "Feature not found" },
+        { status: 404 }
+      );
+    }
+
+    // Check if user is workspace owner or member
+    const isOwner = feature.workspace.ownerId === userId;
+    const isMember = feature.workspace.members.length > 0;
+
+    if (!isOwner && !isMember) {
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
+    }
+
+    return NextResponse.json(
+      {
+        success: true,
+        data: feature,
+      },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error("Error fetching feature:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch feature" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ featureId: string }> }
+) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const userId = (session.user as { id?: string })?.id;
+    if (!userId) {
+      return NextResponse.json(
+        { error: "Invalid user session" },
+        { status: 401 }
+      );
+    }
+
+    const { featureId } = await params;
+    const body = await request.json();
+    const { title, status, priority, assigneeId } = body;
+
+    // Fetch the feature with workspace info
+    const feature = await db.feature.findUnique({
+      where: {
+        id: featureId,
+      },
+      select: {
+        id: true,
+        workspace: {
+          select: {
+            id: true,
+            ownerId: true,
+            members: {
+              where: {
+                userId: userId,
+              },
+              select: {
+                role: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!feature) {
+      return NextResponse.json(
+        { error: "Feature not found" },
+        { status: 404 }
+      );
+    }
+
+    // Check if user is workspace owner or member
+    const isOwner = feature.workspace.ownerId === userId;
+    const isMember = feature.workspace.members.length > 0;
+
+    if (!isOwner && !isMember) {
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
+    }
+
+    // Validate status if provided
+    if (status && !Object.values(FeatureStatus).includes(status as FeatureStatus)) {
+      return NextResponse.json(
+        {
+          error: `Invalid status. Must be one of: ${Object.values(FeatureStatus).join(", ")}`,
+        },
+        { status: 400 }
+      );
+    }
+
+    // Validate priority if provided
+    if (priority && !Object.values(FeaturePriority).includes(priority as FeaturePriority)) {
+      return NextResponse.json(
+        {
+          error: `Invalid priority. Must be one of: ${Object.values(FeaturePriority).join(", ")}`,
+        },
+        { status: 400 }
+      );
+    }
+
+    // Validate assignee exists if provided
+    if (assigneeId !== undefined && assigneeId !== null) {
+      const assignee = await db.user.findFirst({
+        where: {
+          id: assigneeId,
+        },
+      });
+
+      if (!assignee) {
+        return NextResponse.json(
+          { error: "Assignee not found" },
+          { status: 400 }
+        );
+      }
+    }
+
+    // Build update data object
+    const updateData: {
+      title?: string;
+      status?: FeatureStatus;
+      priority?: FeaturePriority;
+      assigneeId?: string | null;
+      updatedById: string;
+    } = {
+      updatedById: userId,
+    };
+
+    if (title !== undefined) {
+      updateData.title = title.trim();
+    }
+    if (status !== undefined) {
+      updateData.status = status as FeatureStatus;
+    }
+    if (priority !== undefined) {
+      updateData.priority = priority as FeaturePriority;
+    }
+    if (assigneeId !== undefined) {
+      updateData.assigneeId = assigneeId;
+    }
+
+    // Update the feature
+    const updatedFeature = await db.feature.update({
+      where: {
+        id: featureId,
+      },
+      data: updateData,
+      include: {
+        workspace: {
+          select: {
+            id: true,
+            name: true,
+            slug: true,
+          },
+        },
+        assignee: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            image: true,
+          },
+        },
+        createdBy: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            image: true,
+          },
+        },
+        updatedBy: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            image: true,
+          },
+        },
+        userStories: {
+          orderBy: {
+            order: "asc",
+          },
+        },
+      },
+    });
+
+    return NextResponse.json(
+      {
+        success: true,
+        data: updatedFeature,
+      },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error("Error updating feature:", error);
+    return NextResponse.json(
+      { error: "Failed to update feature" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
Implement GET and PATCH endpoints for /api/features/[featureId]:
- GET: Fetch single feature with user stories and related data
- PATCH: Update feature title, status, priority, and assignee
- Include workspace access control and authentication
- Add comprehensive integration test coverage (18 tests)

Part of roadmap feature implementation (Ticket 1.2)