### PR TITLE
Remove unused imports and variables from KanbanView

### DIFF
--- a/src/components/tasks/KanbanView.tsx
+++ b/src/components/tasks/KanbanView.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import { TaskData } from "@/hooks/useWorkspaceTasks";
 import { TaskCard } from "./TaskCard";
 import { WorkflowStatus } from "@prisma/client";
-import { Clock, Loader2, CheckCircle, AlertCircle, Pause, XCircle } from "lucide-react";
+import { Loader2, CheckCircle, AlertCircle, Pause } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface KanbanViewProps {
@@ -54,7 +53,7 @@ const kanbanColumns: KanbanColumn[] = [
   },
 ];
 
-export function KanbanView({ tasks, workspaceSlug, loading }: KanbanViewProps) {
+export function KanbanView({ tasks, workspaceSlug }: KanbanViewProps) {
   // Group tasks by workflow status - PENDING goes to IN_PROGRESS, FAILED goes to ERROR
   const tasksByStatus = tasks.reduce((acc, task) => {
     let status = task.workflowStatus || WorkflowStatus.IN_PROGRESS;


### PR DESCRIPTION
Remove unused imports and variables from KanbanView

- Remove unused Card, CardContent, CardHeader, CardTitle imports from ui/card
- Remove unused Clock and XCircle imports from lucide-react
- Remove unused loading parameter from KanbanView function signature