### PR TITLE
Remove /api/tests/coverage from public routes

### DIFF
--- a/src/config/middleware.ts
+++ b/src/config/middleware.ts
@@ -24,7 +24,6 @@ export const ROUTE_POLICIES: ReadonlyArray<RoutePolicy> = [
   { path: "/api/auth", strategy: "prefix", access: "public" },
   { path: "/api/cron", strategy: "prefix", access: "public" },
   { path: "/api/mock", strategy: "prefix", access: "public" },
-  { path: "/api/tests/coverage", strategy: "prefix", access: "public" },
   { path: "/api/github/webhook", strategy: "prefix", access: "webhook" },
   { path: "/api/stakwork/webhook", strategy: "prefix", access: "webhook" },
   { path: "/api/janitors/webhook", strategy: "prefix", access: "webhook" },


### PR DESCRIPTION
The endpoint already has its own authentication check, so it should not be in the public routes list. This adds defense in depth by requiring auth at both middleware and route level.