### PR TITLE
feat: add ignore filter and column to coverage inventory table

### DIFF
--- a/src/app/api/tests/nodes/route.ts
+++ b/src/app/api/tests/nodes/route.ts
@@ -124,6 +124,7 @@ function normalizeResponse(
   const mapToConcise = (n: unknown): CoverageNodeConcise => {
     const o = n as Record<string, unknown> | null;
     const props = (o?.properties as Record<string, unknown> | undefined) || undefined;
+    const meta = (o?.meta as Record<string, unknown> | undefined) || undefined;
     const name = (o?.name as string) || (props?.name as string) || "";
     const file = (o?.file as string) || (props?.file as string) || "";
     const ref_id = (o?.ref_id as string) || "";
@@ -133,7 +134,11 @@ function normalizeResponse(
     const body_length = typeof o?.body_length === "number" ? (o?.body_length as number) : null;
     const line_count = typeof o?.line_count === "number" ? (o?.line_count as number) : null;
     const verb = (o?.verb as string | undefined) || undefined;
-    return { name, file, ref_id, weight, test_count: testCount, covered, body_length, line_count, verb };
+    // is_muted can be in meta as string "true"/"false", or elsewhere as boolean
+    const is_muted = meta?.is_muted === "true" || meta?.is_muted === true ||
+                     o?.is_muted === "true" || o?.is_muted === true ||
+                     props?.is_muted === "true" || props?.is_muted === true;
+    return { name, file, ref_id, weight, test_count: testCount, covered, body_length, line_count, verb, is_muted };
   };
 
     if (isItemsOrNodes(payload)) {

--- a/src/stores/useCoverageStore.ts
+++ b/src/stores/useCoverageStore.ts
@@ -5,6 +5,8 @@ import type { UncoveredNodeType } from "@/types/stakgraph";
 export type CoverageSortOption = "test_count" | "name" | "body_length" | "line_count";
 export type SortDirection = "asc" | "desc";
 
+export type IgnoredFilter = "all" | "ignored" | "not_ignored";
+
 type CoverageStore = {
   nodeType: UncoveredNodeType;
   sort: CoverageSortOption;
@@ -13,6 +15,7 @@ type CoverageStore = {
   offset: number;
   coverage: "all" | "tested" | "untested";
   mocked: "all" | "mocked" | "unmocked";
+  ignored: IgnoredFilter;
   ignoreDirs: string;
   repo: string;
   unitGlob: string;
@@ -27,6 +30,7 @@ type CoverageStore = {
   setOffset: (n: number) => void;
   setCoverage: (c: "all" | "tested" | "untested") => void;
   setMocked: (m: "all" | "mocked" | "unmocked") => void;
+  setIgnored: (i: IgnoredFilter) => void;
   setIgnoreDirs: (dirs: string) => void;
   setRepo: (repo: string) => void;
   setUnitGlob: (glob: string) => void;
@@ -45,6 +49,7 @@ export const useCoverageStore = create<CoverageStore>()(
     offset: 0,
     coverage: "all",
     mocked: "all",
+    ignored: "all",
     ignoreDirs: "",
     repo: "",
     unitGlob: "",
@@ -66,6 +71,7 @@ export const useCoverageStore = create<CoverageStore>()(
     setOffset: (n) => set({ offset: Math.max(0, n) }),
     setCoverage: (c) => set({ coverage: c, offset: 0 }),
     setMocked: (m) => set({ mocked: m, offset: 0 }),
+    setIgnored: (i) => set({ ignored: i, offset: 0 }),
     setIgnoreDirs: (dirs) => set({ ignoreDirs: dirs, offset: 0 }),
     setRepo: (repo) => set({ repo, offset: 0 }),
     setUnitGlob: (glob) => set({ unitGlob: glob, offset: 0 }),

--- a/src/types/stakgraph.ts
+++ b/src/types/stakgraph.ts
@@ -69,6 +69,7 @@ export interface CoverageNodeConcise {
   line_count: number | null;
   verb?: string;
   meta?: Record<string, unknown>;
+  is_muted?: boolean;
 }
 
 export interface CoverageNodesResponse {


### PR DESCRIPTION
- Add is_muted field to CoverageNodeConcise type
- Extract is_muted from meta object in API response (handles string/bool)
- Add ignored filter to store with All/Yes/No options
- Add client-side filtering in useCoverageNodes hook
- Add Ignored column with Yes/No badges
- Add ignore/unignore toggle button using PUT /nodes endpoint