### PR TITLE
feat: add missing toast notifications for user feedback

### DIFF
--- a/src/components/CreateWorkspaceDialog.tsx
+++ b/src/components/CreateWorkspaceDialog.tsx
@@ -14,6 +14,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { useSession } from "next-auth/react";
+import { toast } from "sonner";
 import type { WorkspaceResponse } from "@/types/workspace";
 import { ErrorDisplay } from "@/components/ui/error-display";
 
@@ -66,11 +67,16 @@ export function CreateWorkspaceDialog({
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || "Failed to create workspace");
       onCreated?.(data.workspace);
+      toast.success("Workspace created");
       setFormData({ name: "", description: "", slug: "" });
       setErrors({});
       onOpenChange(false);
     } catch (err: unknown) {
-      setApiError(err instanceof Error ? err.message : "Unknown error");
+      const message = err instanceof Error ? err.message : "Unknown error";
+      setApiError(message);
+      toast.error("Failed to create workspace", {
+        description: message,
+      });
     } finally {
       setLoading(false);
     }

--- a/src/components/DisconnectAccount.tsx
+++ b/src/components/DisconnectAccount.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { signOut } from "next-auth/react";
 import { Button } from "@/components/ui/button";
 import { Github, Unlink } from "lucide-react";
+import { toast } from "sonner";
 
 interface DisconnectAccountProps {
   user: {
@@ -70,7 +71,9 @@ export function DisconnectAccount({ user }: DisconnectAccountProps) {
     } catch (error) {
       console.error("Error disconnecting account:", error);
       setIsDisconnecting(false);
-      alert("Failed to disconnect GitHub account. Please try again.");
+      toast.error("Failed to disconnect GitHub account", {
+        description: "Please try again.",
+      });
     }
   };
 

--- a/src/components/workspace/AddMemberModal.tsx
+++ b/src/components/workspace/AddMemberModal.tsx
@@ -33,6 +33,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { InfoIcon, Search, UserCheck } from "lucide-react";
+import { toast } from "sonner";
 import { useDebounce } from "@/hooks/useDebounce";
 import { AssignableMemberRoleSchema, WorkspaceRole, RoleLabels } from "@/lib/auth/roles";
 
@@ -128,9 +129,14 @@ export function AddMemberModal({ open, onOpenChange, workspaceSlug, onMemberAdde
 
       // Success - refresh parent and close modal
       await onMemberAdded();
+      toast.success("Member added");
       handleClose();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to add member");
+      const message = err instanceof Error ? err.message : "Failed to add member";
+      setError(message);
+      toast.error("Failed to add member", {
+        description: message,
+      });
     } finally {
       setIsSubmitting(false);
     }

--- a/src/components/workspace/WorkspaceMembers.tsx
+++ b/src/components/workspace/WorkspaceMembers.tsx
@@ -18,6 +18,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Users, Plus, MoreHorizontal, Trash2 } from "lucide-react";
+import { toast } from "sonner";
 import { AddMemberModal } from "./AddMemberModal";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { useWorkspace } from "@/hooks/useWorkspace";
@@ -91,8 +92,11 @@ export function WorkspaceMembers({ canAdmin }: WorkspaceMembersProps) {
       }
       // Refresh members list
       await fetchMembers();
+      toast.success("Member removed");
     } catch (err) {
-      alert(err instanceof Error ? err.message : "Failed to remove member");
+      toast.error("Failed to remove member", {
+        description: err instanceof Error ? err.message : undefined,
+      });
     }
   };
 
@@ -108,8 +112,11 @@ export function WorkspaceMembers({ canAdmin }: WorkspaceMembersProps) {
       }
       // Refresh members list
       await fetchMembers();
+      toast.success("Role updated");
     } catch (err) {
-      alert(err instanceof Error ? err.message : "Failed to update role");
+      toast.error("Failed to update role", {
+        description: err instanceof Error ? err.message : undefined,
+      });
     }
   };
 


### PR DESCRIPTION
Add toast notifications to workspace member management, workspace creation, and account disconnect flows to provide consistent user feedback across the application.