### PR TITLE
feat: add graph visualization to call detail page

### DIFF
--- a/src/app/w/[slug]/calls/[ref_id]/page.tsx
+++ b/src/app/w/[slug]/calls/[ref_id]/page.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
+import { Graph } from "@/components/graph";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { CallRecording } from "@/types/calls";
 
@@ -154,6 +155,23 @@ export default function CallPage() {
               No description available for this call recording.
             </p>
           )}
+        </CardContent>
+      </Card>
+
+      {/* Episode Knowledge Graph */}
+      <Card>
+        <CardContent className="pt-6">
+          <Graph
+            endpoint="/api/subgraph"
+            params={{
+              workspace: slug,
+              ref_id: call.ref_id,
+            }}
+            height={600}
+            title="Graph View"
+            showStats={true}
+            layout="layered"
+          />
         </CardContent>
       </Card>
     </div>

--- a/src/components/graph/GraphVisualizationLayered.tsx
+++ b/src/components/graph/GraphVisualizationLayered.tsx
@@ -28,13 +28,16 @@ interface GraphVisualizationLayeredProps {
 
 // Define layer order: top to bottom
 const LAYER_ORDER: Record<string, number> = {
+  Episode: 0,
   Hint: 0,
   Prompt: 0,
+  Video: 1,
   File: 1,
   Datamodel: 2,
   Function: 2,
   Endpoint: 2,
   Request: 2,
+  Topic: 3
 };
 
 const getNodeLayer = (type: string): number => {


### PR DESCRIPTION
- Add Graph component below description on call detail page
- Display episode knowledge graph with nodes and edges
- Add Episode and Video node types to layered graph layout
- Add Topic node type to LAYER_ORDER for proper positioning