### PR TITLE
Add GENERAL_REFACTORING janitor type

### DIFF
--- a/prisma/migrations/20251218144312_add_general_refactoring_janitor/migration.sql
+++ b/prisma/migrations/20251218144312_add_general_refactoring_janitor/migration.sql
@@ -1,0 +1,5 @@
+-- AlterEnum
+ALTER TYPE "JanitorType" ADD VALUE 'GENERAL_REFACTORING';
+
+-- AlterTable
+ALTER TABLE "janitor_configs" ADD COLUMN     "general_refactoring_enabled" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -541,11 +541,12 @@ model JanitorConfig {
   workspaceId String @unique @map("workspace_id")
 
   // Individual janitor toggles
-  unitTestsEnabled        Boolean @default(false) @map("unit_tests_enabled")
-  integrationTestsEnabled Boolean @default(false) @map("integration_tests_enabled")
-  e2eTestsEnabled         Boolean @default(false) @map("e2e_tests_enabled")
-  securityReviewEnabled   Boolean @default(false) @map("security_review_enabled")
-  mockGenerationEnabled   Boolean @default(false) @map("mock_generation_enabled")
+  unitTestsEnabled           Boolean @default(false) @map("unit_tests_enabled")
+  integrationTestsEnabled    Boolean @default(false) @map("integration_tests_enabled")
+  e2eTestsEnabled            Boolean @default(false) @map("e2e_tests_enabled")
+  securityReviewEnabled      Boolean @default(false) @map("security_review_enabled")
+  mockGenerationEnabled      Boolean @default(false) @map("mock_generation_enabled")
+  generalRefactoringEnabled  Boolean @default(false) @map("general_refactoring_enabled")
 
   // Task Coordinator automation
   taskCoordinatorEnabled     Boolean @default(false) @map("task_coordinator_enabled")
@@ -717,6 +718,7 @@ enum JanitorType {
   E2E_TESTS
   SECURITY_REVIEW
   MOCK_GENERATION
+  GENERAL_REFACTORING
 }
 
 enum JanitorStatus {

--- a/src/__tests__/unit/lib/constants/janitor.test.ts
+++ b/src/__tests__/unit/lib/constants/janitor.test.ts
@@ -127,6 +127,8 @@ describe("constants/janitor", () => {
         integrationTestsEnabled: false,
         e2eTestsEnabled: false,
         securityReviewEnabled: false,
+        mockGenerationEnabled: false,
+        generalRefactoringEnabled: false,
       };
 
       expect(isJanitorEnabled(config, JanitorType.UNIT_TESTS)).toBe(true);
@@ -138,6 +140,8 @@ describe("constants/janitor", () => {
         integrationTestsEnabled: true,
         e2eTestsEnabled: false,
         securityReviewEnabled: false,
+        mockGenerationEnabled: false,
+        generalRefactoringEnabled: false,
       };
 
       expect(isJanitorEnabled(config, JanitorType.UNIT_TESTS)).toBe(false);
@@ -149,6 +153,8 @@ describe("constants/janitor", () => {
         integrationTestsEnabled: true,
         e2eTestsEnabled: false,
         securityReviewEnabled: false,
+        mockGenerationEnabled: false,
+        generalRefactoringEnabled: false,
       };
 
       expect(isJanitorEnabled(config, JanitorType.UNIT_TESTS)).toBe(true);
@@ -165,6 +171,8 @@ describe("constants/janitor", () => {
         integrationTestsEnabled: false,
         e2eTestsEnabled: true,
         securityReviewEnabled: false,
+        mockGenerationEnabled: false,
+        generalRefactoringEnabled: false,
       };
 
       const enabled = getEnabledJanitorTypes(config);
@@ -181,6 +189,8 @@ describe("constants/janitor", () => {
         integrationTestsEnabled: false,
         e2eTestsEnabled: false,
         securityReviewEnabled: false,
+        mockGenerationEnabled: false,
+        generalRefactoringEnabled: false,
       };
 
       const enabled = getEnabledJanitorTypes(config);
@@ -193,14 +203,18 @@ describe("constants/janitor", () => {
         integrationTestsEnabled: true,
         e2eTestsEnabled: true,
         securityReviewEnabled: true,
+        mockGenerationEnabled: true,
+        generalRefactoringEnabled: true,
       };
 
       const enabled = getEnabledJanitorTypes(config);
-      expect(enabled).toHaveLength(4);
+      expect(enabled).toHaveLength(6);
       expect(enabled).toContain(JanitorType.UNIT_TESTS);
       expect(enabled).toContain(JanitorType.INTEGRATION_TESTS);
       expect(enabled).toContain(JanitorType.E2E_TESTS);
       expect(enabled).toContain(JanitorType.SECURITY_REVIEW);
+      expect(enabled).toContain(JanitorType.MOCK_GENERATION);
+      expect(enabled).toContain(JanitorType.GENERAL_REFACTORING);
     });
   });
 
@@ -233,12 +247,13 @@ describe("constants/janitor", () => {
     it("should return items for all janitor types except E2E_TESTS", () => {
       const items = getAllJanitorItems();
 
-      expect(items).toHaveLength(4);
+      expect(items).toHaveLength(5);
       expect(items.some((item) => item.id === JanitorType.UNIT_TESTS)).toBe(true);
       expect(items.some((item) => item.id === JanitorType.INTEGRATION_TESTS)).toBe(true);
       expect(items.some((item) => item.id === JanitorType.E2E_TESTS)).toBe(false);
       expect(items.some((item) => item.id === JanitorType.SECURITY_REVIEW)).toBe(true);
       expect(items.some((item) => item.id === JanitorType.MOCK_GENERATION)).toBe(true);
+      expect(items.some((item) => item.id === JanitorType.GENERAL_REFACTORING)).toBe(true);
     });
 
     it("should return items with all required properties", () => {
@@ -258,12 +273,13 @@ describe("constants/janitor", () => {
     it("should create OR conditions for all janitor types", () => {
       const conditions = createEnabledJanitorWhereConditions();
 
-      expect(conditions).toHaveLength(5);
+      expect(conditions).toHaveLength(6);
       expect(conditions).toContainEqual({ unitTestsEnabled: true });
       expect(conditions).toContainEqual({ integrationTestsEnabled: true });
       expect(conditions).toContainEqual({ e2eTestsEnabled: true });
       expect(conditions).toContainEqual({ securityReviewEnabled: true });
       expect(conditions).toContainEqual({ mockGenerationEnabled: true });
+      expect(conditions).toContainEqual({ generalRefactoringEnabled: true });
     });
   });
 

--- a/src/app/w/[slug]/janitors/page.tsx
+++ b/src/app/w/[slug]/janitors/page.tsx
@@ -14,7 +14,7 @@ import { useEffect } from "react";
 // Get all janitor items and separate them by category
 const allJanitors = getAllJanitorItems();
 const testingJanitors: JanitorItem[] = [
-  ...allJanitors.filter((j) => j.id !== "SECURITY_REVIEW"),
+  ...allJanitors.filter((j) => j.id !== "SECURITY_REVIEW" && j.id !== "GENERAL_REFACTORING"),
   {
     id: "pr-reviews",
     name: "PR Reviews",
@@ -24,12 +24,13 @@ const testingJanitors: JanitorItem[] = [
   },
 ];
 const securityReviewJanitor = allJanitors.find((j) => j.id === "SECURITY_REVIEW");
+const refactoringJanitor = allJanitors.find((j) => j.id === "GENERAL_REFACTORING");
 
-// Maintainability janitors - coming soon
+// Maintainability janitors - refactoring is active, others coming soon
 const maintainabilityJanitors: JanitorItem[] = [
-  { id: "refactoring", name: "Refactoring", icon: Wrench, description: "Identify refactoring opportunities." },
-  { id: "semantic", name: "Semantic Renaming", icon: Type, description: "Suggest better variable names." },
-  { id: "documentation", name: "Documentation", icon: BookOpen, description: "Generate missing documentation." },
+  ...(refactoringJanitor ? [refactoringJanitor] : []),
+  { id: "semantic", name: "Semantic Renaming", icon: Type, description: "Suggest better variable names.", comingSoon: true },
+  { id: "documentation", name: "Documentation", icon: BookOpen, description: "Generate missing documentation.", comingSoon: true },
 ];
 
 // Security janitors
@@ -110,7 +111,6 @@ export default function DefenseJanitorsPage() {
           description="Code quality and maintainability improvements"
           icon={<Wrench className="h-5 w-5 text-orange-500" />}
           janitors={maintainabilityJanitors}
-          comingSoon={true}
         />
 
         <JanitorSection

--- a/src/lib/constants/janitor.ts
+++ b/src/lib/constants/janitor.ts
@@ -1,5 +1,5 @@
 import { JanitorType, Priority } from "@prisma/client";
-import { FlaskConical, Zap, Monitor, Shield, Boxes, LucideIcon } from "lucide-react";
+import { FlaskConical, Zap, Monitor, Shield, Boxes, Wrench, LucideIcon } from "lucide-react";
 
 /**
  * Janitor system error messages
@@ -27,6 +27,7 @@ export interface JanitorConfigFields {
   e2eTestsEnabled: boolean;
   securityReviewEnabled: boolean;
   mockGenerationEnabled: boolean;
+  generalRefactoringEnabled: boolean;
 }
 
 /**
@@ -67,6 +68,12 @@ export const JANITOR_CONFIG: Record<JanitorType, {
     description: "Generate mock data and fixtures for testing.",
     icon: Boxes,
     enabledField: "mockGenerationEnabled",
+  },
+  GENERAL_REFACTORING: {
+    name: "Refactoring",
+    description: "Identify refactoring opportunities.",
+    icon: Wrench,
+    enabledField: "generalRefactoringEnabled",
   },
 } as const;
 

--- a/src/services/janitor-cron.ts
+++ b/src/services/janitor-cron.ts
@@ -34,6 +34,7 @@ export async function getWorkspacesWithEnabledJanitors(): Promise<Array<{
     e2eTestsEnabled: boolean;
     securityReviewEnabled: boolean;
     mockGenerationEnabled: boolean;
+    generalRefactoringEnabled: boolean;
   } | null;
 }>> {
   return await db.workspace.findMany({
@@ -56,6 +57,7 @@ export async function getWorkspacesWithEnabledJanitors(): Promise<Array<{
           e2eTestsEnabled: true,
           securityReviewEnabled: true,
           mockGenerationEnabled: true,
+          generalRefactoringEnabled: true,
         }
       }
     }
@@ -69,6 +71,7 @@ const SEQUENTIAL_JANITOR_TYPES: JanitorType[] = [
   JanitorType.E2E_TESTS,
   JanitorType.SECURITY_REVIEW,
   JanitorType.MOCK_GENERATION,
+  JanitorType.GENERAL_REFACTORING,
 ];
 
 /**

--- a/src/services/janitor.ts
+++ b/src/services/janitor.ts
@@ -807,9 +807,9 @@ export async function processJanitorWebhook(webhookData: StakworkWebhookPayload)
     }
 
     // Auto-create task from first recommendation if flag is set
-    // Only for sequential janitor types (UNIT_TESTS, INTEGRATION_TESTS, MOCK_GENERATION)
+    // Only for sequential janitor types (UNIT_TESTS, INTEGRATION_TESTS, MOCK_GENERATION, GENERAL_REFACTORING)
     let autoCreatedTaskId: string | undefined;
-    const sequentialJanitorTypes: JanitorType[] = ["UNIT_TESTS", "INTEGRATION_TESTS", "MOCK_GENERATION"];
+    const sequentialJanitorTypes: JanitorType[] = ["UNIT_TESTS", "INTEGRATION_TESTS", "MOCK_GENERATION", "GENERAL_REFACTORING"];
 
     if (
       autoCreateTasks &&

--- a/src/types/janitor.ts
+++ b/src/types/janitor.ts
@@ -13,6 +13,7 @@ export interface JanitorConfigUpdate {
   e2eTestsEnabled?: boolean;
   securityReviewEnabled?: boolean;
   mockGenerationEnabled?: boolean;
+  generalRefactoringEnabled?: boolean;
   taskCoordinatorEnabled?: boolean;
   recommendationSweepEnabled?: boolean;
   ticketSweepEnabled?: boolean;


### PR DESCRIPTION
- Add GENERAL_REFACTORING to JanitorType enum in schema
- Add generalRefactoringEnabled field to JanitorConfig model
- Add janitor config entry with Wrench icon and description
- Add to SEQUENTIAL_JANITOR_TYPES for one-task-at-a-time behavior
- Add to auto-create tasks array for recommendation processing
- Update janitors page to show Refactoring in Maintainability section
- Update unit tests with new janitor type