### PR TITLE
fix: remove unused variables to resolve linter warnings

### DIFF
--- a/src/components/dashboard/pool-status-widget/index.tsx
+++ b/src/components/dashboard/pool-status-widget/index.tsx
@@ -21,7 +21,7 @@ export function PoolStatusWidget() {
 
   const [poolStatus, setPoolStatus] = useState<PoolStatusResponse | null>(null);
   const [loading, setLoading] = useState(false);
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [isExpanded] = useState(false);
 
   const isPoolActive = workspace?.poolState === "COMPLETE";
   const servicesReady = workspace?.containerFilesSetUp === true;

--- a/src/components/features/AITextareaSection.tsx
+++ b/src/components/features/AITextareaSection.tsx
@@ -192,7 +192,7 @@ export function AITextareaSection({
             const text = await response.text();
             errorMessage = text || `Server error: ${response.status} ${response.statusText}`;
           }
-        } catch (parseError) {
+        } catch {
           errorMessage = `Server error: ${response.status} ${response.statusText}`;
         }
         throw new Error(errorMessage);

--- a/src/components/features/DependencyGraph/index.tsx
+++ b/src/components/features/DependencyGraph/index.tsx
@@ -71,8 +71,8 @@ export function DependencyGraph<T extends GraphEntity>({
     });
   }, [entities, getDependencies, direction]);
 
-  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
-  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+  const [nodes, , onNodesChange] = useNodesState(initialNodes);
+  const [edges, , onEdgesChange] = useEdgesState(initialEdges);
 
   const handleNodeClick = useCallback(
     (_event: React.MouseEvent, node: Node) => {

--- a/src/components/knowledge-graph/Universe/Graph/Cubes/Text/index.tsx
+++ b/src/components/knowledge-graph/Universe/Graph/Cubes/Text/index.tsx
@@ -5,8 +5,8 @@ import { NodeExtended } from '@Universe/types'
 import { removeEmojis } from '@Universe/utils/removeEmojisFromText'
 import { removeLeadingMentions } from '@Universe/utils/removeLeadingMentions'
 import { truncateText } from '@Universe/utils/truncateText'
-import { memo, useEffect, useRef, useState } from 'react'
-import { Group, Mesh, Texture, TextureLoader } from 'three'
+import { memo, useRef } from 'react'
+import { Group, Mesh } from 'three'
 import { TextWithBackground } from './TextWithBackgound'
 
 type Props = {
@@ -18,10 +18,7 @@ type Props = {
 export const TextNode = memo(
   (props: Props) => {
     const { node, hide, scale } = props
-    const iconRef = useRef<Mesh | null>(null)
     const nodeRef = useRef<Mesh | null>(null)
-    const [texture, setTexture] = useState<Texture | null>(null)
-    const [iconTexture, setIconTexture] = useState<Texture | null>(null)
     const backgroundRef = useRef<Group | null>(null)
 
     const { normalizedSchemasByType, getNodeKeysByType } = useSchemaStore((s) => s)
@@ -31,36 +28,6 @@ export const TextNode = memo(
       keyProperty && node?.properties
         ? removeLeadingMentions(removeEmojis(String(node?.properties[keyProperty] || '')))
         : removeLeadingMentions(node.name || '')
-
-    const primaryIcon = normalizedSchemasByType[node.node_type]?.icon
-    const Icon = primaryIcon ? Icons[primaryIcon] : null
-    const iconName = Icon ? primaryIcon : 'NodesIcon'
-
-    useEffect(() => {
-      if (!node?.properties?.image_url) {
-        return
-      }
-
-      const loader = new TextureLoader()
-
-      loader.load(node.properties.image_url, setTexture, undefined, () =>
-        console.error(`Failed to load texture: ${node?.properties?.image_url}`),
-      )
-    }, [node?.properties?.image_url])
-
-    // Load SVG icon as texture
-    useEffect(() => {
-
-      const loader = new TextureLoader()
-
-      loader.load(`/svg-icons/${iconName}.svg`, setIconTexture, undefined, (error) => {
-        console.error(`Failed to load icon texture: ${iconName}.svg`, error)
-        // Fallback: try to load a default icon
-        loader.load('/svg-icons/NodesIcon.svg', setIconTexture, undefined, () => {
-          console.error('Failed to load fallback icon')
-        })
-      })
-    }, [iconName])
 
     return (
       <Billboard follow lockX={false} lockY={false} lockZ={false} name="billboard" userData={node}>

--- a/src/components/knowledge-graph/Universe/Graph/HighlightedNodes/ChunkLayer/CalloutLabel.tsx
+++ b/src/components/knowledge-graph/Universe/Graph/HighlightedNodes/ChunkLayer/CalloutLabel.tsx
@@ -3,7 +3,6 @@ import { NodeExtended } from "@Universe/types";
 export const CalloutLabel = ({
     node,
     title,
-    baseColor = '#7DDCFF',
     onHover,
     onUnhover,
     onClick

--- a/src/components/knowledge-graph/Universe/Graph/HighlightedNodes/MockNodesLayer.tsx
+++ b/src/components/knowledge-graph/Universe/Graph/HighlightedNodes/MockNodesLayer.tsx
@@ -28,7 +28,6 @@ export const MockNodesLayer = memo<MockNodesLayerProps>(({ radius = DEFAULT_CIRC
   const nodeTypes = useDataStore((s) => s.nodeTypes)
 
   const [mockNodes, setMockNodes] = useState<MockNode[]>([])
-  const [isLoadingNodes, setIsLoadingNodes] = useState(false)
   const [hasFetchedMocks, setHasFetchedMocks] = useState(false)
 
   // Calculate Y position for Mock nodes (put them at the top) - updates when nodeTypes change
@@ -45,8 +44,6 @@ export const MockNodesLayer = memo<MockNodesLayerProps>(({ radius = DEFAULT_CIRC
     }
 
     try {
-      setIsLoadingNodes(true)
-
       const depth = 0
       const limit = 5000
       const topNodeCount = 5000
@@ -100,8 +97,6 @@ export const MockNodesLayer = memo<MockNodesLayerProps>(({ radius = DEFAULT_CIRC
     } catch (error) {
       console.error(`[MockNodesLayer] Error fetching Mock data:`, error)
       setMockNodes([])
-    } finally {
-      setIsLoadingNodes(false)
     }
   }, [workspaceId, hasFetchedMocks, radius])
 

--- a/src/components/knowledge-graph/Universe/Graph/HighlightedNodes/TestConnectionsLayer.tsx
+++ b/src/components/knowledge-graph/Universe/Graph/HighlightedNodes/TestConnectionsLayer.tsx
@@ -18,7 +18,6 @@ type TestConnectionsLayerProps = {
 const NODE_SIZE = 50 // Size of test indicator nodes
 const NODE_SCALE = 0.7 // Scale factor for test indicator nodes
 const NODE_OPACITY = 0.8 // Opacity for test indicator nodes
-const CLONE_OFFSET = 15 // Distance to offset the test indicator nodes
 const LINE_WIDTH = 0.1 // Width of test edge lines
 const LINE_OPACITY = 0.3 // Opacity for test edge lines
 

--- a/src/components/workspace/AddMemberModal.tsx
+++ b/src/components/workspace/AddMemberModal.tsx
@@ -32,7 +32,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { InfoIcon, Search, UserCheck } from "lucide-react";
+import { Search, UserCheck } from "lucide-react";
 import { toast } from "sonner";
 import { useDebounce } from "@/hooks/useDebounce";
 import { AssignableMemberRoleSchema, WorkspaceRole, RoleLabels } from "@/lib/auth/roles";

--- a/src/components/workspace/WorkspaceMembers.tsx
+++ b/src/components/workspace/WorkspaceMembers.tsx
@@ -24,7 +24,6 @@ import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import type { WorkspaceMember } from "@/types/workspace";
 import type { WorkspaceRole } from "@/lib/auth/roles";
-import { useSession } from "next-auth/react";
 
 interface WorkspaceMembersProps {
   canAdmin: boolean;


### PR DESCRIPTION
fix: remove unused variables to resolve linter warnings

- Remove unused setter 'setIsExpanded' from pool-status-widget
- Remove unused 'parseError' from AITextareaSection
- Remove unused setters 'setNodes' and 'setEdges' from DependencyGraph
- Remove unused 'InfoIcon' import from AddMemberModal
- Remove unused 'useSession' import from WorkspaceMembers
- Remove unused 'iconRef', 'texture', and 'iconTexture' from Text component
- Remove unused 'baseColor' parameter from CalloutLabel
- Remove unused 'isLoadingNodes' from MockNodesLayer
- Remove unused 'CLONE_OFFSET' constant from TestConnectionsLayer