### PR TITLE
Fix: Exclude /js/ directory from middleware matcher

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -141,7 +141,7 @@ export async function middleware(request: NextRequest) {
 // Configure which routes the middleware should run on
 export const config = {
   matcher: [
-    // Apply to all routes except Next.js internals
-    "/((?!_next/static|_next/image|favicon.ico).*)",
+    // Apply to all routes except Next.js internals and public static files
+    "/((?!_next/static|_next/image|favicon.ico|js/).*)",
   ],
 };


### PR DESCRIPTION
## Problem

Middleware matcher was intercepting requests to static JS files in /js/ directory (staktrak.js, playwright-generator.js). Unauthenticated users were redirected to homepage HTML instead of receiving the JS files, causing browser syntax errors: "Uncaught SyntaxError: Unexpected token '<'".

## Solution

Updated middleware matcher to exclude js/ directory from authentication checks.

Changed from:
```
"/((?!_next/static|_next/image|favicon.ico).*)"
```

To:
```
"/((?!_next/static|_next/image|favicon.ico|js/).*)"
```

Tested locally - static JS files now load correctly on unauthenticated pages.