### PR TITLE
Fix vertical alignment of bottom graph view elements

### DIFF
--- a/src/app/w/[slug]/dashboard/index.tsx
+++ b/src/app/w/[slug]/dashboard/index.tsx
@@ -82,8 +82,8 @@ function DashboardInner() {
         <TestCoverageStats />
       </div>
 
-      {/* Bottom-left widget */}
-      <div className="absolute bottom-4 left-4 z-10">
+      {/* Bottom-left widget - aligned by bottom edge of content */}
+      <div className="absolute left-4 z-10 flex items-end" style={{ bottom: '16px' }}>
         <WorkspaceMembersPreview workspaceSlug={slug} />
       </div>
 
@@ -97,9 +97,9 @@ function DashboardInner() {
         />
       </div>
 
-      {/* Dashboard Chat - only show when onboarding is complete */}
+      {/* Dashboard Chat - only show when onboarding is complete, aligned by bottom edge of input */}
       {!isOnboarding && (
-        <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-0" style={{ width: 'calc(100% - 340px)' }}>
+        <div className="absolute left-1/2 -translate-x-1/2 z-0 flex items-end" style={{ bottom: '16px', width: 'calc(100% - 340px)' }}>
           <DashboardChat />
         </div>
       )}

--- a/src/components/dashboard/DashboardChat/ChatInput.tsx
+++ b/src/components/dashboard/DashboardChat/ChatInput.tsx
@@ -146,7 +146,7 @@ export function ChatInput({
       onDragLeave={handleDragLeave}
       onDragOver={handleDragOver}
       onDrop={handleDrop}
-      className="relative flex justify-center items-center gap-2 w-full px-4 py-4"
+      className="relative flex justify-center items-center gap-2 w-full px-4 py-3"
     >
       {/* Drag overlay */}
       {isDragging && (

--- a/src/components/knowledge-graph/Universe/Overlay/ActionsToolbar/index.tsx
+++ b/src/components/knowledge-graph/Universe/Overlay/ActionsToolbar/index.tsx
@@ -11,7 +11,7 @@ export const ActionsToolbar = () => {
     }
 
     return (
-        <div className="absolute right-5 bottom-5 pointer-events-auto flex flex-col items-end" id="actions-toolbar">
+        <div className="absolute right-4 pointer-events-auto flex flex-col items-end" id="actions-toolbar" style={{ bottom: '16px' }}>
             <div className="flex flex-col gap-1">
                 <CameraRecenterControl />
             </div>

--- a/src/components/workspace/WorkspaceMembersPreview/index.tsx
+++ b/src/components/workspace/WorkspaceMembersPreview/index.tsx
@@ -58,7 +58,7 @@ export function WorkspaceMembersPreview({
   };
 
   return (
-    <div className={`flex items-center gap-2 px-3 py-2 rounded-lg border border-border bg-card/95 backdrop-blur-sm transition-all duration-300 max-h-[120px] overflow-y-auto ${loading ? 'opacity-0' : 'opacity-100'}`}>
+    <div className={`flex items-center gap-2 px-3 py-3 rounded-lg border border-border bg-card/95 backdrop-blur-sm transition-all duration-300 max-h-[120px] overflow-y-auto ${loading ? 'opacity-0' : 'opacity-100'}`}>
       {/* Avatar list */}
       <div className="flex items-center gap-2 flex-wrap">
         {displayMembers.map((member, index) => {


### PR DESCRIPTION
Fix vertical alignment of bottom graph view elements

- Standardize bottom positioning to 16px for all three bottom elements
- Update WorkspaceMembersPreview padding from py-2 to py-3
- Update ChatInput padding from py-4 to py-3  
- Update ActionsToolbar to use consistent bottom positioning
- Add flex items-end to dashboard layout containers
- Ensures team profile images, chat bar, and graph view selectors align properly despite different heights