### PR TITLE
feat: add autoMergePr param to janitor webhook

### DIFF
--- a/src/app/api/janitors/webhook/route.ts
+++ b/src/app/api/janitors/webhook/route.ts
@@ -8,6 +8,7 @@ const stakworkWebhookSchema = z.object({
   status: z.string(),
   workspaceId: z.string().optional(), // For external workflows without janitor run
   autoCreateTasks: z.boolean().optional(), // Auto-create task from first recommendation
+  autoMergePr: z.boolean().optional(), // Auto-merge PR when autoCreateTasks is true
   results: z.object({
     recommendations: z.array(z.object({
       title: z.string(),

--- a/src/services/janitor.ts
+++ b/src/services/janitor.ts
@@ -656,7 +656,7 @@ export async function dismissJanitorRecommendation(
  * Process Stakwork webhook for janitor run completion
  */
 export async function processJanitorWebhook(webhookData: StakworkWebhookPayload) {
-  const { projectId, status, results, error, workspaceId, autoCreateTasks } = webhookData;
+  const { projectId, status, results, error, workspaceId, autoCreateTasks, autoMergePr } = webhookData;
 
   const isCompleted = status.toLowerCase() === "completed" || status.toLowerCase() === "success";
   const isFailed = status.toLowerCase() === "failed" || status.toLowerCase() === "error";
@@ -827,7 +827,7 @@ export async function processJanitorWebhook(webhookData: StakworkWebhookPayload)
           const result = await acceptJanitorRecommendation(
             createdRec.id,
             janitorRun.janitorConfig.workspace.ownerId,
-            { autoMergePr: true },
+            { autoMergePr: autoMergePr ?? false },
             "JANITOR"
           );
           autoCreatedTaskId = result.task.id;

--- a/src/types/janitor.ts
+++ b/src/types/janitor.ts
@@ -33,6 +33,7 @@ export interface StakworkWebhookPayload {
   status: string;
   workspaceId?: string; // For external workflows without janitor run
   autoCreateTasks?: boolean; // Auto-create task from first recommendation
+  autoMergePr?: boolean; // Auto-merge PR when autoCreateTasks is true
   results?: {
     recommendations: Array<{
       title: string;


### PR DESCRIPTION
Allow Stakwork to control auto-merge behavior when auto-creating tasks. Defaults to false when not specified.