### PR TITLE
Fix task list pagination UX issues

### DIFF
--- a/src/components/tasks/TasksList.tsx
+++ b/src/components/tasks/TasksList.tsx
@@ -39,7 +39,7 @@ export function TasksList({ workspaceId, workspaceSlug }: TasksListProps) {
     workspaceId,
     workspaceSlug,
     true,
-    5,
+    10,
     activeTab === "archived"
   );
   const { stats } = useTaskStats(workspaceId);

--- a/src/hooks/usePusherConnection.ts
+++ b/src/hooks/usePusherConnection.ts
@@ -27,6 +27,7 @@ export interface TaskTitleUpdateEvent {
   taskId: string;
   newTitle: string;
   previousTitle: string;
+  archived?: boolean;
   timestamp: Date;
 }
 


### PR DESCRIPTION
- Increase tasks per page from 5 to 10 for better visibility
- Fix bug where archiving tasks caused refetch to clear all tasks when on last page
- Add refetch logic to backfill archived tasks only when more tasks are available
- Fix circular dependency by reordering fetchTasks before handleTaskTitleUpdate
- Use pageLimit variable consistently in restoreFromStorage
- Add archived field to TaskTitleUpdateEvent TypeScript interface