### PR TITLE
Restore previewPlaywrightTest function from stakgraph

### DIFF
--- a/public/js/staktrak.js
+++ b/public/js/staktrak.js
@@ -4276,6 +4276,27 @@ var userBehaviour = (() => {
       console.error(`[Screenshot] Error capturing for actionIndex=${actionIndex}:`, error);
     }
   }
+  function previewPlaywrightTest(testCode) {
+    try {
+      const actions = parsePlaywrightTest(testCode);
+      window.parent.postMessage(
+        {
+          type: "staktrak-playwright-replay-preview-ready",
+          totalActions: actions.length,
+          actions
+        },
+        getParentOrigin()
+      );
+    } catch (error) {
+      window.parent.postMessage(
+        {
+          type: "staktrak-playwright-replay-preview-error",
+          error: error instanceof Error ? error.message : "Unknown error"
+        },
+        getParentOrigin()
+      );
+    }
+  }
   async function startPlaywrightReplay(testCode) {
     try {
       const actions = parsePlaywrightTest(testCode);
@@ -4446,6 +4467,11 @@ var userBehaviour = (() => {
         parentOrigin = event.origin;
       }
       switch (data.type) {
+        case "staktrak-playwright-replay-preview":
+          if (data.testCode) {
+            previewPlaywrightTest(data.testCode);
+          }
+          break;
         case "staktrak-playwright-replay-start":
           if (data.testCode) {
             startPlaywrightReplay(data.testCode);


### PR DESCRIPTION
Restores previewPlaywrightTest function that was accidentally removed in PR #1754. Syncs staktrak.js bundle with stakgraph upstream/main.