### PR TITLE
feat: add mobile preview toggle for live preview

### DIFF
--- a/src/app/w/[slug]/task/[...taskParams]/artifacts/browser.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/artifacts/browser.tsx
@@ -35,6 +35,7 @@ export function BrowserArtifactPanel({
   onUserJourneySave,
   externalTestCode,
   externalTestTitle,
+  isMobile = false,
 }: {
   artifacts: Artifact[];
   ide?: boolean;
@@ -44,6 +45,7 @@ export function BrowserArtifactPanel({
   onUserJourneySave?: (filename: string, generatedCode: string) => void;
   externalTestCode?: string | null;
   externalTestTitle?: string | null;
+  isMobile?: boolean;
 }) {
   const [activeTab, setActiveTab] = useState(0);
   const [refreshKey, setRefreshKey] = useState(0);
@@ -332,7 +334,7 @@ export function BrowserArtifactPanel({
                         <TooltipContent side="bottom">Go back</TooltipContent>
                       </Tooltip>
                     </TooltipProvider>
-                    <Monitor className="w-4 h-4 flex-shrink-0" />
+                    {/* <Monitor className="w-4 h-4 flex-shrink-0" /> */}
                     <form onSubmit={handleUrlSubmit} className="flex-1 min-w-0">
                       <Input
                         type="text"
@@ -419,7 +421,7 @@ export function BrowserArtifactPanel({
                       </TooltipProvider>
                     )}
 
-                    {!onUserJourneySave && (
+                    {!onUserJourneySave && !isMobile && (
                       <TooltipProvider>
                         <Tooltip>
                           <TooltipTrigger asChild>
@@ -436,7 +438,7 @@ export function BrowserArtifactPanel({
                         </Tooltip>
                       </TooltipProvider>
                     )}
-                    {!onUserJourneySave && (
+                    {!onUserJourneySave && !isMobile && (
                       <TooltipProvider>
                         <Tooltip>
                           <TooltipTrigger asChild>

--- a/src/app/w/[slug]/task/[...taskParams]/components/AgentChatArea.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/components/AgentChatArea.tsx
@@ -2,7 +2,7 @@
 
 import React, { useRef, useEffect, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { ArrowLeft, GitCommit } from "lucide-react";
+import { ArrowLeft, GitCommit, Monitor } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { AgentChatMessage } from "./AgentChatMessage";
 import { ChatInput } from "./ChatInput";
@@ -24,6 +24,9 @@ interface AgentChatAreaProps {
   workspaceSlug?: string;
   onCommit?: () => Promise<void>;
   isCommitting?: boolean;
+  showPreviewToggle?: boolean;
+  showPreview?: boolean;
+  onTogglePreview?: () => void;
 }
 
 export function AgentChatArea({
@@ -39,6 +42,9 @@ export function AgentChatArea({
   workspaceSlug,
   onCommit,
   isCommitting = false,
+  showPreviewToggle = false,
+  showPreview = false,
+  onTogglePreview,
 }: AgentChatAreaProps) {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
@@ -124,6 +130,19 @@ export function AgentChatArea({
                   </motion.h2>
                 </AnimatePresence>
               </div>
+
+              {/* Preview Toggle Button (Mobile Only) */}
+              {showPreviewToggle && onTogglePreview && (
+                <Button
+                  variant={showPreview ? "default" : "ghost"}
+                  size="sm"
+                  onClick={onTogglePreview}
+                  className="flex-shrink-0"
+                  title={showPreview ? "Show Chat" : "Show Live Preview"}
+                >
+                  <Monitor className="w-4 h-4" />
+                </Button>
+              )}
 
               {/* Commit Button */}
               {onCommit && (

--- a/src/app/w/[slug]/task/[...taskParams]/components/ArtifactsPanel.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/components/ArtifactsPanel.tsx
@@ -3,6 +3,8 @@
 import { useMemo, useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
+import { Monitor } from "lucide-react";
 import { Artifact, ArtifactType } from "@/lib/chat";
 import { CodeArtifactPanel, BrowserArtifactPanel, GraphArtifactPanel, WorkflowArtifactPanel } from "../artifacts";
 
@@ -11,9 +13,11 @@ interface ArtifactsPanelProps {
   workspaceId?: string;
   taskId?: string;
   onDebugMessage?: (message: string, debugArtifact?: Artifact) => Promise<void>;
+  isMobile?: boolean;
+  onTogglePreview?: () => void;
 }
 
-export function ArtifactsPanel({ artifacts, workspaceId, taskId, onDebugMessage }: ArtifactsPanelProps) {
+export function ArtifactsPanel({ artifacts, workspaceId, taskId, onDebugMessage, isMobile = false, onTogglePreview }: ArtifactsPanelProps) {
   const [activeTab, setActiveTab] = useState<ArtifactType | null>(null);
 
   // Separate artifacts by type
@@ -60,40 +64,60 @@ export function ArtifactsPanel({ artifacts, workspaceId, taskId, onDebugMessage 
           setActiveTab(value as ArtifactType);
         }}
       >
-        <motion.div
-          className="border-b bg-background/80 backdrop-blur"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ duration: 0.4 }}
-        >
-          <TabsList className="w-full flex">
-            {codeArtifacts.length > 0 && (
-              <TabsTrigger className="cursor-pointer" value="CODE">
-                Code / Files
-              </TabsTrigger>
-            )}
-            {browserArtifacts.length > 0 && (
-              <TabsTrigger className="cursor-pointer" value="BROWSER">
-                Live Preview
-              </TabsTrigger>
-            )}
-            {ideArtifacts.length > 0 && (
-              <TabsTrigger className="cursor-pointer" value="IDE">
-                IDE
-              </TabsTrigger>
-            )}
-            {graphArtifacts.length > 0 && (
-              <TabsTrigger className="cursor-pointer" value="GRAPH">
-                Graph
-              </TabsTrigger>
-            )}
-            {workflowArtifacts.length > 0 && (
-              <TabsTrigger className="cursor-pointer" value="WORKFLOW">
-                Workflow
-              </TabsTrigger>
-            )}
-          </TabsList>
-        </motion.div>
+        {!isMobile && (
+          <motion.div
+            className="border-b bg-background/80 backdrop-blur"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.4 }}
+          >
+            <TabsList className="w-full flex">
+              {codeArtifacts.length > 0 && (
+                <TabsTrigger className="cursor-pointer" value="CODE">
+                  Code / Files
+                </TabsTrigger>
+              )}
+              {browserArtifacts.length > 0 && (
+                <TabsTrigger className="cursor-pointer" value="BROWSER">
+                  Live Preview
+                </TabsTrigger>
+              )}
+              {ideArtifacts.length > 0 && (
+                <TabsTrigger className="cursor-pointer" value="IDE">
+                  IDE
+                </TabsTrigger>
+              )}
+              {graphArtifacts.length > 0 && (
+                <TabsTrigger className="cursor-pointer" value="GRAPH">
+                  Graph
+                </TabsTrigger>
+              )}
+              {workflowArtifacts.length > 0 && (
+                <TabsTrigger className="cursor-pointer" value="WORKFLOW">
+                  Workflow
+                </TabsTrigger>
+              )}
+            </TabsList>
+          </motion.div>
+        )}
+        {isMobile && onTogglePreview && (
+          <motion.div
+            className="border-b bg-background/80 backdrop-blur px-3 py-2"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.4 }}
+          >
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onTogglePreview}
+              className="gap-2"
+            >
+              <Monitor className="w-4 h-4" />
+              Back to Chat
+            </Button>
+          </motion.div>
+        )}
 
         <motion.div
           className="flex-1 overflow-hidden min-h-0"
@@ -123,6 +147,7 @@ export function ArtifactsPanel({ artifacts, workspaceId, taskId, onDebugMessage 
                 workspaceId={workspaceId}
                 taskId={taskId}
                 onDebugMessage={onDebugMessage}
+                isMobile={isMobile}
               />
             </TabsContent>
           )}
@@ -139,6 +164,7 @@ export function ArtifactsPanel({ artifacts, workspaceId, taskId, onDebugMessage 
                 workspaceId={workspaceId}
                 taskId={taskId}
                 onDebugMessage={onDebugMessage}
+                isMobile={isMobile}
               />
             </TabsContent>
           )}

--- a/src/app/w/[slug]/task/[...taskParams]/components/ChatArea.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/components/ChatArea.tsx
@@ -2,7 +2,7 @@
 
 import React, { useRef, useEffect, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { ArrowLeft, ExternalLink } from "lucide-react";
+import { ArrowLeft, ExternalLink, Monitor } from "lucide-react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { ChatMessage as ChatMessageType, Option, Artifact, WorkflowStatus } from "@/lib/chat";
@@ -28,6 +28,9 @@ interface ChatAreaProps {
   taskTitle?: string | null;
   stakworkProjectId?: number | null;
   workspaceSlug?: string;
+  showPreviewToggle?: boolean;
+  showPreview?: boolean;
+  onTogglePreview?: () => void;
 }
 
 export function ChatArea({
@@ -45,6 +48,9 @@ export function ChatArea({
   taskTitle,
   stakworkProjectId,
   workspaceSlug,
+  showPreviewToggle = false,
+  showPreview = false,
+  onTogglePreview,
 }: ChatAreaProps) {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
@@ -133,6 +139,19 @@ export function ChatArea({
                   </motion.h2>
                 </AnimatePresence>
               </div>
+
+              {/* Preview Toggle Button (Mobile Only) */}
+              {showPreviewToggle && onTogglePreview && (
+                <Button
+                  variant={showPreview ? "default" : "ghost"}
+                  size="sm"
+                  onClick={onTogglePreview}
+                  className="flex-shrink-0"
+                  title={showPreview ? "Show Chat" : "Show Live Preview"}
+                >
+                  <Monitor className="w-4 h-4" />
+                </Button>
+              )}
 
               {/* Stakwork Project Link */}
               {stakworkProjectId && (

--- a/src/app/w/[slug]/task/[...taskParams]/page.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/page.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState, useCallback, useRef } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { useSession } from "next-auth/react";
 import { useToast } from "@/components/ui/use-toast";
+import { Button } from "@/components/ui/button";
+import { Monitor } from "lucide-react";
 import {
   ChatMessage,
   ChatRole,
@@ -79,6 +81,7 @@ export default function TaskChatPage() {
   const [commitMessage, setCommitMessage] = useState("");
   const [branchName, setBranchName] = useState("");
   const [isGeneratingCommitInfo, setIsGeneratingCommitInfo] = useState(false);
+  const [showPreview, setShowPreview] = useState(false);
 
   // Use hook to check for active chat form and get webhook
   const { hasActiveChatForm, webhook: chatWebhook } = useChatForm(messages);
@@ -773,6 +776,7 @@ export default function TaskChatPage() {
   // Separate artifacts by type
   const allArtifacts = messages.flatMap((msg) => msg.artifacts || []);
   const hasNonFormArtifacts = allArtifacts.some((a) => a.type !== "FORM" && a.type !== "LONGFORM");
+  const browserArtifact = allArtifacts.find((a) => a.type === "BROWSER");
 
   const inputDisabled = isLoading || !isConnected;
   if (hasActiveChatForm) {
@@ -802,25 +806,39 @@ export default function TaskChatPage() {
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y: -60 }}
           transition={{ duration: 0.4, ease: [0.4, 0.0, 0.2, 1] }}
-          className="h-[92vh] md:h-[97vh] flex"
+          className="h-[92vh] md:h-[97vh] flex overflow-hidden"
         >
           {taskMode === "agent" && hasNonFormArtifacts ? (
             isMobile ? (
-              <div className="flex-1 min-w-0">
-                <AgentChatArea
-                  messages={messages}
-                  onSend={handleSend}
-                  inputDisabled={inputDisabled}
-                  isLoading={isLoading}
-                  logs={logs}
-                  pendingDebugAttachment={pendingDebugAttachment}
-                  onRemoveDebugAttachment={() => setPendingDebugAttachment(null)}
-                  workflowStatus={workflowStatus}
-                  taskTitle={taskTitle}
-                  workspaceSlug={slug}
-                  onCommit={handleCommit}
-                  isCommitting={isGeneratingCommitInfo || isCommitting}
-                />
+              <div className="flex-1 min-w-0 flex flex-col">
+                {showPreview && browserArtifact ? (
+                  <ArtifactsPanel
+                    artifacts={[browserArtifact]}
+                    workspaceId={effectiveWorkspaceId || undefined}
+                    taskId={currentTaskId || undefined}
+                    onDebugMessage={handleDebugMessage}
+                    isMobile={isMobile}
+                    onTogglePreview={() => setShowPreview(!showPreview)}
+                  />
+                ) : (
+                  <AgentChatArea
+                    messages={messages}
+                    onSend={handleSend}
+                    inputDisabled={inputDisabled}
+                    isLoading={isLoading}
+                    logs={logs}
+                    pendingDebugAttachment={pendingDebugAttachment}
+                    onRemoveDebugAttachment={() => setPendingDebugAttachment(null)}
+                    workflowStatus={workflowStatus}
+                    taskTitle={taskTitle}
+                    workspaceSlug={slug}
+                    onCommit={handleCommit}
+                    isCommitting={isGeneratingCommitInfo || isCommitting}
+                    showPreviewToggle={!!browserArtifact}
+                    showPreview={showPreview}
+                    onTogglePreview={() => setShowPreview(!showPreview)}
+                  />
+                )}
               </div>
             ) : (
               <ResizablePanelGroup direction="horizontal" className="flex flex-1 min-w-0 min-h-0 gap-2">
@@ -874,24 +892,38 @@ export default function TaskChatPage() {
             </div>
           ) : hasNonFormArtifacts ? (
             isMobile ? (
-              <div className="flex-1 min-w-0">
-                <ChatArea
-                  logs={logs}
-                  messages={messages}
-                  onSend={handleSend}
-                  onArtifactAction={handleArtifactAction}
-                  inputDisabled={inputDisabled}
-                  isLoading={isLoading}
-                  hasNonFormArtifacts={hasNonFormArtifacts}
-                  isChainVisible={isChainVisible}
-                  lastLogLine={lastLogLine}
-                  pendingDebugAttachment={pendingDebugAttachment}
-                  onRemoveDebugAttachment={() => setPendingDebugAttachment(null)}
-                  workflowStatus={workflowStatus}
-                  taskTitle={taskTitle}
-                  stakworkProjectId={stakworkProjectId}
-                  workspaceSlug={slug}
-                />
+              <div className="flex-1 min-w-0 flex flex-col">
+                {showPreview && browserArtifact ? (
+                  <ArtifactsPanel
+                    artifacts={[browserArtifact]}
+                    workspaceId={effectiveWorkspaceId || undefined}
+                    taskId={currentTaskId || undefined}
+                    onDebugMessage={handleDebugMessage}
+                    isMobile={isMobile}
+                    onTogglePreview={() => setShowPreview(!showPreview)}
+                  />
+                ) : (
+                  <ChatArea
+                    logs={logs}
+                    messages={messages}
+                    onSend={handleSend}
+                    onArtifactAction={handleArtifactAction}
+                    inputDisabled={inputDisabled}
+                    isLoading={isLoading}
+                    hasNonFormArtifacts={hasNonFormArtifacts}
+                    isChainVisible={isChainVisible}
+                    lastLogLine={lastLogLine}
+                    pendingDebugAttachment={pendingDebugAttachment}
+                    onRemoveDebugAttachment={() => setPendingDebugAttachment(null)}
+                    workflowStatus={workflowStatus}
+                    taskTitle={taskTitle}
+                    stakworkProjectId={stakworkProjectId}
+                    workspaceSlug={slug}
+                    showPreviewToggle={!!browserArtifact}
+                    showPreview={showPreview}
+                    onTogglePreview={() => setShowPreview(!showPreview)}
+                  />
+                )}
               </div>
             ) : (
               <ResizablePanelGroup direction="horizontal" className="flex flex-1 min-w-0 min-h-0 gap-2">


### PR DESCRIPTION
- Add Monitor icon toggle in chat headers to switch between chat and live preview on mobile
- Hide artifacts panel tabs header on mobile, show "Back to Chat" button instead
- Hide Tests and Debug buttons in browser toolbar on mobile
- Fix page scroll issue by adding overflow-hidden to main container
- Only show toggle when BROWSER artifact exists
- Pass isMobile prop through component tree for responsive behavior