### PR TITLE
Fix personas suggestions not reopening after selection

### DIFF
--- a/src/components/features/PersonasSection/index.tsx
+++ b/src/components/features/PersonasSection/index.tsx
@@ -58,7 +58,6 @@ export function PersonasSection({
       onChange(newPersonas);
       onBlur(newPersonas);
       setInputValue("");
-      setIsOpen(false);
     }
   };
 


### PR DESCRIPTION
Removed the setIsOpen(false) call when adding a persona, which was causing a race condition that prevented the suggestions dropdown from reopening when tapping the input field again. The dropdown now stays open after selecting a suggestion, improving UX for adding multiple personas. Existing click-outside and blur handlers still properly close the dropdown when needed.