### PR TITLE
fix: add null check for workspace claim when pool is empty

### DIFF
--- a/src/__tests__/unit/lib/pods/claimPodAndGetFrontend.test.ts
+++ b/src/__tests__/unit/lib/pods/claimPodAndGetFrontend.test.ts
@@ -37,11 +37,11 @@ describe('claimPodAndGetFrontend', () => {
     image: 'stakwork/hive:latest',
     customImage: false,
     created: '2024-01-15T10:30:00Z',
-    marked_at: null,
+    marked_at: '',
     usage_status: 'available',
     flagged_for_recreation: false,
-    primaryRepo: null,
-    repoName: null,
+    primaryRepo: '',
+    repoName: '',
     repositories: [],
     branches: [],
     useDevContainer: false,
@@ -642,9 +642,9 @@ describe('claimPodAndGetFrontend', () => {
       expect(result.processList?.length).toBe(5);
     });
 
-    it('should handle workspace with null or undefined optional fields', async () => {
+    it('should handle workspace with empty string optional fields', async () => {
       // Arrange
-      const workspaceWithNulls: PodWorkspace = {
+      const workspaceWithEmptyStrings: PodWorkspace = {
         id: 'workspace-xyz',
         password: 'password',
         fqdn: 'xyz.example.com',
@@ -652,16 +652,16 @@ describe('claimPodAndGetFrontend', () => {
           '3000': 'https://app-xyz.example.com',
         },
         state: 'running',
-        url: null,
+        url: 'https://ide-xyz.example.com',
         subdomain: 'xyz',
         image: 'default',
-        customImage: null,
+        customImage: false,
         created: '2024-01-01T00:00:00Z',
-        marked_at: null,
+        marked_at: '',
         usage_status: 'available',
         flagged_for_recreation: false,
-        primaryRepo: null,
-        repoName: null,
+        primaryRepo: '',
+        repoName: '',
         repositories: [],
         branches: [],
         useDevContainer: false,
@@ -670,7 +670,7 @@ describe('claimPodAndGetFrontend', () => {
       mockFetch
         .mockResolvedValueOnce({
           ok: true,
-          json: async () => ({ workspace: workspaceWithNulls }),
+          json: async () => ({ workspace: workspaceWithEmptyStrings }),
         })
         .mockResolvedValueOnce({
           ok: true,
@@ -681,9 +681,9 @@ describe('claimPodAndGetFrontend', () => {
       const result = await claimPodAndGetFrontend(mockPoolName, mockPoolApiKey);
 
       // Assert
-      expect(result.workspace.url).toBeNull();
-      expect(result.workspace.customImage).toBeNull();
-      expect(result.workspace.primaryRepo).toBeNull();
+      expect(result.workspace.marked_at).toBe('');
+      expect(result.workspace.primaryRepo).toBe('');
+      expect(result.workspace.repoName).toBe('');
       expect(result.frontend).toBe('https://app-xyz.example.com');
     });
 

--- a/src/lib/pods/utils.ts
+++ b/src/lib/pods/utils.ts
@@ -47,7 +47,7 @@ interface ProcessInfo {
   cwd?: string;
 }
 
-export async function getWorkspaceFromPool(poolName: string, poolApiKey: string): Promise<PodWorkspace> {
+export async function getWorkspaceFromPool(poolName: string, poolApiKey: string): Promise<PodWorkspace | null> {
   console.log(">>> getWorkspaceFromPool poolName", poolName);
   const url = `${getBaseUrl()}/pools/${encodeURIComponent(poolName)}/workspace`;
 
@@ -67,7 +67,7 @@ export async function getWorkspaceFromPool(poolName: string, poolApiKey: string)
 
   const data = await response.json();
   console.log(">>> getWorkspaceFromPool workspace data", data);
-  return data.workspace as PodWorkspace;
+  return (data.workspace as PodWorkspace) || null;
 }
 
 export async function getPodFromPool(podId: string, poolApiKey: string): Promise<PodWorkspace> {
@@ -220,6 +220,10 @@ export async function claimPodAndGetFrontend(
 ): Promise<{ frontend: string; workspace: PodWorkspace; processList?: ProcessInfo[] }> {
   // Get workspace from pool
   const workspace = await getWorkspaceFromPool(poolName, poolApiKey);
+
+  if (!workspace) {
+    throw new Error(`No available workspaces in pool: ${poolName}`);
+  }
 
   console.log(">>> workspace data", workspace);
 


### PR DESCRIPTION
fix: add null check for workspace claim when pool is empty

- Update getWorkspaceFromPool return type to Promise<PodWorkspace | null>
- Add null check in claimPodAndGetFrontend before accessing workspace.id
- Throw clear error message when no workspaces available in pool
- Fix test mocks to use empty strings instead of null for string fields
- Update test description to reflect empty string handling

Fixes TypeError: Cannot read properties of null (reading 'id') when pool is empty