### PR TITLE
Fix form artifact webhook not being called

### DIFF
--- a/src/app/api/chat/message/route.ts
+++ b/src/app/api/chat/message/route.ts
@@ -310,6 +310,7 @@ export async function POST(request: NextRequest) {
         repoUrl,
         baseBranch,
         history,
+        webhook,
       });
 
       if (stakworkData.success) {

--- a/src/services/task-workflow.ts
+++ b/src/services/task-workflow.ts
@@ -464,6 +464,7 @@ export async function callStakworkAPI(params: {
   baseBranch?: string | null;
   history?: Record<string, unknown>[];
   autoMergePr?: boolean;
+  webhook?: string;
 }) {
   const {
     taskId,
@@ -487,6 +488,7 @@ export async function callStakworkAPI(params: {
     baseBranch = null,
     history = [],
     autoMergePr,
+    webhook,
   } = params;
 
   if (!config.STAKWORK_API_KEY || !config.STAKWORK_WORKFLOW_ID) {
@@ -565,8 +567,11 @@ export async function callStakworkAPI(params: {
   };
 
   // Make Stakwork API call (replicating fetch call from chat/message route)
+  // If webhook is provided, use it to continue existing workflow; otherwise start new project
+  const stakworkURL = webhook || `${config.STAKWORK_BASE_URL}/projects`;
+
   try {
-    const response = await fetch(`${config.STAKWORK_BASE_URL}/projects`, {
+    const response = await fetch(stakworkURL, {
       method: "POST",
       body: JSON.stringify(stakworkPayload),
       headers: {


### PR DESCRIPTION
Regression from 479af372 which consolidated Stakwork API calls but dropped the webhook parameter. When responding to FORM artifacts, the webhook URL should be used to continue the existing workflow instead of starting a new project.

Restores original behavior: `webhook || /projects` URL selection.