### PR TITLE
fix: include mocked filter in useCoverageNodes params object

### DIFF
--- a/src/hooks/useCoverageNodes.ts
+++ b/src/hooks/useCoverageNodes.ts
@@ -223,7 +223,7 @@ export function useCoverageNodes() {
     loading: query.isLoading,
     filterLoading: query.isFetching && !query.isLoading,
     error: query.error ? (query.error as Error).message : null,
-    params: { nodeType, limit, offset, sort, sortDirection, coverage },
+    params: { nodeType, limit, offset, sort, sortDirection, coverage, mocked },
     page: query.data?.data?.page || 1,
     totalPages: query.data?.data?.total_pages,
     totalCount: query.data?.data?.total_count,


### PR DESCRIPTION
fix: include mocked filter in useCoverageNodes params object

The useCoverageNodes hook was missing the 'mocked' field in its returned
params object, causing inconsistency between the actual filter state and
what was exposed to components. This fix adds the mocked parameter to the
params object alongside the existing coverage filter, ensuring components
can reliably access the current mocked/unmocked filter state.