### PR TITLE
feat: add voice input to dashboard and learn page question fields

### DIFF
--- a/src/app/w/[slug]/learn/components/LearnChatArea.tsx
+++ b/src/app/w/[slug]/learn/components/LearnChatArea.tsx
@@ -166,7 +166,7 @@ export function LearnChatArea({
       </div>
 
       {/* Input - Fixed at bottom of viewport */}
-      <div className="absolute bottom-0 left-0 right-0 bg-background border-t shadow-lg">
+      <div className="absolute bottom-0 left-0 right-0 bg-background border-t shadow-lg pr-80">
         <LearnChatInput
           onSend={onSend}
           disabled={isLoading}

--- a/src/components/workspace/WorkspaceMembersPreview/index.tsx
+++ b/src/components/workspace/WorkspaceMembersPreview/index.tsx
@@ -30,7 +30,7 @@ function getInitials(user: {
 
 export function WorkspaceMembersPreview({
   workspaceSlug,
-  maxDisplay = 4,
+  maxDisplay = 3,
 }: WorkspaceMembersPreviewProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const { members, loading } = useWorkspaceMembers(workspaceSlug, {


### PR DESCRIPTION
feat: add voice input to dashboard and learn page question fields

- Add speech recognition with microphone button to dashboard chat input
- Add voice input functionality to learn page chat input
- Add real-time transcription with visual feedback (red pulsing animation)
- Add proper layout spacing (pr-80) to learn chat input to prevent overlap
- Reduce workspace members preview from 4 to 3 max display
- Gracefully hide mic button if browser doesn't support Web Speech API
- Add toggle between Mic/MicOff icons during recording state