### PR TITLE
chore: remove unused eslint-disable directives for no-explicit-any

### DIFF
--- a/src/lib/ai/message-sanitizer.ts
+++ b/src/lib/ai/message-sanitizer.ts
@@ -18,9 +18,7 @@ export async function sanitizeAndCompleteToolCalls(
     if (msg.role === "tool" && Array.isArray(msg.content)) {
       toolResultMessages.push(msg);
       for (const item of msg.content) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         if ((item as any).type === "tool-result" && (item as any).toolCallId) {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           toolCallIdsWithResults.add((item as any).toolCallId);
         }
       }
@@ -31,14 +29,12 @@ export async function sanitizeAndCompleteToolCalls(
   const missingToolCalls: Array<{
     toolCallId: string;
     toolName: string;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     input: any;
   }> = [];
 
   for (const msg of messages) {
     if (msg.role === "assistant" && Array.isArray(msg.content)) {
       for (const item of msg.content) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const toolCall = item as any;
         if (toolCall.type === "tool-call" && !toolCallIdsWithResults.has(toolCall.toolCallId)) {
           missingToolCalls.push({
@@ -107,7 +103,6 @@ export async function sanitizeAndCompleteToolCalls(
               type: "tool-result",
               toolCallId: toolCall.toolCallId,
               toolName: toolCall.toolName,
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
               output: { type: "json", value: output as any },
             },
           ],
@@ -129,7 +124,6 @@ export async function sanitizeAndCompleteToolCalls(
   for (const resultMsg of newToolResults) {
     if (Array.isArray(resultMsg.content)) {
       for (const item of resultMsg.content) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const result = item as any;
         if (result.type === "tool-result" && result.toolCallId) {
           newResultsByCallId.set(result.toolCallId, resultMsg);
@@ -144,14 +138,12 @@ export async function sanitizeAndCompleteToolCalls(
     if (msg.role === "assistant" && Array.isArray(msg.content)) {
       // Check if this message has tool-calls
       const hasToolCalls = msg.content.some(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (item: any) => item.type === "tool-call"
       );
 
       if (hasToolCalls) {
         // Filter out tool-calls without results (that we couldn't execute)
         const filteredContent = msg.content.filter((item) => {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const toolCall = item as any;
           if (toolCall.type === "tool-call") {
             return toolCallIdsWithResults.has(toolCall.toolCallId);

--- a/src/lib/ai/provider.ts
+++ b/src/lib/ai/provider.ts
@@ -87,6 +87,5 @@ export function getProviderTool(
   }
 
   // Otherwise, use the real aieo implementation
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return getProviderToolAieo(provider, apiKey, toolName as ProviderTool) as any;
 }

--- a/src/lib/constants/prompt.ts
+++ b/src/lib/constants/prompt.ts
@@ -35,7 +35,6 @@ export function getQuickAskPrefixMessages(concepts: Record<string, unknown>[], r
           toolName: "list_concepts",
           output: {
             type: "json",
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             value: concepts as any,
           },
         },

--- a/src/services/swarm/db.ts
+++ b/src/services/swarm/db.ts
@@ -79,7 +79,6 @@ export async function saveOrUpdateSwarm(params: SaveOrUpdateSwarmParams) {
     where: { workspaceId: params.workspaceId },
   });
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const data: Record<string, any> = {};
   if (params.name !== undefined) data.name = params.name;
   if (params.instanceType !== undefined) data.instanceType = params.instanceType;
@@ -152,7 +151,6 @@ export async function saveOrUpdateSwarm(params: SaveOrUpdateSwarmParams) {
       ingestRefId: params.ingestRefId,
       poolState: params.poolState || PoolState.NOT_STARTED,
       ingestRequestInProgress: params.ingestRequestInProgress || false,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
     console.log("[saveOrUpdateSwarm] Create data:", createData);
     swarm = await db.swarm.create({


### PR DESCRIPTION
chore: remove unused eslint-disable directives for no-explicit-any

Remove unused eslint-disable comments for @typescript-eslint/no-explicit-any
across multiple files to reduce lint warnings. These directives were no longer
needed as the code at those locations doesn't trigger the linting rule.

Files updated:
- src/lib/ai/message-sanitizer.ts (8 directives removed)
- src/lib/ai/provider.ts (1 directive removed)
- src/lib/constants/prompt.ts (1 directive removed)
- src/services/swarm/db.ts (2 directives removed)