### PR TITLE
feat: add partial update support to stakgraph API

### DIFF
--- a/src/__tests__/integration/api/workspaces-stakgraph.test.ts
+++ b/src/__tests__/integration/api/workspaces-stakgraph.test.ts
@@ -4,79 +4,561 @@ import {
   PUT as PUT_STAK,
 } from "@/app/api/workspaces/[slug]/stakgraph/route";
 import { db } from "@/lib/db";
-import { encryptEnvVars } from "@/lib/encryption";
+import { encryptEnvVars, EncryptionService } from "@/lib/encryption";
 import {
   createAuthenticatedSession,
   generateUniqueId,
   generateUniqueSlug,
   getMockedSession,
   createGetRequest,
+  createPutRequest,
+  expectSuccess,
 } from "@/__tests__/support/helpers";
+
+// Test fixtures for PM2 config and container files
+const DEFAULT_PM2_CONFIG = `module.exports = {
+  apps: [
+    {
+      name: "frontend",
+      script: "bin/rails",
+      args: "server -b 0.0.0.0 -p 3000",
+      cwd: "/workspaces/acme",
+      interpreter: "/usr/local/rvm/rubies/ruby-3.3.10/bin/ruby",
+      instances: 1,
+      autorestart: true,
+      watch: false,
+      max_memory_restart: "1G",
+      env: {
+        PORT: "3000",
+        INSTALL_COMMAND: "bundle install",
+        BUILD_COMMAND: "echo 'Build not needed'",
+        PRE_START_COMMAND: "echo 'Skipping db:prepare'"
+      }
+    },
+    {
+      name: "sidekiq",
+      script: "bin/worker",
+      cwd: "/workspaces/acme",
+      instances: 1,
+      autorestart: true,
+      watch: false,
+      max_memory_restart: "1G",
+      env: {
+        PORT: "0"
+      }
+    }
+  ],
+};`;
+
+const UPDATED_PM2_CONFIG = `module.exports = {
+  apps: [
+    {
+      name: "api",
+      script: "npm",
+      args: "start",
+      cwd: "/workspaces/acme",
+      instances: 1,
+      autorestart: true,
+      watch: false,
+      max_memory_restart: "1G",
+      env: {
+        PORT: "4000",
+        INSTALL_COMMAND: "npm install"
+      }
+    }
+  ],
+};`;
+
+const DEFAULT_SERVICES = [
+  {
+    name: "frontend",
+    port: 3000,
+    scripts: {
+      start: "bin/rails server -b 0.0.0.0 -p 3000",
+      install: "bundle install",
+      build: "echo 'Build not needed'",
+      preStart: "echo 'Skipping db:prepare'",
+    },
+    interpreter: "/usr/local/rvm/rubies/ruby-3.3.10/bin/ruby",
+    cwd: "",
+  },
+  {
+    name: "sidekiq",
+    port: 0,
+    scripts: {
+      start: "bin/worker",
+    },
+    cwd: "",
+  },
+];
+
+const DEFAULT_DOCKERFILE =
+  "FROM ghcr.io/stakwork/staklink-universal:latest\nRUN echo 'original'";
+const UPDATED_DOCKERFILE = "FROM node:20-alpine\nRUN echo 'updated'";
+const DEFAULT_DOCKER_COMPOSE =
+  "version: '3.8'\nservices:\n  app:\n    build: .";
+
+// Helper to base64 encode strings
+const toBase64 = (str: string) => Buffer.from(str).toString("base64");
+const fromBase64 = (str: string) => Buffer.from(str, "base64").toString("utf-8");
+
+const encryptionService = EncryptionService.getInstance();
 
 describe("/api/workspaces/[slug]/stakgraph", () => {
   const PLAINTEXT_ENV = [{ name: "SECRET", value: "my_value" }];
-  let testData: { user: any; workspace: any; swarm: any };
+  let testData: {
+    user: any;
+    workspace: any;
+    swarm: any;
+    repository: any;
+  };
 
   beforeEach(async () => {
     vi.clearAllMocks();
-    
-    // Don't manually clean - let the global cleanup handle it
-    // Use transaction to atomically create test data
+
+    // Use transaction to atomically create test data with services and containerFiles
     testData = await db.$transaction(async (tx) => {
       const user = await tx.user.create({
         data: {
           id: generateUniqueId("user"),
           email: `user-${generateUniqueId()}@example.com`,
-          name: "User 2",
+          name: "Test User",
         },
       });
 
       const workspace = await tx.workspace.create({
         data: {
-          name: "w2",
-          slug: generateUniqueSlug("w2"),
+          name: "Test Workspace",
+          slug: generateUniqueSlug("test-ws"),
           ownerId: user.id,
+        },
+      });
+
+      // Create repository for repoName extraction
+      const repository = await tx.repository.create({
+        data: {
+          workspaceId: workspace.id,
+          repositoryUrl: "https://github.com/testorg/acme",
+          branch: "main",
+          name: "acme",
         },
       });
 
       const swarm = await tx.swarm.create({
         data: {
           workspaceId: workspace.id,
-          name: generateUniqueId("s2"),
+          name: generateUniqueId("swarm"),
           status: "ACTIVE",
+          swarmUrl: "https://test.sphinx.chat",
+          poolCpu: "2",
+          poolMemory: "4Gi",
+          poolApiKey: JSON.stringify(encryptionService.encryptField("poolApiKey", "test-pool-key")),
           environmentVariables: encryptEnvVars(PLAINTEXT_ENV as any) as any,
-          services: [],
+          services: DEFAULT_SERVICES,
+          containerFiles: {
+            "pm2.config.js": toBase64(DEFAULT_PM2_CONFIG),
+            Dockerfile: toBase64(DEFAULT_DOCKERFILE),
+            "docker-compose.yml": toBase64(DEFAULT_DOCKER_COMPOSE),
+          },
           agentRequestId: null,
           agentStatus: null,
         },
       });
 
-      return { user, workspace, swarm };
+      return { user, workspace, swarm, repository };
     });
 
-    getMockedSession().mockResolvedValue(createAuthenticatedSession(testData.user));
+    getMockedSession().mockResolvedValue(
+      createAuthenticatedSession(testData.user)
+    );
   });
 
-  it("GET returns decrypted env vars but DB remains encrypted", async () => {
-    const req = createGetRequest(
-      `http://localhost:3000/api/workspaces/${testData.workspace.slug}/stakgraph`
-    );
-    const res = await GET_STAK(req, {
-      params: Promise.resolve({ slug: testData.workspace.slug }),
-    });
-    const response = await res.json();
-    console.log("Response status:", res.status);
-    console.log("Response body:", JSON.stringify(response, null, 2));
-    
-    expect(res.status).toBe(200);
-    const envVars = response.data.environmentVariables as Array<{
-      name: string;
-      value: string;
-    }>;
-    expect(envVars).toEqual(PLAINTEXT_ENV);
+  describe("GET /api/workspaces/[slug]/stakgraph", () => {
+    it("returns decrypted env vars but DB remains encrypted", async () => {
+      const req = createGetRequest(
+        `http://localhost:3000/api/workspaces/${testData.workspace.slug}/stakgraph`
+      );
+      const res = await GET_STAK(req, {
+        params: Promise.resolve({ slug: testData.workspace.slug }),
+      });
+      const response = await expectSuccess(res, 200);
 
-    const swarm = await db.swarm.findFirst({ where: { name: testData.swarm.name } });
-    const stored = swarm?.environmentVariables as unknown as string;
-    expect(JSON.stringify(stored)).not.toContain("my_value");
+      expect(response.data.environmentVariables).toEqual(PLAINTEXT_ENV);
+
+      // Verify DB remains encrypted
+      const swarm = await db.swarm.findFirst({
+        where: { name: testData.swarm.name },
+      });
+      const stored = swarm?.environmentVariables as unknown as string;
+      expect(JSON.stringify(stored)).not.toContain("my_value");
+    });
+  });
+
+  describe("PUT /api/workspaces/[slug]/stakgraph - Partial Updates", () => {
+    describe("containerFiles partial updates", () => {
+      it("updates only Dockerfile when only Dockerfile sent", async () => {
+        const newDockerfile = toBase64(UPDATED_DOCKERFILE);
+
+        const req = createPutRequest(
+          `http://localhost:3000/api/workspaces/${testData.workspace.slug}/stakgraph`,
+          { containerFiles: { Dockerfile: newDockerfile } }
+        );
+
+        const res = await PUT_STAK(req, {
+          params: Promise.resolve({ slug: testData.workspace.slug }),
+        });
+        const response = await expectSuccess(res, 200);
+        expect(response.success).toBe(true);
+
+        // Verify in database
+        const swarm = await db.swarm.findUnique({
+          where: { workspaceId: testData.workspace.id },
+        });
+        const containerFiles = swarm?.containerFiles as Record<string, string>;
+
+        // Dockerfile should be updated
+        expect(containerFiles["Dockerfile"]).toBe(newDockerfile);
+
+        // Other files should be unchanged
+        expect(containerFiles["pm2.config.js"]).toBe(toBase64(DEFAULT_PM2_CONFIG));
+        expect(containerFiles["docker-compose.yml"]).toBe(toBase64(DEFAULT_DOCKER_COMPOSE));
+
+        // Services should be unchanged
+        const services = swarm?.services as any[];
+        expect(services).toHaveLength(2);
+        expect(services.map((s) => s.name)).toEqual(["frontend", "sidekiq"]);
+      });
+
+      it("updates docker-compose.yml without affecting other files", async () => {
+        const newDockerCompose = toBase64(
+          "version: '3.8'\nservices:\n  app:\n    build: .\n    ports:\n      - '3000:3000'"
+        );
+
+        const req = createPutRequest(
+          `http://localhost:3000/api/workspaces/${testData.workspace.slug}/stakgraph`,
+          { containerFiles: { "docker-compose.yml": newDockerCompose } }
+        );
+
+        const res = await PUT_STAK(req, {
+          params: Promise.resolve({ slug: testData.workspace.slug }),
+        });
+        await expectSuccess(res, 200);
+
+        const swarm = await db.swarm.findUnique({
+          where: { workspaceId: testData.workspace.id },
+        });
+        const containerFiles = swarm?.containerFiles as Record<string, string>;
+
+        expect(containerFiles["docker-compose.yml"]).toBe(newDockerCompose);
+        expect(containerFiles["Dockerfile"]).toBe(toBase64(DEFAULT_DOCKERFILE));
+        expect(containerFiles["pm2.config.js"]).toBe(toBase64(DEFAULT_PM2_CONFIG));
+      });
+
+      it("updates multiple non-pm2 containerFiles at once", async () => {
+        const newDockerfile = toBase64(UPDATED_DOCKERFILE);
+        const newDockerCompose = toBase64("version: '3.9'\nservices:\n  updated: true");
+
+        const req = createPutRequest(
+          `http://localhost:3000/api/workspaces/${testData.workspace.slug}/stakgraph`,
+          {
+            containerFiles: {
+              Dockerfile: newDockerfile,
+              "docker-compose.yml": newDockerCompose,
+            },
+          }
+        );
+
+        const res = await PUT_STAK(req, {
+          params: Promise.resolve({ slug: testData.workspace.slug }),
+        });
+        await expectSuccess(res, 200);
+
+        const swarm = await db.swarm.findUnique({
+          where: { workspaceId: testData.workspace.id },
+        });
+        const containerFiles = swarm?.containerFiles as Record<string, string>;
+
+        expect(containerFiles["Dockerfile"]).toBe(newDockerfile);
+        expect(containerFiles["docker-compose.yml"]).toBe(newDockerCompose);
+        // pm2.config.js unchanged
+        expect(containerFiles["pm2.config.js"]).toBe(toBase64(DEFAULT_PM2_CONFIG));
+      });
+    });
+
+    describe("pm2.config.js ↔ services bidirectional sync", () => {
+      it("updates pm2.config.js and syncs to services column", async () => {
+        const newPm2Config = toBase64(UPDATED_PM2_CONFIG);
+
+        const req = createPutRequest(
+          `http://localhost:3000/api/workspaces/${testData.workspace.slug}/stakgraph`,
+          { containerFiles: { "pm2.config.js": newPm2Config } }
+        );
+
+        const res = await PUT_STAK(req, {
+          params: Promise.resolve({ slug: testData.workspace.slug }),
+        });
+        await expectSuccess(res, 200);
+
+        const swarm = await db.swarm.findUnique({
+          where: { workspaceId: testData.workspace.id },
+        });
+        const containerFiles = swarm?.containerFiles as Record<string, string>;
+        const services = swarm?.services as any[];
+
+        // pm2.config.js should be updated
+        expect(containerFiles["pm2.config.js"]).toBe(newPm2Config);
+
+        // Services should include the new "api" service from pm2 parsing
+        const apiService = services.find((s) => s.name === "api");
+        expect(apiService).toBeDefined();
+        expect(apiService.port).toBe(4000);
+
+        // Existing services should be preserved (merge behavior)
+        expect(services.find((s) => s.name === "frontend")).toBeDefined();
+        expect(services.find((s) => s.name === "sidekiq")).toBeDefined();
+      });
+
+      it("updates services and regenerates pm2.config.js", async () => {
+        const newServices = [
+          {
+            name: "backend",
+            port: 5000,
+            scripts: { start: "npm run server", install: "npm ci" },
+          },
+        ];
+
+        const req = createPutRequest(
+          `http://localhost:3000/api/workspaces/${testData.workspace.slug}/stakgraph`,
+          { services: newServices }
+        );
+
+        const res = await PUT_STAK(req, {
+          params: Promise.resolve({ slug: testData.workspace.slug }),
+        });
+        await expectSuccess(res, 200);
+
+        const swarm = await db.swarm.findUnique({
+          where: { workspaceId: testData.workspace.id },
+        });
+        const containerFiles = swarm?.containerFiles as Record<string, string>;
+        const services = swarm?.services as any[];
+
+        // New service should be added
+        const backendService = services.find((s) => s.name === "backend");
+        expect(backendService).toBeDefined();
+        expect(backendService.port).toBe(5000);
+
+        // pm2.config.js should be regenerated with new service
+        const pm2Content = fromBase64(containerFiles["pm2.config.js"]);
+        expect(pm2Content).toContain("backend");
+        expect(pm2Content).toContain("5000");
+      });
+
+      it("services takes precedence when both services and pm2.config.js sent", async () => {
+        const newServices = [
+          { name: "winner-service", port: 9999, scripts: { start: "npm run winner" } },
+        ];
+        const newPm2Config = toBase64(UPDATED_PM2_CONFIG); // Has "api" service
+
+        const req = createPutRequest(
+          `http://localhost:3000/api/workspaces/${testData.workspace.slug}/stakgraph`,
+          {
+            services: newServices,
+            containerFiles: { "pm2.config.js": newPm2Config },
+          }
+        );
+
+        const res = await PUT_STAK(req, {
+          params: Promise.resolve({ slug: testData.workspace.slug }),
+        });
+        await expectSuccess(res, 200);
+
+        const swarm = await db.swarm.findUnique({
+          where: { workspaceId: testData.workspace.id },
+        });
+        const containerFiles = swarm?.containerFiles as Record<string, string>;
+        const services = swarm?.services as any[];
+
+        // Services should include winner-service (from services array)
+        const winnerService = services.find((s) => s.name === "winner-service");
+        expect(winnerService).toBeDefined();
+        expect(winnerService.port).toBe(9999);
+
+        // pm2.config.js should be REGENERATED from services (not the one sent)
+        const pm2Content = fromBase64(containerFiles["pm2.config.js"]);
+        expect(pm2Content).toContain("winner-service");
+        expect(pm2Content).toContain("9999");
+      });
+
+      it("merges services by name - updating existing service", async () => {
+        // Update existing "frontend" service with new port
+        const updatedFrontend = {
+          name: "frontend",
+          port: 8080, // Changed from 3000
+          scripts: { start: "npm run dev" },
+        };
+
+        const req = createPutRequest(
+          `http://localhost:3000/api/workspaces/${testData.workspace.slug}/stakgraph`,
+          { services: [updatedFrontend] }
+        );
+
+        const res = await PUT_STAK(req, {
+          params: Promise.resolve({ slug: testData.workspace.slug }),
+        });
+        await expectSuccess(res, 200);
+
+        const swarm = await db.swarm.findUnique({
+          where: { workspaceId: testData.workspace.id },
+        });
+        const services = swarm?.services as any[];
+
+        // Frontend should be updated
+        const frontend = services.find((s) => s.name === "frontend");
+        expect(frontend.port).toBe(8080);
+        expect(frontend.scripts.start).toBe("npm run dev");
+
+        // Sidekiq should still exist (preserved)
+        expect(services.find((s) => s.name === "sidekiq")).toBeDefined();
+      });
+    });
+
+    describe("other field partial updates", () => {
+      it("updates only name when only name sent", async () => {
+        const newName = "updated-swarm-name";
+
+        const req = createPutRequest(
+          `http://localhost:3000/api/workspaces/${testData.workspace.slug}/stakgraph`,
+          { name: newName }
+        );
+
+        const res = await PUT_STAK(req, {
+          params: Promise.resolve({ slug: testData.workspace.slug }),
+        });
+        const response = await expectSuccess(res, 200);
+        expect(response.data.name).toBe(newName);
+
+        const swarm = await db.swarm.findUnique({
+          where: { workspaceId: testData.workspace.id },
+        });
+        expect(swarm?.name).toBe(newName);
+
+        // Everything else unchanged
+        const services = swarm?.services as any[];
+        expect(services).toHaveLength(2);
+        const containerFiles = swarm?.containerFiles as Record<string, string>;
+        expect(containerFiles["Dockerfile"]).toBe(toBase64(DEFAULT_DOCKERFILE));
+      });
+
+      it("updates swarmUrl only", async () => {
+        const newUrl = "https://new-swarm.sphinx.chat";
+
+        const req = createPutRequest(
+          `http://localhost:3000/api/workspaces/${testData.workspace.slug}/stakgraph`,
+          { swarmUrl: newUrl }
+        );
+
+        const res = await PUT_STAK(req, {
+          params: Promise.resolve({ slug: testData.workspace.slug }),
+        });
+        const response = await expectSuccess(res, 200);
+        expect(response.data.swarmUrl).toBe(newUrl);
+
+        const swarm = await db.swarm.findUnique({
+          where: { workspaceId: testData.workspace.id },
+        });
+        expect(swarm?.swarmUrl).toBe(newUrl);
+      });
+
+      it("updates poolCpu and poolMemory only", async () => {
+        const req = createPutRequest(
+          `http://localhost:3000/api/workspaces/${testData.workspace.slug}/stakgraph`,
+          { poolCpu: "4", poolMemory: "8Gi" }
+        );
+
+        const res = await PUT_STAK(req, {
+          params: Promise.resolve({ slug: testData.workspace.slug }),
+        });
+        await expectSuccess(res, 200);
+
+        const swarm = await db.swarm.findUnique({
+          where: { workspaceId: testData.workspace.id },
+        });
+        expect(swarm?.poolCpu).toBe("4");
+        expect(swarm?.poolMemory).toBe("8Gi");
+
+        // Name unchanged
+        expect(swarm?.name).toBe(testData.swarm.name);
+      });
+    });
+
+    describe("edge cases", () => {
+      it("makes no changes on empty request", async () => {
+        const originalSwarm = await db.swarm.findUnique({
+          where: { workspaceId: testData.workspace.id },
+        });
+
+        const req = createPutRequest(
+          `http://localhost:3000/api/workspaces/${testData.workspace.slug}/stakgraph`,
+          {}
+        );
+
+        const res = await PUT_STAK(req, {
+          params: Promise.resolve({ slug: testData.workspace.slug }),
+        });
+        await expectSuccess(res, 200);
+
+        const swarm = await db.swarm.findUnique({
+          where: { workspaceId: testData.workspace.id },
+        });
+
+        expect(swarm?.name).toBe(originalSwarm?.name);
+        expect(JSON.stringify(swarm?.services)).toBe(
+          JSON.stringify(originalSwarm?.services)
+        );
+        expect(JSON.stringify(swarm?.containerFiles)).toBe(
+          JSON.stringify(originalSwarm?.containerFiles)
+        );
+      });
+
+      it("handles empty services array gracefully", async () => {
+        const req = createPutRequest(
+          `http://localhost:3000/api/workspaces/${testData.workspace.slug}/stakgraph`,
+          { services: [] }
+        );
+
+        const res = await PUT_STAK(req, {
+          params: Promise.resolve({ slug: testData.workspace.slug }),
+        });
+        await expectSuccess(res, 200);
+
+        // Empty services array should not change existing services
+        // (treated as "not sent" for merge purposes)
+        const swarm = await db.swarm.findUnique({
+          where: { workspaceId: testData.workspace.id },
+        });
+        const services = swarm?.services as any[];
+        expect(services).toHaveLength(2);
+      });
+
+      it("handles empty containerFiles object gracefully", async () => {
+        const req = createPutRequest(
+          `http://localhost:3000/api/workspaces/${testData.workspace.slug}/stakgraph`,
+          { containerFiles: {} }
+        );
+
+        const res = await PUT_STAK(req, {
+          params: Promise.resolve({ slug: testData.workspace.slug }),
+        });
+        await expectSuccess(res, 200);
+
+        // Empty containerFiles should not change existing files
+        const swarm = await db.swarm.findUnique({
+          where: { workspaceId: testData.workspace.id },
+        });
+        const containerFiles = swarm?.containerFiles as Record<string, string>;
+        expect(Object.keys(containerFiles)).toHaveLength(3);
+      });
+    });
   });
 });

--- a/src/app/api/workspaces/[slug]/stakgraph/route.ts
+++ b/src/app/api/workspaces/[slug]/stakgraph/route.ts
@@ -12,7 +12,9 @@ import { getWorkspaceBySlug } from "@/services/workspace";
 import { ServiceConfig } from "@/types";
 import type { SwarmSelectResult } from "@/types/swarm";
 import { getDevContainerFilesFromBase64 } from "@/utils/devContainerUtils";
+import { syncPM2AndServices, extractRepoName } from "@/utils/stakgraphSync";
 import { SwarmStatus } from "@prisma/client";
+import { ServiceConfig as SwarmServiceConfig } from "@/services/swarm/db";
 import { getServerSession } from "next-auth/next";
 import { NextRequest, NextResponse } from "next/server";
 import { getPrimaryRepository } from "@/lib/helpers/repository";
@@ -23,9 +25,9 @@ export const runtime = "nodejs";
 
 const encryptionService: EncryptionService = EncryptionService.getInstance();
 
-// Validation schema for stakgraph settings
+// Validation schema for stakgraph settings - all fields optional for partial updates
 const stakgraphSettingsSchema = z.object({
-  name: z.string().min(1, "Name is required"),
+  name: z.string().min(1, "Name is required").optional(),
   repositories: z
     .array(
       z.object({
@@ -35,15 +37,15 @@ const stakgraphSettingsSchema = z.object({
         name: z.string().min(1, "Repository name is required"),
       }),
     )
-    .min(1, "At least one repository is required"),
-  swarmUrl: z.string().url("Invalid swarm URL"),
-  swarmSecretAlias: z.string().min(1, "Swarm API key is required"),
+    .optional(),
+  swarmUrl: z.string().url("Invalid swarm URL").optional(),
+  swarmSecretAlias: z.string().min(1, "Swarm API key is required").optional(),
   swarmApiKey: z.string().optional(),
-  poolName: z.string().min(1, "Pool name is required"),
+  poolName: z.string().min(1, "Pool name is required").optional(),
   poolCpu: z.string().optional(),
   poolMemory: z.string().optional(),
   description: z.string().optional(),
-  containerFiles: z.record(z.string(), z.string()).optional().default({}),
+  containerFiles: z.record(z.string(), z.string()).optional(),
   environmentVariables: z
     .array(
       z.object({
@@ -51,8 +53,7 @@ const stakgraphSettingsSchema = z.object({
         value: z.string(),
       }),
     )
-    .optional()
-    .default([]),
+    .optional(),
   services: z
     .array(
       z.object({
@@ -82,8 +83,7 @@ const stakgraphSettingsSchema = z.object({
         cwd: z.string().optional(),
       }),
     )
-    .optional()
-    .default([]),
+    .optional(),
 });
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ slug: string }> }) {
@@ -310,61 +310,97 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
 
     const settings = validationResult.data;
 
-    const existingRepos = await db.repository.findMany({
+    // Only process repositories if provided
+    if (settings.repositories && settings.repositories.length > 0) {
+      const existingRepos = await db.repository.findMany({
+        where: { workspaceId: workspace.id },
+      });
+
+      const incomingRepos = settings.repositories;
+      const existingRepoIds = existingRepos.map((r) => r.id);
+      const incomingRepoIds = incomingRepos.filter((r) => r.id).map((r) => r.id!);
+
+      const reposToCreate = incomingRepos.filter((r) => !r.id);
+      if (reposToCreate.length > 0) {
+        await db.repository.createMany({
+          data: reposToCreate.map((repo) => ({
+            workspaceId: workspace.id,
+            repositoryUrl: repo.repositoryUrl,
+            branch: repo.branch,
+            name: repo.name,
+          })),
+        });
+      }
+
+      const reposToUpdate = incomingRepos.filter((r) => r.id);
+      for (const repo of reposToUpdate) {
+        await db.repository.update({
+          where: { id: repo.id },
+          data: {
+            repositoryUrl: repo.repositoryUrl,
+            branch: repo.branch,
+            name: repo.name,
+          },
+        });
+      }
+
+      const repoIdsToDelete = existingRepoIds.filter((id) => !incomingRepoIds.includes(id));
+      if (repoIdsToDelete.length > 0) {
+        await db.repository.deleteMany({
+          where: {
+            id: { in: repoIdsToDelete },
+            workspaceId: workspace.id,
+          },
+        });
+      }
+    }
+
+    // Fetch existing swarm for merge (partial update support)
+    const existingSwarm = await db.swarm.findUnique({
       where: { workspaceId: workspace.id },
+      select: {
+        name: true,
+        swarmUrl: true,
+        swarmSecretAlias: true,
+        poolName: true,
+        poolCpu: true,
+        poolMemory: true,
+        services: true,
+        containerFiles: true,
+        environmentVariables: true,
+      },
     });
 
-    const incomingRepos = settings.repositories;
-    const existingRepoIds = existingRepos.map((r) => r.id);
-    const incomingRepoIds = incomingRepos.filter((r) => r.id).map((r) => r.id!);
+    // Get repo name for pm2 generation
+    const primaryRepo = await getPrimaryRepository(workspace.id);
+    const repoName = extractRepoName(
+      primaryRepo?.repositoryUrl || settings.repositories?.[0]?.repositoryUrl
+    );
 
-    const reposToCreate = incomingRepos.filter((r) => !r.id);
-    if (reposToCreate.length > 0) {
-      await db.repository.createMany({
-        data: reposToCreate.map((repo) => ({
-          workspaceId: workspace.id,
-          repositoryUrl: repo.repositoryUrl,
-          branch: repo.branch,
-          name: repo.name,
-        })),
-      });
-    }
+    // Perform bidirectional sync for services/containerFiles
+    const syncResult = syncPM2AndServices(
+      (existingSwarm?.services as unknown as SwarmServiceConfig[]) || [],
+      (existingSwarm?.containerFiles as unknown as Record<string, string>) || {},
+      settings.services as SwarmServiceConfig[] | undefined,
+      settings.containerFiles,
+      repoName
+    );
 
-    const reposToUpdate = incomingRepos.filter((r) => r.id);
-    for (const repo of reposToUpdate) {
-      await db.repository.update({
-        where: { id: repo.id },
-        data: {
-          repositoryUrl: repo.repositoryUrl,
-          branch: repo.branch,
-          name: repo.name,
-        },
-      });
-    }
-
-    const repoIdsToDelete = existingRepoIds.filter((id) => !incomingRepoIds.includes(id));
-    if (repoIdsToDelete.length > 0) {
-      await db.repository.deleteMany({
-        where: {
-          id: { in: repoIdsToDelete },
-          workspaceId: workspace.id,
-        },
-      });
-    }
-
+    // Merge all fields - use incoming if provided, else preserve existing
+    // Convert null to undefined for database fields
     await saveOrUpdateSwarm({
       workspaceId: workspace.id,
-      name: settings.name,
-      swarmUrl: settings.swarmUrl,
-      status: SwarmStatus.ACTIVE, // auto active
-      swarmSecretAlias: settings.swarmSecretAlias,
+      name: settings.name ?? existingSwarm?.name ?? undefined,
+      swarmUrl: settings.swarmUrl ?? existingSwarm?.swarmUrl ?? undefined,
+      status: SwarmStatus.ACTIVE,
+      swarmSecretAlias: settings.swarmSecretAlias ?? existingSwarm?.swarmSecretAlias ?? undefined,
       swarmApiKey: settings.swarmApiKey,
-      poolName: settings.poolName,
-      poolCpu: settings.poolCpu,
-      poolMemory: settings.poolMemory,
-      services: settings.services,
+      poolName: settings.poolName ?? existingSwarm?.poolName ?? undefined,
+      poolCpu: settings.poolCpu ?? existingSwarm?.poolCpu ?? undefined,
+      poolMemory: settings.poolMemory ?? existingSwarm?.poolMemory ?? undefined,
+      services: syncResult.services,
       environmentVariables: settings.environmentVariables,
-      containerFiles: settings.containerFiles,
+      containerFiles: syncResult.containerFiles,
     });
 
     const swarm = (await db.swarm.findUnique({
@@ -405,8 +441,7 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
         const callbackUrl = getGithubWebhookCallbackUrl(request, workspace.id);
         const webhookService = new WebhookService(getServiceConfig("github"));
 
-        const primaryRepo = await getPrimaryRepository(workspace.id);
-
+        // Reuse primaryRepo from above if available
         if (primaryRepo) {
           const { defaultBranch } = await webhookService.setupRepositoryWithWebhook({
             userId,
@@ -430,22 +465,24 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
       }
     }
 
+    // Use merged values for pool name check (convert null to undefined)
+    const mergedPoolName = settings.poolName ?? existingSwarm?.poolName ?? undefined;
+    const mergedPoolCpu = settings.poolCpu ?? existingSwarm?.poolCpu ?? undefined;
+    const mergedPoolMemory = settings.poolMemory ?? existingSwarm?.poolMemory ?? undefined;
+
     // After updating/creating the swarm, update environment variables in Pool Manager if poolName, poolApiKey, and environmentVariables are present
-    if (settings.poolName && decryptedPoolApiKey && Array.isArray(settings.environmentVariables)) {
+    if (mergedPoolName && decryptedPoolApiKey && Array.isArray(settings.environmentVariables)) {
       try {
         const poolManager = new PoolManagerService(config as unknown as ServiceConfig);
 
         if (swarm) {
           const currentEnvVars = await poolManager.getPoolEnvVars(swarm.id, decryptedPoolApiKey);
 
-          // TODO: This is a solution to preserve data structure.
-          const files = getDevContainerFilesFromBase64(settings.containerFiles);
+          // Use synced containerFiles for Pool Manager update
+          const files = getDevContainerFilesFromBase64(syncResult.containerFiles);
 
           // Only get GitHub PAT when using session auth
           const github_pat = userId ? await getGithubUsernameAndPAT(userId, slug) : null;
-
-          // Get the primary repository to access the branch
-          const primaryRepo = await getPrimaryRepository(workspace.id);
 
           await poolManager.updatePoolData(
             swarm.id,
@@ -460,8 +497,8 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
               masked?: boolean;
             }>,
             files,
-            settings.poolCpu,
-            settings.poolMemory,
+            mergedPoolCpu,
+            mergedPoolMemory,
             github_pat?.token || "",
             github_pat?.username || "",
             primaryRepo?.branch || "",
@@ -491,13 +528,14 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
       message: "Pool settings saved successfully",
       data: {
         id: typedSwarm.id,
-        name: typedSwarm.name || settings.name,
+        name: typedSwarm.name || "",
         description: settings.description || "",
         repositories: updatedRepositories,
         swarmUrl: typedSwarm.swarmUrl,
         poolName: typedSwarm.poolName,
         swarmSecretAlias: typedSwarm.swarmSecretAlias || "",
         services: typeof typedSwarm.services === "string" ? JSON.parse(typedSwarm.services) : typedSwarm.services || [],
+        containerFiles: typedSwarm.containerFiles || {},
         status: typedSwarm.status,
         updatedAt: typedSwarm.updatedAt,
       },

--- a/src/utils/stakgraphSync.ts
+++ b/src/utils/stakgraphSync.ts
@@ -1,0 +1,97 @@
+import { ServiceConfig } from "@/services/swarm/db";
+import { ServiceDataConfig } from "@/components/stakgraph/types";
+import { getPM2AppsContent, parsePM2Content } from "./devContainerUtils";
+
+interface SyncResult {
+  services: ServiceConfig[];
+  containerFiles: Record<string, string>;
+}
+
+/**
+ * Merge services by name - incoming services overwrite existing ones with the same name
+ */
+export function mergeServices(existing: ServiceConfig[], incoming: ServiceConfig[]): ServiceConfig[] {
+  const serviceMap = new Map<string, ServiceConfig>();
+  for (const service of existing) serviceMap.set(service.name, service);
+  for (const service of incoming) serviceMap.set(service.name, service);
+  return Array.from(serviceMap.values());
+}
+
+/**
+ * Merge containerFiles - incoming files overwrite existing ones with the same key, no deletion
+ */
+export function mergeContainerFiles(
+  existing: Record<string, string>,
+  incoming: Record<string, string>
+): Record<string, string> {
+  return { ...existing, ...incoming };
+}
+
+/**
+ * Synchronize pm2.config.js and services bidirectionally with merge support
+ *
+ * Cases:
+ * 1. Neither sent → return existing unchanged
+ * 2. Only services sent → merge services + regenerate pm2.config.js
+ * 3. Only pm2.config.js sent → merge files + parse PM2 → update services
+ * 4. Both sent → services wins, regenerate pm2.config.js
+ * 5. Only other containerFiles sent (no pm2, no services) → merge files only
+ */
+export function syncPM2AndServices(
+  existingServices: ServiceConfig[],
+  existingContainerFiles: Record<string, string>,
+  incomingServices: ServiceConfig[] | undefined,
+  incomingContainerFiles: Record<string, string> | undefined,
+  repoName: string
+): SyncResult {
+  const hasIncomingServices = incomingServices && incomingServices.length > 0;
+  const hasIncomingPM2 = incomingContainerFiles?.["pm2.config.js"];
+
+  // Case 1: Neither sent - return existing
+  if (!hasIncomingServices && !incomingContainerFiles) {
+    return { services: existingServices, containerFiles: existingContainerFiles };
+  }
+
+  // Case 5: Only non-pm2 containerFiles sent (e.g., Dockerfile, docker-compose.yml)
+  // Just merge files, don't touch services
+  if (!hasIncomingServices && incomingContainerFiles && !hasIncomingPM2) {
+    const mergedFiles = mergeContainerFiles(existingContainerFiles, incomingContainerFiles);
+    return { services: existingServices, containerFiles: mergedFiles };
+  }
+
+  // Case 2: Only services sent - regenerate pm2.config.js
+  if (hasIncomingServices && !hasIncomingPM2) {
+    const mergedServices = mergeServices(existingServices, incomingServices);
+    const pm2Content = getPM2AppsContent(repoName, mergedServices as ServiceDataConfig[]);
+    const mergedFiles = mergeContainerFiles(existingContainerFiles, incomingContainerFiles || {});
+    mergedFiles["pm2.config.js"] = Buffer.from(pm2Content.content).toString("base64");
+    return { services: mergedServices, containerFiles: mergedFiles };
+  }
+
+  // Case 3: Only pm2.config.js sent (no services or empty services) - parse and update services
+  if (!hasIncomingServices && hasIncomingPM2) {
+    // Decode base64 before parsing since containerFiles are stored as base64
+    const decodedPM2 = Buffer.from(incomingContainerFiles["pm2.config.js"], "base64").toString("utf-8");
+    const parsedServices = parsePM2Content(decodedPM2);
+    const mergedServices = mergeServices(existingServices, parsedServices);
+    const mergedFiles = mergeContainerFiles(existingContainerFiles, incomingContainerFiles);
+    return { services: mergedServices, containerFiles: mergedFiles };
+  }
+
+  // Case 4: Both sent - services wins, regenerate pm2.config.js
+  console.warn("[syncPM2AndServices] Both services and pm2.config.js provided, using services array");
+  const mergedServices = mergeServices(existingServices, incomingServices!);
+  const pm2Content = getPM2AppsContent(repoName, mergedServices as ServiceDataConfig[]);
+  const mergedFiles = mergeContainerFiles(existingContainerFiles, incomingContainerFiles || {});
+  mergedFiles["pm2.config.js"] = Buffer.from(pm2Content.content).toString("base64");
+  return { services: mergedServices, containerFiles: mergedFiles };
+}
+
+/**
+ * Extract repository name from GitHub URL
+ */
+export function extractRepoName(repositoryUrl: string | undefined): string {
+  if (!repositoryUrl) return "workspace";
+  const match = repositoryUrl.match(/\/([^/]+?)(?:\.git)?$/);
+  return match?.[1]?.replace(/\.git$/i, "") || "workspace";
+}


### PR DESCRIPTION
**Summary**

Added partial update support to the PUT /api/workspaces/[slug]/stakgraph endpoint with bidirectional sync between pm2.config.js and services.

**Changes**

New file: src/utils/stakgraphSync.ts
  - mergeServices() - merges services by name (incoming overwrites existing)
  - mergeContainerFiles() - merges files by key (no deletion)
  - syncPM2AndServices() - bidirectional sync logic
  - extractRepoName() - extracts repo name from GitHub URL

Modified: src/app/api/workspaces/[slug]/stakgraph/route.ts
  - All schema fields now optional (was required)
  - Fetches existing swarm data before save
  - Merges incoming fields with existing using nullish coalescing (??)
  - Uses syncPM2AndServices() for containerFiles/services sync

  **Sync Behavior**

- containerFiles only (no pm2)  → Merge files, services unchanged
- containerFiles with pm2          →  Merge files, parse pm2 → sync to services
- services only                            →  Merge services, regenerate pm2.config.js
- services + pm2 (both)             →  Services wins, regenerate pm2.config.js
- empty request {}                      →  No changes
  
**Tests**
- Added 12 integration tests covering all partial update scenarios in workspaces-stakgraph.test.ts.