### PR TITLE
refactor: remove redundant updatedAt touch in processTicketSweep

### DIFF
--- a/src/services/task-coordinator-cron.ts
+++ b/src/services/task-coordinator-cron.ts
@@ -182,12 +182,6 @@ async function processTicketSweep(
   }
   console.log(`[TaskCoordinator] Processing ticket ${task.id} (${task.priority}) for workspace ${workspaceSlug}`);
 
-  // Touch updatedAt so task bubbles to top of "recently active" sorted list
-  await db.task.update({
-    where: { id: task.id },
-    data: { updatedAt: new Date() },
-  });
-
   try {
     // Assign to task creator, fall back to feature creator if needed
     const userId = task.createdById ?? task.feature?.createdById;


### PR DESCRIPTION
The explicit updatedAt touch is unnecessary because startTaskWorkflow already updates the task (workflowStatus, workflowStartedAt, etc.), which automatically bumps updatedAt via Prisma's @updatedAt directive.