### PR TITLE
feat: show toast when task is assigned to coordinator

### DIFF
--- a/src/app/w/[slug]/phases/[phaseId]/page.tsx
+++ b/src/app/w/[slug]/phases/[phaseId]/page.tsx
@@ -22,6 +22,7 @@ import { useWorkspace } from "@/hooks/useWorkspace";
 import { useDetailResource } from "@/hooks/useDetailResource";
 import { useRoadmapTaskMutations } from "@/hooks/useRoadmapTaskMutations";
 import { generateSphinxBountyUrl } from "@/lib/sphinx-tribes";
+import { toast } from "sonner";
 import type { PhaseWithTickets, TicketListItem } from "@/types/roadmap";
 import type { PhaseStatus, TaskStatus, Priority } from "@prisma/client";
 
@@ -130,7 +131,11 @@ export default function PhaseDetailPage() {
         tasks: [...phase.tasks, ticket],
       });
 
-      if (newTicketAssigneeId === "system:bounty-hunter") {
+      if (newTicketAssigneeId === "system:task-coordinator") {
+        toast.info("Task queued for coordinator", {
+          description: "Processing begins when a machine is available",
+        });
+      } else if (newTicketAssigneeId === "system:bounty-hunter") {
         const bountyUrl = generateSphinxBountyUrl({
           id: ticket.id,
           title: ticket.title,

--- a/src/components/features/AssigneeCombobox.tsx
+++ b/src/components/features/AssigneeCombobox.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { Check, User as UserIcon, Bot } from "lucide-react";
+import { toast } from "sonner";
 import { generateSphinxBountyUrl } from "@/lib/sphinx-tribes";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -89,7 +90,13 @@ export function AssigneeCombobox({ workspaceSlug, currentAssignee, onSelect, sho
       setUpdating(true);
       await onSelect(memberId, memberData);
       setOpen(false);
-      
+
+      if (memberId === "system:task-coordinator" && ticketData) {
+        toast.info("Task queued for coordinator", {
+          description: "Processing begins when a machine is available",
+        });
+      }
+
       if (memberId === "system:bounty-hunter" && ticketData) {
         const bountyUrl = generateSphinxBountyUrl({
           ...ticketData,

--- a/src/components/features/TicketsList/index.tsx
+++ b/src/components/features/TicketsList/index.tsx
@@ -26,6 +26,7 @@ import { GenerationControls } from "@/components/features/GenerationControls";
 import type { FeatureDetail, TicketListItem } from "@/types/roadmap";
 import { TaskStatus, Priority } from "@prisma/client";
 import { generateSphinxBountyUrl } from "@/lib/sphinx-tribes";
+import { toast } from "sonner";
 
 interface TicketsListProps {
   featureId: string;
@@ -160,7 +161,11 @@ export function TicketsList({ featureId, feature, onUpdate }: TicketsListProps) 
         phases: updatedPhases,
       });
 
-      if (newTicketAssigneeId === "system:bounty-hunter") {
+      if (newTicketAssigneeId === "system:task-coordinator") {
+        toast.info("Task queued for coordinator", {
+          description: "Processing begins when a machine is available",
+        });
+      } else if (newTicketAssigneeId === "system:bounty-hunter") {
         const bountyUrl = generateSphinxBountyUrl({
           id: ticket.id,
           title: ticket.title,


### PR DESCRIPTION
Shows informational toast feedback when a task is assigned to the Task Coordinator, letting users know the task is queued for processing.