### PR TITLE
fix: use sourceType instead of janitorType for GitHub webhook janitor la

### DIFF
--- a/src/app/api/github/webhook/route.ts
+++ b/src/app/api/github/webhook/route.ts
@@ -203,7 +203,7 @@ export async function POST(request: NextRequest) {
             where: {
               workspaceId: repository.workspaceId,
               repositoryId: repository.id,
-              janitorType: { not: null },
+              sourceType: "JANITOR",
               // Match by stakworkProjectId if extracted from branch name
               ...(branchStakworkProjectId && { stakworkProjectId: branchStakworkProjectId }),
               // Only check recent tasks (created in the last 7 days)
@@ -216,18 +216,18 @@ export async function POST(request: NextRequest) {
             },
             select: {
               id: true,
-              janitorType: true,
+              sourceType: true,
               stakworkProjectId: true,
             },
           });
 
-          if (task?.janitorType) {
+          if (task?.sourceType === "JANITOR") {
             console.log("[GithubWebhook] Found janitor task for PR", {
               delivery,
               workspaceId: repository.workspaceId,
               prNumber,
               taskId: task.id,
-              janitorType: task.janitorType,
+              sourceType: task.sourceType,
             });
 
             // Add janitor label to the PR


### PR DESCRIPTION
fix: use sourceType instead of janitorType for GitHub webhook janitor label detection

Changed GitHub Actions webhook to check sourceType === "JANITOR" instead of 
janitorType field when determining whether to apply janitor label to PRs.
This fixes janitor tasks not being labeled correctly since sourceType is the 
reliable field that indicates task origin.