### PR TITLE
Add 'Created by' column to Features list on Roadmap page

### DIFF
--- a/src/components/features/FeaturesList.tsx
+++ b/src/components/features/FeaturesList.tsx
@@ -74,6 +74,9 @@ function FeatureRow({
       <TableCell className="w-[150px] text-right text-muted-foreground text-sm">
         {new Date(feature.createdAt).toLocaleDateString()}
       </TableCell>
+      <TableCell className="w-[150px] text-muted-foreground text-sm">
+        {feature.createdBy?.name || "Unknown"}
+      </TableCell>
       <TableCell className="w-[50px]" onClick={(e) => e.stopPropagation()}>
         <ActionMenu
           actions={[
@@ -561,6 +564,7 @@ const FeaturesListComponent = forwardRef<{ triggerCreate: () => void }, Features
                   <TableHead className="w-[120px]">Status</TableHead>
                   <TableHead className="w-[180px]">Assigned</TableHead>
                   <TableHead className="w-[150px] text-right">Created</TableHead>
+                  <TableHead className="w-[150px]">Created by</TableHead>
                   <TableHead className="w-[50px]"></TableHead>
                 </TableRow>
               </TableHeader>
@@ -578,6 +582,9 @@ const FeaturesListComponent = forwardRef<{ triggerCreate: () => void }, Features
                     </TableCell>
                     <TableCell className="w-[150px] text-right">
                       <Skeleton className="h-4 w-24 ml-auto" />
+                    </TableCell>
+                    <TableCell className="w-[150px]">
+                      <Skeleton className="h-4 w-32" />
                     </TableCell>
                     <TableCell className="w-[50px]"></TableCell>
                   </TableRow>
@@ -726,13 +733,14 @@ const FeaturesListComponent = forwardRef<{ triggerCreate: () => void }, Features
                       align="right"
                     />
                   </TableHead>
+                  <TableHead className="w-[150px]">Created by</TableHead>
                   <TableHead className="w-[50px]"></TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
                 {features.length === 0 ? (
                   <TableRow>
-                    <TableCell colSpan={5} className="h-32 text-center">
+                    <TableCell colSpan={6} className="h-32 text-center">
                       <p className="text-muted-foreground">No features match your filters</p>
                     </TableCell>
                   </TableRow>


### PR DESCRIPTION
## Description
This PR adds a 'Created by' column to the Features list on the Roadmap page, displaying the username of the user who created each feature.

## Changes
- Added 'Created by' column to the right of the 'Created' column
- Displays the creator's name (falls back to 'Unknown' if not available)
- Updated table headers, loading skeleton, and empty state to accommodate the new column
- Updated colspan from 5 to 6 in the empty state message

## Technical Details
- The data for `createdBy` is already being fetched from the API
- Column width: 150px to provide adequate space for usernames
- Displays `feature.createdBy?.name` or 'Unknown' as fallback (no email for privacy)

## Testing
- [x] Code compiles without errors
- [ ] UI displays correctly in list view
- [ ] Column appears in the correct position
- [ ] Creator username displays properly
- [ ] 'Unknown' fallback works when name is not available