### PR TITLE
Fix priority badge size inconsistency in feature views

### DIFF
--- a/src/app/w/[slug]/plan/[featureId]/page.tsx
+++ b/src/app/w/[slug]/plan/[featureId]/page.tsx
@@ -9,7 +9,7 @@ import { EditableTitle } from "@/components/ui/editable-title";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { StatusPopover } from "@/components/ui/status-popover";
-import { PrioritySelector } from "@/components/ui/priority-selector";
+import { FeaturePriorityPopover } from "@/components/ui/feature-priority-popover";
 import { ActionMenu } from "@/components/ui/action-menu";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { AssigneeCombobox } from "@/components/features/AssigneeCombobox";
@@ -398,7 +398,7 @@ export default function FeatureDetailPage() {
             {/* Status, Priority, Assignee & Actions */}
             <div className="flex flex-wrap items-center gap-4">
               <StatusPopover statusType="feature" currentStatus={feature.status} onUpdate={handleUpdateStatus} />
-              <PrioritySelector value={feature.priority} onChange={handleUpdatePriority} />
+              <FeaturePriorityPopover currentPriority={feature.priority} onUpdate={handleUpdatePriority} showLowPriority={true} />
               <AssigneeCombobox
                 workspaceSlug={workspaceSlug}
                 currentAssignee={feature.assignee}

--- a/src/components/features/FeaturesList.tsx
+++ b/src/components/features/FeaturesList.tsx
@@ -15,7 +15,6 @@ import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import type { FeatureWithDetails, FeatureListResponse, FeatureStatus, FeaturePriority } from "@/types/roadmap";
 import { FEATURE_KANBAN_COLUMNS } from "@/types/roadmap";
 import { StatusPopover } from "@/components/ui/status-popover";
-import { PrioritySelector } from "@/components/ui/priority-selector";
 import { FeaturePriorityPopover } from "@/components/ui/feature-priority-popover";
 import { AssigneeCombobox } from "./AssigneeCombobox";
 import { FeatureCard } from "./FeatureCard";
@@ -791,9 +790,10 @@ const FeaturesListComponent = forwardRef<{ triggerCreate: () => void }, Features
                     currentStatus={newFeatureStatus}
                     onUpdate={async (status) => setNewFeatureStatus(status)}
                   />
-                  <PrioritySelector
-                    value={newFeaturePriority}
-                    onChange={(priority) => setNewFeaturePriority(priority)}
+                  <FeaturePriorityPopover
+                    currentPriority={newFeaturePriority}
+                    onUpdate={async (priority) => setNewFeaturePriority(priority)}
+                    showLowPriority={true}
                   />
                   <AssigneeCombobox
                     workspaceSlug={workspaceSlug}


### PR DESCRIPTION
Replace PrioritySelector (180px fixed width) with FeaturePriorityPopover (compact badge) to match StatusPopover styling in feature detail page and create feature form.