### PR TITLE
Fix kanban view user display and remove roadmap subtitles

### DIFF
--- a/src/app/w/[slug]/roadmap/page.tsx
+++ b/src/app/w/[slug]/roadmap/page.tsx
@@ -11,7 +11,6 @@ export default function RoadmapPage() {
     <div className="space-y-6">
       <PageHeader
         title="Roadmap"
-        description="Plan and track your product features and development roadmap."
       />
 
       <FeaturesList workspaceId={workspaceId} />

--- a/src/components/features/FeatureCard.tsx
+++ b/src/components/features/FeatureCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Users, Calendar, User } from "lucide-react";
+import { Calendar, User } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
@@ -40,20 +40,14 @@ export function FeatureCard({ feature, workspaceSlug, hideStatus = false }: Feat
       </div>
 
       <div className="flex items-center gap-4 text-xs text-muted-foreground">
-        <div className="flex items-center gap-2">
-          <Avatar className="size-5">
-            <AvatarImage src={feature.createdBy.image || undefined} />
-            <AvatarFallback className="text-xs">
-              <User className="w-3 h-3" />
-            </AvatarFallback>
-          </Avatar>
-          <span>
-            {feature.createdBy.name || feature.createdBy.email}
-          </span>
-        </div>
         {feature.assignee && (
-          <div className="flex items-center gap-1">
-            <Users className="w-3 h-3" />
+          <div className="flex items-center gap-2">
+            <Avatar className="size-5">
+              <AvatarImage src={feature.assignee.image || undefined} />
+              <AvatarFallback className="text-xs">
+                <User className="w-3 h-3" />
+              </AvatarFallback>
+            </Avatar>
             <span>{feature.assignee.name || feature.assignee.email}</span>
           </div>
         )}

--- a/src/components/features/FeaturesList.tsx
+++ b/src/components/features/FeaturesList.tsx
@@ -225,7 +225,6 @@ export function FeaturesList({ workspaceId }: FeaturesListProps) {
             <span>Features</span>
             <span className="font-normal text-sm text-muted-foreground">Loading...</span>
           </CardTitle>
-          <CardDescription>Your product roadmap features and their current status</CardDescription>
         </CardHeader>
         <CardContent>
           <div className="mb-4">
@@ -351,7 +350,6 @@ export function FeaturesList({ workspaceId }: FeaturesListProps) {
             </ToggleGroup>
           </div>
         </CardTitle>
-        <CardDescription>Your product roadmap features and their current status</CardDescription>
       </CardHeader>
       <CardContent>
         {!isCreating && (


### PR DESCRIPTION
- Issue #1130: Show assignee instead of createdBy user in kanban FeatureCard
  - Display assignee avatar and name when assigned
  - Remove createdBy user display from card footer
  - Remove unused Users icon import

- Issue #1126: Remove subtitle descriptions from roadmap views
  - Remove description from roadmap page PageHeader
  - Remove CardDescription from FeaturesList component
  - Reduces visual clutter in web application UI