### PR TITLE
Enhancement: Move replay button from toolbar to actions list

### DIFF
--- a/src/app/w/[slug]/task/[...taskParams]/artifacts/browser.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/artifacts/browser.tsx
@@ -12,8 +12,6 @@ import {
   Target,
   FlaskConical,
   Bug,
-  Play,
-  Pause,
   List,
   CheckCircle2,
   ArrowLeft,
@@ -397,29 +395,6 @@ export function BrowserArtifactPanel({
                       </TooltipProvider>
                     )}
 
-                    {(generatedPlaywrightTest || externalTestCode) && (
-                      <TooltipProvider>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={handleReplayToggle}
-                              className={`h-8 w-8 p-0 ${
-                                isPlaywrightReplaying
-                                  ? "bg-orange-100 text-orange-600 hover:bg-orange-200 dark:bg-orange-900 dark:text-orange-300 dark:hover:bg-orange-800"
-                                  : "hover:bg-accent hover:text-accent-foreground"
-                              }`}
-                            >
-                              {isPlaywrightReplaying ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
-                            </Button>
-                          </TooltipTrigger>
-                          <TooltipContent side="bottom">
-                            {isPlaywrightReplaying ? "Stop replay" : "Start replay"}
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                    )}
                     {isSetup && isRecorderReady && (
                       <TooltipProvider>
                         <Tooltip>
@@ -519,6 +494,7 @@ export function BrowserArtifactPanel({
                     totalActions={playwrightProgress.total}
                     screenshots={replayScreenshots}
                     title={externalTestTitle || undefined}
+                    onReplayToggle={(generatedPlaywrightTest || externalTestCode) ? handleReplayToggle : undefined}
                   />
                 </div>
               )}

--- a/src/components/ActionsList.tsx
+++ b/src/components/ActionsList.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { X, CheckCircle2, Loader2, Camera } from "lucide-react";
+import { X, CheckCircle2, Loader2, Camera, Play, Square } from "lucide-react";
 import { useRef, useEffect, useState } from "react";
 import { Screenshot } from "@/types/common";
 import { ScreenshotModal } from "@/components/ScreenshotModal";
@@ -30,6 +30,7 @@ interface ActionsListProps {
   totalActions?: number;
   screenshots?: Screenshot[];
   title?: string;
+  onReplayToggle?: () => void;
 }
 
 // Helper function to extract the most descriptive element identifier
@@ -179,6 +180,7 @@ export function ActionsList({
   totalActions = 0,
   screenshots = [],
   title,
+  onReplayToggle,
 }: ActionsListProps) {
   const actionRefs = useRef<(HTMLDivElement | null)[]>([]);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -243,14 +245,27 @@ export function ActionsList({
               <>Test Actions ({actions.length})</>
             )}
           </h3>
-          <Button
-            variant="destructive"
-            size="sm"
-            onClick={onClearAll}
-            disabled={!isRecording || isReplaying || actions.length === 0}
-          >
-            Clear All
-          </Button>
+          <div className="flex items-center gap-2">
+            {onReplayToggle && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onReplayToggle}
+                className="h-8 w-8 p-0"
+                title={isReplaying ? "Stop replay" : "Start replay"}
+              >
+                {isReplaying ? <Square className="h-4 w-4" /> : <Play className="h-4 w-4" />}
+              </Button>
+            )}
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={onClearAll}
+              disabled={!isRecording || isReplaying || actions.length === 0}
+            >
+              Clear All
+            </Button>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
Moves the replay button from the iframe toolbar to the actions list header for more convenient access. Closes #1599