### PR TITLE
Fix JWT token persistence in NextAuth callback

### DIFF
--- a/src/lib/auth/nextauth.ts
+++ b/src/lib/auth/nextauth.ts
@@ -400,18 +400,23 @@ export const authOptions: NextAuthOptions = {
       return session;
     },
     async jwt({ token, user, account }) {
-      // For JWT sessions (mock provider), store user info in token
-      if (account?.provider === "mock" && user) {
+      // Initial sign-in: populate token with user data
+      if (user) {
         token.id = user.id;
         token.email = user.email;
         token.name = user.name;
         token.picture = user.image;
-        token.github = {
-          username: user.name?.toLowerCase().replace(/\s+/g, "-") || "mock-user",
-          publicRepos: 5,
-          followers: 10,
-        };
+
+        // For mock provider, add mock GitHub data
+        if (account?.provider === "mock") {
+          token.github = {
+            username: user.name?.toLowerCase().replace(/\s+/g, "-") || "mock-user",
+            publicRepos: 5,
+            followers: 10,
+          };
+        }
       }
+      // Subsequent requests: token already has the data, just return it
       return token;
     },
   },


### PR DESCRIPTION
The jwt callback was only setting token.id for mock provider during initial sign-in, but the session callback expects token.id for all JWT sessions when POD_URL is set. This caused "Cannot read properties of undefined (reading 'id')" errors on subsequent requests.

Now token.id is set whenever user is present (regardless of provider), ensuring token data persists across all JWT session requests.