### PR TITLE
fix: pass branch_name parameter to updatePoolData method

### DIFF
--- a/src/app/api/workspaces/[slug]/stakgraph/route.ts
+++ b/src/app/api/workspaces/[slug]/stakgraph/route.ts
@@ -421,6 +421,10 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
           const files = getDevContainerFilesFromBase64(settings.containerFiles);
 
           const github_pat = await getGithubUsernameAndPAT(userId, slug);
+          
+          // Get the primary repository to access the branch
+          const primaryRepo = await getPrimaryRepository(workspace.id);
+          
           await poolManager.updatePoolData(
             swarm.id,
             decryptedPoolApiKey,
@@ -438,6 +442,7 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
             settings.poolMemory,
             github_pat?.token || "",
             github_pat?.username || "",
+            primaryRepo?.branch || "",
           );
         }
       } catch (err) {

--- a/src/services/pool-manager/PoolManagerService.ts
+++ b/src/services/pool-manager/PoolManagerService.ts
@@ -24,6 +24,7 @@ interface IPoolManagerService {
     poolMemory: string,
     github_pat: string,
     github_username: string,
+    branch_name: string,
   ) => Promise<void>;
   getPoolStatus: (poolId: string, poolApiKey: string) => Promise<PoolStatusResponse>;
   getPoolWorkspaces: (poolId: string, poolApiKey: string) => Promise<PoolWorkspacesResponse>;
@@ -67,6 +68,7 @@ export class PoolManagerService extends BaseServiceClass implements IPoolManager
     poolMemory: string | undefined,
     github_pat: string,
     github_username: string,
+    branch_name: string,
   ): Promise<void> {
     return updatePoolDataApi(
       poolName,
@@ -78,6 +80,7 @@ export class PoolManagerService extends BaseServiceClass implements IPoolManager
       poolMemory,
       github_pat,
       github_username,
+      branch_name,
     );
   }
 

--- a/src/services/pool-manager/api/envVars.ts
+++ b/src/services/pool-manager/api/envVars.ts
@@ -41,6 +41,7 @@ export async function updatePoolDataApi(
   poolMemory: string | undefined,
   github_pat: string,
   github_username: string,
+  branch_name: string,
 ): Promise<void> {
   const url = `${config.POOL_MANAGER_BASE_URL}/pools/${encodeURIComponent(poolName)}`;
   const currentMap = new Map(currentEnvVars.map((env) => [env.name, env.value]));
@@ -64,6 +65,7 @@ export async function updatePoolDataApi(
     pm2_config_js: Buffer.from(containerFiles["pm2_config_js"].content).toString("base64"),
     github_pat: github_pat,
     github_username: github_username,
+    branch_name: branch_name,
   });
 
   const response = await fetch(url, {


### PR DESCRIPTION
fix: pass branch_name parameter to updatePoolData method

- Add branch_name parameter to updatePoolDataApi function in envVars.ts
- Add branch_name parameter to PoolManagerService.updatePoolData method
- Pass primaryRepo?.branch || "" to poolManager.updatePoolData call in route.ts
- Makes updatePoolData consistent with createPool method