### PR TITLE
feat: improve testing page UI with cleaner tabs and full-screen brows…

### DIFF
--- a/src/app/w/[slug]/task/[...taskParams]/artifacts/browser.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/artifacts/browser.tsx
@@ -15,6 +15,7 @@ import {
   CheckCircle2,
   ArrowLeft,
   Loader2,
+  X,
 } from "lucide-react";
 import { Artifact, BrowserContent } from "@/lib/chat";
 import { useStaktrak } from "@/hooks/useStaktrak";
@@ -38,6 +39,7 @@ export function BrowserArtifactPanel({
   externalTestCode,
   externalTestTitle,
   isMobile = false,
+  onClose,
 }: {
   artifacts: Artifact[];
   ide?: boolean;
@@ -48,6 +50,7 @@ export function BrowserArtifactPanel({
   externalTestCode?: string | null;
   externalTestTitle?: string | null;
   isMobile?: boolean;
+  onClose?: () => void;
 }) {
   const [activeTab, setActiveTab] = useState(0);
   const [refreshKey, setRefreshKey] = useState(0);
@@ -423,6 +426,23 @@ export function BrowserArtifactPanel({
                         <TooltipContent side="bottom">Open in new tab</TooltipContent>
                       </Tooltip>
                     </TooltipProvider>
+                    {onClose && (
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={onClose}
+                              className="h-8 w-8 p-0"
+                            >
+                              <X className="w-4 h-4" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom">Close</TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    )}
                   </div>
                 </div>
               )}

--- a/src/app/w/[slug]/testing/page.tsx
+++ b/src/app/w/[slug]/testing/page.tsx
@@ -8,9 +8,11 @@ import UserJourneys from "@/components/UserJourneys";
 import { useFeatureFlag } from "@/hooks/useFeatureFlag";
 import { FEATURE_FLAGS } from "@/lib/feature-flags";
 import { redirect } from "next/navigation";
+import { useState } from "react";
 
 export default function DefenseTestingPage() {
   const canAccessDefense = useFeatureFlag(FEATURE_FLAGS.CODEBASE_RECOMMENDATION);
+  const [isBrowserMode, setIsBrowserMode] = useState(false);
 
   if (!canAccessDefense) {
     redirect("/");
@@ -18,22 +20,24 @@ export default function DefenseTestingPage() {
 
   return (
     <div className="space-y-6">
-      <PageHeader title="Testing" />
+      {!isBrowserMode && <PageHeader title="Testing" />}
 
-      <div className="max-w-5xl">
+      <div className={isBrowserMode ? "w-full" : "max-w-5xl"}>
         <Tabs defaultValue="coverage" className="w-full">
-          <TabsList className="grid w-full max-w-md grid-cols-2">
-            <TabsTrigger value="coverage">Coverage</TabsTrigger>
-            <TabsTrigger value="user-journeys">User Journeys</TabsTrigger>
-          </TabsList>
+          {!isBrowserMode && (
+            <TabsList>
+              <TabsTrigger value="coverage">Coverage</TabsTrigger>
+              <TabsTrigger value="user-journeys">User Journeys</TabsTrigger>
+            </TabsList>
+          )}
 
           <TabsContent value="coverage" className="space-y-6 mt-6">
             <TestCoverageCard />
             <CoverageInsights />
           </TabsContent>
 
-          <TabsContent value="user-journeys" className="mt-6">
-            <UserJourneys />
+          <TabsContent value="user-journeys" className={isBrowserMode ? "" : "mt-6"}>
+            <UserJourneys onBrowserModeChange={setIsBrowserMode} />
           </TabsContent>
         </Tabs>
       </div>

--- a/src/components/UserJourneys.tsx
+++ b/src/components/UserJourneys.tsx
@@ -51,7 +51,11 @@ interface UserJourneyRow {
   };
 }
 
-export default function UserJourneys() {
+interface UserJourneysProps {
+  onBrowserModeChange?: (isOpen: boolean) => void;
+}
+
+export default function UserJourneys({ onBrowserModeChange }: UserJourneysProps) {
   const { id, slug, workspace } = useWorkspace();
   const [isLoading, setIsLoading] = useState(false);
   const [frontend, setFrontend] = useState<string | null>(null);
@@ -105,6 +109,11 @@ export default function UserJourneys() {
       fetchUserJourneys();
     }
   }, [frontend, fetchUserJourneys]);
+
+  // Notify parent when browser mode changes
+  useEffect(() => {
+    onBrowserModeChange?.(!!frontend);
+  }, [frontend, onBrowserModeChange]);
 
   // Updated filter logic
   const filteredRows = userJourneys.filter((row) => {
@@ -483,22 +492,16 @@ export default function UserJourneys() {
       {viewMode === "video" ? (
         renderVideoView()
       ) : frontend ? (
-        <div className="space-y-4">
-          <div className="flex items-center justify-end">
-            <Button variant="ghost" size="sm" onClick={handleCloseBrowser} className="h-8 w-8 p-0">
-              ✕
-            </Button>
-          </div>
-          <div className="h-[600px] border rounded-lg overflow-hidden">
-            <BrowserArtifactPanel
-              artifacts={browserArtifacts}
-              ide={false}
-              workspaceId={id || workspace?.id}
-              onUserJourneySave={saveUserJourneyTest}
-              externalTestCode={replayTestCode}
-              externalTestTitle={replayTitle}
-            />
-          </div>
+        <div className="h-[calc(100vh-120px)] border rounded-lg overflow-hidden">
+          <BrowserArtifactPanel
+            artifacts={browserArtifacts}
+            ide={false}
+            workspaceId={id || workspace?.id}
+            onUserJourneySave={saveUserJourneyTest}
+            externalTestCode={replayTestCode}
+            externalTestTitle={replayTitle}
+            onClose={handleCloseBrowser}
+          />
         </div>
       ) : (
         <Card>


### PR DESCRIPTION
…er mode

- Update tab styling to match tasks page (inline-flex instead of grid)
- Add full-screen browser mode when creating user journey
- Hide page title and tabs during browser recording mode
- Move X button inline into browser header via new onClose prop
- Browser/IDE artifacts on task pages remain unchanged (no X button)