### PR TITLE
fix: make graph artifact expand to fill container instead of using fixed

### DIFF
--- a/src/components/chat/artifacts/GraphArtifact.tsx
+++ b/src/components/chat/artifacts/GraphArtifact.tsx
@@ -21,17 +21,19 @@ export function GraphArtifact({ content, workspaceSlug }: GraphArtifactProps) {
   const refId = content.ref_id.split(",")[0].trim();
 
   return (
-    <Graph
-      endpoint="/api/subgraph"
-      params={{
-        ref_id: refId,
-        workspace: workspaceSlug || "",
-        ...(content.depth && { depth: content.depth.toString() }),
-      }}
-      height={500}
-      title={content.cluster_title || "Knowledge Graph"}
-      showStats={true}
-      emptyMessage="No graph data available for this reference"
-    />
+    <div className="h-full w-full">
+      <Graph
+        endpoint="/api/subgraph"
+        params={{
+          ref_id: refId,
+          workspace: workspaceSlug || "",
+          ...(content.depth && { depth: content.depth.toString() }),
+        }}
+        title={content.cluster_title || "Knowledge Graph"}
+        showStats={true}
+        emptyMessage="No graph data available for this reference"
+        className="h-full"
+      />
+    </div>
   );
 }

--- a/src/components/graph/Graph.tsx
+++ b/src/components/graph/Graph.tsx
@@ -42,7 +42,7 @@ export function Graph({
   params,
   transform,
   width,
-  height = 600,
+  height,
   colorMap,
   onNodeClick,
   title,
@@ -57,9 +57,13 @@ export function Graph({
     transform,
   });
 
+  // Determine if we should use flex layout (when no height specified)
+  const useFlexLayout = height === undefined;
+  const effectiveHeight = height || 600;
+
   if (loading) {
     return (
-      <div className={`border rounded-lg bg-card p-4 ${className}`}>
+      <div className={`border rounded-lg bg-card p-4 ${useFlexLayout ? 'flex flex-col h-full' : ''} ${className}`}>
         <div className="flex items-center justify-center h-64">
           <div className="text-muted-foreground">Loading graph...</div>
         </div>
@@ -69,7 +73,7 @@ export function Graph({
 
   if (error) {
     return (
-      <div className={`border rounded-lg bg-card p-4 ${className}`}>
+      <div className={`border rounded-lg bg-card p-4 ${useFlexLayout ? 'flex flex-col h-full' : ''} ${className}`}>
         <div className="flex items-center justify-center h-64">
           <div className="text-destructive">Error: {error}</div>
         </div>
@@ -79,7 +83,7 @@ export function Graph({
 
   if (nodes.length === 0) {
     return (
-      <div className={`border rounded-lg bg-card p-4 ${className}`}>
+      <div className={`border rounded-lg bg-card p-4 ${useFlexLayout ? 'flex flex-col h-full' : ''} ${className}`}>
         <div className="flex items-center justify-center h-64">
           <div className="text-muted-foreground">{emptyMessage}</div>
         </div>
@@ -90,9 +94,9 @@ export function Graph({
   const VisualizationComponent = layout === "layered" ? GraphVisualizationLayered : GraphVisualization;
 
   return (
-    <div className={`border rounded-lg bg-card p-4 ${className}`}>
+    <div className={`border rounded-lg bg-card p-4 ${useFlexLayout ? 'flex flex-col h-full' : ''} ${className}`}>
       {(title || showStats) && (
-        <div className="mb-3 flex justify-between items-center">
+        <div className="mb-3 flex justify-between items-center flex-shrink-0">
           {title && <h3 className="text-sm font-medium">{title}</h3>}
           {showStats && (
             <div className="text-xs text-muted-foreground">
@@ -102,12 +106,12 @@ export function Graph({
         </div>
       )}
 
-      <div className="border rounded overflow-hidden bg-background">
+      <div className={`border rounded overflow-hidden bg-background ${useFlexLayout ? 'flex-1 min-h-0' : ''}`}>
         <VisualizationComponent
           nodes={nodes}
           edges={edges}
           width={width}
-          height={height}
+          height={useFlexLayout ? undefined : effectiveHeight}
           colorMap={colorMap}
           onNodeClick={onNodeClick}
         />


### PR DESCRIPTION
fix: make graph artifact expand to fill container instead of using fixed height

- Remove fixed height prop from GraphArtifact component
- Update Graph component to use flexbox layout when height is undefined
- Make GraphVisualizationLayered responsive to container dimensions
- Graph now properly expands to full panel size without being cut off