### PR TITLE
fix: add MOCK_GENERATION to autoCreateTasks supported janitor types

### DIFF
--- a/src/services/janitor.ts
+++ b/src/services/janitor.ts
@@ -807,9 +807,9 @@ export async function processJanitorWebhook(webhookData: StakworkWebhookPayload)
     }
 
     // Auto-create task from first recommendation if flag is set
-    // Only for sequential janitor types (UNIT_TESTS, INTEGRATION_TESTS)
+    // Only for sequential janitor types (UNIT_TESTS, INTEGRATION_TESTS, MOCK_GENERATION)
     let autoCreatedTaskId: string | undefined;
-    const sequentialJanitorTypes: JanitorType[] = ["UNIT_TESTS", "INTEGRATION_TESTS"];
+    const sequentialJanitorTypes: JanitorType[] = ["UNIT_TESTS", "INTEGRATION_TESTS", "MOCK_GENERATION"];
 
     if (
       autoCreateTasks &&


### PR DESCRIPTION
fix: add MOCK_GENERATION to autoCreateTasks supported janitor types

When autoCreateTasks: true is passed to the janitor webhook, tasks are
now auto-created for MOCK_GENERATION janitor runs. Previously, these
recommendations stayed in pending state with accept/dismiss options.

- Add MOCK_GENERATION to sequentialJanitorTypes array in janitor.ts
- Update comment to reflect the new supported janitor type