### PR TITLE
Fix: prevent auto-focus on mount, only focus after creation

### DIFF
--- a/src/app/w/[slug]/roadmap/[featureId]/page.tsx
+++ b/src/app/w/[slug]/roadmap/[featureId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import { useRouter, useParams } from "next/navigation";
 import { ArrowLeft, Loader2, Check, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -29,6 +29,7 @@ export default function FeatureDetailPage() {
   // User story creation state
   const [newStoryTitle, setNewStoryTitle] = useState("");
   const [creatingStory, setCreatingStory] = useState(false);
+  const storyFocusRef = useRef(false);
 
   const fetchFeature = useCallback(
     async (id: string) => {
@@ -109,6 +110,7 @@ export default function FeatureDetailPage() {
           ...feature,
           userStories: [...feature.userStories, result.data],
         });
+        storyFocusRef.current = true;
         setNewStoryTitle("");
       }
     } catch (error) {
@@ -412,6 +414,7 @@ export default function FeatureDetailPage() {
             onAddUserStory={handleAddUserStory}
             onDeleteUserStory={handleDeleteUserStory}
             onReorderUserStories={handleReorderUserStories}
+            shouldFocusRef={storyFocusRef}
           />
 
           <AutoSaveTextarea

--- a/src/components/features/PhaseSection.tsx
+++ b/src/components/features/PhaseSection.tsx
@@ -35,6 +35,7 @@ export function PhaseSection({ featureId, workspaceSlug, phases, onUpdate }: Pha
   const [newPhaseName, setNewPhaseName] = useState("");
   const [creatingPhase, setCreatingPhase] = useState(false);
   const phaseInputRef = useRef<HTMLInputElement>(null);
+  const shouldFocusRef = useRef(false);
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -45,10 +46,11 @@ export function PhaseSection({ featureId, workspaceSlug, phases, onUpdate }: Pha
 
   const phaseIds = useMemo(() => phases.map((phase) => phase.id), [phases]);
 
-  // Auto-focus after phase creation completes
+  // Auto-focus after phase creation completes (not on mount)
   useEffect(() => {
-    if (!creatingPhase && !newPhaseName) {
+    if (shouldFocusRef.current && !creatingPhase && !newPhaseName) {
       phaseInputRef.current?.focus();
+      shouldFocusRef.current = false;
     }
   }, [creatingPhase, newPhaseName]);
 
@@ -70,6 +72,7 @@ export function PhaseSection({ featureId, workspaceSlug, phases, onUpdate }: Pha
       const result = await response.json();
       if (result.success) {
         onUpdate([...phases, result.data]);
+        shouldFocusRef.current = true;
         setNewPhaseName("");
       }
     } catch (error) {

--- a/src/components/features/UserStoriesSection.tsx
+++ b/src/components/features/UserStoriesSection.tsx
@@ -31,6 +31,7 @@ interface UserStoriesSectionProps {
   onAddUserStory: () => void;
   onDeleteUserStory: (storyId: string) => void;
   onReorderUserStories: (stories: FeatureDetail["userStories"]) => void;
+  shouldFocusRef: React.MutableRefObject<boolean>;
 }
 
 export function UserStoriesSection({
@@ -41,6 +42,7 @@ export function UserStoriesSection({
   onAddUserStory,
   onDeleteUserStory,
   onReorderUserStories,
+  shouldFocusRef,
 }: UserStoriesSectionProps) {
   const storyInputRef = useRef<HTMLInputElement>(null);
 
@@ -52,10 +54,11 @@ export function UserStoriesSection({
     })
   );
 
-  // Auto-focus after story creation
+  // Auto-focus after story creation (not on mount)
   useEffect(() => {
-    if (!creatingStory && !newStoryTitle) {
+    if (shouldFocusRef.current && !creatingStory && !newStoryTitle) {
       storyInputRef.current?.focus();
+      shouldFocusRef.current = false;
     }
   }, [creatingStory, newStoryTitle]);
 


### PR DESCRIPTION
- Use shouldFocusRef pattern to explicitly control focus timing
- PhaseSection: focus only after successful phase creation
- UserStoriesSection: focus only after successful user story creation
- Prevents unwanted focus on page load and component remounts