### PR TITLE
Add syntax highlighting to diff artifacts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -123,6 +123,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@types/react-syntax-highlighter": "^15.5.13",
+        "@types/refractor": "^3.4.1",
         "dotenv-cli": "^10.0.0",
         "eslint": "^9",
         "eslint-config-next": "15.3.4",
@@ -11125,6 +11126,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/refractor": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@types/refractor/-/refractor-3.4.1.tgz",
+      "integrity": "sha512-wYuorIiCTSuvRT9srwt+taF6mH/ww+SyN2psM0sjef2qW+sS8GmshgDGTEDgWB1sTVGgYVE6EK7dBA2MxQxibg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prismjs": "*"
       }
     },
     "node_modules/@types/shimmer": {

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/react-syntax-highlighter": "^15.5.13",
+    "@types/refractor": "^3.4.1",
     "dotenv-cli": "^10.0.0",
     "eslint": "^9",
     "eslint-config-next": "15.3.4",

--- a/src/app/w/[slug]/task/[...taskParams]/artifacts/DiffArtifact.css
+++ b/src/app/w/[slug]/task/[...taskParams]/artifacts/DiffArtifact.css
@@ -45,19 +45,58 @@
     font-weight: bold;
 }
 
+/* Gap indicator for unchanged lines between hunks */
+.diff-gap-indicator {
+    display: grid;
+    grid-template-columns: 60px 60px 1fr;
+    align-items: center;
+    padding: 8px 0;
+    background-color: #f6f8fa;
+    border-top: 1px solid #d0d7de;
+    border-bottom: 1px solid #d0d7de;
+    color: #57606a;
+    font-size: 12px;
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+}
+
+.diff-artifact-container.dark-mode .diff-gap-indicator {
+    background-color: #0d1117;
+    border-top: 1px solid #21262d;
+    border-bottom: 1px solid #21262d;
+    color: #8b949e;
+}
+
+.diff-gap-text {
+    grid-column: 1 / -1;
+    margin-left: 8px;
+    padding: 4px 10px;
+    background-color: #ffffff;
+    border: 1px solid #d0d7de;
+    border-radius: 6px;
+    font-weight: 500;
+    text-align: center;
+    width: fit-content;
+    white-space: nowrap;
+}
+
+.diff-artifact-container.dark-mode .diff-gap-text {
+    background-color: #161b22;
+    border-color: #30363d;
+}
+
 /* Dark mode styles */
 .diff-artifact-container.dark-mode {
     --diff-background-color: #0d1117;
     --diff-text-color: #c9d1d9;
     --diff-selection-background-color: #1f6feb;
     --diff-selection-text-color: #ffffff;
-    --diff-gutter-insert-background-color: #1a4d2e;
+    --diff-gutter-insert-background-color: rgba(26, 77, 46, 0.6);
     --diff-gutter-insert-text-color: #56d364;
-    --diff-gutter-delete-background-color: #6f2828;
+    --diff-gutter-delete-background-color: rgba(111, 40, 40, 0.6);
     --diff-gutter-delete-text-color: #f85149;
-    --diff-code-insert-background-color: #1a4d2e;
+    --diff-code-insert-background-color: rgba(26, 77, 46, 0.4);
     --diff-code-insert-text-color: #aff5b4;
-    --diff-code-delete-background-color: #6f2828;
+    --diff-code-delete-background-color: rgba(111, 40, 40, 0.4);
     --diff-code-delete-text-color: #ffdcd7;
     --diff-code-insert-edit-background-color: #2ea043;
     --diff-code-insert-edit-text-color: #ffffff;

--- a/src/app/w/[slug]/task/[...taskParams]/artifacts/diff.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/artifacts/diff.tsx
@@ -13,6 +13,15 @@ import tsx from "refractor/lang/tsx.js";
 import css from "refractor/lang/css.js";
 import python from "refractor/lang/python.js";
 import json from "refractor/lang/json.js";
+import bash from "refractor/lang/bash.js";
+import go from "refractor/lang/go.js";
+import rust from "refractor/lang/rust.js";
+import java from "refractor/lang/java.js";
+import ruby from "refractor/lang/ruby.js";
+import markdown from "refractor/lang/markdown.js";
+import yaml from "refractor/lang/yaml.js";
+import sql from "refractor/lang/sql.js";
+import html from "refractor/lang/markup.js";
 
 // Register languages with refractor
 refractor.register(javascript);
@@ -22,6 +31,15 @@ refractor.register(tsx);
 refractor.register(css);
 refractor.register(python);
 refractor.register(json);
+refractor.register(bash);
+refractor.register(go);
+refractor.register(rust);
+refractor.register(java);
+refractor.register(ruby);
+refractor.register(markdown);
+refractor.register(yaml);
+refractor.register(sql);
+refractor.register(html);
 import {
   FilePlus,
   FileEdit,
@@ -83,6 +101,7 @@ const createTokens = (hunks: HunkData[], language: string) => {
   }
 };
 
+
 export function DiffArtifactPanel({ artifacts, viewType: initialViewType = "unified", className = "" }: DiffArtifactPanelProps) {
   const { resolvedTheme } = useTheme();
   const isDark = resolvedTheme === "dark";
@@ -143,14 +162,15 @@ export function DiffArtifactPanel({ artifacts, viewType: initialViewType = "unif
 
           // Detect language and create tokens for syntax highlighting
           const language = getLanguageFromFile(diff.file);
-          const tokens = createTokens(file.hunks || [], language);
+          const hunks = file.hunks || EMPTY_HUNKS;
+          const tokens = createTokens(hunks, language);
 
           return {
             fileName: diff.file,
             action: diff.action,
             repoName: diff.repoName,
             type: file.type,
-            hunks: file.hunks || EMPTY_HUNKS,
+            hunks,
             hasError: false as boolean,
             additions,
             deletions,
@@ -361,11 +381,30 @@ export function DiffArtifactPanel({ artifacts, viewType: initialViewType = "unif
                         hunks={file.hunks}
                         tokens={file.tokens}
                       >
-                        {(hunks) =>
-                          hunks.map((hunk) => (
-                            <Hunk key={hunk.content} hunk={hunk} />
-                          ))
-                        }
+                        {(hunks) => (
+                          <>
+                            {hunks.map((hunk, i) => {
+                              // Check if there's a gap before the next hunk
+                              const nextHunk = hunks[i + 1];
+                              const currentEnd = hunk.oldStart + hunk.oldLines;
+                              const gap = nextHunk ? nextHunk.oldStart - currentEnd : 0;
+                              const showGap = gap > 5;
+
+                              return (
+                                <React.Fragment key={hunk.content}>
+                                  <Hunk hunk={hunk} />
+                                  {showGap && (
+                                    <div className="diff-gap-indicator">
+                                      <span className="diff-gap-text">
+                                        ⋯ {gap} unchanged lines ⋯
+                                      </span>
+                                    </div>
+                                  )}
+                                </React.Fragment>
+                              );
+                            })}
+                          </>
+                        )}
                       </Diff>
                     </div>
                   )}

--- a/src/types/refractor.d.ts
+++ b/src/types/refractor.d.ts
@@ -1,0 +1,23 @@
+declare module 'refractor/core.js' {
+  export interface RefractorNode {
+    type: string;
+    value?: string;
+    children?: RefractorNode[];
+    tagName?: string;
+    properties?: { [key: string]: any };
+  }
+
+  export interface Refractor {
+    highlight(value: string, language: string): RefractorNode[];
+    register(syntax: any): void;
+    listLanguages(): string[];
+  }
+
+  const refractor: Refractor;
+  export default refractor;
+}
+
+declare module 'refractor/lang/*.js' {
+  const syntax: any;
+  export default syntax;
+}


### PR DESCRIPTION
- Install refractor@3 for code tokenization (required by react-diff-view)
- Implement syntax highlighting for TypeScript, JavaScript, JSX, TSX, CSS, Python, and JSON
- Add +/- indicators in diff gutters for better readability
- Import Prism dark theme for token colors in both light and dark modes
- Detect file language automatically and tokenize diff hunks
- Handle unsupported languages gracefully with fallback to plain text