### PR TITLE
Fix 307 redirect loop by switching to JWT sessions

### DIFF
--- a/src/lib/auth/nextauth.ts
+++ b/src/lib/auth/nextauth.ts
@@ -439,7 +439,7 @@ export const authOptions: NextAuthOptions = {
     error: "/auth/error",
   },
   session: {
-    strategy: process.env.POD_URL ? "jwt" : "database",
+    strategy: "jwt",
     maxAge: 30 * 24 * 60 * 60, // 30 days
   },
   secret: process.env.NEXTAUTH_SECRET,


### PR DESCRIPTION
Middleware uses getToken() which only works with JWT sessions, but production was configured to use database sessions. This caused middleware to fail authentication checks and trigger redirect loops.

Changes:
- Always use JWT session strategy
- Always include PrismaAdapter (safe for CredentialsProvider)