### PR TITLE
fix: prevent re-halting already halted tasks and use updatedAt for st…

### DIFF
--- a/src/__tests__/integration/api/cron/task-coordinator.test.ts
+++ b/src/__tests__/integration/api/cron/task-coordinator.test.ts
@@ -207,6 +207,7 @@ describe("Integration: /api/cron/task-coordinator", () => {
           sourceType: "USER",
           priority: "MEDIUM",
           createdAt: twentyFiveHoursAgo,
+          updatedAt: twentyFiveHoursAgo,
         },
       });
 
@@ -248,6 +249,7 @@ describe("Integration: /api/cron/task-coordinator", () => {
           sourceType: "USER",
           priority: "MEDIUM",
           createdAt: twoHoursAgo,
+          updatedAt: twoHoursAgo,
         },
       });
 

--- a/src/services/task-coordinator-cron.ts
+++ b/src/services/task-coordinator-cron.ts
@@ -240,12 +240,13 @@ export async function haltStaleAgentTasks(): Promise<{
     const twentyFourHoursAgo = new Date();
     twentyFourHoursAgo.setHours(twentyFourHoursAgo.getHours() - 24);
 
-    // Find agent tasks that have been in IN_PROGRESS status for more than 24 hours
+    // Find agent tasks that have been in IN_PROGRESS status with no activity for more than 24 hours
     const staleTasks = await db.task.findMany({
       where: {
         mode: "agent",
         status: "IN_PROGRESS",
-        createdAt: {
+        workflowStatus: { not: "HALTED" },
+        updatedAt: {
           lt: twentyFourHoursAgo,
         },
         deleted: false,
@@ -254,7 +255,7 @@ export async function haltStaleAgentTasks(): Promise<{
         id: true,
         title: true,
         workspaceId: true,
-        createdAt: true,
+        updatedAt: true,
       },
     });
 


### PR DESCRIPTION
…aleness

- Use updatedAt instead of createdAt to detect actual inactivity (24h)
- Add workflowStatus filter to exclude already-halted tasks
- Prevents tasks from being updated every 5 minutes by the cron