### PR TITLE
Add real-time ingestion status widget

### DIFF
--- a/src/app/w/[slug]/dashboard/index.tsx
+++ b/src/app/w/[slug]/dashboard/index.tsx
@@ -1,34 +1,16 @@
 "use client";
 
 import { GraphComponent } from "@/components/knowledge-graph";
-import { useIngestStatus } from "@/hooks/useIngestStatus";
-import { Loader2 } from "lucide-react";
 
 interface DashboardProps {
   setupInProgress?: boolean;
 }
 
 export function Dashboard({ setupInProgress = false }: DashboardProps) {
-  const { isIngesting, statusMessage } = useIngestStatus();
-
   return (
     <div className="flex flex-col flex-1 h-full">
       <div className="flex-1 min-h-0">
-        {isIngesting ? (
-          <div className="dark h-full w-full border rounded-lg relative bg-card flex flex-col">
-            <div className="border rounded overflow-hidden bg-card flex-1 flex">
-              <div className="flex w-full flex-col items-center justify-center gap-4">
-                <Loader2 className="h-8 w-8 animate-spin text-gray-400" />
-                <div className="flex flex-col items-center gap-2">
-                  <div className="text-lg text-gray-300">{statusMessage}</div>
-                  <div className="text-sm text-gray-500">This usually takes a few minutes</div>
-                </div>
-              </div>
-            </div>
-          </div>
-        ) : (
-          <GraphComponent enablePolling={true} height="h-full" width="w-full" showWidgets={true} />
-        )}
+        <GraphComponent enablePolling={true} height="h-full" width="w-full" showWidgets={true} />
       </div>
     </div>
   );

--- a/src/components/dashboard/ingestion-status-widget/index.tsx
+++ b/src/components/dashboard/ingestion-status-widget/index.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useIngestStatus } from "@/hooks/useIngestStatus";
+
+export function IngestionStatusWidget() {
+  const { isIngesting, statusMessage } = useIngestStatus();
+
+  if (!isIngesting) {
+    return null;
+  }
+
+  return (
+    <div className="absolute top-4 left-4 z-10 flex items-center gap-2 px-3 py-2 rounded-lg border border-border bg-card/95 backdrop-blur-sm">
+      <div className="relative flex items-center justify-center w-4 h-4 flex-shrink-0">
+        <div className="absolute inset-0 rounded-full border-2 border-muted-foreground/20" />
+        <div className="absolute inset-0 rounded-full border-2 border-t-muted-foreground border-r-transparent border-b-transparent border-l-transparent animate-spin" />
+      </div>
+      <div
+        key={statusMessage}
+        className="text-xs font-mono text-foreground animate-in fade-in duration-300"
+      >
+        {statusMessage}
+      </div>
+    </div>
+  );
+}

--- a/src/components/knowledge-graph/index.tsx
+++ b/src/components/knowledge-graph/index.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from "react";
 import { Universe } from "./Universe";
 import { GitHubStatusWidget } from "@/components/dashboard/github-status-widget";
 import { PoolStatusWidget } from "@/components/dashboard/pool-status-widget";
+import { IngestionStatusWidget } from "@/components/dashboard/ingestion-status-widget";
 
 // --- TYPE DEFINITIONS ---
 
@@ -124,7 +125,10 @@ export const GraphComponent = ({
 
   return (
     <div data-testid="graph-component" className={`dark ${height} ${width} border rounded-lg relative bg-card flex flex-col ${className || ''}`}>
-      {/* Widgets overlaid in top-right corner - only show on dashboard */}
+      {/* Ingestion widget in top-left corner */}
+      {showWidgets && <IngestionStatusWidget />}
+
+      {/* Status widgets in top-right corner - only show on dashboard */}
       {showWidgets && (
         <div className="absolute top-4 right-4 z-10 flex items-center gap-2">
           <GitHubStatusWidget />

--- a/src/services/swarm/stakgraph-actions.ts
+++ b/src/services/swarm/stakgraph-actions.ts
@@ -74,6 +74,7 @@ export async function triggerIngestAsync(
     username: creds.username,
     pat: creds.pat,
     use_lsp: useLsp,
+    realtime: true,
   };
   if (callbackUrl) data.callback_url = callbackUrl;
   return swarmApiRequest({


### PR DESCRIPTION
- Add realtime=true parameter to /ingest_async API calls
- Create IngestionStatusWidget in top-left corner with clean fade transitions
- Remove blocking loading state from dashboard - graph now visible during ingestion
- Widget shows current ingestion step with subtle spinner animation
- Uses monospace font for terminal-like appearance
- Auto-hides when ingestion completes
- Positioned separately from GitHub/Pool status widgets