### PR TITLE
feat: send repoName, podId, podPassword to stakwork workflows

### DIFF
--- a/src/app/api/chat/message/route.ts
+++ b/src/app/api/chat/message/route.ts
@@ -174,6 +174,7 @@ export async function POST(request: NextRequest) {
               take: 1,
               orderBy: { createdAt: "desc" },
               select: {
+                name: true,
                 repositoryUrl: true,
                 branch: true,
               },
@@ -281,9 +282,10 @@ export async function POST(request: NextRequest) {
     const poolName = swarm?.id || null;
     const repo2GraphUrl = transformSwarmUrlToRepo2Graph(swarm?.swarmUrl);
 
-    // Extract repository URL and branch from workspace repositories
+    // Extract repository URL, branch, and name from workspace repositories
     const repoUrl = task.workspace.repositories?.[0]?.repositoryUrl || null;
     const baseBranch = task.workspace.repositories?.[0]?.branch || null;
+    const repoName = task.workspace.repositories?.[0]?.name || null;
 
     let stakworkData = null;
 
@@ -319,10 +321,11 @@ export async function POST(request: NextRequest) {
         workspaceId: task.workspaceId,
         repoUrl,
         baseBranch,
-        history,
-        webhook,
+        repoName,
         podId: task.podId,
         podPassword,
+        history,
+        webhook,
       });
 
       if (stakworkData.success) {


### PR DESCRIPTION
Add repository name and pod credentials to all task workflow triggers:
- Chat messages via /api/chat/message
- Task start via createChatMessageAndTriggerStakwork (used by manual start, janitor tasks, and task coordinator)

Pod credentials are decrypted from task.agentPassword when available and conditionally included in the Stakwork workflow vars.