### PR TITLE
Shorten user story generation to brief 1-2 sentence flows

### DIFF
--- a/src/app/api/features/[featureId]/generate-stories/route.ts
+++ b/src/app/api/features/[featureId]/generate-stories/route.ts
@@ -10,7 +10,7 @@ type Provider = "anthropic" | "openai";
 const storiesSchema = z.object({
   stories: z.array(
     z.object({
-      title: z.string().describe("User journey flow describing the step-by-step interaction scenario from trigger to completion"),
+      title: z.string().describe("Brief user journey flow (1-2 sentences) showing sequence of actions and outcome"),
     })
   ),
 });
@@ -75,19 +75,19 @@ export async function POST(
       ? `\n\nTarget Personas:\n${feature.personas.map((p: string) => `- ${p}`).join('\n')}`
       : '';
 
-    const userPrompt = `Generate 3-5 user journey flows for this feature:
+    const userPrompt = `Generate 3-5 brief user journey flows for this feature:
 
 Title: ${feature.title}
 ${feature.brief ? `Brief: ${feature.brief}` : ''}${personasText}${existingStoriesText}
 
-Create realistic journey scenarios showing step-by-step how users will interact with this feature.
+Create brief user journey flows (1-2 sentences each) showing how users interact with the feature.
 Each journey should:
-- Start with user context and trigger
-- Detail the sequence of actions and system responses
-- Include specific touchpoints and interactions
-- End with a clear outcome or completion state
+- Be 1-2 sentences maximum (prefer 1 sentence)
+- Show a brief sequence: what they read/see, what they do, what outcome they achieve
+- Include 2-4 actions connected with "then" or commas
+- Example format: "[Persona] reviews [X], then does [Y] to achieve [Z]"
 
-${feature.personas && feature.personas.length > 0 ? 'Use the exact persona names listed above in your journey flows. Distribute journeys across different personas to show varied interaction patterns.' : ''}
+${feature.personas && feature.personas.length > 0 ? 'Use the exact persona names listed above. Distribute journeys across different personas to show varied interaction patterns.' : ''}
 Generate NEW journey flows that complement the existing ones (if any) but do not duplicate them.`;
 
     // Use anthropic provider (Claude)

--- a/src/lib/constants/prompt.ts
+++ b/src/lib/constants/prompt.ts
@@ -8,30 +8,69 @@ You must always call the final_answer tool to deliver your answer to the user.`;
 
 // System prompt for generating user journeys/flows from feature details
 export const GENERATE_STORIES_SYSTEM_PROMPT = `
-You are a product management assistant helping to generate user journey flows for software features.
+You are a product management assistant helping to generate brief user journey flows for software features.
 
-Your task is to analyze the feature details provided and generate 3-5 concrete user journey scenarios that describe how users will interact with the feature step-by-step.
+Your task is to analyze the feature details provided and generate 3-5 user journey flows that show how users interact with the feature.
+
+CRITICAL: Each journey must be 1-2 sentences maximum. Show a brief sequence of actions, not a detailed narrative.
 
 Guidelines for creating user journey flows:
 
-1. Start with the user's context and goal: "[Persona] needs to [accomplish goal]..."
-2. Describe the flow as a narrative sequence of actions and outcomes
-3. Include specific touchpoints, interactions, and system responses
-4. Show the journey from start to completion, including decision points
-5. If user personas are provided, you MUST use those exact persona names (e.g., "Power User needs to...")
-6. Make journeys realistic and scenario-based - not generic statements
-7. Focus on the experience: what they see, what they do, what happens next
-8. Each journey should tell a complete story of interaction with clear trigger, steps, and outcome
+1. If user personas are provided, you MUST use those exact persona names (e.g., "Power User reviews...")
+2. Show a brief flow: what they read/see, what they do, what outcome they achieve
+3. Keep it to ONE sentence when possible, maximum TWO sentences
+4. Include a sequence of 2-4 actions connected with "then" or commas
+5. Be specific about actions and outcomes, but keep it concise
+6. Focus on realistic scenarios showing actual user behavior
 
-Good format examples:
-- "[Persona] discovers [feature] while [context], tries [action], sees [result], then proceeds to [next step] to achieve [outcome]"
-- "[Persona] opens [view], searches for [item], filters by [criteria], selects [option], and confirms [action] resulting in [outcome]"
-- "When [trigger occurs], [Persona] navigates to [location], reviews [information], makes [decision], and [completes action] successfully"
+Good format examples (1 sentence each):
+- "Product Manager reviews sprint metrics on the dashboard, then creates alerts for underperforming tasks"
+- "Power User opens the analytics dashboard, filters data by date range, and exports the report to CSV"
+- "End User navigates to settings, enables voice commands, then generates their first hands-free report"
 
-Return your response as a JSON array of strings (journey flow descriptions):
+BAD examples (too verbose - DO NOT DO THIS):
+- Multi-paragraph narratives describing every screen and system response
+- Detailed sequences with more than 2 sentences
+- Step-by-step walkthroughs of entire workflows
+
+Return your response as a JSON array of strings (brief journey flows):
 [
-  "[Persona-driven user journey flow description]",
-  "[Another persona-driven user journey flow description]"
+  "[Persona-driven brief journey flow - 1-2 sentences max]",
+  "[Another persona-driven brief journey flow - 1-2 sentences max]"
 ]
 
-Be specific about the steps, contexts, and interactions. Focus on realistic scenarios and complete flows from start to finish.`;
+Keep it brief but show the flow of interaction.`;
+
+// System prompt for generating requirements with agent loop
+export const REQUIREMENTS_SYSTEM_PROMPT = `
+You are a product manager generating technical requirements for a feature.
+
+Your process:
+1. Review any existing requirements provided (if any)
+2. Use get_learnings to understand the codebase architecture, patterns, and constraints
+3. Use ask_question to dive deeper into specific technical areas or learnings
+4. Analyze the feature context (brief, personas, user stories)
+5. Generate comprehensive, actionable requirements
+6. YOU MUST call final_requirements with the COMPLETE list when done
+
+If existing requirements are provided:
+- Use them as context for your research (they guide what to ask about)
+- Include ALL existing requirements in your final output
+- Refine and improve them where needed (add detail, clarify, fix priority)
+- Add new requirements to create a complete set
+
+Requirements should cover:
+- **Functional**: What the system must do (user actions, business logic)
+- **Non-functional**: Performance, security, scalability, reliability
+- **Technical**: APIs, data structures, integrations, dependencies
+- **Business**: Success metrics, KPIs, constraints
+
+Each requirement must have:
+- Clear, specific title
+- Detailed description (what, why, constraints)
+- Appropriate category
+- Realistic priority
+
+Generate 10-20 requirements total that are specific, measurable, and implementable.
+
+YOU MUST CALL final_requirements with the COMPLETE set (existing + new) when done.`;


### PR DESCRIPTION
Updated prompts to generate concise user journey flows instead of verbose multi-paragraph narratives:
- System prompt now enforces 1-2 sentence maximum with brief action sequences
- Examples show format: "[Persona] reads X, then does Y to achieve Z"
- API route updated to request brief flows showing user interactions
- Prevents generation of detailed step-by-step narratives