### PR TITLE
Add API_TOKEN support for roadmap and task endpoints

### DIFF
--- a/src/app/api/features/[featureId]/tickets/route.ts
+++ b/src/app/api/features/[featureId]/tickets/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getMiddlewareContext, requireAuth } from "@/lib/middleware/utils";
+import { getMiddlewareContext } from "@/lib/middleware/utils";
+import { requireAuthWithApiToken } from "@/lib/middleware/auth-helpers";
 import { createTicket } from "@/services/roadmap";
 import type { CreateTicketRequest, TicketResponse } from "@/types/roadmap";
 
@@ -8,14 +9,16 @@ export async function POST(
   { params }: { params: Promise<{ featureId: string }> }
 ) {
   try {
-    const context = getMiddlewareContext(request);
-    const userOrResponse = requireAuth(context);
-    if (userOrResponse instanceof NextResponse) return userOrResponse;
-
     const { featureId } = await params;
     const body: CreateTicketRequest = await request.json();
 
-    const ticket = await createTicket(featureId, userOrResponse.id, body);
+    const context = getMiddlewareContext(request);
+    const authResult = await requireAuthWithApiToken(request, context, {
+      featureId,
+    });
+    if (authResult instanceof NextResponse) return authResult;
+
+    const ticket = await createTicket(featureId, authResult.userId, body);
 
     return NextResponse.json<TicketResponse>(
       {

--- a/src/lib/middleware/auth-helpers.ts
+++ b/src/lib/middleware/auth-helpers.ts
@@ -1,0 +1,151 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import type { MiddlewareContext, MiddlewareUser } from "@/types/middleware";
+import { unauthorizedError } from "@/types/errors";
+import { requireAuth } from "./utils";
+
+interface AuthResult {
+  userId: string;
+  email: string;
+  name: string;
+}
+
+interface WorkspaceResolutionParams {
+  workspaceId?: string;
+  featureId?: string;
+  taskId?: string;
+}
+
+/**
+ * Resolves workspace and owner information from various IDs
+ */
+async function resolveWorkspaceOwner(
+  params: WorkspaceResolutionParams
+): Promise<{ ownerId: string; ownerEmail: string; ownerName: string } | null> {
+  const { workspaceId, featureId, taskId } = params;
+
+  if (workspaceId) {
+    const workspace = await db.workspace.findUnique({
+      where: { id: workspaceId, deleted: false },
+      include: {
+        owner: {
+          select: {
+            id: true,
+            email: true,
+            name: true,
+          },
+        },
+      },
+    });
+
+    if (!workspace) return null;
+
+    return {
+      ownerId: workspace.owner.id,
+      ownerEmail: workspace.owner.email!,
+      ownerName: workspace.owner.name!,
+    };
+  }
+
+  if (featureId) {
+    const feature = await db.feature.findUnique({
+      where: { id: featureId, deleted: false },
+      include: {
+        workspace: {
+          include: {
+            owner: {
+              select: {
+                id: true,
+                email: true,
+                name: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!feature) return null;
+
+    return {
+      ownerId: feature.workspace.owner.id,
+      ownerEmail: feature.workspace.owner.email!,
+      ownerName: feature.workspace.owner.name!,
+    };
+  }
+
+  if (taskId) {
+    const task = await db.task.findFirst({
+      where: { id: taskId, deleted: false },
+      include: {
+        workspace: {
+          include: {
+            owner: {
+              select: {
+                id: true,
+                email: true,
+                name: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!task) return null;
+
+    return {
+      ownerId: task.workspace.owner.id,
+      ownerEmail: task.workspace.owner.email!,
+      ownerName: task.workspace.owner.name!,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Requires authentication via either NextAuth session or API_TOKEN
+ * When API_TOKEN is used, resolves userId from workspace owner
+ *
+ * @param request - The Next.js request object
+ * @param context - Middleware context from getMiddlewareContext()
+ * @param resolutionParams - IDs to resolve workspace owner (workspaceId, featureId, or taskId)
+ * @returns AuthResult with userId, email, name or NextResponse with error
+ */
+export async function requireAuthWithApiToken(
+  request: NextRequest,
+  context: MiddlewareContext,
+  resolutionParams: WorkspaceResolutionParams = {}
+): Promise<AuthResult | NextResponse> {
+  // Check if middleware validated API_TOKEN
+  if (context.authStatus === "api_token") {
+    // Middleware already validated the token, now resolve workspace owner
+    const ownerInfo = await resolveWorkspaceOwner(resolutionParams);
+
+    if (!ownerInfo) {
+      return NextResponse.json(
+        { error: "Workspace not found or invalid resource ID" },
+        { status: 404 }
+      );
+    }
+
+    return {
+      userId: ownerInfo.ownerId,
+      email: ownerInfo.ownerEmail,
+      name: ownerInfo.ownerName,
+    };
+  }
+
+  // Fall back to NextAuth session authentication
+  const userOrResponse = requireAuth(context);
+  if (userOrResponse instanceof NextResponse) {
+    return userOrResponse;
+  }
+
+  return {
+    userId: userOrResponse.id,
+    email: userOrResponse.email,
+    name: userOrResponse.name,
+  };
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -113,6 +113,14 @@ export async function middleware(request: NextRequest) {
       return continueRequest(requestHeaders, routeAccess);
     }
 
+    // Check for API_TOKEN authentication on protected routes
+    const apiToken = request.headers.get("x-api-token");
+    if (apiToken && apiToken === process.env.API_TOKEN) {
+      // Valid API_TOKEN - allow through without session check
+      return continueRequest(requestHeaders, "api_token");
+    }
+
+    // Check for NextAuth session
     const token = await getToken({ req: request, secret: process.env.NEXTAUTH_SECRET });
     if (!token) {
       if (isApiRoute) {

--- a/src/types/middleware.ts
+++ b/src/types/middleware.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server";
 
 // Middleware authentication status
-export type AuthStatus = "authenticated" | "public" | "webhook" | "error";
+export type AuthStatus = "authenticated" | "public" | "webhook" | "api_token" | "error";
 
 // User context from middleware
 export interface MiddlewareUser {


### PR DESCRIPTION
DO NOT MERGE!

This commit adds API_TOKEN authentication support to feature, phase, ticket, and task workflow endpoints, enabling programmatic access alongside existing NextAuth session authentication.

Changes:
- Added "api_token" to AuthStatus type in middleware types
- Updated middleware to validate x-api-token header on protected routes
- Created requireAuthWithApiToken() helper that supports dual auth:
  * API_TOKEN: Resolves workspace owner from workspaceId/featureId/taskId
  * NextAuth session: Uses authenticated user ID (unchanged behavior)
- Updated 6 API endpoints to use new auth helper:
  * POST /api/features - Feature creation
  * POST /api/features/[featureId]/phases - Phase creation
  * POST /api/features/[featureId]/tickets - Ticket creation
  * POST /api/features/[featureId]/phases/batch-create - Batch phase creation
  * POST /api/features/[featureId]/user-stories - User story creation
  * PATCH /api/tasks/[taskId] - Task workflow (start task)

Security:
- Routes remain "protected" by default (not webhook)
- API_TOKEN must match environment variable
- Actions attributed to workspace owner when using API_TOKEN
- Maintains backward compatibility with session auth

Testing:
- All 1837 tests passing
- Build passes with no TypeScript errors
- Fixed batch-create endpoint to check auth before body validation