### PR TITLE
fix: navigate back to list after saving user journey test

### DIFF
--- a/src/components/UserJourneys.tsx
+++ b/src/components/UserJourneys.tsx
@@ -417,11 +417,17 @@ export default function UserJourneys() {
 
         // Refetch tasks to show the new one
         await fetchUserJourneyTasks();
+
+        // Close the browser panel and release the pod
+        handleCloseBrowser();
       } else {
         toast({
           title: "Test Saved",
           description: "Test was saved but task creation may have failed.",
         });
+
+        // Still close the browser panel even if task creation failed
+        handleCloseBrowser();
       }
     } catch (error) {
       console.error("Error saving user journey:", error);


### PR DESCRIPTION
After clicking "Save test", users are now automatically returned to the recordings list with proper cleanup by calling handleCloseBrowser() which:
- Closes the browser panel
- Releases the claimed pod
- Clears replay state