### PR TITLE
Fix Sharp library serverless initialization error

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,7 @@ const nextConfig: NextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  serverExternalPackages: ["sharp"],
   images: {
     remotePatterns: [
       {

--- a/src/lib/image-processing.ts
+++ b/src/lib/image-processing.ts
@@ -1,5 +1,3 @@
-import sharp from 'sharp'
-
 const WORKSPACE_LOGO_MAX_WIDTH = 1200
 const WORKSPACE_LOGO_MAX_HEIGHT = 400
 const IMAGE_QUALITY = 80
@@ -27,6 +25,7 @@ export async function resizeWorkspaceLogo(
   maxHeight: number = WORKSPACE_LOGO_MAX_HEIGHT
 ): Promise<ProcessedImage> {
   try {
+    const sharp = (await import('sharp')).default
     const image = sharp(buffer)
     const metadata = await image.metadata()
 
@@ -50,7 +49,8 @@ export async function resizeWorkspaceLogo(
       .jpeg({ quality: IMAGE_QUALITY, mozjpeg: true })
       .toBuffer()
 
-    const processedMetadata = await sharp(processedBuffer).metadata()
+    const processedImage = sharp(processedBuffer)
+    const processedMetadata = await processedImage.metadata()
 
     return {
       buffer: processedBuffer,

--- a/src/services/workspace-logo.ts
+++ b/src/services/workspace-logo.ts
@@ -1,10 +1,6 @@
 import { getS3Service } from '@/services/s3'
 import { getWorkspaceBySlug } from '@/services/workspace'
 import { db } from '@/lib/db'
-import {
-  resizeWorkspaceLogo,
-  isSupportedImageType,
-} from '@/lib/image-processing'
 import type { WorkspaceWithAccess } from '@/types/workspace'
 import type { WorkspaceRole } from '@prisma/client'
 
@@ -106,6 +102,10 @@ export class WorkspaceLogoService {
     userId: string,
     confirmation: ConfirmUploadRequest
   ): Promise<ConfirmUploadResponse> {
+    const { isSupportedImageType, resizeWorkspaceLogo } = await import(
+      '@/lib/image-processing'
+    )
+
     const workspace = await this.validateWorkspaceAccess(slug, userId)
     const { s3Path, mimeType } = confirmation
 


### PR DESCRIPTION
- Add serverExternalPackages config for Next.js 15 compatibility
- Lazy-load Sharp in image-processing to prevent premature initialization
- Move image-processing import to confirmUpload method in workspace-logo service
- Prevents Sharp from loading on upload-url endpoint which only needs S3