### PR TITLE
Add API token authentication to chat response endpoint

### DIFF
--- a/src/app/api/chat/response/route.ts
+++ b/src/app/api/chat/response/route.ts
@@ -20,6 +20,12 @@ interface ArtifactRequest {
 
 export async function POST(request: NextRequest) {
   try {
+    // Check API token authentication
+    const apiToken = request.headers.get("x-api-token");
+    if (!apiToken || apiToken !== process.env.API_TOKEN) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
     const body = await request.json();
     const {
       taskId,


### PR DESCRIPTION
Add x-api-token header validation to /api/chat/response endpoint to secure it from unauthorized access. This aligns with other webhook endpoints in the codebase that handle external requests.