### PR TITLE
fix: hide search bar and graph controls during onboarding

### DIFF
--- a/src/app/w/[slug]/dashboard/index.tsx
+++ b/src/app/w/[slug]/dashboard/index.tsx
@@ -97,9 +97,12 @@ function DashboardInner() {
         />
       </div>
 
-      <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-0" style={{ width: 'calc(100% - 340px)' }}>
-        <DashboardChat />
-      </div>
+      {/* Dashboard Chat - only show when onboarding is complete */}
+      {!isOnboarding && (
+        <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-0" style={{ width: 'calc(100% - 340px)' }}>
+          <DashboardChat />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/knowledge-graph/Universe/Overlay/ActionsToolbar/index.tsx
+++ b/src/components/knowledge-graph/Universe/Overlay/ActionsToolbar/index.tsx
@@ -1,8 +1,15 @@
-
+import { useDataStore } from '@/stores/useStores'
 import { GraphViewControl } from './GraphViewControl'
 import { CameraRecenterControl } from './CameraRecenterControl'
 
 export const ActionsToolbar = () => {
+    const isOnboarding = useDataStore((s) => s.isOnboarding);
+
+    // Hide controls during onboarding
+    if (isOnboarding) {
+        return null;
+    }
+
     return (
         <div className="absolute right-5 bottom-5 pointer-events-auto flex flex-col items-end" id="actions-toolbar">
             <div className="flex flex-col gap-1">


### PR DESCRIPTION
fix: hide search bar and graph controls during onboarding

- Conditionally render DashboardChat based on isOnboarding state
- Conditionally render ActionsToolbar (graph controls) during onboarding
- Replace useIngestStatus with isOnboarding from createDataStore
- Ensures cleaner UI until workspace setup is complete