### PR TITLE
refactor: redesign user journey save modal for PMs

### DIFF
--- a/src/app/w/[slug]/task/[...taskParams]/artifacts/TestManagerModal.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/artifacts/TestManagerModal.tsx
@@ -3,15 +3,10 @@
 import { useEffect, useState } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { useToast } from "@/components/ui/use-toast";
-import { Copy, Save } from "lucide-react";
+import { CheckCircle2 } from "lucide-react";
 import { Input } from "@/components/ui/input";
-import Prism from "prismjs";
-import "prismjs/components/prism-javascript";
-import "prismjs/components/prism-typescript";
-import "prismjs/components/prism-jsx";
-import "prismjs/themes/prism-tomorrow.css";
+import { Label } from "@/components/ui/label";
 
 interface TestManagerModalProps {
   isOpen: boolean;
@@ -19,7 +14,6 @@ interface TestManagerModalProps {
   generatedCode?: string;
   errorMessage?: string;
   onUserJourneySave?: (filename: string, generatedCode: string) => void;
-  initialTab?: string;
 }
 
 export function TestManagerModal({
@@ -28,78 +22,95 @@ export function TestManagerModal({
   generatedCode = "",
   errorMessage = "",
   onUserJourneySave,
-  initialTab = "",
 }: TestManagerModalProps) {
-  const [copying, setCopying] = useState(false);
-  const [filename, setFilename] = useState<string>("");
+  const [testName, setTestName] = useState<string>("");
   const [saving, setSaving] = useState(false);
   const { toast } = useToast();
 
+  const generateFilename = (name: string) => {
+    if (!name.trim()) {
+      const ts = new Date().toISOString().replace(/[:.]/g, "-");
+      return `test-recording-${ts}.spec.js`;
+    }
+    const sanitized = name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+    return `${sanitized}.spec.js`;
+  };
+
+  const filename = generateFilename(testName);
+
   useEffect(() => {
     if (isOpen && generatedCode) {
-      const ts = new Date().toISOString().replace(/[:.]/g, "-");
-      setFilename(`test-recording-${ts}.spec.js`);
+      setTestName("");
     }
   }, [isOpen, generatedCode]);
 
-  useEffect(() => {
-    if (!isOpen) return;
-    setTimeout(() => {
-      try {
-        Prism.highlightAll();
-      } catch {}
-    }, 50);
-  }, [isOpen, generatedCode]);
-
   const handleSave = async () => {
+    if (!testName.trim()) {
+      toast({
+        title: "Test name required",
+        description: "Please enter a name for your test",
+        variant: "destructive",
+      });
+      return;
+    }
     if (onUserJourneySave) {
-      onUserJourneySave(filename.trim(), generatedCode);
+      setSaving(true);
+      onUserJourneySave(filename, generatedCode);
+      setSaving(false);
       onClose();
       return;
     }
   };
 
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(generatedCode);
-      setCopying(true);
-      setTimeout(() => setCopying(false), 1200);
-      toast({ title: "Copied", description: "Test code copied to clipboard" });
-    } catch {}
-  };
-
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="w-[98vw] h-[75vh] flex flex-col" style={{ width: "94vw", maxWidth: "1200px" }}>
-        <DialogHeader className="flex-shrink-0">
-          <DialogTitle>Generated Test</DialogTitle>
+      <DialogContent className="sm:max-w-[600px]">
+        <DialogHeader>
+          <DialogTitle className="text-2xl">Save User Journey</DialogTitle>
         </DialogHeader>
 
-        <div className="flex-1 min-h-0 flex flex-col">
-          <div className="flex items-center gap-2 mb-3">
-            {onUserJourneySave && (
-              <>
-                <Input
-                  placeholder="filename e.g. my-test.spec.js"
-                  value={filename}
-                  onChange={(e) => setFilename(e.target.value)}
-                />
-                <Button onClick={handleSave} disabled={!filename.trim() || !generatedCode || saving}>
-                  <Save className="w-4 h-4 mr-1" /> {saving ? "Saving…" : "Save Test"}
-                </Button>
-              </>
-            )}
-            <Button variant="outline" onClick={handleCopy} className={onUserJourneySave ? "" : "ml-auto"}>
-              <Copy className="w-4 h-4 mr-1" /> {copying ? "Copied!" : "Copy"}
+        <div className="space-y-6 py-4">
+          <div className="space-y-2">
+            <Label htmlFor="name" className="text-base font-medium">
+              Name
+            </Label>
+            <Input
+              id="name"
+              placeholder="e.g., User Login Flow"
+              value={testName}
+              onChange={(e) => setTestName(e.target.value)}
+              className="text-base h-12"
+              autoFocus
+            />
+          </div>
+          {errorMessage && (
+            <div className="text-sm text-destructive bg-destructive/10 p-3 rounded-lg">
+              {errorMessage}
+            </div>
+          )}
+        </div>
+
+        <div className="flex gap-3">
+          {onUserJourneySave && (
+            <Button
+              onClick={handleSave}
+              disabled={!testName.trim() || !generatedCode || saving}
+              size="lg"
+              className="flex-1 h-12 text-base"
+            >
+              {saving ? (
+                <>Saving...</>
+              ) : (
+                <>
+                  <CheckCircle2 className="w-5 h-5 mr-2" />
+                  Save Test
+                </>
+              )}
             </Button>
-          </div>
-          <div className="flex-1 min-h-0 border rounded overflow-hidden">
-            <ScrollArea className="h-full">
-              <pre className="text-sm bg-background/50 p-4 overflow-auto whitespace-pre max-h-[60vh]">
-                <code className="language-javascript">{generatedCode}</code>
-              </pre>
-            </ScrollArea>
-          </div>
+          )}
         </div>
       </DialogContent>
     </Dialog>

--- a/src/app/w/[slug]/task/[...taskParams]/artifacts/browser.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/artifacts/browser.tsx
@@ -525,7 +525,6 @@ export function BrowserArtifactPanel({
         }}
         generatedCode={generatedPlaywrightTest}
         errorMessage={generationError}
-        initialTab={"generated"}
         onUserJourneySave={onUserJourneySave}
       />
     </div>


### PR DESCRIPTION
- Replace code-heavy layout with clean, PM-focused design
- Add prominent test name input field with auto-generated filename
- Remove collapsed code preview and copy button (not needed for PM workflow)
- Implement large, clear "Save Test" CTA button
- Reduce modal size from 98vw to 600px for better UX
- Add validation requiring test name before save