### PR TITLE
fix: exclude user journey tasks from main task list

### DIFF
--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -85,6 +85,8 @@ export async function GET(request: NextRequest) {
       workspaceId,
       deleted: false,
       archived: isShowingArchived,
+      // Exclude user journey tasks - they have their own dedicated page
+      sourceType: { not: TaskSourceType.USER_JOURNEY },
     };
 
     // If showing non-archived tasks (Recent tab), apply visibility rules


### PR DESCRIPTION
User journey tasks have their own dedicated page and were causing issues by bubbling to the top of the task list when the user-journeys sync logic updated their updatedAt timestamp.