### PR TITLE
fix: sort tasks by updatedAt instead of createdAt and remove subtext

### DIFF
--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -175,7 +175,7 @@ export async function GET(request: NextRequest) {
           }),
         },
         orderBy: {
-          createdAt: "desc",
+          updatedAt: "desc",
         },
         skip,
         take: limit,

--- a/src/components/tasks/TasksList.tsx
+++ b/src/components/tasks/TasksList.tsx
@@ -118,9 +118,6 @@ export function TasksList({ workspaceId, workspaceSlug }: TasksListProps) {
             </ToggleGroup>
           </div>
         </CardTitle>
-        <CardDescription>
-          Your latest tasks in this workspace
-        </CardDescription>
       </CardHeader>
       <CardContent className={viewType === "kanban" ? "p-0" : "space-y-3"}>
         {viewType === "list" ? (


### PR DESCRIPTION
- Change task list sorting from createdAt to updatedAt to show recently active tasks first
- Remove CardDescription subtext from TasksList header
- Fixes issue where newly started tasks from roadmap don't appear at top of list