### PR TITLE
refactor: remove formatRelativeTime in favor of formatRelativeOrDate

### DIFF
--- a/src/__tests__/unit/api/chat/message/call-stakwork.test.ts
+++ b/src/__tests__/unit/api/chat/message/call-stakwork.test.ts
@@ -46,7 +46,6 @@ vi.mock("@/services/s3");
 vi.mock("@/lib/utils", () => ({
   getBaseUrl: vi.fn(),
   cn: vi.fn(),
-  formatRelativeTime: vi.fn(),
   getRelativeUrl: vi.fn(),
 }));
 vi.mock("@/lib/utils/swarm");

--- a/src/__tests__/unit/api/chat/message/callMock.test.ts
+++ b/src/__tests__/unit/api/chat/message/callMock.test.ts
@@ -43,7 +43,6 @@ vi.mock("@/services/s3");
 vi.mock("@/lib/utils", () => ({
   getBaseUrl: vi.fn(),
   cn: vi.fn(),
-  formatRelativeTime: vi.fn(),
   getRelativeUrl: vi.fn(),
 }));
 vi.mock("@/lib/utils/swarm");

--- a/src/__tests__/unit/lib/utils.test.ts
+++ b/src/__tests__/unit/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { cn, formatRelativeTime, getBaseUrl, getRelativeUrl } from "@/lib/utils";
+import { cn, getBaseUrl, getRelativeUrl } from "@/lib/utils";
 
 describe("utils", () => {
   describe("cn", () => {
@@ -43,86 +43,6 @@ describe("utils", () => {
         true && "conditional",
         "final"
       )).toBe("base foo bar active conditional final");
-    });
-  });
-
-  describe("formatRelativeTime", () => {
-    beforeEach(() => {
-      vi.useFakeTimers();
-      vi.setSystemTime(new Date('2024-01-15T12:00:00Z'));
-    });
-
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
-    it.each([
-      { seconds: 0, expected: "just now" },
-      { seconds: 30, expected: "just now" },
-      { seconds: 45, expected: "just now" },
-    ])("should return '$expected' for $seconds seconds ago", ({ seconds, expected }) => {
-      const now = new Date();
-      const date = new Date(now.getTime() - seconds * 1000);
-      expect(formatRelativeTime(date)).toBe(expected);
-    });
-
-    it.each([
-      { minutes: 1, expected: "1 minute ago" },
-      { minutes: 5, expected: "5 minutes ago" },
-      { minutes: 30, expected: "30 minutes ago" },
-      { minutes: 59, expected: "59 minutes ago" },
-    ])("should return '$expected' for $minutes minutes ago", ({ minutes, expected }) => {
-      const now = new Date();
-      const date = new Date(now.getTime() - minutes * 60 * 1000);
-      expect(formatRelativeTime(date)).toBe(expected);
-    });
-
-    it.each([
-      { hours: 1, expected: "1 hour ago" },
-      { hours: 5, expected: "5 hours ago" },
-      { hours: 12, expected: "12 hours ago" },
-      { hours: 23, expected: "23 hours ago" },
-    ])("should return '$expected' for $hours hours ago", ({ hours, expected }) => {
-      const now = new Date();
-      const date = new Date(now.getTime() - hours * 60 * 60 * 1000);
-      expect(formatRelativeTime(date)).toBe(expected);
-    });
-
-    it.each([
-      { days: 1, expected: "1 day ago" },
-      { days: 3, expected: "3 days ago" },
-      { days: 6, expected: "6 days ago" },
-    ])("should return '$expected' for $days days ago", ({ days, expected }) => {
-      const now = new Date();
-      const date = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
-      expect(formatRelativeTime(date)).toBe(expected);
-    });
-
-    it.each([
-      { days: 7 },
-      { days: 30 },
-      { days: 365 },
-    ])("should format dates $days days ago as formatted date string", ({ days }) => {
-      const now = new Date();
-      const date = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
-      const result = formatRelativeTime(date);
-      expect(result).toMatch(/\d{1,2}\/\d{1,2}\/\d{4}/);
-    });
-
-    it("should handle string date inputs", () => {
-      const now = new Date();
-      const fiveMinutesAgo = new Date(now.getTime() - 5 * 60 * 1000);
-
-      expect(formatRelativeTime(fiveMinutesAgo.toISOString())).toBe("5 minutes ago");
-      expect(formatRelativeTime("2024-01-15T11:55:00Z")).toBe("5 minutes ago");
-    });
-
-    it("should handle future dates", () => {
-      const now = new Date();
-      const futureDate = new Date(now.getTime() + 5 * 60 * 1000);
-
-      const result = formatRelativeTime(futureDate);
-      expect(result).toBe("just now");
     });
   });
 

--- a/src/app/w/[slug]/learn/components/LearnSidebar.tsx
+++ b/src/app/w/[slug]/learn/components/LearnSidebar.tsx
@@ -5,6 +5,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { RefreshCw, Sprout, Box, ChevronDown, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { CreateFeatureModal } from "./CreateFeatureModal";
+import { formatRelativeOrDate } from "@/lib/date-utils";
 
 interface Feature {
   id: string;
@@ -84,21 +85,6 @@ export function LearnSidebar({ workspaceSlug, onFeatureClick }: LearnSidebarProp
     } finally {
       setIsSeeding(false);
     }
-  };
-
-  const formatRelativeTime = (isoString: string) => {
-    const now = Date.now();
-    const timestamp = new Date(isoString).getTime();
-    const diffMs = now - timestamp;
-    const diffSec = Math.floor(diffMs / 1000);
-    const diffMin = Math.floor(diffSec / 60);
-    const diffHour = Math.floor(diffMin / 60);
-    const diffDay = Math.floor(diffHour / 24);
-
-    if (diffDay > 0) return `${diffDay} day${diffDay > 1 ? "s" : ""} ago`;
-    if (diffHour > 0) return `${diffHour} hour${diffHour > 1 ? "s" : ""} ago`;
-    if (diffMin > 0) return `${diffMin} minute${diffMin > 1 ? "s" : ""} ago`;
-    return "just now";
   };
 
   const handleFeatureCreated = async () => {
@@ -187,7 +173,7 @@ export function LearnSidebar({ workspaceSlug, onFeatureClick }: LearnSidebarProp
         </div>
         <div className="mb-3">
           <p className="text-xs text-muted-foreground">
-            {lastProcessed ? `Last processed: ${formatRelativeTime(lastProcessed)}` : "Never processed"}
+            {lastProcessed ? `Last processed: ${formatRelativeOrDate(lastProcessed)}` : "Never processed"}
           </p>
         </div>
         <div className="flex gap-2">

--- a/src/components/dashboard/github-status-widget/index.tsx
+++ b/src/components/dashboard/github-status-widget/index.tsx
@@ -10,7 +10,7 @@ import {
 import { toast } from "sonner";
 import { useGithubApp } from "@/hooks/useGithubApp";
 import { useWorkspace } from "@/hooks/useWorkspace";
-import { formatRelativeTime } from "@/lib/utils";
+import { formatRelativeOrDate } from "@/lib/date-utils";
 import { ExternalLink, Github, Loader2 } from "lucide-react";
 import { useState } from "react";
 
@@ -98,7 +98,7 @@ export function GitHubStatusWidget() {
                 <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
-                <span>{formatRelativeTime(lastUpdated)}</span>
+                <span>{formatRelativeOrDate(lastUpdated)}</span>
               </div>
             )}
           </div>

--- a/src/components/dashboard/pool-status-widget/index.tsx
+++ b/src/components/dashboard/pool-status-widget/index.tsx
@@ -9,7 +9,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useWorkspace } from "@/hooks/useWorkspace";
-import { formatRelativeTime } from "@/lib/utils";
+import { formatRelativeOrDate } from "@/lib/date-utils";
 import { Clock, Loader2, Server } from "lucide-react";
 import Link from "next/link";
 import { useModal } from "@/components/modals/ModlaProvider";
@@ -108,7 +108,7 @@ export function PoolStatusWidget() {
                 )}
                 {poolStatus.status.lastCheck && (
                   <div className="text-muted-foreground">
-                    Updated {formatRelativeTime(poolStatus.status.lastCheck.endsWith('Z')
+                    Updated {formatRelativeOrDate(poolStatus.status.lastCheck.endsWith('Z')
                       ? poolStatus.status.lastCheck
                       : poolStatus.status.lastCheck + 'Z')}
                   </div>

--- a/src/components/dashboard/repository-card/index.tsx
+++ b/src/components/dashboard/repository-card/index.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { toast } from "sonner";
 import { useGithubApp } from "@/hooks/useGithubApp";
 import { useWorkspace } from "@/hooks/useWorkspace";
-import { formatRelativeTime } from "@/lib/utils";
+import { formatRelativeOrDate } from "@/lib/date-utils";
 import { ExternalLink, GitBranch, Github, Loader2, RefreshCw } from "lucide-react";
 import { useState } from "react";
 
@@ -224,7 +224,7 @@ export function RepositoryCard() {
             </div>
             <div className="flex items-center gap-1 text-muted-foreground">
               <RefreshCw className="w-3 h-3" />
-              {formatRelativeTime(repository.updatedAt)}
+              {formatRelativeOrDate(repository.updatedAt)}
             </div>
           </div>
         </div>

--- a/src/components/features/FeatureCard.tsx
+++ b/src/components/features/FeatureCard.tsx
@@ -4,7 +4,7 @@ import { Calendar, User } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
-import { formatRelativeTime } from "@/lib/utils";
+import { formatRelativeOrDate } from "@/lib/date-utils";
 import type { FeatureWithDetails } from "@/types/roadmap";
 import { FEATURE_STATUS_LABELS, FEATURE_STATUS_COLORS } from "@/types/roadmap";
 import { PriorityBadge } from "@/components/ui/priority-selector";
@@ -57,7 +57,7 @@ export function FeatureCard({ feature, workspaceSlug, hideStatus = false }: Feat
         )}
         <div className="flex items-center gap-1">
           <Calendar className="w-3 h-3" />
-          <span>{formatRelativeTime(feature.createdAt)}</span>
+          <span>{formatRelativeOrDate(feature.createdAt)}</span>
         </div>
       </div>
     </div>

--- a/src/components/pool-status/index.tsx
+++ b/src/components/pool-status/index.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useWorkspace } from "@/hooks/useWorkspace";
-import { formatRelativeTime } from "@/lib/utils";
+import { formatRelativeOrDate } from "@/lib/date-utils";
 import { Clock, MoreHorizontal, Server, Settings, Zap } from "lucide-react";
 import Link from "next/link";
 import { useModal } from "../modals/ModlaProvider";
@@ -135,7 +135,7 @@ export function VMConfigSection() {
 
               {poolStatus.status.lastCheck && (
                 <div className="text-xs text-muted-foreground">
-                  Updated {formatRelativeTime(poolStatus.status.lastCheck.endsWith('Z')
+                  Updated {formatRelativeOrDate(poolStatus.status.lastCheck.endsWith('Z')
                     ? poolStatus.status.lastCheck
                     : poolStatus.status.lastCheck + 'Z')}
                 </div>

--- a/src/components/tasks/TaskCard.tsx
+++ b/src/components/tasks/TaskCard.tsx
@@ -11,7 +11,7 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { formatRelativeTime } from "@/lib/utils";
+import { formatRelativeOrDate } from "@/lib/date-utils";
 
 interface TaskCardProps {
   task: TaskData;
@@ -141,7 +141,7 @@ export function TaskCard({ task, workspaceSlug, hideWorkflowStatus = false, isAr
         {/* Date */}
         <div className="flex items-center gap-1">
           <Calendar className="w-3 h-3" />
-          <span>{formatRelativeTime(task.createdAt)}</span>
+          <span>{formatRelativeOrDate(task.createdAt)}</span>
         </div>
 
         {/* Pod indicator - shows when pod is active */}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,27 +5,6 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export function formatRelativeTime(date: string | Date): string {
-  const now = new Date();
-  const targetDate = new Date(date);
-  const diffInMs = now.getTime() - targetDate.getTime();
-  const diffInMinutes = Math.floor(diffInMs / (1000 * 60));
-  const diffInHours = Math.floor(diffInMs / (1000 * 60 * 60));
-  const diffInDays = Math.floor(diffInMs / (1000 * 60 * 60 * 24));
-  
-  if (diffInMinutes < 1) {
-    return 'just now';
-  } else if (diffInMinutes < 60) {
-    return `${diffInMinutes} minute${diffInMinutes === 1 ? '' : 's'} ago`;
-  } else if (diffInHours < 24) {
-    return `${diffInHours} hour${diffInHours === 1 ? '' : 's'} ago`;
-  } else if (diffInDays < 7) {
-    return `${diffInDays} day${diffInDays === 1 ? '' : 's'} ago`;
-  } else {
-    return targetDate.toLocaleDateString();
-  }
-}
-
 export function getBaseUrl(hostHeader?: string | null): string {
   // Use the provided host header, NEXTAUTH_URL, or fallback to localhost
   if (hostHeader) {


### PR DESCRIPTION
Refactor date formatting utilities to consolidate implementations