### PR TITLE
Remove unused variables and @typescript-eslint/no-unused-vars suppressio

### DIFF
--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -336,8 +336,7 @@ export async function GET(request: NextRequest) {
         }
 
         // Return task with hasActionArtifact flag and PR artifact, removing chatMessages array to keep response clean
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { chatMessages, ...taskWithoutMessages } = task;
+        const { chatMessages: _, ...taskWithoutMessages } = task;
         return {
           ...taskWithoutMessages,
           hasActionArtifact,

--- a/src/app/w/[slug]/task/[...taskParams]/artifacts/browser.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/artifacts/browser.tsx
@@ -36,7 +36,6 @@ export function BrowserArtifactPanel({
   onUserJourneySave,
   externalTestCode,
   externalTestTitle,
-  isMobile = false,
   onClose,
 }: {
   artifacts: Artifact[];
@@ -157,7 +156,6 @@ export function BrowserArtifactPanel({
     debugMode,
     isSubmittingDebug,
     setDebugMode,
-    handleDebugElement,
     handleDebugSelection: handleDebugSelectionHook,
   } = useDebugSelection({ onDebugMessage, iframeRef });
   const [isTestModalOpen, setIsTestModalOpen] = useState(false);

--- a/src/app/w/[slug]/task/[...taskParams]/page.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/page.tsx
@@ -39,8 +39,6 @@ function generateUniqueId() {
 }
 
 export default function TaskChatPage() {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { data: session } = useSession(); // TODO: Use for authentication when creating tasks
   const params = useParams();
   const { id: workspaceId, workspace } = useWorkspace();
   const isMobile = useIsMobile();

--- a/src/components/capacity/FireParticles.tsx
+++ b/src/components/capacity/FireParticles.tsx
@@ -21,14 +21,12 @@ export function FireParticles({ position }: { position: [number, number, number]
         return temp;
     }, [count]);
 
-    useFrame((state) => {
+    useFrame(() => {
         if (!mesh.current) return;
 
         particles.forEach((particle, i) => {
-            let { t, factor, speed, xFactor, yFactor, zFactor } = particle;
+            let { t, speed } = particle;
             t = particle.t += speed / 2;
-            const a = Math.cos(t) + Math.sin(t * 1) / 10;
-            const b = Math.sin(t) + Math.cos(t * 2) / 10;
             const s = Math.cos(t);
 
             // Move up and fade

--- a/src/components/capacity/ServerModel.tsx
+++ b/src/components/capacity/ServerModel.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useMemo } from 'react';
+import { useRef, useState } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { Text, useCursor } from '@react-three/drei';
 import * as THREE from 'three';
@@ -35,7 +35,7 @@ function getUsageColor(percentage: number): string {
     return '#ef4444'; // Red
 }
 
-export function ServerModel({ position, state, usageStatus, cpuUsage = "0", memoryUsage = "0", name, subdomain, userInfo, created, repoName, onClick, selected }: ServerModelProps) {
+export function ServerModel({ position, state, usageStatus, cpuUsage = "0", memoryUsage = "0", subdomain, userInfo, repoName, onClick, selected }: ServerModelProps) {
     const meshRef = useRef<THREE.Group>(null);
     const [hovered, setHover] = useState(false);
     useCursor(hovered);

--- a/src/components/capacity/ServerParticles.tsx
+++ b/src/components/capacity/ServerParticles.tsx
@@ -29,22 +29,21 @@ export function ServerParticles({ position, active, intensity }: ServerParticles
         return temp;
     }, []);
 
-    useFrame((state) => {
+    useFrame(() => {
         if (!mesh.current || !active) return;
 
         particles.forEach((particle, i) => {
             // Calculate particle movement
-            let { t, factor, speed, xFactor, yFactor, zFactor } = particle;
-            t = particle.t += speed / 2;
+            let t = particle.t += particle.speed / 2;
+            const s = Math.cos(t);
             const a = Math.cos(t) + Math.sin(t * 1) / 10;
             const b = Math.sin(t) + Math.cos(t * 2) / 10;
-            const s = Math.cos(t);
 
             // Update position relative to server center
             dummy.position.set(
-                (particle.mx / 10) * a + xFactor + Math.cos((t / 10) * factor) + (Math.sin(t * 1) * factor) / 10,
-                (particle.my / 10) * b + yFactor + Math.sin((t / 10) * factor) + (Math.cos(t * 2) * factor) / 10,
-                (particle.my / 10) * b + zFactor + Math.cos((t / 10) * factor) + (Math.sin(t * 3) * factor) / 10
+                (particle.mx / 10) * a + particle.xFactor + Math.cos((t / 10) * particle.factor) + (Math.sin(t * 1) * particle.factor) / 10,
+                (particle.my / 10) * b + particle.yFactor + Math.sin((t / 10) * particle.factor) + (Math.cos(t * 2) * particle.factor) / 10,
+                (particle.my / 10) * b + particle.zFactor + Math.cos((t / 10) * particle.factor) + (Math.sin(t * 3) * particle.factor) / 10
             );
 
             // Scale based on intensity

--- a/src/lib/helpers/tasks.ts
+++ b/src/lib/helpers/tasks.ts
@@ -19,8 +19,7 @@ import { TaskStatus, Prisma } from "@prisma/client";
 export function sanitizeTask<T extends { agentPassword?: string | null; agentUrl?: string | null }>(
   task: T,
 ): Omit<T, "agentPassword" | "agentUrl"> {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { agentPassword, agentUrl, ...sanitized } = task;
+  const { agentPassword: _, agentUrl: __, ...sanitized } = task;
   return sanitized;
 }
 


### PR DESCRIPTION
Remove unused variables and @typescript-eslint/no-unused-vars suppressions

- Delete unused variables instead of suppressing lint warnings
- Remove eslint-disable-next-line comments for no-unused-vars
- Clean up code by removing unnecessary variable declarations