### PR TITLE
fix: POST api/auth/verify-landing throwing 500 error when no json body

### DIFF
--- a/src/__tests__/integration/api/auth-verify-landing.test.ts
+++ b/src/__tests__/integration/api/auth-verify-landing.test.ts
@@ -400,7 +400,7 @@ describe("POST /api/auth/verify-landing Integration Tests", () => {
   });
 
   describe("Error handling", () => {
-    test("should return 500 for malformed JSON body", async () => {
+    test("should return 400 for malformed JSON body", async () => {
       const request = new Request("http://localhost:3000/api/auth/verify-landing", {
         method: "POST",
         headers: {
@@ -412,9 +412,9 @@ describe("POST /api/auth/verify-landing Integration Tests", () => {
       const response = await POST(request as any);
       const data = await response.json();
 
-      expect(response.status).toBe(500);
+      expect(response.status).toBe(400);
       expect(data.success).toBe(false);
-      expect(data.message).toBe("An error occurred");
+      expect(data.message).toBe("Invalid or missing JSON body");
     });
 
     test("should handle missing NEXTAUTH_SECRET gracefully during signCookie", async () => {

--- a/src/app/api/auth/verify-landing/route.ts
+++ b/src/app/api/auth/verify-landing/route.ts
@@ -8,7 +8,16 @@ import {
 
 export async function POST(request: NextRequest) {
   try {
-    const { password } = await request.json();
+    let password = ""
+    try {
+      const body = await request.json();
+      password = body.password
+    } catch (error) {
+      return NextResponse.json(
+        { success: false, message: "Invalid or missing JSON body"},
+        { status: 400 }
+      );
+    }
 
     // Check if landing page password is set
     const landingPassword = process.env.LANDING_PAGE_PASSWORD;


### PR DESCRIPTION
This change fixes the POST api/auth/verify-landing endpoint where if you call it with no json body it would give you a 500 internal error when instead it should give you a 400 error.