### PR TITLE
Update toast message for pool settings save

### DIFF
--- a/src/app/api/workspaces/[slug]/stakgraph/route.ts
+++ b/src/app/api/workspaces/[slug]/stakgraph/route.ts
@@ -169,7 +169,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 
     return NextResponse.json({
       success: true,
-      message: "Stakgraph settings retrieved successfully",
+      message: "Pool settings retrieved successfully",
       data: {
         name: swarm.name || "",
         description: "",

--- a/src/stores/useStakgraphStore.ts
+++ b/src/stores/useStakgraphStore.ts
@@ -291,7 +291,7 @@ export const useStakgraphStore = create<StakgraphStore>()(
         if (response.ok && result.success) {
           set({ saved: true });
           toast.success("Configuration saved", {
-            description: "Your Stakgraph settings have been saved successfully!",
+            description: "Your pool settings have been saved successfully!",
           });
 
           // Update form data with response data


### PR DESCRIPTION
Update toast message for pool settings save

Changed the toast message from "Stakgraph settings saved successfully" to "Pool settings saved successfully" to make it more user-friendly and use consistent terminology.