### PR TITLE
refactor: extract AI generation code into reusable utilities

### DIFF
--- a/src/app/api/features/[featureId]/generate/route.ts
+++ b/src/app/api/features/[featureId]/generate/route.ts
@@ -1,63 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { streamObject } from "ai";
 import { getModel, getApiKeyForProvider } from "aieo";
 import { db } from "@/lib/db";
 import { getMiddlewareContext, requireAuth } from "@/lib/middleware/utils";
-import { z } from "zod";
-import {
-  GENERATE_STORIES_SYSTEM_PROMPT,
-  GENERATE_REQUIREMENTS_PROMPT,
-  GENERATE_ARCHITECTURE_PROMPT,
-  GENERATE_PHASES_TICKETS_PROMPT,
-} from "@/lib/constants/prompt";
+import { buildFeatureContext, generateWithStreaming } from "@/lib/ai/utils";
+import { GENERATION_TYPES, GENERATION_CONFIG_MAP, GenerationType } from "@/lib/ai/generation-config";
 
 type Provider = "anthropic" | "openai";
-type ModelType = Awaited<ReturnType<typeof getModel>>;
-type FeatureData = {
-  id: string;
-  title: string;
-  brief: string | null;
-  personas: string[];
-  requirements: string | null;
-  architecture: string | null;
-  userStories: { title: string }[];
-  workspace: {
-    id: string;
-    description: string | null;
-    ownerId: string;
-    members: { role: string }[];
-  };
-};
-
-const storiesSchema = z.object({
-  stories: z.array(
-    z.object({
-      title: z.string().describe("Brief user journey flow (1-2 sentences) showing sequence of actions and outcome"),
-    })
-  ),
-});
-
-const contentSchema = z.object({
-  content: z.string().describe("Complete final content incorporating all context"),
-});
-
-const phasesTicketsSchema = z.object({
-  phases: z.array(
-    z.object({
-      name: z.string().describe("Phase name (e.g., 'Foundation', 'Core Features')"),
-      description: z.string().optional().describe("Brief description of the phase"),
-      tickets: z.array(
-        z.object({
-          title: z.string().describe("Ticket title"),
-          description: z.string().optional().describe("Detailed ticket description"),
-          priority: z.enum(["LOW", "MEDIUM", "HIGH", "CRITICAL"]).default("MEDIUM").describe("Ticket priority level"),
-          tempId: z.string().describe("Temporary ID for dependency mapping (e.g., 'T1', 'T2')"),
-          dependsOn: z.array(z.string()).optional().describe("Array of tempIds this ticket depends on (e.g., ['T1', 'T2'])"),
-        })
-      ),
-    })
-  ),
-});
 
 export async function POST(
   request: NextRequest,
@@ -72,9 +20,9 @@ export async function POST(
     const body = await request.json();
     const { type, existingStories } = body;
 
-    if (!type || !["userStories", "requirements", "architecture", "phasesTickets"].includes(type)) {
+    if (!type || !GENERATION_TYPES.includes(type)) {
       return NextResponse.json(
-        { error: "Invalid type parameter. Must be 'userStories', 'requirements', 'architecture', or 'phasesTickets'" },
+        { error: `Invalid type parameter. Must be one of: ${GENERATION_TYPES.join(", ")}` },
         { status: 400 }
       );
     }
@@ -117,7 +65,6 @@ export async function POST(
       );
     }
 
-    // Check workspace access
     const isOwner = feature.workspace.ownerId === userOrResponse.id;
     const isMember = feature.workspace.members.length > 0;
 
@@ -128,7 +75,6 @@ export async function POST(
       );
     }
 
-    // Use anthropic provider (Claude)
     const provider: Provider = "anthropic";
     const apiKey = getApiKeyForProvider(provider);
 
@@ -140,21 +86,19 @@ export async function POST(
     }
 
     const model = await getModel(provider, apiKey);
+    const featureContext = buildFeatureContext(feature);
+    const config = GENERATION_CONFIG_MAP[type as GenerationType];
 
-    // Generate based on type
-    if (type === "userStories") {
-      return await generateUserStories(model, feature, existingStories || [], featureId);
-    } else if (type === "requirements") {
-      return await generateRequirements(model, feature, featureId);
-    } else if (type === "architecture") {
-      return await generateArchitecture(model, feature, featureId);
-    } else if (type === "phasesTickets") {
-      return await generatePhasesAndTickets(model, feature, featureId);
-    }
+    const prompt = config.buildPrompt(featureContext, existingStories || []);
 
-    return NextResponse.json(
-      { error: "Generation type not implemented yet" },
-      { status: 500 }
+    return await generateWithStreaming(
+      model,
+      config.schema,
+      prompt,
+      config.systemPrompt,
+      featureId,
+      feature.title,
+      type
     );
   } catch (error) {
     console.error("Error generating content:", error);
@@ -163,180 +107,4 @@ export async function POST(
       { status: 500 }
     );
   }
-}
-
-async function generateUserStories(model: ModelType, feature: FeatureData, existingStories: string[], featureId: string) {
-  const existingStoriesText = existingStories.length > 0
-    ? `\n\nExisting user stories (DO NOT repeat these):\n${existingStories.map((s: string) => `- ${s}`).join('\n')}`
-    : '';
-
-  const personasText = feature.personas && feature.personas.length > 0
-    ? `\n\nTarget Personas:\n${feature.personas.map((p: string) => `- ${p}`).join('\n')}`
-    : '';
-
-  const userPrompt = `Generate 3-5 brief user journey flows for this feature:
-
-Title: ${feature.title}
-${feature.brief ? `Brief: ${feature.brief}` : ''}${personasText}${existingStoriesText}
-
-Create brief user journey flows (1-2 sentences each) showing how users interact with the feature.
-Each journey should:
-- Be 1-2 sentences maximum (prefer 1 sentence)
-- Show a brief sequence: what they read/see, what they do, what outcome they achieve
-- Include 2-4 actions connected with "then" or commas
-- Example format: "[Persona] reviews [X], then does [Y] to achieve [Z]"
-
-${feature.personas && feature.personas.length > 0 ? 'Use the exact persona names listed above. Distribute journeys across different personas to show varied interaction patterns.' : ''}
-Generate NEW journey flows that complement the existing ones (if any) but do not duplicate them.`;
-
-  console.log("🤖 Generating user journey flows with:", {
-    model: model?.modelId,
-    featureId,
-    featureTitle: feature.title,
-  });
-
-  const result = streamObject({
-    model,
-    schema: storiesSchema,
-    prompt: userPrompt,
-    system: GENERATE_STORIES_SYSTEM_PROMPT,
-    temperature: 0.7,
-  });
-
-  return result.toTextStreamResponse();
-}
-
-async function generateRequirements(model: ModelType, feature: FeatureData, featureId: string) {
-  const workspaceDesc = feature.workspace.description
-    ? `\n\nWorkspace Context: ${feature.workspace.description}`
-    : '';
-
-  const personasText = feature.personas && feature.personas.length > 0
-    ? `\n\nTarget Personas:\n${feature.personas.map((p: string) => `- ${p}`).join('\n')}`
-    : '';
-
-  const userStoriesText = feature.userStories && feature.userStories.length > 0
-    ? `\n\nUser Stories:\n${feature.userStories.map((s) => `- ${s.title}`).join('\n')}`
-    : '';
-
-  const existingRequirements = feature.requirements
-    ? `\n\nExisting Requirements:\n${feature.requirements}`
-    : '';
-
-  const userPrompt = `Generate COMPLETE requirements for this feature (incorporating all context below):
-
-Title: ${feature.title}
-${feature.brief ? `Brief: ${feature.brief}` : ''}${workspaceDesc}${personasText}${userStoriesText}${existingRequirements}
-
-Return the FULL final requirements (200-400 words) covering functional, technical, and non-functional aspects.
-${feature.requirements ? 'Incorporate and enhance the existing requirements above.' : ''}`;
-
-  console.log("🤖 Generating requirements with:", {
-    model: model?.modelId,
-    featureId,
-    featureTitle: feature.title,
-  });
-
-  const result = streamObject({
-    model,
-    schema: contentSchema,
-    prompt: userPrompt,
-    system: GENERATE_REQUIREMENTS_PROMPT,
-    temperature: 0.7,
-  });
-
-  return result.toTextStreamResponse();
-}
-
-async function generateArchitecture(model: ModelType, feature: FeatureData, featureId: string) {
-  const workspaceDesc = feature.workspace.description
-    ? `\n\nWorkspace Context: ${feature.workspace.description}`
-    : '';
-
-  const personasText = feature.personas && feature.personas.length > 0
-    ? `\n\nTarget Personas:\n${feature.personas.map((p: string) => `- ${p}`).join('\n')}`
-    : '';
-
-  const userStoriesText = feature.userStories && feature.userStories.length > 0
-    ? `\n\nUser Stories:\n${feature.userStories.map((s) => `- ${s.title}`).join('\n')}`
-    : '';
-
-  const requirementsText = feature.requirements
-    ? `\n\nRequirements:\n${feature.requirements}`
-    : '';
-
-  const existingArchitecture = feature.architecture
-    ? `\n\nExisting Architecture:\n${feature.architecture}`
-    : '';
-
-  const userPrompt = `Generate COMPLETE architecture for this feature (incorporating all context below):
-
-Title: ${feature.title}
-${feature.brief ? `Brief: ${feature.brief}` : ''}${workspaceDesc}${personasText}${userStoriesText}${requirementsText}${existingArchitecture}
-
-Return the FULL final architecture (200-400 words) covering system design, components, and technical approach.
-${feature.architecture ? 'Incorporate and enhance the existing architecture above.' : ''}`;
-
-  console.log("🤖 Generating architecture with:", {
-    model: model?.modelId,
-    featureId,
-    featureTitle: feature.title,
-  });
-
-  const result = streamObject({
-    model,
-    schema: contentSchema,
-    prompt: userPrompt,
-    system: GENERATE_ARCHITECTURE_PROMPT,
-    temperature: 0.7,
-  });
-
-  return result.toTextStreamResponse();
-}
-
-async function generatePhasesAndTickets(model: ModelType, feature: FeatureData, featureId: string) {
-  const workspaceDesc = feature.workspace.description
-    ? `\n\nWorkspace Context: ${feature.workspace.description}`
-    : '';
-
-  const personasText = feature.personas && feature.personas.length > 0
-    ? `\n\nTarget Personas:\n${feature.personas.map((p: string) => `- ${p}`).join('\n')}`
-    : '';
-
-  const userStoriesText = feature.userStories && feature.userStories.length > 0
-    ? `\n\nUser Stories:\n${feature.userStories.map((s) => `- ${s.title}`).join('\n')}`
-    : '';
-
-  const requirementsText = feature.requirements
-    ? `\n\nRequirements:\n${feature.requirements}`
-    : '';
-
-  const architectureText = feature.architecture
-    ? `\n\nArchitecture:\n${feature.architecture}`
-    : '';
-
-  const userPrompt = `Generate a complete project breakdown with phases and tickets for this feature (incorporating all context below):
-
-Title: ${feature.title}
-${feature.brief ? `Brief: ${feature.brief}` : ''}${workspaceDesc}${personasText}${userStoriesText}${requirementsText}${architectureText}
-
-Break down the work into 1-5 logical phases (fewer for simpler features), with 2-8 actionable tickets per phase.
-Use tempIds (T1, T2, T3...) for dependency mapping between tickets.
-Return a structured breakdown developers can immediately start working from.`;
-
-  console.log("🤖 Generating phases and tickets with:", {
-    model: model?.modelId,
-    featureId,
-    featureTitle: feature.title,
-  });
-
-  const result = streamObject({
-    model,
-    schema: phasesTicketsSchema,
-    prompt: userPrompt,
-    system: GENERATE_PHASES_TICKETS_PROMPT,
-    temperature: 0.7,
-  });
-
-  return result.toTextStreamResponse();
 }

--- a/src/lib/ai/generation-config.ts
+++ b/src/lib/ai/generation-config.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+import { storiesSchema, contentSchema, phasesTicketsSchema } from "./schemas";
+import {
+  buildUserStoriesPrompt,
+  buildRequirementsPrompt,
+  buildArchitecturePrompt,
+  buildPhasesTicketsPrompt,
+} from "./prompt-builders";
+import {
+  GENERATE_STORIES_SYSTEM_PROMPT,
+  GENERATE_REQUIREMENTS_PROMPT,
+  GENERATE_ARCHITECTURE_PROMPT,
+  GENERATE_PHASES_TICKETS_PROMPT,
+} from "../constants/prompt";
+import { FeatureContext } from "./utils";
+
+export const GENERATION_TYPES = ["userStories", "requirements", "architecture", "phasesTickets"] as const;
+export type GenerationType = (typeof GENERATION_TYPES)[number];
+
+type GenerationConfig = {
+  schema: z.ZodTypeAny;
+  systemPrompt: string;
+  buildPrompt: (context: FeatureContext, existingStories?: string[]) => string;
+};
+
+export const GENERATION_CONFIG_MAP: Record<GenerationType, GenerationConfig> = {
+  userStories: {
+    schema: storiesSchema,
+    systemPrompt: GENERATE_STORIES_SYSTEM_PROMPT,
+    buildPrompt: (context, existingStories = []) => buildUserStoriesPrompt(context, existingStories),
+  },
+  requirements: {
+    schema: contentSchema,
+    systemPrompt: GENERATE_REQUIREMENTS_PROMPT,
+    buildPrompt: (context) => buildRequirementsPrompt(context),
+  },
+  architecture: {
+    schema: contentSchema,
+    systemPrompt: GENERATE_ARCHITECTURE_PROMPT,
+    buildPrompt: (context) => buildArchitecturePrompt(context),
+  },
+  phasesTickets: {
+    schema: phasesTicketsSchema,
+    systemPrompt: GENERATE_PHASES_TICKETS_PROMPT,
+    buildPrompt: (context) => buildPhasesTicketsPrompt(context),
+  },
+};

--- a/src/lib/ai/prompt-builders.ts
+++ b/src/lib/ai/prompt-builders.ts
@@ -1,0 +1,61 @@
+import { FeatureContext } from "./utils";
+
+export function buildUserStoriesPrompt(context: FeatureContext, existingStories: string[]): string {
+  const existingStoriesText = existingStories.length > 0
+    ? `\n\nExisting user stories (DO NOT repeat these):\n${existingStories.map((s: string) => `- ${s}`).join('\n')}`
+    : '';
+
+  return `Generate 3-5 brief user journey flows for this feature:
+
+Title: ${context.title}
+${context.brief ? `Brief: ${context.brief}` : ''}${context.personasText}${existingStoriesText}
+
+Create brief user journey flows (1-2 sentences each) showing how users interact with the feature.
+Each journey should:
+- Be 1-2 sentences maximum (prefer 1 sentence)
+- Show a brief sequence: what they read/see, what they do, what outcome they achieve
+- Include 2-4 actions connected with "then" or commas
+- Example format: "[Persona] reviews [X], then does [Y] to achieve [Z]"
+
+${context.personasText ? 'Use the exact persona names listed above. Distribute journeys across different personas to show varied interaction patterns.' : ''}
+Generate NEW journey flows that complement the existing ones (if any) but do not duplicate them.`;
+}
+
+export function buildRequirementsPrompt(context: FeatureContext): string {
+  const existingRequirements = context.requirementsText
+    ? `\n\nExisting Requirements:\n${context.requirementsText}`
+    : '';
+
+  return `Generate COMPLETE requirements for this feature (incorporating all context below):
+
+Title: ${context.title}
+${context.brief ? `Brief: ${context.brief}` : ''}${context.workspaceDesc}${context.personasText}${context.userStoriesText}${existingRequirements}
+
+Return the FULL final requirements (200-400 words) covering functional, technical, and non-functional aspects.
+${context.requirementsText ? 'Incorporate and enhance the existing requirements above.' : ''}`;
+}
+
+export function buildArchitecturePrompt(context: FeatureContext): string {
+  const existingArchitecture = context.architectureText
+    ? `\n\nExisting Architecture:\n${context.architectureText}`
+    : '';
+
+  return `Generate COMPLETE architecture for this feature (incorporating all context below):
+
+Title: ${context.title}
+${context.brief ? `Brief: ${context.brief}` : ''}${context.workspaceDesc}${context.personasText}${context.userStoriesText}${context.requirementsText ? `\n\nRequirements:\n${context.requirementsText}` : ''}${existingArchitecture}
+
+Return the FULL final architecture (200-400 words) covering system design, components, and technical approach.
+${context.architectureText ? 'Incorporate and enhance the existing architecture above.' : ''}`;
+}
+
+export function buildPhasesTicketsPrompt(context: FeatureContext): string {
+  return `Generate a complete project breakdown with phases and tickets for this feature (incorporating all context below):
+
+Title: ${context.title}
+${context.brief ? `Brief: ${context.brief}` : ''}${context.workspaceDesc}${context.personasText}${context.userStoriesText}${context.requirementsText ? `\n\nRequirements:\n${context.requirementsText}` : ''}${context.architectureText ? `\n\nArchitecture:\n${context.architectureText}` : ''}
+
+Break down the work into 1-5 logical phases (fewer for simpler features), with 2-8 actionable tickets per phase.
+Use tempIds (T1, T2, T3...) for dependency mapping between tickets.
+Return a structured breakdown developers can immediately start working from.`;
+}

--- a/src/lib/ai/schemas.ts
+++ b/src/lib/ai/schemas.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+export const storiesSchema = z.object({
+  stories: z.array(
+    z.object({
+      title: z.string().describe("Brief user journey flow (1-2 sentences) showing sequence of actions and outcome"),
+    })
+  ),
+});
+
+export const contentSchema = z.object({
+  content: z.string().describe("Complete final content incorporating all context"),
+});
+
+export const phasesTicketsSchema = z.object({
+  phases: z.array(
+    z.object({
+      name: z.string().describe("Phase name (e.g., 'Foundation', 'Core Features')"),
+      description: z.string().optional().describe("Brief description of the phase"),
+      tickets: z.array(
+        z.object({
+          title: z.string().describe("Ticket title"),
+          description: z.string().optional().describe("Detailed ticket description"),
+          priority: z.enum(["LOW", "MEDIUM", "HIGH", "CRITICAL"]).default("MEDIUM").describe("Ticket priority level"),
+          tempId: z.string().describe("Temporary ID for dependency mapping (e.g., 'T1', 'T2')"),
+          dependsOn: z.array(z.string()).optional().describe("Array of tempIds this ticket depends on (e.g., ['T1', 'T2'])"),
+        })
+      ),
+    })
+  ),
+});


### PR DESCRIPTION
- Create schemas.ts for centralized Zod schemas
- Create prompt-builders.ts for prompt generation logic
- Create generation-config.ts for type-safe config mapping
- Add buildFeatureContext() and generateWithStreaming() to utils.ts
- Simplify generate route from 343 to 111 lines (68% reduction)
- Eliminate ~150 lines of duplicated code
- Maintain 100% backward compatibility