### PR TITLE
feat: treat HALTED workflow status as discarded in janitor cron

### DIFF
--- a/src/__tests__/unit/services/janitor-cron.test.ts
+++ b/src/__tests__/unit/services/janitor-cron.test.ts
@@ -202,6 +202,16 @@ describe("shouldSkipJanitorRun", () => {
       expect(result).toBe(false);
     });
 
+    it("should return false when task workflowStatus is HALTED (discarded)", async () => {
+      vi.mocked(mockedDb.task.findFirst).mockResolvedValue(
+        createMockTask({ workflowStatus: WorkflowStatus.HALTED }) as any,
+      );
+
+      const result = await shouldSkipJanitorRun("ws-1", JanitorType.UNIT_TESTS);
+
+      expect(result).toBe(false);
+    });
+
     it("should query for the most recent task of the specified janitor type", async () => {
       vi.mocked(mockedDb.task.findFirst).mockResolvedValue(null);
 

--- a/src/services/janitor-cron.ts
+++ b/src/services/janitor-cron.ts
@@ -115,8 +115,8 @@ export async function shouldSkipJanitorRun(
     return false;
   }
 
-  // Discarded tasks (cancelled or failed workflow) don't block
-  if (task.status === "CANCELLED" || task.workflowStatus === "FAILED") {
+  // Discarded tasks (cancelled, failed, or halted workflow) don't block
+  if (task.status === "CANCELLED" || task.workflowStatus === "FAILED" || task.workflowStatus === "HALTED") {
     console.log(`[JanitorCron] Most recent ${janitorType} task ${task.id} is discarded (status: ${task.status}, workflow: ${task.workflowStatus})`);
     return false;
   }


### PR DESCRIPTION
feat: treat HALTED workflow status as discarded in janitor cron

- Update shouldSkipJanitorRun() to include HALTED status check
- Modify condition to treat HALTED workflows like FAILED (discarded)
- Update comment to reflect cancelled, failed, or halted workflows
- Add unit test verifying HALTED workflows don't block new janitor runs
- Ensures console log includes HALTED in discarded status message