### PR TITLE
Add global scrollbar styling and remove ScrollArea components

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -128,6 +128,33 @@
   }
 }
 
+/* Global scrollbar styling - outside layers for maximum specificity */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--muted) transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background: var(--muted);
+  border-radius: 9999px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background: var(--border);
+  background-clip: padding-box;
+}
+
 /* React Flow Controls Styling */
 .react-flow__controls {
   display: flex !important;

--- a/src/app/w/[slug]/task/[...taskParams]/artifacts/TestManagerModal.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/artifacts/TestManagerModal.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { useToast } from "@/components/ui/use-toast";
 import { Copy, Save } from "lucide-react";
 import { Input } from "@/components/ui/input";
@@ -91,12 +90,10 @@ export function TestManagerModal({
               <Copy className="w-4 h-4 mr-1" /> {copying ? "Copied!" : "Copy"}
             </Button>
           </div>
-          <div className="flex-1 min-h-0 border rounded overflow-hidden">
-            <ScrollArea className="h-full">
-              <pre className="text-sm bg-background/50 p-4 overflow-auto whitespace-pre max-h-[60vh]">
-                <code className="language-javascript">{generatedCode}</code>
-              </pre>
-            </ScrollArea>
+          <div className="flex-1 min-h-0 border rounded overflow-auto">
+            <pre className="text-sm bg-background/50 p-4 whitespace-pre max-h-[60vh]">
+              <code className="language-javascript">{generatedCode}</code>
+            </pre>
           </div>
         </div>
       </DialogContent>

--- a/src/components/calls/TranscriptPanel.tsx
+++ b/src/components/calls/TranscriptPanel.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { ScrollArea } from '@/components/ui/scroll-area'
 import { Badge } from '@/components/ui/badge'
 import { Clock } from 'lucide-react'
 
@@ -89,9 +88,8 @@ export const TranscriptPanel: React.FC<TranscriptPanelProps> = ({
           </Badge>
         </CardTitle>
       </CardHeader>
-      <CardContent className="flex-1 p-0 min-h-0">
-        <ScrollArea className="h-full">
-          <div className="p-4">
+      <CardContent className="flex-1 p-0 min-h-0 overflow-auto">
+        <div className="p-4">
             {currentSegment ? (
               <div className="space-y-4">
                 {/* Timestamp and Speaker */}
@@ -140,8 +138,7 @@ export const TranscriptPanel: React.FC<TranscriptPanelProps> = ({
                 </p>
               </div>
             )}
-          </div>
-        </ScrollArea>
+        </div>
       </CardContent>
     </Card>
   )

--- a/src/components/tasks/KanbanView.tsx
+++ b/src/components/tasks/KanbanView.tsx
@@ -2,7 +2,6 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import { TaskData } from "@/hooks/useWorkspaceTasks";
 import { TaskCard } from "./TaskCard";
 import { WorkflowStatus } from "@prisma/client";
@@ -138,7 +137,7 @@ export function KanbanView({ tasks, workspaceSlug, loading }: KanbanViewProps) {
       </div>
 
       {/* Desktop view - horizontal scrollable */}
-      <ScrollArea className="hidden md:block w-full whitespace-nowrap">
+      <div className="hidden md:block w-full whitespace-nowrap overflow-x-auto pb-2">
         <div className="flex gap-4 pb-4 min-h-[500px]">
           {kanbanColumns.map((column) => {
             const columnTasks = tasksByStatus[column.status] || [];
@@ -192,8 +191,7 @@ export function KanbanView({ tasks, workspaceSlug, loading }: KanbanViewProps) {
             );
           })}
         </div>
-        <ScrollBar orientation="horizontal" className="mt-2" />
-      </ScrollArea>
+      </div>
     </div>
   );
 }

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -62,12 +62,6 @@ const CommandList = React.forwardRef<
     ref={ref}
     className={cn(
       "max-h-[300px] overflow-y-auto overflow-x-hidden",
-      "[&::-webkit-scrollbar]:w-2",
-      "[&::-webkit-scrollbar-track]:bg-transparent",
-      "[&::-webkit-scrollbar-thumb]:bg-muted",
-      "[&::-webkit-scrollbar-thumb]:rounded-full",
-      "[&::-webkit-scrollbar-thumb]:border-2",
-      "[&::-webkit-scrollbar-thumb]:border-transparent",
       className
     )}
     {...props}

--- a/src/components/ui/kanban-view.tsx
+++ b/src/components/ui/kanban-view.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Badge } from "@/components/ui/badge";
-import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import { ReactNode, useState } from "react";
 import {
@@ -215,7 +214,7 @@ export function KanbanView<T, S extends string>({
       </div>
 
       {/* Desktop view - horizontal scrollable */}
-      <ScrollArea className="hidden md:block w-full whitespace-nowrap">
+      <div className="hidden md:block w-full whitespace-nowrap overflow-x-auto pb-2">
         <div className="flex gap-4 pb-4 min-h-[500px]">
           {columns.map((column) => {
             const columnItems = itemsByStatus[column.status] || [];
@@ -277,8 +276,7 @@ export function KanbanView<T, S extends string>({
             );
           })}
         </div>
-        <ScrollBar orientation="horizontal" className="mt-2" />
-      </ScrollArea>
+      </div>
     </div>
   );
 


### PR DESCRIPTION
- Add consistent scrollbar styling globally in globals.css using CSS variables
- Replace Radix ScrollArea with native scrolling in kanban views, artifacts modal, and transcript panel
- Remove redundant scrollbar styles from command component
- Improves performance and consistency across the app