### PR TITLE
Update pending and halted status colors from orange to yellow

### DIFF
--- a/src/app/w/[slug]/task/[...taskParams]/components/WorkflowStatusBadge.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/components/WorkflowStatusBadge.tsx
@@ -42,7 +42,7 @@ const statusConfig = {
   [WorkflowStatus.HALTED]: {
     label: "Halted",
     icon: Pause,
-    className: "text-orange-600",
+    className: "text-yellow-600",
     iconClassName: "",
   },
   [WorkflowStatus.FAILED]: {

--- a/src/components/capacity/VMGrid.tsx
+++ b/src/components/capacity/VMGrid.tsx
@@ -12,7 +12,7 @@ function getStatusIndicator(state: string, usage_status: string) {
     return <Circle className="h-2 w-2 fill-green-500 text-green-500" />;
   }
   if (state === "pending") {
-    return <Circle className="h-2 w-2 fill-amber-500 text-amber-500" />;
+    return <Circle className="h-2 w-2 fill-yellow-500 text-yellow-500" />;
   }
   if (state === "failed") {
     return <Circle className="h-2 w-2 fill-red-500 text-red-500" />;

--- a/src/components/dashboard/github-status-widget/index.tsx
+++ b/src/components/dashboard/github-status-widget/index.tsx
@@ -86,7 +86,7 @@ export function GitHubStatusWidget() {
   const lastUpdated = repository?.updatedAt;
 
   // Determine status color
-  const statusColor = status === "SYNCED" ? "bg-green-500" : status === "PENDING" ? "bg-orange-500" : "bg-red-500";
+  const statusColor = status === "SYNCED" ? "bg-green-500" : status === "PENDING" ? "bg-yellow-500" : "bg-red-500";
 
   return (
     <TooltipProvider>
@@ -99,7 +99,7 @@ export function GitHubStatusWidget() {
         </TooltipTrigger>
         <TooltipContent side="bottom" className="max-w-xs">
           <div className="space-y-1.5 text-xs">
-            <div className={`font-medium ${status === "SYNCED" ? "text-green-600" : status === "PENDING" ? "text-orange-600" : "text-red-600"}`}>
+            <div className={`font-medium ${status === "SYNCED" ? "text-green-600" : status === "PENDING" ? "text-yellow-600" : "text-red-600"}`}>
               {status}
             </div>
             {lastUpdated && (

--- a/src/components/dashboard/pool-status-widget/index.tsx
+++ b/src/components/dashboard/pool-status-widget/index.tsx
@@ -84,7 +84,7 @@ export function PoolStatusWidget() {
                   <span className="text-muted-foreground">{totalVms}</span>
                 </div>
                 {hasIssues && (
-                  <div className="w-1.5 h-1.5 rounded-full bg-orange-500" />
+                  <div className="w-1.5 h-1.5 rounded-full bg-yellow-500" />
                 )}
               </div>
             </TooltipTrigger>
@@ -97,7 +97,7 @@ export function PoolStatusWidget() {
                   <span className="text-muted-foreground">{poolStatus.status.unusedVms} available</span>
                 </div>
                 {poolStatus.status.pendingVms > 0 && (
-                  <div className="text-orange-600">
+                  <div className="text-yellow-600">
                     {poolStatus.status.pendingVms} pending
                   </div>
                 )}

--- a/src/components/pool-status/index.tsx
+++ b/src/components/pool-status/index.tsx
@@ -119,7 +119,7 @@ export function VMConfigSection() {
                 <div className="flex items-center gap-2 text-xs text-muted-foreground">
                   {poolStatus.status.pendingVms > 0 && (
                     <>
-                      <span className="text-orange-600">
+                      <span className="text-yellow-600">
                         {poolStatus.status.pendingVms} pending
                       </span>
                       {poolStatus.status.failedVms > 0 && <span>•</span>}

--- a/src/components/tasks/KanbanView.tsx
+++ b/src/components/tasks/KanbanView.tsx
@@ -49,8 +49,8 @@ const kanbanColumns: KanbanColumn[] = [
     status: WorkflowStatus.HALTED,
     title: "Halted",
     icon: <Pause className="h-4 w-4" />,
-    color: "text-orange-600 dark:text-orange-400",
-    bgColor: "bg-orange-50/30 dark:bg-orange-950/10",
+    color: "text-yellow-600 dark:text-yellow-400",
+    bgColor: "bg-yellow-50/30 dark:bg-yellow-950/10",
   },
 ];
 


### PR DESCRIPTION
- PENDING pods: orange → yellow across all components
- HALTED workflows: orange → yellow across all components

Components updated:
- WorkflowStatusBadge: HALTED status badge
- KanbanView: HALTED column styling
- github-status-widget: PENDING repository status
- VMGrid: pending VM status indicators
- pool-status: pending VMs text
- pool-status-widget: pending VMs and issue indicators