### PR TITLE
Fix task status to default to IN_PROGRESS when workflow starts immedi…

### DIFF
--- a/src/__tests__/integration/api/janitors.test.ts
+++ b/src/__tests__/integration/api/janitors.test.ts
@@ -812,6 +812,7 @@ describe("Janitor API Integration Tests", () => {
       });
       expect(task).toBeTruthy();
       expect(task?.sourceType).toBe("JANITOR");
+      expect(task?.status).toBe("IN_PROGRESS");
     });
 
     test("POST /api/janitors/recommendations/[id]/dismiss - should dismiss recommendation", async () => {

--- a/src/__tests__/unit/services/task-workflow.test.ts
+++ b/src/__tests__/unit/services/task-workflow.test.ts
@@ -920,7 +920,7 @@ describe("createChatMessageAndTriggerStakwork (via createTaskWithStakworkWorkflo
       );
     });
 
-    test("should default to TODO status when not specified", async () => {
+    test("should default to IN_PROGRESS status when not specified", async () => {
       MockSetup.setupTaskCreationWorkflow();
 
       await createTaskWithStakworkWorkflow({
@@ -935,7 +935,7 @@ describe("createChatMessageAndTriggerStakwork (via createTaskWithStakworkWorkflo
       expect(mockDb.task.create).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({
-            status: "TODO",
+            status: "IN_PROGRESS",
           }),
         })
       );

--- a/src/services/task-workflow.ts
+++ b/src/services/task-workflow.ts
@@ -32,7 +32,7 @@ export async function createTaskWithStakworkWorkflow(params: {
     sourceType = "USER",
     userId,
     initialMessage,
-    status = "TODO",
+    status = "IN_PROGRESS",  // Default to IN_PROGRESS since workflow starts immediately
     mode = "default",
   } = params;
 


### PR DESCRIPTION
…ately

Tasks created via createTaskWithStakworkWorkflow now default to IN_PROGRESS status instead of TODO, since the workflow begins execution immediately. This affects all automated agents (JANITOR, TASK_COORDINATOR) that create and immediately start work on tasks.