### PR TITLE
fix: update swarm secret alias regex to support alphanumeric IDs

### DIFF
--- a/src/__tests__/integration/api/swarm-poll.test.ts
+++ b/src/__tests__/integration/api/swarm-poll.test.ts
@@ -397,7 +397,7 @@ describe("Swarm Poll API Integration Tests", () => {
       expect(decryptedKey).toBe(newApiKey);
 
       // Verify swarmSecretAlias was updated
-      expect(updatedSwarm?.swarmSecretAlias).toMatch(/^{{SWARM_\d+_API_KEY}}$/);
+      expect(updatedSwarm?.swarmSecretAlias).toMatch(/^{{.+_API_KEY}}$/);
     });
 
     it("should return immediately for ACTIVE swarms without polling", async () => {
@@ -743,8 +743,8 @@ describe("Swarm Poll API Integration Tests", () => {
         where: { id: swarm.id },
       });
 
-      // Verify pattern: {{SWARM_{numeric}_API_KEY}}
-      expect(updatedSwarm?.swarmSecretAlias).toBe("{{SWARM_456_API_KEY}}");
+      // Verify pattern uses swarm_id directly: {{swarm_id_API_KEY}}
+      expect(updatedSwarm?.swarmSecretAlias).toBe("{{test-swarm-456_API_KEY}}");
     });
 
     it("should persist all aggregated data fields", async () => {
@@ -778,7 +778,7 @@ describe("Swarm Poll API Integration Tests", () => {
       // Verify all critical fields were updated
       expect(updatedSwarm?.status).toBe(SwarmStatus.ACTIVE);
       expect(updatedSwarm?.swarmApiKey).toBeTruthy();
-      expect(updatedSwarm?.swarmSecretAlias).toMatch(/^{{SWARM_\d+_API_KEY}}$/);
+      expect(updatedSwarm?.swarmSecretAlias).toMatch(/^{{.+_API_KEY}}$/);
 
       // Verify API key decrypts correctly
       const decryptedKey = EncryptionService.getInstance().decryptField(

--- a/src/__tests__/unit/api/swarm-route.test.ts
+++ b/src/__tests__/unit/api/swarm-route.test.ts
@@ -172,12 +172,12 @@ describe("POST /api/swarm - Unit Tests", () => {
         canAdmin: true,
       });
 
-      mockSaveOrUpdateSwarm.mockResolvedValue({ id: "final-swarm", swarmId: "swarm-456" });
+      mockSaveOrUpdateSwarm.mockResolvedValue({ id: "final-swarm", swarmId: "swarm2bCar4" });
 
       mockSwarmServiceInstance.createSwarm.mockResolvedValue({
         data: {
-          swarm_id: "swarm-456",
-          address: "test-swarm.sphinx.chat",
+          swarm_id: "swarm2bCar4",
+          address: "swarm2bCar4.sphinx.chat",
           x_api_key: "sensitive-api-key-789",
         },
       });
@@ -244,12 +244,12 @@ describe("POST /api/swarm - Unit Tests", () => {
     });
 
     test("should generate secure password for swarm", async () => {
-      mockSaveOrUpdateSwarm.mockResolvedValue({ id: "final-swarm", swarmId: "swarm-456" });
+      mockSaveOrUpdateSwarm.mockResolvedValue({ id: "final-swarm", swarmId: "swarm2bCar4" });
 
       mockSwarmServiceInstance.createSwarm.mockResolvedValue({
         data: {
-          swarm_id: "swarm-456",
-          address: "test-swarm.sphinx.chat",
+          swarm_id: "swarm2bCar4",
+          address: "swarm2bCar4.sphinx.chat",
           x_api_key: "sensitive-api-key-789",
         },
       });
@@ -269,12 +269,12 @@ describe("POST /api/swarm - Unit Tests", () => {
     test("should handle API key securely", async () => {
       const sensitiveApiKey = "very-sensitive-api-key-123";
 
-      mockSaveOrUpdateSwarm.mockResolvedValue({ id: "final-swarm", swarmId: "swarm-456" });
+      mockSaveOrUpdateSwarm.mockResolvedValue({ id: "final-swarm", swarmId: "swarm2bCar4" });
 
       mockSwarmServiceInstance.createSwarm.mockResolvedValue({
         data: {
-          swarm_id: "swarm-456",
-          address: "test-swarm.sphinx.chat",
+          swarm_id: "swarm2bCar4",
+          address: "swarm2bCar4.sphinx.chat",
           x_api_key: sensitiveApiKey,
         },
       });
@@ -290,7 +290,7 @@ describe("POST /api/swarm - Unit Tests", () => {
       expect(JSON.stringify(data)).not.toContain(sensitiveApiKey);
       expect(data.data).toEqual({
         id: "final-swarm",
-        swarmId: "swarm-456",
+        swarmId: "swarm2bCar4",
       });
 
       // Verify API key was saved to database securely
@@ -304,12 +304,12 @@ describe("POST /api/swarm - Unit Tests", () => {
     });
 
     test("should create secure secret alias", async () => {
-      mockSaveOrUpdateSwarm.mockResolvedValue({ id: "final-swarm", swarmId: "swarm-456" });
+      mockSaveOrUpdateSwarm.mockResolvedValue({ id: "final-swarm", swarmId: "swarm2bCar4" });
 
       mockSwarmServiceInstance.createSwarm.mockResolvedValue({
         data: {
-          swarm_id: "swarm-456",
-          address: "test-swarm.sphinx.chat",
+          swarm_id: "swarm2bCar4",
+          address: "swarm2bCar4.sphinx.chat",
           x_api_key: "api-key-123",
         },
       });
@@ -318,7 +318,7 @@ describe("POST /api/swarm - Unit Tests", () => {
       await POST(request);
 
       const saveCall = mockSaveOrUpdateSwarm.mock.calls[0][0];
-      expect(saveCall.swarmSecretAlias).toBe("{{SWARM_456_API_KEY}}");
+      expect(saveCall.swarmSecretAlias).toBe("{{swarm2bCar4_API_KEY}}");
     });
   });
 
@@ -370,7 +370,7 @@ describe("POST /api/swarm - Unit Tests", () => {
     });
 
     test("should handle malformed external service responses", async () => {
-      mockSaveOrUpdateSwarm.mockResolvedValue({ id: "final-swarm", swarmId: "swarm-456" });
+      mockSaveOrUpdateSwarm.mockResolvedValue({ id: "final-swarm", swarmId: "swarm2bCar4" });
 
       // Malformed response missing required fields
       mockSwarmServiceInstance.createSwarm.mockResolvedValue({
@@ -390,7 +390,7 @@ describe("POST /api/swarm - Unit Tests", () => {
         workspaceId: "workspace-123",
         swarmUrl: "https://undefined/api", // undefined address becomes "undefined"
         swarmApiKey: undefined,
-        swarmSecretAlias: "{{SWARM_undefined_API_KEY}}", // undefined swarm_id becomes "undefined"
+        swarmSecretAlias: undefined, // undefined swarm_id results in undefined
       });
     });
   });
@@ -411,8 +411,8 @@ describe("POST /api/swarm - Unit Tests", () => {
       mockSaveOrUpdateSwarm.mockResolvedValueOnce({ id: "final-swarm" });
       mockSwarmServiceInstance.createSwarm.mockResolvedValue({
         data: {
-          swarm_id: "swarm-456",
-          address: "test-swarm.sphinx.chat",
+          swarm_id: "swarm2bCar4",
+          address: "swarm2bCar4.sphinx.chat",
           x_api_key: "api-key-123",
           ec2_id: "i-1234567890abcdef0",
         },
@@ -423,14 +423,14 @@ describe("POST /api/swarm - Unit Tests", () => {
 
       expect(mockSaveOrUpdateSwarm).toHaveBeenCalledWith({
         workspaceId: "workspace-123",
-        name: "swarm-456", // Uses swarm_id as name
+        name: "swarm2bCar4", // Uses swarm_id as name
         instanceType: "m6i.xlarge",
         status: SwarmStatus.ACTIVE,
-        swarmUrl: "https://test-swarm.sphinx.chat/api",
+        swarmUrl: "https://swarm2bCar4.sphinx.chat/api",
         ec2Id: "i-1234567890abcdef0",
         swarmApiKey: "api-key-123",
-        swarmSecretAlias: "{{SWARM_456_API_KEY}}",
-        swarmId: "swarm-456",
+        swarmSecretAlias: "{{swarm2bCar4_API_KEY}}",
+        swarmId: "swarm2bCar4",
         swarmPassword: "secure-test-password-123",
       });
     });
@@ -438,8 +438,8 @@ describe("POST /api/swarm - Unit Tests", () => {
     test("should handle database save failure after service creation", async () => {
       mockSwarmServiceInstance.createSwarm.mockResolvedValue({
         data: {
-          swarm_id: "swarm-456",
-          address: "test-swarm.sphinx.chat",
+          swarm_id: "swarm2bCar4",
+          address: "swarm2bCar4.sphinx.chat",
           x_api_key: "api-key-123",
         },
       });
@@ -459,8 +459,8 @@ describe("POST /api/swarm - Unit Tests", () => {
 
       mockSwarmServiceInstance.createSwarm.mockResolvedValue({
         data: {
-          swarm_id: "swarm-456",
-          address: "test-swarm.sphinx.chat",
+          swarm_id: "swarm2bCar4",
+          address: "swarm2bCar4.sphinx.chat",
           x_api_key: "api-key-123",
         },
       });
@@ -486,12 +486,12 @@ describe("POST /api/swarm - Unit Tests", () => {
         canAdmin: true,
       });
 
-      mockSaveOrUpdateSwarm.mockResolvedValue({ id: "final-swarm", swarmId: "swarm-456" });
+      mockSaveOrUpdateSwarm.mockResolvedValue({ id: "final-swarm", swarmId: "swarm2bCar4" });
 
       mockSwarmServiceInstance.createSwarm.mockResolvedValue({
         data: {
-          swarm_id: "swarm-456",
-          address: "test-swarm.sphinx.chat",
+          swarm_id: "swarm2bCar4",
+          address: "swarm2bCar4.sphinx.chat",
           x_api_key: "api-key-123",
         },
       });
@@ -507,7 +507,7 @@ describe("POST /api/swarm - Unit Tests", () => {
         message: "Swarm was created successfully",
         data: {
           id: "final-swarm",
-          swarmId: "swarm-456",
+          swarmId: "swarm2bCar4",
         },
       });
 

--- a/src/app/api/swarm/poll/route.ts
+++ b/src/app/api/swarm/poll/route.ts
@@ -118,11 +118,8 @@ export async function POST(request: NextRequest) {
       const xApiKey = details.data?.x_api_key;
       const swarm_id =
         (swarm as { swarmId?: string; id: string }).swarmId || swarm.id;
-      // Extract the numeric part from swarm_id using regex
-      const match =
-        typeof swarm_id === "string" ? swarm_id.match(/(\d+)/) : null;
-      const swarm_id_num = match ? match[1] : swarm_id;
-      const swarmSecretAlias = `{{SWARM_${swarm_id_num}_API_KEY}}`;
+      // Use swarm_id directly for secret alias - works with any format
+      const swarmSecretAlias = swarm_id ? `{{${swarm_id}_API_KEY}}` : undefined;
 
       await saveOrUpdateSwarm({
         workspaceId: swarm.workspaceId,
@@ -246,11 +243,8 @@ export async function GET(request: NextRequest) {
       const xApiKey = details.data?.x_api_key;
       const swarm_id =
         (swarm as { swarmId?: string; id: string }).swarmId || swarm.id;
-      // Extract the numeric part from swarm_id using regex
-      const match =
-        typeof swarm_id === "string" ? swarm_id.match(/(\d+)/) : null;
-      const swarm_id_num = match ? match[1] : swarm_id;
-      const swarmSecretAlias = `{{SWARM_${swarm_id_num}_API_KEY}}`;
+      // Use swarm_id directly for secret alias - works with any format
+      const swarmSecretAlias = swarm_id ? `{{${swarm_id}_API_KEY}}` : undefined;
 
       await saveOrUpdateSwarm({
         workspaceId: swarm.workspaceId,

--- a/src/app/api/swarm/route.ts
+++ b/src/app/api/swarm/route.ts
@@ -77,9 +77,8 @@ export async function POST(request: NextRequest) {
     const x_api_key = apiResponse?.data?.x_api_key;
     const ec2_id = apiResponse?.data?.ec2_id;
 
-    const match = typeof swarm_id === "string" ? swarm_id.match(/(\d+)/) : null;
-    const swarm_id_num = match ? match[1] : swarm_id;
-    const swarmSecretAlias = `{{SWARM_${swarm_id_num}_API_KEY}}`;
+    // Use swarm_id directly for secret alias - works with any format
+    const swarmSecretAlias = swarm_id ? `{{${swarm_id}_API_KEY}}` : undefined;
 
     // Create the swarm record in database only after successful external service creation
     const createdSwarm = await saveOrUpdateSwarm({


### PR DESCRIPTION
 ## Summary

  Simplifies swarm secret alias generation by using `swarm_id` directly instead of regex parsing.

  ## Problem

  Previously used regex to extract parts of `swarm_id` (e.g., `"swarm7A9oOV"` → extract → `"{{SWARM_7A9oOV_API_KEY}}"`). This broke when the external swarm service changed ID formats from numeric to alphanumeric.

  ## Solution

  Use `swarm_id` directly without parsing:
  ```typescript
  // Before (fragile)
  const match = swarm_id.match(/(?:swarm)?([a-zA-Z0-9]+)$/i);
  const swarm_id_num = match ? match[1] : swarm_id;
  const swarmSecretAlias = `{{SWARM_${swarm_id_num}_API_KEY}}`;

  // After (simple)
  const swarmSecretAlias = swarm_id ? `{{${swarm_id}_API_KEY}}` : undefined;

  Example: "swarm7A9oOV" → "{{swarm7A9oOV_API_KEY}}"

  Benefits

  - Works with ANY format the external service returns
  - Simpler code (removed 11 lines of regex)
  - Won't break if external service changes format again
  - Easier to maintain

  Changes

  - src/app/api/swarm/route.ts - Simplified alias creation
  - src/app/api/swarm/poll/route.ts - Simplified alias creation (POST + GET)
  - Tests updated with realistic data format