### PR TITLE
Fix default workspace to use last accessed workspace

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -104,6 +104,10 @@ export const WORKSPACE_SLUG_PATTERNS = {
   MAX_LENGTH: 50,
 } as const;
 
+// Workspace navigation cookies
+export const LAST_WORKSPACE_COOKIE = "lastWorkspaceSlug";
+export const LAST_WORKSPACE_COOKIE_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
+
 import { WorkspaceRole } from "@prisma/client";
 
 // Workspace access levels for permission checking


### PR DESCRIPTION
Resolves #1135 - When a user session ends, the default workspace now remembers the last workspace they accessed instead of defaulting to the first workspace alphabetically.

Changes:
- Add lastWorkspaceSlug cookie with 30-day expiry
- Update workspace-resolver to check cookie before falling back to default
- Persist cookie when workspace loads or user switches workspaces
- Validate user still has access to last workspace before redirecting
- Update tests for new cookie-based resolution logic