### PR TITLE
Remove descriptive text from page headers

### DIFF
--- a/src/app/w/[slug]/calls/page.tsx
+++ b/src/app/w/[slug]/calls/page.tsx
@@ -101,7 +101,6 @@ export default function CallsPage() {
       <div className="space-y-6">
         <PageHeader
           title="Calls"
-          description="View your call recordings"
         />
         <ConnectRepository
           workspaceSlug={slug}
@@ -117,7 +116,6 @@ export default function CallsPage() {
     <div className="space-y-6">
       <PageHeader
         title="Calls"
-        description="View your call recordings"
         actions={
           workspace?.isCodeGraphSetup ? (
             <Button onClick={handleStartCall} disabled={generatingLink}>

--- a/src/app/w/[slug]/insights/page.tsx
+++ b/src/app/w/[slug]/insights/page.tsx
@@ -131,7 +131,7 @@ export default function InsightsPage() {
 
   return (
     <div className="space-y-6">
-      <PageHeader title="Insights" description="Automated codebase analysis and recommendations" />
+      <PageHeader title="Insights" />
 
       <div className="max-w-5xl space-y-6">
         {/* Content container */}

--- a/src/app/w/[slug]/tasks/page.tsx
+++ b/src/app/w/[slug]/tasks/page.tsx
@@ -13,9 +13,8 @@ export default function TasksPage() {
   const { workspace, slug, id: workspaceId } = useWorkspace();
   return (
     <div className="space-y-6">
-      <PageHeader 
+      <PageHeader
         title="Tasks"
-        description="Manage and track your development tasks and issues."
         actions={workspace?.isCodeGraphSetup && (
           <Button onClick={() => router.push(`/w/${slug}/task/new`)}>
             <Plus className="w-4 h-4 mr-2" />

--- a/src/components/UserJourneys.tsx
+++ b/src/components/UserJourneys.tsx
@@ -231,7 +231,6 @@ export default function UserJourneys() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold">User Journeys</h1>
-          <p className="text-muted-foreground mt-2">Track and optimize user experiences through your product</p>
         </div>
         {frontend ? (
           <Button variant="ghost" size="sm" onClick={handleCloseBrowser} className="h-8 w-8 p-0">


### PR DESCRIPTION
Remove subtitle descriptions from Tasks, Insights, User Journeys, and Calls pages to simplify the UI.