### PR TITLE
feat: auto-bump pool memory on OOMKilled pod failures

### DIFF
--- a/src/components/stakgraph/forms/EnvironmentForm.tsx
+++ b/src/components/stakgraph/forms/EnvironmentForm.tsx
@@ -168,7 +168,11 @@ export default function EnvironmentForm({
               <SelectItem value="1Gi">1 Gi</SelectItem>
               <SelectItem value="2Gi">2 Gi</SelectItem>
               <SelectItem value="4Gi">4 Gi</SelectItem>
+              <SelectItem value="6Gi">6 Gi</SelectItem>
               <SelectItem value="8Gi">8 Gi</SelectItem>
+              <SelectItem value="10Gi">10 Gi</SelectItem>
+              <SelectItem value="12Gi">12 Gi</SelectItem>
+              <SelectItem value="14Gi">14 Gi</SelectItem>
               <SelectItem value="16Gi">16 Gi</SelectItem>
             </SelectContent>
           </Select>

--- a/src/services/pool-manager/sync.ts
+++ b/src/services/pool-manager/sync.ts
@@ -1,0 +1,142 @@
+import { db } from "@/lib/db";
+import { EncryptionService } from "@/lib/encryption";
+import { getGithubUsernameAndPAT } from "@/lib/auth/nextauth";
+import { getPrimaryRepository } from "@/lib/helpers/repository";
+import { PoolManagerService } from "@/services/pool-manager";
+import { getServiceConfig } from "@/config/services";
+import { ServiceConfig } from "@/types";
+import { DevContainerFile, getDevContainerFilesFromBase64 } from "@/utils/devContainerUtils";
+
+const encryptionService = EncryptionService.getInstance();
+
+export interface SyncPoolManagerParams {
+  workspaceId: string;
+  workspaceSlug: string;
+  swarmId: string;
+  poolApiKey: string; // encrypted
+  poolCpu?: string | null;
+  poolMemory?: string | null;
+  environmentVariables?: Array<{ name: string; value: string }>;
+  containerFiles?: Record<string, string>; // base64 encoded files
+  userId?: string; // optional - for getting GitHub credentials
+}
+
+export interface SyncPoolManagerResult {
+  success: boolean;
+  error?: string;
+}
+
+/**
+ * Sync pool settings to Pool Manager
+ * Extracted from stakgraph route for reuse in memory bump and other scenarios
+ */
+export async function syncPoolManagerSettings(
+  params: SyncPoolManagerParams
+): Promise<SyncPoolManagerResult> {
+  const {
+    workspaceId,
+    workspaceSlug,
+    swarmId,
+    poolApiKey,
+    poolCpu,
+    poolMemory,
+    environmentVariables,
+    containerFiles,
+    userId,
+  } = params;
+
+  try {
+    // Decrypt pool API key
+    const decryptedPoolApiKey = encryptionService.decryptField(
+      "poolApiKey",
+      poolApiKey
+    );
+
+    const config = getServiceConfig("poolManager");
+    const poolManager = new PoolManagerService(config as unknown as ServiceConfig);
+
+    // Get current env vars from Pool Manager (returns { key, value } format)
+    const currentEnvVarsRaw = await poolManager.getPoolEnvVars(
+      swarmId,
+      decryptedPoolApiKey
+    );
+
+    // Transform to expected format { name, value, masked }
+    const currentEnvVars = currentEnvVarsRaw.map((env) => ({
+      name: env.key,
+      value: env.value,
+      masked: true, // Existing vars are masked
+    }));
+
+    // Get container files - either from params or fetch from swarm
+    let files: Record<string, DevContainerFile>;
+    if (containerFiles) {
+      files = getDevContainerFilesFromBase64(containerFiles);
+    } else {
+      // Fetch from swarm if not provided
+      const swarm = await db.swarm.findUnique({
+        where: { id: swarmId },
+        select: { containerFiles: true },
+      });
+
+      if (!swarm?.containerFiles) {
+        return {
+          success: false,
+          error: "No container files found for swarm",
+        };
+      }
+
+      files = getDevContainerFilesFromBase64(
+        swarm.containerFiles as Record<string, string>
+      );
+    }
+
+    // Get environment variables - either from params or fetch from swarm
+    let envVars: Array<{ name: string; value: string }>;
+    if (environmentVariables) {
+      envVars = environmentVariables;
+    } else {
+      const swarm = await db.swarm.findUnique({
+        where: { id: swarmId },
+        select: { environmentVariables: true },
+      });
+
+      envVars = (swarm?.environmentVariables as Array<{ name: string; value: string }>) || [];
+    }
+
+    // Get GitHub credentials if userId provided
+    const githubCreds = userId
+      ? await getGithubUsernameAndPAT(userId, workspaceSlug)
+      : null;
+
+    // Get primary repo branch
+    const primaryRepo = await getPrimaryRepository(workspaceId);
+
+    // Call Pool Manager update API
+    await poolManager.updatePoolData(
+      swarmId,
+      decryptedPoolApiKey,
+      envVars,
+      currentEnvVars,
+      files,
+      poolCpu || undefined,
+      poolMemory || undefined,
+      githubCreds?.token || "",
+      githubCreds?.username || "",
+      primaryRepo?.branch || ""
+    );
+
+    console.log(
+      `[PoolManagerSync] Successfully synced settings for workspace ${workspaceSlug}`
+    );
+
+    return { success: true };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    console.error(
+      `[PoolManagerSync] Failed to sync settings for workspace ${workspaceSlug}:`,
+      errorMessage
+    );
+    return { success: false, error: errorMessage };
+  }
+}

--- a/src/types/pool-manager.ts
+++ b/src/types/pool-manager.ts
@@ -219,3 +219,27 @@ export const PodLaunchFailureWebhookSchema = z.object({
   reason: z.string(),
   containers: z.array(ContainerStatusSchema),
 });
+
+// Ordered list of memory tiers for auto-bump on OOMKilled
+export const POOL_MEMORY_TIERS = [
+  "1Gi",
+  "2Gi",
+  "4Gi",
+  "6Gi",
+  "8Gi",
+  "10Gi",
+  "12Gi",
+  "14Gi",
+  "16Gi",
+] as const;
+export type PoolMemoryTier = (typeof POOL_MEMORY_TIERS)[number];
+
+export function getNextMemoryTier(
+  current: string | null | undefined
+): PoolMemoryTier | null {
+  if (!current) return "2Gi";
+  const currentIndex = POOL_MEMORY_TIERS.indexOf(current as PoolMemoryTier);
+  if (currentIndex === -1) return "2Gi";
+  if (currentIndex >= POOL_MEMORY_TIERS.length - 1) return null;
+  return POOL_MEMORY_TIERS[currentIndex + 1];
+}


### PR DESCRIPTION
- Add POOL_MEMORY_TIERS constant and getNextMemoryTier() helper
- Add memory options 6Gi, 10Gi, 12Gi, 14Gi to UI
- Detect OOMKilled in pod launch failure webhook
- Auto-bump memory to next tier on OOMKilled
- Set podState to FAILED when at max memory (16Gi)
- Extract Pool Manager sync logic into reusable service
- Refactor stakgraph route to use sync service