### PR TITLE
refactor: use created_at instead of workflow_started_at in haltStaleAgentTasks

### DIFF
--- a/src/__tests__/unit/services/halt-stale-agent-tasks.test.ts
+++ b/src/__tests__/unit/services/halt-stale-agent-tasks.test.ts
@@ -35,13 +35,13 @@ describe("haltStaleAgentTasks", () => {
         id: "task-1",
         title: "Stale Agent Task 1",
         workspaceId: "workspace-1",
-        workflowStartedAt: twentyFiveHoursAgo,
+        createdAt: twentyFiveHoursAgo,
       },
       {
         id: "task-2",
         title: "Stale Agent Task 2",
         workspaceId: "workspace-1",
-        workflowStartedAt: twentyFiveHoursAgo,
+        createdAt: twentyFiveHoursAgo,
       },
     ];
 
@@ -55,7 +55,7 @@ describe("haltStaleAgentTasks", () => {
       where: {
         mode: "agent",
         workflowStatus: "PENDING",
-        workflowStartedAt: {
+        createdAt: {
           lt: expect.any(Date),
         },
         deleted: false,
@@ -64,7 +64,7 @@ describe("haltStaleAgentTasks", () => {
         id: true,
         title: true,
         workspaceId: true,
-        workflowStartedAt: true,
+        createdAt: true,
       },
     });
 
@@ -128,13 +128,13 @@ describe("haltStaleAgentTasks", () => {
         id: "task-1",
         title: "Task 1",
         workspaceId: "workspace-1",
-        workflowStartedAt: twentyFiveHoursAgo,
+        createdAt: twentyFiveHoursAgo,
       },
       {
         id: "task-2",
         title: "Task 2",
         workspaceId: "workspace-1",
-        workflowStartedAt: twentyFiveHoursAgo,
+        createdAt: twentyFiveHoursAgo,
       },
     ];
 
@@ -242,7 +242,7 @@ describe("haltStaleAgentTasks", () => {
         id: "task-1",
         title: "Task 1",
         workspaceId: "workspace-1",
-        workflowStartedAt: twentyFiveHoursAgo,
+        createdAt: twentyFiveHoursAgo,
       },
     ];
 

--- a/src/services/task-coordinator-cron.ts
+++ b/src/services/task-coordinator-cron.ts
@@ -124,7 +124,7 @@ export async function haltStaleAgentTasks(): Promise<{
       where: {
         mode: "agent",
         workflowStatus: "PENDING",
-        workflowStartedAt: {
+        createdAt: {
           lt: twentyFourHoursAgo,
         },
         deleted: false,
@@ -133,7 +133,7 @@ export async function haltStaleAgentTasks(): Promise<{
         id: true,
         title: true,
         workspaceId: true,
-        workflowStartedAt: true,
+        createdAt: true,
       },
     });
 
@@ -146,7 +146,7 @@ export async function haltStaleAgentTasks(): Promise<{
 
         tasksHalted++;
         console.log(
-          `[HaltStaleAgentTasks] Halted task ${task.id} (${task.title}) - was pending since ${task.workflowStartedAt}`
+          `[HaltStaleAgentTasks] Halted task ${task.id} (${task.title}) - created at ${task.createdAt}`
         );
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
I'm changing this to `created_at` since the `workflow_started_at` column seems to be filled with `NULL` values.

Thus making this functionality not work currently