### PR TITLE
Fix back button navigation in feature detail page

### DIFF
--- a/src/app/w/[slug]/plan/[featureId]/page.tsx
+++ b/src/app/w/[slug]/plan/[featureId]/page.tsx
@@ -223,7 +223,7 @@ export default function FeatureDetailPage() {
         throw new Error("Failed to delete feature");
       }
 
-      router.push(`/w/${workspaceSlug}/roadmap`);
+      router.push(`/w/${workspaceSlug}/plan`);
     } catch (error) {
       console.error("Failed to delete feature:", error);
     }
@@ -259,7 +259,7 @@ export default function FeatureDetailPage() {
       <div className="space-y-6">
         {/* Header with back button */}
         <div className="flex items-center gap-4">
-          <Button variant="ghost" size="sm" onClick={() => router.push(`/w/${workspaceSlug}/roadmap`)}>
+          <Button variant="ghost" size="sm" onClick={() => router.push(`/w/${workspaceSlug}/plan`)}>
             <ArrowLeft className="h-4 w-4 mr-2" />
             Back
           </Button>
@@ -340,7 +340,7 @@ export default function FeatureDetailPage() {
   if (error || !feature) {
     return (
       <div className="space-y-6">
-        <Button variant="ghost" size="sm" onClick={() => router.push(`/w/${workspaceSlug}/roadmap`)}>
+        <Button variant="ghost" size="sm" onClick={() => router.push(`/w/${workspaceSlug}/plan`)}>
           <ArrowLeft className="h-4 w-4 mr-2" />
           Back
         </Button>
@@ -360,7 +360,7 @@ export default function FeatureDetailPage() {
     <div className="space-y-6">
       {/* Header with back button */}
       <div className="flex items-center gap-4">
-        <Button variant="ghost" size="sm" onClick={() => router.push(`/w/${workspaceSlug}/roadmap`)}>
+        <Button variant="ghost" size="sm" onClick={() => router.push(`/w/${workspaceSlug}/plan`)}>
           <ArrowLeft className="h-4 w-4 mr-2" />
           Back
         </Button>


### PR DESCRIPTION
Update all back button navigation from /roadmap to /plan route. Previously, clicking back after creating a feature would navigate to the non-existent /roadmap route instead of /plan.

Fixed 4 instances:
- Delete feature handler
- Loading state back button
- Error state back button
- Main page back button