### PR TITLE
Remove unused eslint-disable directives for no-explicit-any

### DIFF
--- a/src/lib/ai/askTools.ts
+++ b/src/lib/ai/askTools.ts
@@ -260,8 +260,7 @@ export async function clueToolMsgs(swarmUrl: string, swarmApiKey: string, query:
           toolName: "search_relevant_clues",
           output: {
             type: "json" as const,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            value: limitedClues as unknown as any,
+            value: limitedClues as unknown,
           },
         },
       ],

--- a/src/lib/ai/provider.ts
+++ b/src/lib/ai/provider.ts
@@ -87,6 +87,5 @@ export function getProviderTool(
   }
 
   // Otherwise, use the real aieo implementation
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return getProviderToolAieo(provider, apiKey, toolName as ProviderTool) as any;
+  return getProviderToolAieo(provider, apiKey, toolName as ProviderTool);
 }

--- a/src/lib/constants/prompt.ts
+++ b/src/lib/constants/prompt.ts
@@ -35,8 +35,7 @@ export function getQuickAskPrefixMessages(concepts: Record<string, unknown>[], r
           toolName: "list_concepts",
           output: {
             type: "json",
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            value: concepts as any,
+            value: concepts as unknown,
           },
         },
       ],

--- a/src/services/swarm/db.ts
+++ b/src/services/swarm/db.ts
@@ -1,6 +1,6 @@
 import { db } from "@/lib/db";
 import { EncryptionService, encryptEnvVars } from "@/lib/encryption";
-import { PoolState, SwarmStatus } from "@prisma/client";
+import { PoolState, SwarmStatus, Prisma } from "@prisma/client";
 
 const encryptionService: EncryptionService = EncryptionService.getInstance();
 
@@ -79,8 +79,7 @@ export async function saveOrUpdateSwarm(params: SaveOrUpdateSwarmParams) {
     where: { workspaceId: params.workspaceId },
   });
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const data: Record<string, any> = {};
+  const data: Record<string, unknown> = {};
   if (params.name !== undefined) data.name = params.name;
   if (params.instanceType !== undefined) data.instanceType = params.instanceType;
   if (params.environmentVariables !== undefined)
@@ -119,7 +118,7 @@ export async function saveOrUpdateSwarm(params: SaveOrUpdateSwarmParams) {
       select,
     });
   } else {
-    const createData = {
+    const createData: Prisma.SwarmCreateInput = {
       workspaceId: params.workspaceId,
       name: params.name || "",
       instanceType: params.instanceType || "",
@@ -129,7 +128,7 @@ export async function saveOrUpdateSwarm(params: SaveOrUpdateSwarmParams) {
             name: string;
             value: string;
           }>,
-        ) as unknown)
+        ) as unknown as Prisma.InputJsonValue)
         : [],
       status: params.status || SwarmStatus.PENDING,
       swarmUrl: params.swarmUrl || null,
@@ -145,15 +144,14 @@ export async function saveOrUpdateSwarm(params: SaveOrUpdateSwarmParams) {
       poolName: params.poolName || "",
       poolCpu: params.poolCpu || "2",
       poolMemory: params.poolMemory || "4Gi",
-      services: params.services ? params.services : [],
+      services: params.services ? (params.services as unknown as Prisma.InputJsonValue) : [],
       swarmSecretAlias: params.swarmSecretAlias || "",
-      containerFiles: params.containerFiles,
+      containerFiles: params.containerFiles as unknown as Prisma.InputJsonValue | undefined,
       swarmId: params.swarmId,
       ingestRefId: params.ingestRefId,
       poolState: params.poolState || PoolState.NOT_STARTED,
       ingestRequestInProgress: params.ingestRequestInProgress || false,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } as any;
+    };
     console.log("[saveOrUpdateSwarm] Create data:", createData);
     swarm = await db.swarm.create({
       data: createData,


### PR DESCRIPTION
Remove unused eslint-disable directives for no-explicit-any

Remove unnecessary eslint-disable comments for @typescript-eslint/no-explicit-any
across multiple files where the any type is no longer used or has been replaced
with proper types. This cleans up unused linting suppressions in askTools.ts,
message-sanitizer.ts, provider.ts, prompt.ts, and swarm/db.ts.