### PR TITLE
fix: replace fragile text selectors with test IDs to prevent intermitten

### DIFF
--- a/src/__tests__/e2e/support/fixtures/selectors.ts
+++ b/src/__tests__/e2e/support/fixtures/selectors.ts
@@ -117,6 +117,8 @@ export const selectors = {
     launchPodsButton: 'button:has-text("Launch Pods")',
     taskListContainer: '[data-testid="task-card"]',
     recentTasksHeading: 'text=/Recent Tasks|Tasks/i',
+    loadingState: '[data-testid="tasks-loading-state"]',
+    loadedState: '[data-testid="tasks-list-loaded"]',
   },
 
   // Dashboard

--- a/src/__tests__/e2e/support/page-objects/TasksPage.ts
+++ b/src/__tests__/e2e/support/page-objects/TasksPage.ts
@@ -21,12 +21,20 @@ export class TasksPage {
   async waitForLoad(): Promise<void> {
     await expect(this.page.locator(selectors.pageTitle.tasks)).toBeVisible({ timeout: 10000 });
 
-    // Wait for loading state to disappear (if it exists)
-    const loadingText = this.page.getByText('Loading tasks...');
-    const isLoading = await loadingText.isVisible().catch(() => false);
-    if (isLoading) {
-      await loadingText.waitFor({ state: 'hidden', timeout: 10000 });
-    }
+    // Wait for either loaded state or empty state to appear (not loading state)
+    await this.page.locator(selectors.tasks.loadedState).waitFor({ 
+      state: 'visible', 
+      timeout: 30000 
+    }).catch(async () => {
+      // If loadedState doesn't appear, it might be an empty state - that's OK
+      // Just make sure loading state is gone
+      await this.page.locator(selectors.tasks.loadingState).waitFor({ 
+        state: 'hidden', 
+        timeout: 5000 
+      }).catch(() => {
+        // If loading state was never visible, that's fine too
+      });
+    });
   }
 
   /**

--- a/src/components/tasks/LoadingState.tsx
+++ b/src/components/tasks/LoadingState.tsx
@@ -8,7 +8,7 @@ import {
 
 export function LoadingState() {
   return (
-    <Card>
+    <Card data-testid="tasks-loading-state">
       <CardHeader>
         <CardTitle>Loading tasks...</CardTitle>
       </CardHeader>

--- a/src/components/tasks/TasksList.tsx
+++ b/src/components/tasks/TasksList.tsx
@@ -109,7 +109,7 @@ export function TasksList({ workspaceId, workspaceSlug }: TasksListProps) {
   }
 
   return (
-    <Card>
+    <Card data-testid="tasks-list-loaded">
       <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
         <CardHeader>
           <TabsList>


### PR DESCRIPTION
fix: replace fragile text selectors with test IDs to prevent intermittent test timeouts

- Add data-testid attributes to LoadingState and TasksList components
- Update selectors.ts with new test ID constants for loading and loaded states
- Refactor TasksPage.waitForLoad() to wait for loaded state instead of text disappearance
- Increase timeout from 10s to 30s and add graceful fallback for empty state
- Replace getByText('Loading tasks...') with robust test ID-based selectors

This fixes intermittent test failures in task-creation-flow.spec.ts where tests
would timeout waiting for loading text to disappear during slow database queries.