### PR TITLE
fix: remove repositoryId check from janitor label creation query

### DIFF
--- a/src/app/api/github/webhook/route.ts
+++ b/src/app/api/github/webhook/route.ts
@@ -193,11 +193,10 @@ export async function POST(request: NextRequest) {
             headBranch,
           });
 
-          // Look for a task that matches this repository and is a janitor task
+          // Look for a task that matches this workspace and is a janitor task
           const task = await db.task.findFirst({
             where: {
               workspaceId: repository.workspaceId,
-              repositoryId: repository.id,
               sourceType: "JANITOR",
               // Only check recent tasks (created in the last 7 days)
               createdAt: {


### PR DESCRIPTION
fix: remove repositoryId check from janitor label creation query

Remove the repositoryId filter from the database query when creating janitor labels for GitHub webhook PRs. The repositoryId values are NULL in the database, causing the query to fail to find matching tasks. Now the query only filters by workspaceId, sourceType, and creation date.