### PR TITLE
Add Review Required badge for manual recommendations

### DIFF
--- a/src/components/insights/RecommendationsSection/index.tsx
+++ b/src/components/insights/RecommendationsSection/index.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { CheckCircle2, Loader2, Sparkles, Clock } from "lucide-react";
+import { CheckCircle2, Loader2, Sparkles, Clock, User } from "lucide-react";
 import { useToast } from "@/components/ui/use-toast";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { useInsightsStore } from "@/stores/useInsightsStore";
@@ -140,6 +140,12 @@ export function RecommendationsSection() {
                     </h4>
                   </div>
                   <div className="flex items-center gap-2">
+                    {!recommendation.janitorRun && (
+                      <Badge className="gap-1 px-1.5 py-0.5 text-xs bg-purple-100 text-purple-800 border-purple-200">
+                        <User className="w-3 h-3" />
+                        Review Required
+                      </Badge>
+                    )}
                     {getPriorityBadge(recommendation.priority as Priority)}
                   </div>
                 </div>


### PR DESCRIPTION
Manual recommendations (without janitorRunId) now display a purple 'Review Required' badge to indicate they need human/PM approval and won't be auto-swept by the task coordinator.