### PR TITLE
Hide e2e janitor from janitors list

### DIFF
--- a/src/__tests__/unit/lib/constants/janitor.test.ts
+++ b/src/__tests__/unit/lib/constants/janitor.test.ts
@@ -230,13 +230,13 @@ describe("constants/janitor", () => {
   });
 
   describe("getAllJanitorItems", () => {
-    it("should return items for all janitor types", () => {
+    it("should return items for all janitor types except E2E_TESTS", () => {
       const items = getAllJanitorItems();
 
-      expect(items).toHaveLength(4);
+      expect(items).toHaveLength(3);
       expect(items.some((item) => item.id === JanitorType.UNIT_TESTS)).toBe(true);
       expect(items.some((item) => item.id === JanitorType.INTEGRATION_TESTS)).toBe(true);
-      expect(items.some((item) => item.id === JanitorType.E2E_TESTS)).toBe(true);
+      expect(items.some((item) => item.id === JanitorType.E2E_TESTS)).toBe(false);
       expect(items.some((item) => item.id === JanitorType.SECURITY_REVIEW)).toBe(true);
     });
 

--- a/src/lib/constants/janitor.ts
+++ b/src/lib/constants/janitor.ts
@@ -106,9 +106,12 @@ export function createJanitorItem(janitorType: JanitorType) {
 
 /**
  * Get all available janitor items for UI
+ * Excludes E2E_TESTS from the list
  */
 export function getAllJanitorItems() {
-  return Object.values(JanitorType).map(createJanitorItem);
+  return Object.values(JanitorType)
+    .filter(type => type !== JanitorType.E2E_TESTS)
+    .map(createJanitorItem);
 }
 
 /**


### PR DESCRIPTION
Hide e2e janitor from janitors list

- Filter out E2E_TESTS from getAllJanitorItems() function
- Update tests to reflect E2E janitor exclusion
- E2E janitor config still available for backend use