### PR TITLE
fix: separate git leaks widget and ingestion status positioning

### DIFF
--- a/src/app/w/[slug]/dashboard/index.tsx
+++ b/src/app/w/[slug]/dashboard/index.tsx
@@ -49,15 +49,17 @@ function DashboardInner() {
 
   return (
     <div className="flex flex-col flex-1 h-full relative">
-      {/* Top-left: Git Leaks + Ingestion Status widgets with transition */}
+      {/* Top-left: Git Leaks widget (always fixed) */}
+      <div className="absolute top-4 left-4 z-10">
+        <GitLeaksWidget />
+      </div>
+
+      {/* Ingestion Status widget - transitions from center to top-left (next to shield) */}
       <div className={`absolute z-10 transition-all duration-200 ease-in-out ${isCentered
         ? "top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
-        : "top-4 left-4"
+        : "top-4 left-16"
         }`}>
-        <div className="flex items-center gap-2">
-          <GitLeaksWidget />
-          <IngestionStatusWidget />
-        </div>
+        <IngestionStatusWidget />
       </div>
 
       {/* Top-right widgets */}


### PR DESCRIPTION
Shield now stays fixed in top-left while ingestion logs transition from center to sit next to it.