### PR TITLE
Fix: Auto-set task status to DONE when PR artifacts are created

### DIFF
--- a/src/app/api/chat/message/route.ts
+++ b/src/app/api/chat/message/route.ts
@@ -9,6 +9,7 @@ import { getS3Service } from "@/services/s3";
 import { getBaseUrl } from "@/lib/utils";
 import { transformSwarmUrlToRepo2Graph } from "@/lib/utils/swarm";
 import { callStakworkAPI } from "@/services/task-workflow";
+import { updateTaskStatusForPullRequest } from "@/lib/helpers/tasks";
 
 export const runtime = "nodejs";
 
@@ -240,6 +241,9 @@ export async function POST(request: NextRequest) {
         },
       },
     });
+
+    // Check if artifacts contain PULL_REQUEST to auto-complete task
+    await updateTaskStatusForPullRequest(taskId, artifacts);
 
     // Convert to client-side type
     const clientMessage: ChatMessage = {

--- a/src/lib/helpers/tasks.ts
+++ b/src/lib/helpers/tasks.ts
@@ -138,3 +138,27 @@ export async function extractPrArtifact(
 
   return null;
 }
+
+/**
+ * Update task status to DONE when a PULL_REQUEST artifact is present
+ *
+ * This function checks if any artifact is a PULL_REQUEST and automatically
+ * sets the task status to DONE. This matches agent mode behavior where
+ * tasks are marked complete as soon as a PR is created (not when merged).
+ *
+ * @param taskId - Task ID to update
+ * @param artifacts - Array of artifacts to check
+ */
+export async function updateTaskStatusForPullRequest(
+  taskId: string,
+  artifacts: Array<{ type: string }>,
+): Promise<void> {
+  const hasPullRequest = artifacts.some((artifact) => artifact.type === "PULL_REQUEST");
+
+  if (hasPullRequest) {
+    await db.task.update({
+      where: { id: taskId },
+      data: { status: TaskStatus.DONE },
+    });
+  }
+}


### PR DESCRIPTION
Create shared helper function to automatically update task status to DONE when PULL_REQUEST artifacts are added, ensuring consistent behavior across both agent mode and generic webhook flows.

Changes:
- Add updateTaskStatusForPullRequest() helper in tasks.ts
- Update /api/chat/message to auto-complete tasks with PR artifacts
- Refactor /api/tasks/[taskId]/messages/save to use shared helper
- Only updates status field, preserves workflowStatus

This fixes the issue where generic webhook flow (/api/chat/message) did not automatically set task status to DONE when PR artifacts were created, while agent mode did. Now both endpoints use the same DRY implementation.