### PR TITLE
fix: handle non-JSON error responses in diagram generation

### DIFF
--- a/src/components/features/AITextareaSection.tsx
+++ b/src/components/features/AITextareaSection.tsx
@@ -182,8 +182,20 @@ export function AITextareaSection({
       });
 
       if (!response.ok) {
-        const error = await response.json();
-        throw new Error(error.message || "Failed to generate diagram");
+        let errorMessage = "Failed to generate diagram";
+        try {
+          const contentType = response.headers.get("content-type");
+          if (contentType && contentType.includes("application/json")) {
+            const error = await response.json();
+            errorMessage = error.message || errorMessage;
+          } else {
+            const text = await response.text();
+            errorMessage = text || `Server error: ${response.status} ${response.statusText}`;
+          }
+        } catch (parseError) {
+          errorMessage = `Server error: ${response.status} ${response.statusText}`;
+        }
+        throw new Error(errorMessage);
       }
 
       const data = await response.json();


### PR DESCRIPTION
fix: handle non-JSON error responses in diagram generation

- Add content-type validation before parsing response as JSON
- Catch parsing errors and display meaningful error messages
- Prevent "Unexpected end of JSON input" crash on 405/error responses
- Fallback to plain text parsing for non-JSON server responses