### PR TITLE
fix: include phases in updateFeature response to prevent UI state loss

### DIFF
--- a/src/services/roadmap/features.ts
+++ b/src/services/roadmap/features.ts
@@ -293,6 +293,34 @@ export async function updateFeature(
           order: "asc",
         },
       },
+      phases: {
+        where: {
+          deleted: false,
+        },
+        orderBy: {
+          order: "asc",
+        },
+        include: {
+          tasks: {
+            where: {
+              deleted: false,
+            },
+            orderBy: {
+              order: "asc",
+            },
+            include: {
+              assignee: {
+                select: {
+                  id: true,
+                  name: true,
+                  email: true,
+                  image: true,
+                },
+              },
+            },
+          },
+        },
+      },
     },
   });
 


### PR DESCRIPTION
Fixes #1474

When accepting requirements after phases were already generated and accepted, the phases would disappear from the UI because the PATCH endpoint's response didn't include the phases relation.

This fix adds the phases relation (with nested tasks) to the updateFeature function's include clause, matching the structure returned by the GET endpoint. This ensures the frontend state remains complete after updates and phases stay visible without requiring a hard refresh.