### PR TITLE
fix: conditionally render play button only when test file path exists

### DIFF
--- a/src/components/UserJourneys.tsx
+++ b/src/components/UserJourneys.tsx
@@ -549,22 +549,24 @@ export default function UserJourneys({ onBrowserModeChange }: UserJourneysProps)
                       <TableRow key={row.id}>
                         <TableCell className="font-medium">{row.title}</TableCell>
                         <TableCell>
-                          <Button
-                            size="sm"
-                            variant="ghost"
-                            onClick={() => handleReplay(row)}
-                            disabled={isReplayingTask === row.id}
-                            className="h-8 w-8 p-0"
-                            title={row.hasVideo ? "Play recording" : "Run test"}
-                          >
-                            {isReplayingTask === row.id ? (
-                              <Loader2 className="h-4 w-4 animate-spin" />
-                            ) : row.hasVideo ? (
-                              <PlayCircle className="h-4 w-4" />
-                            ) : (
-                              <Play className="h-4 w-4" />
-                            )}
-                          </Button>
+                          {row.testFilePath && (
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              onClick={() => handleReplay(row)}
+                              disabled={isReplayingTask === row.id}
+                              className="h-8 w-8 p-0"
+                              title={row.hasVideo ? "Play recording" : "Run test"}
+                            >
+                              {isReplayingTask === row.id ? (
+                                <Loader2 className="h-4 w-4 animate-spin" />
+                              ) : row.hasVideo ? (
+                                <PlayCircle className="h-4 w-4" />
+                              ) : (
+                                <Play className="h-4 w-4" />
+                              )}
+                            </Button>
+                          )}
                         </TableCell>
                         <TableCell>{renderBadge(row.badge)}</TableCell>
                         <TableCell>

--- a/src/utils/mockSeedData.ts
+++ b/src/utils/mockSeedData.ts
@@ -383,10 +383,10 @@ async function seedTasks(
     {
       title: "Signup Flow Test",
       description: "E2E test for new user registration flow",
-      status: TaskStatus.TODO,
-      workflowStatus: WorkflowStatus.PENDING,
+      status: TaskStatus.IN_PROGRESS,
+      workflowStatus: WorkflowStatus.IN_PROGRESS,
       sourceType: TaskSourceType.USER_JOURNEY,
-      testFilePath: "src/__tests__/e2e/specs/auth/signup.spec.ts",
+      // No testFilePath yet - test is still being generated
     },
 
     // BLOCKED/CANCELLED


### PR DESCRIPTION
fix: conditionally render play button only when test file path exists

- Hide play button in user journey replay column when testFilePath is null
- Prevents "Task has no test file path" error toast when clicking play on incomplete tests
- Show empty cell instead of dash when no test file available
- Update mock data to remove testFilePath from in-progress signup test