### PR TITLE
fix: eliminate flaky E2E tests by replacing timeouts with element waits

### DIFF
--- a/src/__tests__/e2e/support/fixtures/selectors.ts
+++ b/src/__tests__/e2e/support/fixtures/selectors.ts
@@ -22,6 +22,9 @@ export const selectors = {
     userJourneysLink: '[data-testid="nav-user-journeys"]',
     roadmapLink: '[data-testid="nav-plan"]',
     callsLink: '[data-testid="nav-calls"]',
+    buildButton: '[data-testid="nav-build"]',
+    protectButton: '[data-testid="nav-protect"]',
+    contextButton: '[data-testid="nav-context"]',
   },
 
   // Page titles

--- a/src/__tests__/e2e/support/page-objects/CallsPage.ts
+++ b/src/__tests__/e2e/support/page-objects/CallsPage.ts
@@ -49,7 +49,7 @@ export class CallsPage {
    */
   async navigateViaNavigation(): Promise<void> {
     // First, expand Context section if it's not already expanded
-    const contextButton = this.page.locator('[data-testid="nav-context"]');
+    const contextButton = this.page.locator(selectors.navigation.contextButton);
     const callsLink = this.page.locator(selectors.navigation.callsLink);
 
     // Check if calls link is visible, if not, click context to expand

--- a/src/__tests__/e2e/support/page-objects/DashboardPage.ts
+++ b/src/__tests__/e2e/support/page-objects/DashboardPage.ts
@@ -29,14 +29,14 @@ export class DashboardPage {
    */
   async goToTasks(): Promise<void> {
     // First expand the Build section if not already expanded
-    const buildButton = this.page.locator('[data-testid="nav-build"]');
+    const buildButton = this.page.locator(selectors.navigation.buildButton);
     const tasksLink = this.page.locator(selectors.navigation.tasksLink).first();
 
     // Check if tasks link is visible, if not, click Build to expand
-    const isTasksVisible = await tasksLink.isVisible();
+    const isTasksVisible = await tasksLink.isVisible().catch(() => false);
     if (!isTasksVisible) {
       await buildButton.click();
-      await this.page.waitForTimeout(300); // Wait for expand animation
+      await tasksLink.waitFor({ state: 'visible', timeout: 5000 });
     }
 
     await tasksLink.click();
@@ -48,14 +48,14 @@ export class DashboardPage {
    */
   async goToRoadmap(): Promise<void> {
     // First expand the Build section if not already expanded
-    const buildButton = this.page.locator('[data-testid="nav-build"]');
+    const buildButton = this.page.locator(selectors.navigation.buildButton);
     const planLink = this.page.locator(selectors.navigation.roadmapLink).first();
 
     // Check if plan link is visible, if not, click Build to expand
-    const isPlanVisible = await planLink.isVisible();
+    const isPlanVisible = await planLink.isVisible().catch(() => false);
     if (!isPlanVisible) {
       await buildButton.click();
-      await this.page.waitForTimeout(300); // Wait for expand animation
+      await planLink.waitFor({ state: 'visible', timeout: 5000 });
     }
 
     await planLink.click();
@@ -67,17 +67,14 @@ export class DashboardPage {
    */
   async goToRecommendations(): Promise<void> {
     // First expand the Protect section if not already expanded
-    const protectButton = this.page.locator('[data-testid="nav-protect"]');
+    const protectButton = this.page.locator(selectors.navigation.protectButton);
     const recommendationsLink = this.page.locator(selectors.navigation.recommendationsLink).first();
 
-    // Wait for protect button to be visible (ensures nav is loaded)
-    await protectButton.waitFor({ state: 'visible', timeout: 10000 });
-
     // Check if recommendations link is visible, if not, click Protect to expand
-    const isRecommendationsVisible = await recommendationsLink.isVisible();
+    const isRecommendationsVisible = await recommendationsLink.isVisible().catch(() => false);
     if (!isRecommendationsVisible) {
       await protectButton.click();
-      await this.page.waitForTimeout(300); // Wait for expand animation
+      await recommendationsLink.waitFor({ state: 'visible', timeout: 5000 });
     }
 
     await recommendationsLink.click();

--- a/src/__tests__/e2e/support/page-objects/WorkspaceSettingsPage.ts
+++ b/src/__tests__/e2e/support/page-objects/WorkspaceSettingsPage.ts
@@ -23,35 +23,17 @@ export class WorkspaceSettingsPage {
   }
 
   async waitForLoad(): Promise<void> {
-    // Debug: Wait a moment and then check what's on the page
-    await this.page.waitForTimeout(2000);
-    
+    // Wait for the settings form to be visible
+    const settingsForm = this.page.locator('form');
+    await settingsForm.waitFor({ state: 'visible', timeout: 10000 });
+
     // Check if we're on the sign-in page instead
     const signInButton = this.page.locator(selectors.auth.mockSignInButton);
-    const isSignInPage = await signInButton.isVisible();
-    
+    const isSignInPage = await signInButton.isVisible().catch(() => false);
+
     if (isSignInPage) {
-      console.log('WARNING: On sign-in page instead of workspace settings');
       throw new Error('Authentication failed - redirected to sign-in page');
     }
-    
-    // Check the actual page title that exists
-    const pageTitle = this.page.locator('[data-testid="page-title"]');
-    const pageTitleExists = await pageTitle.isVisible();
-    
-    if (pageTitleExists) {
-      const titleText = await pageTitle.textContent();
-      console.log(`Found page title: "${titleText}"`);
-    } else {
-      console.log('No page title found with data-testid="page-title"');
-    }
-    
-    // Try a more flexible approach - just check if we have the settings form
-    const settingsForm = this.page.locator('form');
-    await expect(settingsForm).toBeVisible({ timeout: 10000 });
-    
-    // If we find the form but not the title, we're probably on the right page
-    console.log('Settings form found - assuming we\'re on the correct page');
   }
 
   async fillWorkspaceName(name: string): Promise<void> {


### PR DESCRIPTION
- Add buildButton, protectButton, contextButton to centralized selectors
- Replace waitForTimeout(300) with waitFor({ state: 'visible' }) in DashboardPage
- Add .catch(() => false) for robust visibility checks
- Use centralized selectors instead of hardcoded data-testid strings
- Remove 2000ms debug timeout in WorkspaceSettingsPage.waitForLoad()

Core principle: Wait for DOM state changes, not arbitrary time delays.