### PR TITLE
Clean up feature page UI and improve consistency

### DIFF
--- a/src/app/w/[slug]/roadmap/[featureId]/page.tsx
+++ b/src/app/w/[slug]/roadmap/[featureId]/page.tsx
@@ -287,8 +287,8 @@ export default function FeatureDetailPage() {
         <Card>
           <CardHeader>
             <div className="space-y-4">
-              {/* Title */}
-              <Skeleton className="h-16 w-3/4" />
+              {/* Title - match text-4xl size */}
+              <Skeleton className="h-14 w-3/4" />
 
               {/* Status & Assignee */}
               <div className="flex flex-wrap items-center gap-4">
@@ -304,66 +304,47 @@ export default function FeatureDetailPage() {
             </div>
           </CardHeader>
 
-          <CardContent className="space-y-6">
-            <Separator />
+          <CardContent>
+            <Tabs defaultValue="overview">
+              <TabsList className="mb-6">
+                <TabsTrigger value="overview">Overview</TabsTrigger>
+                <TabsTrigger value="architecture">Architecture</TabsTrigger>
+                <TabsTrigger value="tickets">Tasks</TabsTrigger>
+              </TabsList>
 
-            {/* Brief */}
-            <div className="space-y-2">
-              <Label htmlFor="brief" className="text-sm font-medium">
-                Brief
-              </Label>
-              <Skeleton className="h-24 w-full rounded-md" />
-            </div>
+              <TabsContent value="overview" className="space-y-6 pt-0">
+                {/* Brief */}
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2 min-h-9">
+                    <Label className="text-sm font-medium">Brief</Label>
+                  </div>
+                  <Skeleton className="h-24 w-full rounded-md" />
+                </div>
+              </TabsContent>
 
-            <Separator />
+              <TabsContent value="architecture" className="space-y-6 pt-0">
+                {/* Architecture */}
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2 min-h-9">
+                    <Label className="text-sm font-medium">Architecture</Label>
+                  </div>
+                  <Skeleton className="h-48 w-full rounded-md" />
+                </div>
+              </TabsContent>
 
-            {/* User Personas */}
-            <div className="space-y-2">
-              <Label className="text-sm font-medium">
-                User Personas
-              </Label>
-              <Skeleton className="h-20 w-full rounded-lg" />
-            </div>
-
-            <Separator />
-
-            {/* User Stories */}
-            <div className="space-y-4">
-              <div>
-                <Label className="text-sm font-medium">User Stories</Label>
-                <p className="text-sm text-muted-foreground mt-1">
-                  Define the user stories and acceptance criteria for this feature.
-                </p>
-              </div>
-              <Skeleton className="h-14 w-full rounded-lg" />
-              {[1, 2, 3].map((i) => (
-                <Skeleton key={i} className="h-14 w-full rounded-lg" />
-              ))}
-            </div>
-
-            <Separator />
-
-            {/* Requirements */}
-            <div className="space-y-2">
-              <Label htmlFor="requirements" className="text-sm font-medium">
-                Requirements
-              </Label>
-              <p className="text-sm text-muted-foreground">
-                Detailed product and technical requirements for implementation.
-              </p>
-              <Skeleton className="h-32 w-full rounded-md" />
-            </div>
-
-            {/* Architecture */}
-            <div className="space-y-2">
-              <Label htmlFor="architecture" className="text-sm font-medium">
-                Architecture
-              </Label>
-              <p className="text-sm text-muted-foreground">
-                Technical architecture, design decisions, and implementation notes.
-              </p>
-              <Skeleton className="h-32 w-full rounded-md" />
-            </div>
+              <TabsContent value="tickets" className="space-y-6 pt-0">
+                {/* Tasks */}
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2 min-h-9">
+                    <Label className="text-sm font-medium">Tasks</Label>
+                  </div>
+                  <Skeleton className="h-14 w-full rounded-lg" />
+                  {[1, 2, 3].map((i) => (
+                    <Skeleton key={i} className="h-14 w-full rounded-lg" />
+                  ))}
+                </div>
+              </TabsContent>
+            </Tabs>
           </CardContent>
         </Card>
       </div>
@@ -419,7 +400,7 @@ export default function FeatureDetailPage() {
                 onChange={(value) => updateFeature({ title: value })}
                 onBlur={(value) => handleFieldBlur("title", value)}
                 placeholder="Enter feature title..."
-                size="xlarge"
+                size="large"
               />
               {/* Save indicator - only show for title/status/assignee changes */}
               {savedField === "title" && saved && !saving && (
@@ -470,12 +451,11 @@ export default function FeatureDetailPage() {
               <TabsTrigger value="tickets">Tasks</TabsTrigger>
             </TabsList>
 
-            <TabsContent value="overview" className="space-y-6">
+            <TabsContent value="overview" className="space-y-6 pt-0">
               {/* Brief - Always visible */}
               <AutoSaveTextarea
                 id="brief"
                 label="Brief"
-                description="High-level overview of what this feature is and why it matters."
                 value={feature.brief}
                 rows={4}
                 className="resize-none"
@@ -521,7 +501,6 @@ export default function FeatureDetailPage() {
                   <AITextareaSection
                     id="requirements"
                     label="Requirements"
-                    description="Functional and technical specifications for implementation."
                     type="requirements"
                     featureId={featureId}
                     value={feature.requirements}
@@ -542,11 +521,10 @@ export default function FeatureDetailPage() {
               </div>
             </TabsContent>
 
-            <TabsContent value="architecture" className="space-y-6">
+            <TabsContent value="architecture" className="space-y-6 pt-0">
               <AITextareaSection
                 id="architecture"
                 label="Architecture"
-                description="Technical design decisions and implementation approach."
                 type="architecture"
                 featureId={featureId}
                 value={feature.architecture}
@@ -568,7 +546,7 @@ export default function FeatureDetailPage() {
               </div>
             </TabsContent>
 
-            <TabsContent value="tickets" className="space-y-6">
+            <TabsContent value="tickets" className="space-y-6 pt-0">
               <TicketsList
                 featureId={featureId}
                 feature={feature}

--- a/src/components/features/AITextareaSection.tsx
+++ b/src/components/features/AITextareaSection.tsx
@@ -24,7 +24,7 @@ interface GeneratedContent {
 interface AITextareaSectionProps {
   id: string;
   label: string;
-  description: string;
+  description?: string;
   type: "requirements" | "architecture";
   featureId: string;
   value: string | null;
@@ -194,9 +194,11 @@ export function AITextareaSection({
           saved={saved}
         />
       </div>
-      <p className="text-sm text-muted-foreground">
-        {description}
-      </p>
+      {description && (
+        <p className="text-sm text-muted-foreground">
+          {description}
+        </p>
+      )}
 
       {aiGeneration.content ? (
         <GenerationPreview

--- a/src/components/features/AutoSaveTextarea.tsx
+++ b/src/components/features/AutoSaveTextarea.tsx
@@ -67,7 +67,7 @@ export function AutoSaveTextarea({
 
   return (
     <div className="space-y-2">
-      <div className="flex items-center">
+      <div className="flex items-center gap-2 min-h-9">
         <Label htmlFor={id} className="text-sm font-medium">
           {label}
         </Label>

--- a/src/components/features/PersonasSection/index.tsx
+++ b/src/components/features/PersonasSection/index.tsx
@@ -104,9 +104,6 @@ export function PersonasSection({
           </div>
         )}
       </div>
-      <p className="text-sm text-muted-foreground">
-        Define the target user types for this feature.
-      </p>
 
       <div className="rounded-lg border bg-muted/30 p-3">
         <div className="flex flex-wrap gap-2 mb-2">

--- a/src/components/features/SaveIndicator.tsx
+++ b/src/components/features/SaveIndicator.tsx
@@ -22,7 +22,7 @@ export function SaveIndicator({
   if (!isSavedField || !saved || saving) return null;
 
   return (
-    <span className="ml-2 inline-flex items-center gap-1.5 text-xs">
+    <span className="inline-flex items-center gap-1.5 text-xs">
       <Check className="h-3 w-3 text-green-600" />
       <span className="text-green-600">Saved</span>
     </span>

--- a/src/components/features/TicketsList/index.tsx
+++ b/src/components/features/TicketsList/index.tsx
@@ -278,11 +278,11 @@ export function TicketsList({ featureId, feature, onUpdate }: TicketsListProps) 
   }
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-2">
       {/* Header with Tasks heading, AI button, view toggle, and Add Task button */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <h3 className="text-lg font-semibold">Tasks</h3>
+          <Label className="text-sm font-medium">Tasks</Label>
           <AIButton<GeneratedContent>
             endpoint={`/api/features/${featureId}/generate`}
             params={{ type: "tickets" }}

--- a/src/components/features/UserStoriesSection.tsx
+++ b/src/components/features/UserStoriesSection.tsx
@@ -162,9 +162,6 @@ export function UserStoriesSection({
             iconOnly
           />
         </div>
-        <p className="text-sm text-muted-foreground mt-1">
-          Define the user stories and acceptance criteria for this feature.
-        </p>
       </div>
 
       <div className="rounded-lg border bg-muted/30">


### PR DESCRIPTION
- Remove helper text descriptions from Brief, Personas, User Stories, Requirements, and Architecture sections
- Make description prop optional in AITextareaSection component
- Fix tab alignment by adding consistent pt-0 spacing and min-h-9 headers
- Standardize font sizes across tabs (text-sm font-medium)
- Reduce feature title size from text-5xl to text-4xl
- Update skeleton loader to match new tab-based structure
- Remove margin-left from SaveIndicator to use parent gap spacing