### PR TITLE
Add TypeScript types for roadmap feature API

### DIFF
--- a/src/app/api/features/[featureId]/user-stories/route.ts
+++ b/src/app/api/features/[featureId]/user-stories/route.ts
@@ -2,6 +2,11 @@ import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth/nextauth";
 import { db } from "@/lib/db";
+import type {
+  CreateUserStoryRequest,
+  UserStoryListResponse,
+  UserStoryResponse,
+} from "@/types/roadmap";
 
 export async function GET(
   request: NextRequest,
@@ -105,7 +110,7 @@ export async function GET(
       },
     });
 
-    return NextResponse.json(
+    return NextResponse.json<UserStoryListResponse>(
       {
         success: true,
         data: userStories,
@@ -140,7 +145,7 @@ export async function POST(
     }
 
     const { featureId } = await params;
-    const body = await request.json();
+    const body: CreateUserStoryRequest = await request.json();
     const { title } = body;
 
     // Validate required fields
@@ -260,7 +265,7 @@ export async function POST(
       },
     });
 
-    return NextResponse.json(
+    return NextResponse.json<UserStoryResponse>(
       {
         success: true,
         data: userStory,

--- a/src/app/api/features/route.ts
+++ b/src/app/api/features/route.ts
@@ -3,6 +3,11 @@ import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth/nextauth";
 import { db } from "@/lib/db";
 import { FeatureStatus, FeaturePriority } from "@prisma/client";
+import type {
+  CreateFeatureRequest,
+  FeatureListResponse,
+  FeatureResponse,
+} from "@/types/roadmap";
 
 export async function GET(request: NextRequest) {
   try {
@@ -130,7 +135,7 @@ export async function GET(request: NextRequest) {
     const totalPages = Math.ceil(totalCount / limit);
     const hasMore = page < totalPages;
 
-    return NextResponse.json(
+    return NextResponse.json<FeatureListResponse>(
       {
         success: true,
         data: features,
@@ -168,7 +173,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = await request.json();
+    const body: CreateFeatureRequest = await request.json();
     const { title, workspaceId, status, priority, assigneeId } = body;
 
     // Validate required fields
@@ -313,7 +318,7 @@ export async function POST(request: NextRequest) {
       },
     });
 
-    return NextResponse.json(
+    return NextResponse.json<FeatureResponse>(
       {
         success: true,
         data: feature,

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -22,6 +22,28 @@ export interface PaginationParams {
   order?: "asc" | "desc";
 }
 
+// Standard pagination metadata for API responses
+export interface PaginationMeta {
+  page: number;
+  limit: number;
+  totalCount: number;
+  totalPages: number;
+  hasMore: boolean;
+}
+
+// Standard success response for single resource
+export interface ApiSuccessResponse<T> {
+  success: true;
+  data: T;
+}
+
+// Standard success response for paginated resources
+export interface PaginatedApiResponse<T> {
+  success: true;
+  data: T[];
+  pagination: PaginationMeta;
+}
+
 // Common error types
 export interface ApiError {
   message: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,3 +28,6 @@ export * from "./stakgraph";
 
 // Github types
 export * from "./github";
+
+// Roadmap types
+export * from "./roadmap";

--- a/src/types/roadmap.ts
+++ b/src/types/roadmap.ts
@@ -1,0 +1,168 @@
+import type { Prisma, FeatureStatus, FeaturePriority } from "@prisma/client";
+import type {
+  ApiSuccessResponse,
+  PaginatedApiResponse,
+} from "./common";
+
+// Re-export Prisma enums for convenience
+export type { FeatureStatus, FeaturePriority };
+
+// Feature with relations (matches GET /api/features query)
+export type FeatureWithDetails = Prisma.FeatureGetPayload<{
+  select: {
+    id: true;
+    title: true;
+    status: true;
+    priority: true;
+    createdAt: true;
+    updatedAt: true;
+    assignee: {
+      select: {
+        id: true;
+        name: true;
+        email: true;
+        image: true;
+      };
+    };
+    createdBy: {
+      select: {
+        id: true;
+        name: true;
+        email: true;
+        image: true;
+      };
+    };
+    _count: {
+      select: {
+        userStories: true;
+      };
+    };
+  };
+}>;
+
+// Feature with workspace (matches POST /api/features response)
+export type FeatureWithWorkspace = Prisma.FeatureGetPayload<{
+  include: {
+    assignee: {
+      select: {
+        id: true;
+        name: true;
+        email: true;
+        image: true;
+      };
+    };
+    createdBy: {
+      select: {
+        id: true;
+        name: true;
+        email: true;
+        image: true;
+      };
+    };
+    workspace: {
+      select: {
+        id: true;
+        name: true;
+        slug: true;
+      };
+    };
+    _count: {
+      select: {
+        userStories: true;
+      };
+    };
+  };
+}>;
+
+// UserStory for list (matches GET user-stories query - no feature relation)
+export type UserStoryListItem = Prisma.UserStoryGetPayload<{
+  select: {
+    id: true;
+    title: true;
+    order: true;
+    completed: true;
+    createdAt: true;
+    updatedAt: true;
+    createdBy: {
+      select: {
+        id: true;
+        name: true;
+        email: true;
+        image: true;
+      };
+    };
+    updatedBy: {
+      select: {
+        id: true;
+        name: true;
+        email: true;
+        image: true;
+      };
+    };
+  };
+}>;
+
+// UserStory with feature relation (matches POST user-stories response)
+export type UserStoryWithDetails = Prisma.UserStoryGetPayload<{
+  include: {
+    createdBy: {
+      select: {
+        id: true;
+        name: true;
+        email: true;
+        image: true;
+      };
+    };
+    updatedBy: {
+      select: {
+        id: true;
+        name: true;
+        email: true;
+        image: true;
+      };
+    };
+    feature: {
+      select: {
+        id: true;
+        title: true;
+        workspaceId: true;
+      };
+    };
+  };
+}>;
+
+// Request types
+export interface CreateFeatureRequest {
+  title: string;
+  workspaceId: string;
+  status?: FeatureStatus;
+  priority?: FeaturePriority;
+  assigneeId?: string;
+}
+
+export interface UpdateFeatureRequest {
+  title?: string;
+  status?: FeatureStatus;
+  priority?: FeaturePriority;
+  assigneeId?: string | null;
+}
+
+export interface CreateUserStoryRequest {
+  title: string;
+}
+
+export interface UpdateUserStoryRequest {
+  title?: string;
+  order?: number;
+  completed?: boolean;
+}
+
+export interface ReorderUserStoriesRequest {
+  userStoryIds: string[];
+}
+
+// Response type aliases using generic types
+export type FeatureListResponse = PaginatedApiResponse<FeatureWithDetails>;
+export type FeatureResponse = ApiSuccessResponse<FeatureWithWorkspace>;
+export type UserStoryListResponse = ApiSuccessResponse<UserStoryListItem[]>;
+export type UserStoryResponse = ApiSuccessResponse<UserStoryWithDetails>;


### PR DESCRIPTION
- Add generic API response types to common.ts (PaginationMeta, ApiSuccessResponse, PaginatedApiResponse)
- Create roadmap.ts with Prisma-derived types for Feature and UserStory entities
- Add request/response types for all Feature API operations
- Update Feature API endpoints with full type safety
- Update UserStory API endpoints with full type safety