### PR TITLE
feat: add workspace members preview widget and refactor graph component

### DIFF
--- a/src/app/w/[slug]/dashboard/index.tsx
+++ b/src/app/w/[slug]/dashboard/index.tsx
@@ -1,11 +1,16 @@
 "use client";
 
 import { GraphComponent } from "@/components/knowledge-graph";
+import { WorkspaceMembersPreview } from "@/components/workspace/WorkspaceMembersPreview";
+import { GitHubStatusWidget } from "@/components/dashboard/github-status-widget";
+import { IngestionStatusWidget } from "@/components/dashboard/ingestion-status-widget";
+import { PoolStatusWidget } from "@/components/dashboard/pool-status-widget";
 import { useGraphPolling } from "@/hooks/useGraphPolling";
 import { useWebhookHighlights } from "@/hooks/useWebhookHighlights";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { logStoreInstances } from "@/stores/createStoreFactory";
 import { StoreProvider } from "@/stores/StoreProvider";
+import { useDataStore } from "@/stores/useStores";
 
 export function Dashboard() {
   const { id: workspaceId } = useWorkspace();
@@ -20,6 +25,9 @@ export function Dashboard() {
 }
 
 function DashboardInner() {
+  const { slug } = useWorkspace();
+  const dataInitial = useDataStore((s) => s.dataInitial);
+
   useGraphPolling({
     enabled: true,
     interval: 5000
@@ -37,7 +45,18 @@ function DashboardInner() {
           enablePolling={true}
           height="h-full"
           width="w-full"
-          showWidgets={true}
+          topLeftWidget={
+            dataInitial?.nodes && dataInitial.nodes.length > 0 ? (
+              <IngestionStatusWidget />
+            ) : undefined
+          }
+          topRightWidget={
+            <div className="flex items-center gap-2">
+              <GitHubStatusWidget />
+              <PoolStatusWidget />
+            </div>
+          }
+          bottomLeftWidget={<WorkspaceMembersPreview workspaceSlug={slug} />}
         />
       </div>
     </div>

--- a/src/components/knowledge-graph/index.tsx
+++ b/src/components/knowledge-graph/index.tsx
@@ -1,8 +1,5 @@
 "use client";
 
-import { GitHubStatusWidget } from "@/components/dashboard/github-status-widget";
-import { IngestionStatusWidget } from "@/components/dashboard/ingestion-status-widget";
-import { PoolStatusWidget } from "@/components/dashboard/pool-status-widget";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { SchemaExtended, useSchemaStore } from "@/stores/useSchemaStore";
 import { useDataStore } from "@/stores/useStores";
@@ -33,7 +30,10 @@ interface GraphComponentProps {
   className?: string;
   height?: string;
   width?: string;
-  showWidgets?: boolean;
+  topLeftWidget?: React.ReactNode;
+  topRightWidget?: React.ReactNode;
+  bottomLeftWidget?: React.ReactNode;
+  bottomRightWidget?: React.ReactNode;
 }
 
 export const GraphComponent = ({
@@ -42,7 +42,10 @@ export const GraphComponent = ({
   className,
   height = "h-full",
   width = "w-full",
-  showWidgets = false
+  topLeftWidget,
+  topRightWidget,
+  bottomLeftWidget,
+  bottomRightWidget
 }: GraphComponentProps = {}) => {
   return (
     <GraphComponentInner
@@ -51,7 +54,10 @@ export const GraphComponent = ({
       className={className}
       height={height}
       width={width}
-      showWidgets={showWidgets}
+      topLeftWidget={topLeftWidget}
+      topRightWidget={topRightWidget}
+      bottomLeftWidget={bottomLeftWidget}
+      bottomRightWidget={bottomRightWidget}
     />
   );
 };
@@ -62,7 +68,10 @@ const GraphComponentInner = ({
   className,
   height = "h-full",
   width = "w-full",
-  showWidgets = false
+  topLeftWidget,
+  topRightWidget,
+  bottomLeftWidget,
+  bottomRightWidget
 }: GraphComponentProps) => {
   const { id: workspaceId } = useWorkspace();
   const [nodesLoading, setNodesLoading] = useState(false);
@@ -133,15 +142,24 @@ const GraphComponentInner = ({
 
   return (
     <div data-testid="graph-component" className={`dark ${height} ${width} border rounded-lg relative bg-card flex flex-col ${className || ''}`}>
-      {/* Ingestion widget in top-left corner - only when we have data */}
-      {showWidgets && dataInitial?.nodes && dataInitial.nodes.length > 0 && <IngestionStatusWidget />}
+      {/* Top-left widget */}
+      {topLeftWidget && (
+        <div className="absolute top-4 left-4 z-10">{topLeftWidget}</div>
+      )}
 
-      {/* Status widgets in top-right corner - only show on dashboard */}
-      {showWidgets && (
-        <div className="absolute top-4 right-4 z-10 flex items-center gap-2">
-          <GitHubStatusWidget />
-          <PoolStatusWidget />
-        </div>
+      {/* Top-right widget */}
+      {topRightWidget && (
+        <div className="absolute top-4 right-4 z-10">{topRightWidget}</div>
+      )}
+
+      {/* Bottom-left widget */}
+      {bottomLeftWidget && (
+        <div className="absolute bottom-4 left-4 z-10">{bottomLeftWidget}</div>
+      )}
+
+      {/* Bottom-right widget */}
+      {bottomRightWidget && (
+        <div className="absolute bottom-4 right-4 z-10">{bottomRightWidget}</div>
       )}
 
       <div className="border rounded overflow-hidden bg-card flex-1">
@@ -151,11 +169,7 @@ const GraphComponentInner = ({
           </div>
         ) : (!dataInitial?.nodes || dataInitial.nodes.length === 0) ? (
           <div className="flex h-full items-center justify-center">
-            {showWidgets ? (
-              <IngestionStatusWidget centered />
-            ) : (
-              <div className="text-lg text-gray-300">No data found</div>
-            )}
+            <div className="text-lg text-gray-300">No data found</div>
           </div>
         ) : (
           <Universe enableRotation={enableRotation} />

--- a/src/components/workspace/WorkspaceMembersPreview/index.tsx
+++ b/src/components/workspace/WorkspaceMembersPreview/index.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import Link from "next/link";
+import { Users } from "lucide-react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { useWorkspaceMembers } from "@/hooks/useWorkspaceMembers";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface WorkspaceMembersPreviewProps {
+  workspaceSlug: string;
+  maxDisplay?: number;
+}
+
+function getInitials(user: {
+  name: string | null;
+  email: string | null;
+}): string {
+  if (user.name) {
+    const names = user.name.split(" ");
+    if (names.length >= 2) {
+      return `${names[0][0]}${names[1][0]}`.toUpperCase();
+    }
+    return user.name.substring(0, 2).toUpperCase();
+  }
+  if (user.email) {
+    return user.email.substring(0, 2).toUpperCase();
+  }
+  return "U";
+}
+
+export function WorkspaceMembersPreview({
+  workspaceSlug,
+  maxDisplay = 4,
+}: WorkspaceMembersPreviewProps) {
+  const { members, loading } = useWorkspaceMembers(workspaceSlug, {
+    includeSystemAssignees: false,
+  });
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 px-3 py-2 rounded-lg border border-border bg-card/95 backdrop-blur-sm">
+        <div className="flex -space-x-2">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="w-8 h-8 rounded-full border-2 border-card" />
+          ))}
+        </div>
+        <Skeleton className="h-8 w-24" />
+      </div>
+    );
+  }
+
+  if (!members || members.length === 0) {
+    return null;
+  }
+
+  // Sort: owner first, then by most recent joinedAt
+  const sortedMembers = [...members].sort((a, b) => {
+    if (a.role === "OWNER") return -1;
+    if (b.role === "OWNER") return 1;
+    return new Date(b.joinedAt).getTime() - new Date(a.joinedAt).getTime();
+  });
+
+  const previewMembers = sortedMembers.slice(0, maxDisplay);
+  const remainingCount = members.length - maxDisplay;
+  const hasMore = remainingCount > 0;
+
+  return (
+    <Link href={`/w/${workspaceSlug}/settings#members`}>
+      <div className="flex items-center gap-2 px-3 py-2 rounded-lg border border-border bg-card/95 backdrop-blur-sm hover:bg-accent/95 transition-colors cursor-pointer">
+        {/* Avatar list */}
+        <div className="flex items-center gap-2">
+          {previewMembers.map((member) => (
+            <Avatar
+              key={member.id}
+              className="w-8 h-8 border-2 border-card hover:scale-110 transition-transform"
+              title={member.user.name || member.user.email || "Unknown user"}
+            >
+              <AvatarImage
+                src={member.user.image || undefined}
+                alt={member.user.name || member.user.email || "User"}
+              />
+              <AvatarFallback className="text-xs">
+                {getInitials(member.user)}
+              </AvatarFallback>
+            </Avatar>
+          ))}
+
+          {/* +N badge if more than 4 members */}
+          {hasMore && (
+            <div className="w-8 h-8 rounded-full border-2 border-card bg-muted flex items-center justify-center">
+              <span className="text-xs font-medium text-muted-foreground">
+                +{remainingCount}
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
+    </Link>
+  );
+}


### PR DESCRIPTION
- Add WorkspaceMembersPreview component displaying member avatars in bottom-left
  - Shows 4 members max with separate (non-overlapping) avatars
  - Displays +N badge for additional members
  - Links to workspace settings members section
  - Sorts by owner first, then most recent joinedAt

- Refactor GraphComponent to be purely presentational
  - Remove hardcoded widget dependencies (GitHub, Pool, Ingestion status)
  - Remove showWidgets prop
  - Accept widgets via props: topLeftWidget, topRightWidget, bottomLeftWidget, bottomRightWidget
  - Makes component more flexible and isolated

- Update dashboard to explicitly pass all widgets as props
  - IngestionStatusWidget in top-left (when graph has data)
  - GitHubStatusWidget + PoolStatusWidget in top-right
  - WorkspaceMembersPreview in bottom-left