### PR TITLE
Add /api/chat/response to webhook routes

### DIFF
--- a/src/config/middleware.ts
+++ b/src/config/middleware.ts
@@ -29,6 +29,7 @@ export const ROUTE_POLICIES: ReadonlyArray<RoutePolicy> = [
   { path: "/api/stakwork/webhook", strategy: "prefix", access: "webhook" },
   { path: "/api/janitors/webhook", strategy: "prefix", access: "webhook" },
   { path: "/api/swarm/stakgraph/webhook", strategy: "prefix", access: "webhook" },
+  { path: "/api/chat/response", strategy: "prefix", access: "webhook" },
 ] as const;
 
 function normalizePath(pathname: string): string {


### PR DESCRIPTION
Allow external services to call the chat response endpoint by adding it to the webhook route policies.