### PR TITLE
Fix: Remove redundant onboarding redirect from signin page

### DIFF
--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -45,11 +45,8 @@ function SignInContent() {
       } else if (user.defaultWorkspaceSlug) {
         // User has a default workspace, redirect to their workspace
         router.push(`/w/${user.defaultWorkspaceSlug}`);
-      } else {
-        console.log("No default workspace, redirecting to onboarding");
-        // User has no workspaces, redirect to onboarding
-        router.push("/onboarding/workspace");
       }
+      // Note: Users without workspaces are handled by root page's handleWorkspaceRedirect()
     }
   }, [session, router, redirectPath]);
 


### PR DESCRIPTION
The signin page was auto-redirecting all authenticated users without workspaces to onboarding on every page load, breaking iframe-based flows like user journey recording. This removes the redundant redirect since workspace routing is already handled by the root page's handleWorkspaceRedirect() function.