### PR TITLE
signin callback

### DIFF
--- a/src/__tests__/unit/lib/auth/signIn.test.ts
+++ b/src/__tests__/unit/lib/auth/signIn.test.ts
@@ -93,7 +93,7 @@ describe('signIn callback', () => {
       (db.workspace.findFirst as any).mockResolvedValue({ slug: 'test-workspace' });
 
       // Act
-      const result = await signInCallback({
+      const result = await authOptions.callbacks?.signIn!({
         user: mockUser,
         account: mockAccount,
       });


### PR DESCRIPTION
```ts
describe('signIn callback', () => {
  let signInCallback: any;
  let mockEncryptionService: any;

  beforeEach(() => {
    vi.clearAllMocks();
    
    // Get the signIn callback from authOptions
    signInCallback = authOptions.callbacks?.signIn;
```

@tomsmith8 The issue with the `signIn` was that `signInCallback = authOptions.callbacks?.signIn;`... so anytime signIn was called, it was using `signInCallback`... making it hard for stakgraph to see the link. Can we force the prompt to call the function directly at least once? Didn't we do a similar thing for another issue ?