### PR TITLE
Fix is_muted filter to use backend filtering

### DIFF
--- a/src/app/api/tests/nodes/route.ts
+++ b/src/app/api/tests/nodes/route.ts
@@ -20,6 +20,7 @@ type ParsedParams = {
   offset: number;
   sort: string;
   coverage: "all" | "tested" | "untested";
+  ignored: "all" | "ignored" | "not_ignored";
   bodyLength: boolean;
   lineCount: boolean;
   search: string;
@@ -41,10 +42,12 @@ function parseAndValidateParams(searchParams: URLSearchParams): ParsedParams | {
   const sort = (searchParams.get("sort") || "test_count").toLowerCase();
   let coverage = (searchParams.get("coverage") || "all").toLowerCase();
   if (!["all", "tested", "untested"].includes(coverage)) coverage = "all";
+  let ignored = (searchParams.get("ignored") || "all").toLowerCase();
+  if (!["all", "ignored", "not_ignored"].includes(ignored)) ignored = "all";
   const bodyLength = searchParams.get("body_length") === "true";
   const lineCount = searchParams.get("line_count") === "true";
   const search = searchParams.get("search") || "";
-  return { nodeType, limit, offset, sort, coverage: coverage as "all" | "tested" | "untested", bodyLength, lineCount, search };
+  return { nodeType, limit, offset, sort, coverage: coverage as "all" | "tested" | "untested", ignored: ignored as "all" | "ignored" | "not_ignored", bodyLength, lineCount, search };
 }
 
 function buildQueryString(params: ParsedParams): string {
@@ -60,6 +63,8 @@ function buildQueryString(params: ParsedParams): string {
     q.set("sort", String(params.sort));
   }
   if (params.coverage && params.coverage !== "all") q.set("coverage", params.coverage);
+  if (params.ignored === "ignored") q.set("is_muted", "true");
+  if (params.ignored === "not_ignored") q.set("is_muted", "false");
   if (params.search) q.set("search", params.search);
   q.set("concise", "true");
   return q.toString();

--- a/src/hooks/useCoverageNodes.ts
+++ b/src/hooks/useCoverageNodes.ts
@@ -122,6 +122,7 @@ export function useCoverageNodes() {
       if (hasInitializedIntegrationGlob.current && integrationGlob) qp.set("integrationGlob", integrationGlob);
       if (hasInitializedE2eGlob.current && e2eGlob) qp.set("e2eGlob", e2eGlob);
       if (search) qp.set("search", search);
+      if (ignored && ignored !== "all") qp.set("ignored", ignored);
       const res = await fetch(`/api/tests/nodes?${qp.toString()}`);
       const json: CoverageNodesResponse = await res.json();
       if (!res.ok || !json.success) {
@@ -208,6 +209,7 @@ export function useCoverageNodes() {
         if (hasInitializedIntegrationGlob.current && integrationGlob) qp.set("integrationGlob", integrationGlob);
         if (hasInitializedE2eGlob.current && e2eGlob) qp.set("e2eGlob", e2eGlob);
         if (search) qp.set("search", search);
+        if (ignored && ignored !== "all") qp.set("ignored", ignored);
         const res = await fetch(`/api/tests/nodes?${qp.toString()}`);
         const json: CoverageNodesResponse = await res.json();
         if (!res.ok || !json.success) {
@@ -218,16 +220,10 @@ export function useCoverageNodes() {
     });
   };
 
-  const rawItems = query.data?.data?.items || [];
-  const filteredItems = rawItems.filter((item) => {
-    if (ignored === "all") return true;
-    if (ignored === "ignored") return item.is_muted === true;
-    if (ignored === "not_ignored") return !item.is_muted;
-    return true;
-  });
+  const items = query.data?.data?.items || [];
 
   return {
-    items: filteredItems,
+    items,
     loading: query.isLoading,
     filterLoading: query.isFetching && !query.isLoading,
     error: query.error ? (query.error as Error).message : null,


### PR DESCRIPTION
- Pass ignored param from UI to API endpoint
- Extract and validate ignored param in route handler
- Map ignored filter to is_muted query param for stakgraph
- Remove redundant client-side filtering