### PR TITLE
fix: update default MAX_WORKSPACES_PER_USER from 3 to 20

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -118,7 +118,7 @@ export const WORKSPACE_PERMISSION_LEVELS: Record<WorkspaceRole, number> = {
 
 // Workspace limits
 export const WORKSPACE_LIMITS = {
-  MAX_WORKSPACES_PER_USER: parseInt(process.env.NEXT_PUBLIC_MAX_WORKSPACES_PER_USER || "3", 10),
+  MAX_WORKSPACES_PER_USER: parseInt(process.env.NEXT_PUBLIC_MAX_WORKSPACES_PER_USER || "20", 10),
 } as const;
 
 // Error messages


### PR DESCRIPTION
fix: update default MAX_WORKSPACES_PER_USER from 3 to 20

Changed the hardcoded default value in src/lib/constants.ts from "3" to "20"
to match the intended workspace limit. The NEXT_PUBLIC_MAX_WORKSPACES_PER_USER
environment variable was not taking effect due to the low fallback value.