### PR TITLE
Fix calls routing to use /context/calls path

### DIFF
--- a/src/__tests__/e2e/specs/calls/calls-navigation.spec.ts
+++ b/src/__tests__/e2e/specs/calls/calls-navigation.spec.ts
@@ -45,11 +45,11 @@ test.describe('Calls Navigation', () => {
     await callsLink.click();
 
     // Wait for URL to change to calls page
-    await page.waitForURL(/\/w\/.*\/calls/, { timeout: 10000 });
+    await page.waitForURL(/\/w\/.*\/context\/calls/, { timeout: 10000 });
 
     // Verify we're on the calls page
     await expect(page.locator(selectors.pageTitle.calls)).toBeVisible();
-    expect(page.url()).toContain('/calls');
+    expect(page.url()).toContain('/context/calls');
   });
 
   test('should display calls page title', async ({ page }) => {

--- a/src/__tests__/e2e/support/page-objects/CallsPage.ts
+++ b/src/__tests__/e2e/support/page-objects/CallsPage.ts
@@ -61,6 +61,6 @@ export class CallsPage {
     }
 
     await callsLink.click();
-    await this.page.waitForURL(/\/w\/.*\/calls/, { timeout: 10000 });
+    await this.page.waitForURL(/\/w\/.*\/context\/calls/, { timeout: 10000 });
   }
 }

--- a/src/app/w/[slug]/context/calls/[ref_id]/page.tsx
+++ b/src/app/w/[slug]/context/calls/[ref_id]/page.tsx
@@ -33,7 +33,7 @@ export default function CallPage() {
   const [transcript, setTranscript] = useState<TranscriptSegment[]>([]);
 
   const handleBackClick = () => {
-    router.push(`/w/${slug}/calls`);
+    router.push(`/w/${slug}/context/calls`);
   };
 
   const handleTimeUpdate = (time: number) => {

--- a/src/components/calls/CallsTable/index.tsx
+++ b/src/components/calls/CallsTable/index.tsx
@@ -31,7 +31,7 @@ export function CallsTable({ calls, workspaceSlug }: CallsTableProps) {
   };
 
   const handleRowClick = (refId: string) => {
-    router.push(`/w/${workspaceSlug}/calls/${refId}`);
+    router.push(`/w/${workspaceSlug}/context/calls/${refId}`);
   };
 
   if (calls.length === 0) {


### PR DESCRIPTION
Update all calls navigation to use the correct /context/calls path structure after recent sidebar refactor. This fixes 404 errors when clicking on calls in the table.

Changes:
- CallsTable: Fix navigation to /context/calls/[ref_id]
- Call detail page: Fix back button to /context/calls
- E2E tests: Update URL pattern matchers and assertions