### PR TITLE
fix: hide Clear All button when not recording

### DIFF
--- a/src/components/ActionsList.tsx
+++ b/src/components/ActionsList.tsx
@@ -257,14 +257,15 @@ export function ActionsList({
                 {isReplaying ? <Square className="h-4 w-4" /> : <Play className="h-4 w-4" />}
               </Button>
             )}
-            <Button
-              variant="destructive"
-              size="sm"
-              onClick={onClearAll}
-              disabled={!isRecording || isReplaying || actions.length === 0}
-            >
-              Clear All
-            </Button>
+            {isRecording && !isReplaying && actions.length > 0 && (
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={onClearAll}
+              >
+                Clear All
+              </Button>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Changes the "Clear All" button to be conditionally rendered instead of disabled when not recording.

Fixes #1613