### PR TITLE
Fix stakwork_runs.decision not persisting on architecture accept

### DIFF
--- a/src/__tests__/unit/hooks/useAIGeneration.test.ts
+++ b/src/__tests__/unit/hooks/useAIGeneration.test.ts
@@ -98,9 +98,9 @@ describe("useAIGeneration", () => {
       json: async () => ({ success: true, run: { id: "run-123", decision: "ACCEPTED" } }),
     });
 
-    // Simulate content being set from webhook/polling
+    // Simulate content being set from webhook/polling (with runId from webhook)
     await waitFor(() => {
-      result.current.setContent("Deep content", "deep");
+      result.current.setContent("Deep content", "deep", "run-123");
     });
 
     // Now accept it
@@ -144,9 +144,9 @@ describe("useAIGeneration", () => {
       json: async () => ({ success: true, run: { id: "run-123", decision: "REJECTED" } }),
     });
 
-    // Simulate content being set from webhook/polling
+    // Simulate content being set from webhook/polling (with runId from webhook)
     await waitFor(() => {
-      result.current.setContent("Content to reject", "deep");
+      result.current.setContent("Content to reject", "deep", "run-123");
     });
 
     // Now reject it

--- a/src/components/features/AITextareaSection.tsx
+++ b/src/components/features/AITextareaSection.tsx
@@ -73,7 +73,7 @@ export function AITextareaSection({
 
   useEffect(() => {
     if (latestRun?.status === "COMPLETED" && !latestRun.decision && latestRun.result) {
-      aiGeneration.setContent(latestRun.result, "deep");
+      aiGeneration.setContent(latestRun.result, "deep", latestRun.id);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [latestRun]); // aiGeneration.setContent is stable (useCallback), safe to omit

--- a/src/hooks/useAIGeneration.ts
+++ b/src/hooks/useAIGeneration.ts
@@ -18,7 +18,7 @@ interface GenerationResult {
   accept: (onSuccess?: () => void) => Promise<void>;
   reject: (feedback?: string) => Promise<void>;
   regenerate: () => Promise<void>;
-  setContent: (content: string | null, source: GenerationSource) => void;
+  setContent: (content: string | null, source: GenerationSource, runId?: string) => void;
   clear: () => void;
 }
 
@@ -34,9 +34,12 @@ export function useAIGeneration({
   const [currentRunId, setCurrentRunId] = useState<string | null>(null);
   const { toast } = useToast();
 
-  const setContentWithSource = useCallback((newContent: string | null, newSource: GenerationSource) => {
+  const setContentWithSource = useCallback((newContent: string | null, newSource: GenerationSource, runId?: string) => {
     setContent(newContent);
     setSource(newSource);
+    if (runId) {
+      setCurrentRunId(runId);
+    }
   }, []);
 
   const accept = useCallback(


### PR DESCRIPTION
Root cause: In commit 845f05cb (refactor to useAIGeneration hook), the runId was not being passed when setting content from webhook.

Before refactor: Component set currentRunId directly from latestRun.id
After refactor: setContent() was called without the runId parameter

This caused accept/reject to skip the API call to update decision because currentRunId was null, even though feature.architecture was being saved via the optimistic update.

Changes:
- Add optional runId parameter to useAIGeneration.setContent()
- Pass latestRun.id when setting content from webhook in AITextareaSection
- Update tests to pass runId for accurate real-world behavior

Now both feature.architecture AND stakwork_runs.decision are properly updated.