### PR TITLE
fix: change URL parameter from tab=tickets to tab=tasks on feature page

### DIFF
--- a/src/app/w/[slug]/plan/[featureId]/page.tsx
+++ b/src/app/w/[slug]/plan/[featureId]/page.tsx
@@ -295,7 +295,7 @@ export default function FeatureDetailPage() {
               <TabsList className="mb-6">
                 <TabsTrigger value="overview">Overview</TabsTrigger>
                 <TabsTrigger value="architecture">Architecture</TabsTrigger>
-                <TabsTrigger value="tickets">Tasks</TabsTrigger>
+                <TabsTrigger value="tasks">Tasks</TabsTrigger>
               </TabsList>
 
               <TabsContent value="overview" className="space-y-6 pt-0">
@@ -318,7 +318,7 @@ export default function FeatureDetailPage() {
                 </div>
               </TabsContent>
 
-              <TabsContent value="tickets" className="space-y-6 pt-0">
+              <TabsContent value="tasks" className="space-y-6 pt-0">
                 {/* Tasks */}
                 <div className="space-y-2">
                   <div className="flex items-center gap-2 min-h-9">
@@ -422,7 +422,7 @@ export default function FeatureDetailPage() {
             <TabsList className="mb-6">
               <TabsTrigger value="overview">Overview</TabsTrigger>
               <TabsTrigger value="architecture">Architecture</TabsTrigger>
-              <TabsTrigger value="tickets">Tasks</TabsTrigger>
+              <TabsTrigger value="tasks">Tasks</TabsTrigger>
             </TabsList>
 
             <TabsContent value="overview" className="space-y-6 pt-0">
@@ -506,11 +506,11 @@ export default function FeatureDetailPage() {
                 <Button variant="outline" onClick={() => setActiveTab("overview")}>
                   Back
                 </Button>
-                <Button onClick={() => setActiveTab("tickets")}>Next</Button>
+                <Button onClick={() => setActiveTab("tasks")}>Next</Button>
               </div>
             </TabsContent>
 
-            <TabsContent value="tickets" className="space-y-6 pt-0">
+            <TabsContent value="tasks" className="space-y-6 pt-0">
               <TicketsList featureId={featureId} feature={feature} onUpdate={setFeature} />
 
               {/* Navigation buttons */}

--- a/src/app/w/[slug]/tickets/[ticketId]/page.tsx
+++ b/src/app/w/[slug]/tickets/[ticketId]/page.tsx
@@ -76,7 +76,7 @@ export default function TicketDetailPage() {
 
   const handleBackClick = () => {
     if (ticket?.feature) {
-      router.push(`/w/${workspaceSlug}/plan/${ticket.feature.id}?tab=tickets`);
+      router.push(`/w/${workspaceSlug}/plan/${ticket.feature.id}?tab=tasks`);
     } else {
       router.push(`/w/${workspaceSlug}/plan`);
     }
@@ -171,7 +171,7 @@ export default function TicketDetailPage() {
             <>
               <span
                 className="hover:underline cursor-pointer"
-                onClick={() => router.push(`/w/${workspaceSlug}/plan/${ticket.feature!.id}?tab=tickets`)}
+                onClick={() => router.push(`/w/${workspaceSlug}/plan/${ticket.feature!.id}?tab=tasks`)}
               >
                 {ticket.feature!.title}
               </span>


### PR DESCRIPTION
fix: change URL parameter from tab=tickets to tab=tasks on feature page

- Updated TabsTrigger and TabsContent values from "tickets" to "tasks" in feature detail page
- Updated navigation button to use "tasks" tab value
- Updated back button and breadcrumb links in ticket detail page to use ?tab=tasks
- Ensures URL accurately reflects the "Tasks" tab name in the feature detail view