### PR TITLE
feat: show terminal state UI for expired/failed/error workflows

### DIFF
--- a/src/app/w/[slug]/task/[...taskParams]/components/AgentChatArea.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/components/AgentChatArea.tsx
@@ -29,6 +29,7 @@ interface AgentChatAreaProps {
   showPreviewToggle?: boolean;
   showPreview?: boolean;
   onTogglePreview?: () => void;
+  taskMode?: string;
 }
 
 export function AgentChatArea({
@@ -47,6 +48,7 @@ export function AgentChatArea({
   showPreviewToggle = false,
   showPreview = false,
   onTogglePreview,
+  taskMode,
 }: AgentChatAreaProps) {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
@@ -208,6 +210,8 @@ export function AgentChatArea({
         onRemoveDebugAttachment={onRemoveDebugAttachment}
         workflowStatus={workflowStatus}
         hasPrArtifact={hasPrArtifact}
+        taskMode={taskMode}
+        workspaceSlug={workspaceSlug}
       />
     </motion.div>
   );

--- a/src/app/w/[slug]/task/[...taskParams]/components/ChatArea.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/components/ChatArea.tsx
@@ -33,6 +33,7 @@ interface ChatAreaProps {
   showPreviewToggle?: boolean;
   showPreview?: boolean;
   onTogglePreview?: () => void;
+  taskMode?: string;
 }
 
 export function ChatArea({
@@ -53,6 +54,7 @@ export function ChatArea({
   showPreviewToggle = false,
   showPreview = false,
   onTogglePreview,
+  taskMode,
 }: ChatAreaProps) {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
@@ -240,6 +242,8 @@ export function ChatArea({
         onRemoveDebugAttachment={onRemoveDebugAttachment}
         workflowStatus={workflowStatus}
         hasPrArtifact={hasPrArtifact}
+        taskMode={taskMode}
+        workspaceSlug={workspaceSlug}
       />
     </motion.div>
   );

--- a/src/app/w/[slug]/task/[...taskParams]/page.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/page.tsx
@@ -722,7 +722,10 @@ export default function TaskChatPage() {
   const hasNonFormArtifacts = artifactsWithoutOldDiffs.some((a) => a.type !== "FORM" && a.type !== "LONGFORM");
   const browserArtifact = artifactsWithoutOldDiffs.find((a) => a.type === "BROWSER");
 
-  const inputDisabled = isLoading || !isConnected;
+  const isTerminalState = workflowStatus === WorkflowStatus.HALTED ||
+    workflowStatus === WorkflowStatus.FAILED ||
+    workflowStatus === WorkflowStatus.ERROR;
+  const inputDisabled = isLoading || !isConnected || isTerminalState;
   if (hasActiveChatForm) {
     // TODO: rm this and only enable if ready below
   }
@@ -781,6 +784,7 @@ export default function TaskChatPage() {
                     showPreviewToggle={!!browserArtifact}
                     showPreview={showPreview}
                     onTogglePreview={() => setShowPreview(!showPreview)}
+                    taskMode={taskMode}
                   />
                 )}
               </div>
@@ -801,6 +805,7 @@ export default function TaskChatPage() {
                       workspaceSlug={slug}
                       onCommit={handleCommit}
                       isCommitting={isGeneratingCommitInfo || isCommitting}
+                      taskMode={taskMode}
                     />
                   </div>
                 </ResizablePanel>
@@ -832,6 +837,7 @@ export default function TaskChatPage() {
                 workspaceSlug={slug}
                 onCommit={handleCommit}
                 isCommitting={isGeneratingCommitInfo || isCommitting}
+                taskMode={taskMode}
               />
             </div>
           ) : hasNonFormArtifacts ? (
@@ -866,6 +872,7 @@ export default function TaskChatPage() {
                     showPreviewToggle={!!browserArtifact}
                     showPreview={showPreview}
                     onTogglePreview={() => setShowPreview(!showPreview)}
+                    taskMode={taskMode}
                   />
                 )}
               </div>
@@ -889,6 +896,7 @@ export default function TaskChatPage() {
                       taskTitle={taskTitle}
                       stakworkProjectId={stakworkProjectId}
                       workspaceSlug={slug}
+                      taskMode={taskMode}
                     />
                   </div>
                 </ResizablePanel>
@@ -923,6 +931,7 @@ export default function TaskChatPage() {
                 taskTitle={taskTitle}
                 stakworkProjectId={stakworkProjectId}
                 workspaceSlug={slug}
+                taskMode={taskMode}
               />
             </div>
           )}


### PR DESCRIPTION
- Display simplified UI when workflow is HALTED, FAILED, or ERROR
- Show mode-specific messages (Session expired vs Workflow halted/failed/error)
- Add New Task button for easy navigation
- Disable chat input for all terminal states