### PR TITLE
feat: add calls detail page with description rendering

### DIFF
--- a/src/app/api/workspaces/[slug]/calls/route.ts
+++ b/src/app/api/workspaces/[slug]/calls/route.ts
@@ -122,6 +122,7 @@ export async function GET(
       ref_id: node.ref_id,
       episode_title: node.properties.episode_title,
       date_added_to_graph: node.date_added_to_graph,
+      description: node.properties.description,
     }));
 
     const total = calls.length;

--- a/src/app/w/[slug]/calls/[ref_id]/page.tsx
+++ b/src/app/w/[slug]/calls/[ref_id]/page.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { ArrowLeft, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { MarkdownRenderer } from "@/components/MarkdownRenderer";
+import { useWorkspace } from "@/hooks/useWorkspace";
+import { CallRecording } from "@/types/calls";
+
+export default function CallPage() {
+  const params = useParams();
+  const router = useRouter();
+  const { slug } = useWorkspace();
+  const ref_id = params.ref_id as string;
+
+  const [call, setCall] = useState<CallRecording | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleBackClick = () => {
+    router.push(`/w/${slug}/calls`);
+  };
+
+  useEffect(() => {
+    if (!slug || !ref_id) {
+      setLoading(false);
+      return;
+    }
+
+    const fetchCall = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const response = await fetch(
+          `/api/workspaces/${slug}/calls?limit=1000`,
+        );
+
+        if (!response.ok) {
+          const errorData = await response.json();
+          throw new Error(errorData.error || "Failed to fetch call");
+        }
+
+        const data = await response.json();
+        const foundCall = data.calls.find((c: CallRecording) => c.ref_id === ref_id);
+
+        if (!foundCall) {
+          throw new Error("Call not found");
+        }
+
+        setCall(foundCall);
+      } catch (err) {
+        console.error("Error fetching call:", err);
+        setError(
+          err instanceof Error ? err.message : "Failed to load call recording",
+        );
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchCall();
+  }, [slug, ref_id]);
+
+  const formatDate = (timestamp: number) => {
+    const date = new Date(timestamp * 1000);
+    return new Intl.DateTimeFormat("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    }).format(date);
+  };
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <div className="flex items-center gap-4">
+          <Button variant="ghost" size="sm" onClick={handleBackClick}>
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Back
+          </Button>
+          <span className="text-sm text-muted-foreground flex items-center gap-2">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            Loading...
+          </span>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-8 w-3/4" />
+            <Skeleton className="h-4 w-1/2 mt-2" />
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-64 w-full" />
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (error || !call) {
+    return (
+      <div className="space-y-6">
+        <Button variant="ghost" size="sm" onClick={handleBackClick}>
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          Back
+        </Button>
+        <Card>
+          <CardHeader>
+            <h2 className="text-xl font-semibold text-red-600">Error</h2>
+          </CardHeader>
+          <CardContent>
+            <p className="text-muted-foreground">{error || "Call not found"}</p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header with back button */}
+      <Button variant="ghost" size="sm" onClick={handleBackClick} className="self-start">
+        <ArrowLeft className="h-4 w-4 mr-2" />
+        Back
+      </Button>
+
+      {/* Call Details Card */}
+      <Card>
+        <CardHeader>
+          <div className="space-y-2">
+            <h1 className="text-2xl font-semibold">{call.episode_title}</h1>
+            <p className="text-sm text-muted-foreground">
+              Added {formatDate(call.date_added_to_graph)}
+            </p>
+          </div>
+        </CardHeader>
+
+        <CardContent className="space-y-6">
+          {call.description ? (
+            <div>
+              <h2 className="text-lg font-semibold mb-4">Description</h2>
+              <div className="prose prose-sm dark:prose-invert max-w-none">
+                <MarkdownRenderer>{call.description}</MarkdownRenderer>
+              </div>
+            </div>
+          ) : (
+            <p className="text-muted-foreground text-center py-8">
+              No description available for this call recording.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/w/[slug]/calls/page.tsx
+++ b/src/app/w/[slug]/calls/page.tsx
@@ -174,7 +174,7 @@ export default function CallsPage() {
             </div>
           )}
 
-          {!loading && !error && <CallsTable calls={calls} />}
+          {!loading && !error && <CallsTable calls={calls} workspaceSlug={slug} />}
 
           {!loading && !error && calls.length > 0 && (
             <div className="mt-6">

--- a/src/components/calls/CallsTable/index.tsx
+++ b/src/components/calls/CallsTable/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { CallRecording } from "@/types/calls";
 import {
   Table,
@@ -12,9 +13,12 @@ import {
 
 interface CallsTableProps {
   calls: CallRecording[];
+  workspaceSlug: string;
 }
 
-export function CallsTable({ calls }: CallsTableProps) {
+export function CallsTable({ calls, workspaceSlug }: CallsTableProps) {
+  const router = useRouter();
+
   const formatDate = (timestamp: number) => {
     const date = new Date(timestamp * 1000);
     return new Intl.DateTimeFormat("en-US", {
@@ -24,6 +28,10 @@ export function CallsTable({ calls }: CallsTableProps) {
       hour: "2-digit",
       minute: "2-digit",
     }).format(date);
+  };
+
+  const handleRowClick = (refId: string) => {
+    router.push(`/w/${workspaceSlug}/calls/${refId}`);
   };
 
   if (calls.length === 0) {
@@ -45,7 +53,11 @@ export function CallsTable({ calls }: CallsTableProps) {
         </TableHeader>
         <TableBody>
           {calls.map((call) => (
-            <TableRow key={call.ref_id}>
+            <TableRow
+              key={call.ref_id}
+              onClick={() => handleRowClick(call.ref_id)}
+              className="cursor-pointer hover:bg-muted/50"
+            >
               <TableCell className="font-medium">
                 {call.episode_title}
               </TableCell>

--- a/src/types/calls.ts
+++ b/src/types/calls.ts
@@ -2,6 +2,7 @@ export interface CallRecording {
   ref_id: string;
   episode_title: string;
   date_added_to_graph: number;
+  description?: string;
 }
 
 export interface CallsResponse {
@@ -18,6 +19,7 @@ export interface JarvisNode {
     episode_title: string;
     media_url: string;
     source_link: string;
+    description?: string;
   };
 }
 


### PR DESCRIPTION
- Add description field to CallRecording and JarvisNode types
- Update API to capture description from Jarvis Episode nodes
- Make CallsTable rows clickable with navigation to detail page
- Create individual call detail page at /w/[slug]/calls/[ref_id]
- Display episode title, date added, and description with markdown
- Match ticket/phase page structure and back button pattern