### PR TITLE
refactor: maximize browser frame in testing page

### DIFF
--- a/src/app/w/[slug]/task/[...taskParams]/artifacts/browser.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/artifacts/browser.tsx
@@ -15,6 +15,7 @@ import {
   CheckCircle2,
   ArrowLeft,
   Loader2,
+  X,
 } from "lucide-react";
 import { Artifact, BrowserContent } from "@/lib/chat";
 import { useStaktrak } from "@/hooks/useStaktrak";
@@ -38,6 +39,7 @@ export function BrowserArtifactPanel({
   externalTestCode,
   externalTestTitle,
   isMobile = false,
+  onClose,
 }: {
   artifacts: Artifact[];
   ide?: boolean;
@@ -48,6 +50,7 @@ export function BrowserArtifactPanel({
   externalTestCode?: string | null;
   externalTestTitle?: string | null;
   isMobile?: boolean;
+  onClose?: () => void;
 }) {
   const [activeTab, setActiveTab] = useState(0);
   const [refreshKey, setRefreshKey] = useState(0);
@@ -423,6 +426,23 @@ export function BrowserArtifactPanel({
                         <TooltipContent side="bottom">Open in new tab</TooltipContent>
                       </Tooltip>
                     </TooltipProvider>
+                    {onClose && (
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={onClose}
+                              className="h-8 w-8 p-0"
+                            >
+                              <X className="w-4 h-4" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom">Close</TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    )}
                   </div>
                 </div>
               )}

--- a/src/app/w/[slug]/testing/page.tsx
+++ b/src/app/w/[slug]/testing/page.tsx
@@ -1,9 +1,5 @@
 "use client";
 
-import { CoverageInsights } from "@/components/insights/CoverageInsights";
-import { TestCoverageCard } from "@/components/insights/TestCoverageCard";
-import { PageHeader } from "@/components/ui/page-header";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import UserJourneys from "@/components/UserJourneys";
 import { useFeatureFlag } from "@/hooks/useFeatureFlag";
 import { FEATURE_FLAGS } from "@/lib/feature-flags";
@@ -17,26 +13,8 @@ export default function DefenseTestingPage() {
   }
 
   return (
-    <div className="space-y-6">
-      <PageHeader title="Testing" />
-
-      <div className="max-w-5xl">
-        <Tabs defaultValue="coverage" className="w-full">
-          <TabsList className="grid w-full max-w-md grid-cols-2">
-            <TabsTrigger value="coverage">Coverage</TabsTrigger>
-            <TabsTrigger value="user-journeys">User Journeys</TabsTrigger>
-          </TabsList>
-
-          <TabsContent value="coverage" className="space-y-6 mt-6">
-            <TestCoverageCard />
-            <CoverageInsights />
-          </TabsContent>
-
-          <TabsContent value="user-journeys" className="mt-6">
-            <UserJourneys />
-          </TabsContent>
-        </Tabs>
-      </div>
+    <div className="h-full">
+      <UserJourneys />
     </div>
   );
 }

--- a/src/components/UserJourneys.tsx
+++ b/src/components/UserJourneys.tsx
@@ -483,22 +483,16 @@ export default function UserJourneys() {
       {viewMode === "video" ? (
         renderVideoView()
       ) : frontend ? (
-        <div className="space-y-4">
-          <div className="flex items-center justify-end">
-            <Button variant="ghost" size="sm" onClick={handleCloseBrowser} className="h-8 w-8 p-0">
-              ✕
-            </Button>
-          </div>
-          <div className="h-[600px] border rounded-lg overflow-hidden">
-            <BrowserArtifactPanel
-              artifacts={browserArtifacts}
-              ide={false}
-              workspaceId={id || workspace?.id}
-              onUserJourneySave={saveUserJourneyTest}
-              externalTestCode={replayTestCode}
-              externalTestTitle={replayTitle}
-            />
-          </div>
+        <div className="h-[600px] border rounded-lg overflow-hidden">
+          <BrowserArtifactPanel
+            artifacts={browserArtifacts}
+            ide={false}
+            workspaceId={id || workspace?.id}
+            onUserJourneySave={saveUserJourneyTest}
+            externalTestCode={replayTestCode}
+            externalTestTitle={replayTitle}
+            onClose={handleCloseBrowser}
+          />
         </div>
       ) : (
         <Card>


### PR DESCRIPTION
refactor: maximize browser frame in testing page

- Remove "Testing" header and navigation tabs (Coverage, User Journeys)
- Move close button from standalone position to browser header toolbar
- Position close icon to the right of "open in new tab" icon
- Remove unused imports from testing page
- Add onClose prop to BrowserArtifactPanel component
- Maximize browser view by utilizing full container height