### PR TITLE
Add waiting for input badge to task page workflow status

### DIFF
--- a/src/app/w/[slug]/task/[...taskParams]/components/ChatArea.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/components/ChatArea.tsx
@@ -182,6 +182,7 @@ export function ChatArea({
       {/* Input Bar */}
       <ChatInput
         logs={logs}
+        messages={messages}
         onSend={onSend}
         disabled={inputDisabled}
         isLoading={isLoading}

--- a/src/app/w/[slug]/task/[...taskParams]/components/ChatInput.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/components/ChatInput.tsx
@@ -5,7 +5,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Mic, MicOff } from "lucide-react";
-import { Artifact, WorkflowStatus } from "@/lib/chat";
+import { Artifact, WorkflowStatus, ChatMessage } from "@/lib/chat";
 import { WorkflowStatusBadge } from "./WorkflowStatusBadge";
 import { InputDebugAttachment } from "@/components/InputDebugAttachment";
 import { LogEntry } from "@/hooks/useProjectLogWebSocket";
@@ -14,6 +14,7 @@ import { useControlKeyHold } from "@/hooks/useControlKeyHold";
 
 interface ChatInputProps {
   logs: LogEntry[];
+  messages: ChatMessage[];
   onSend: (message: string) => Promise<void>;
   disabled?: boolean;
   isLoading?: boolean;
@@ -24,6 +25,7 @@ interface ChatInputProps {
 
 export function ChatInput({
   logs,
+  messages,
   onSend,
   disabled = false,
   isLoading = false,
@@ -80,9 +82,7 @@ export function ChatInput({
   return (
     <div>
       <div className="flex items-center gap-2 text-sm text-muted-foreground">
-        <span>{mode}</span>
-        <span>|</span>
-        <WorkflowStatusBadge logs={logs} status={workflowStatus} />
+        <WorkflowStatusBadge logs={logs} status={workflowStatus} messages={messages} />
       </div>
 
       {/* Debug attachment display */}


### PR DESCRIPTION
- Replace "live" text with "Workflow | [icon]" format in status badge
- Show "Waiting for input" with amber AlertCircle icon when task has FORM artifacts
- Icon-only mode when not waiting for input (removed status text labels)
- Pass messages through component chain to detect FORM artifacts
- Matches task list/kanban card behavior for consistency

Fixes #1296