### PR TITLE
fix: resolve duplicate vi.

### DIFF
--- a/src/__tests__/unit/api/tasks/[taskId]/messages.test.ts
+++ b/src/__tests__/unit/api/tasks/[taskId]/messages.test.ts
@@ -1,17 +1,13 @@
 import { describe, test, expect, vi, beforeEach, Mock } from "vitest";
 import { NextRequest } from "next/server";
 import { GET } from "@/app/api/tasks/[taskId]/messages/route";
-import { getServerSession } from "next-auth/next";
+import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { ChatRole, ChatStatus, ArtifactType } from "@prisma/client";
 
-// Mock next-auth
-vi.mock("next-auth/next", () => ({
-  getServerSession: vi.fn(),
-}));
-
-// Mock authOptions
-vi.mock("@/lib/auth/nextauth", () => ({
+// Mock auth module
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
   authOptions: {},
 }));
 


### PR DESCRIPTION
fix: resolve duplicate vi.mock for auth module in messages test

- Consolidate duplicate vi.mock("@/lib/auth") calls into single mock
- Properly export auth function from mock to fix test error
- Replace getServerSession with auth throughout test file
- Mock auth to return session object directly instead of nested structure

Fixes vitest error: No "auth" export is defined on the "@/lib/auth" mock