### PR TITLE
fix: show clear filters button in both list and kanban view modes

### DIFF
--- a/src/components/features/FeaturesList.tsx
+++ b/src/components/features/FeaturesList.tsx
@@ -706,7 +706,7 @@ const FeaturesListComponent = forwardRef<{ triggerCreate: () => void }, Features
                 </button>
               )}
             </div>
-            {hasActiveFilters && viewType === "list" && (
+            {hasActiveFilters && (
               <Button variant="outline" size="sm" onClick={handleClearFilters}>
                 <X className="h-4 w-4 mr-2" />
                 Clear filters


### PR DESCRIPTION
fix: show clear filters button in both list and kanban view modes