### PR TITLE
simplify theme settings UI

### DIFF
--- a/src/components/ThemeSettings.tsx
+++ b/src/components/ThemeSettings.tsx
@@ -16,20 +16,14 @@ export function ThemeSettings() {
         <CardTitle className="flex items-center gap-2">
           Theme Settings
         </CardTitle>
-        <CardDescription>
-          Customize the appearance of your dashboard
-        </CardDescription>
       </CardHeader>
       <CardContent>
         <div className="space-y-4">
           <div>
             <div className="flex items-center gap-4 mb-2">
-              <label className="text-sm font-medium text-foreground">
-                Choose Theme
-              </label>
               <ThemeToggleDropdown />
             </div>
-            <p className="text-sm text-muted-foreground mb-4">
+            <p className="text-sm text-muted-foreground">
               Select your preferred theme. System will automatically match your
               operating system&apos;s appearance.
             </p>


### PR DESCRIPTION
Remove redundant text elements from theme settings:
- Remove duplicate subtitle in CardDescription
- Remove "Choose Theme" label
- Keep only the clear description text

Reduces visual clutter and text repetition.