### PR TITLE
fix: preserve pagination state when deleting features

### DIFF
--- a/src/app/w/[slug]/plan/[featureId]/page.tsx
+++ b/src/app/w/[slug]/plan/[featureId]/page.tsx
@@ -30,6 +30,15 @@ export default function FeatureDetailPage() {
   const searchParams = useSearchParams();
   const { slug: workspaceSlug, id: workspaceId } = useWorkspace();
   const featureId = params.featureId as string;
+  
+  // Get the page parameter to preserve pagination when navigating back
+  const returnPage = searchParams.get("page") || "1";
+  
+  // Helper function to get the back navigation path
+  const getBackPath = () => {
+    const basePath = `/w/${workspaceSlug}/plan`;
+    return returnPage !== "1" ? `${basePath}?page=${returnPage}` : basePath;
+  };
 
   // Tab state management
   const [activeTab, setActiveTab] = useState(searchParams.get("tab") || "overview");
@@ -230,7 +239,8 @@ export default function FeatureDetailPage() {
         throw new Error("Failed to delete feature");
       }
 
-      router.push(`/w/${workspaceSlug}/plan`);
+      // Navigate back to the list, preserving the page number
+      router.push(getBackPath());
     } catch (error) {
       console.error("Failed to delete feature:", error);
     }
@@ -266,7 +276,7 @@ export default function FeatureDetailPage() {
       <div className="space-y-6">
         {/* Header with back button */}
         <div className="flex items-center gap-4">
-          <Button variant="ghost" size="sm" onClick={() => router.push(`/w/${workspaceSlug}/plan`)}>
+          <Button variant="ghost" size="sm" onClick={() => router.push(getBackPath())}>
             <ArrowLeft className="h-4 w-4 mr-2" />
             Back
           </Button>
@@ -347,7 +357,7 @@ export default function FeatureDetailPage() {
   if (error || !feature) {
     return (
       <div className="space-y-6">
-        <Button variant="ghost" size="sm" onClick={() => router.push(`/w/${workspaceSlug}/plan`)}>
+        <Button variant="ghost" size="sm" onClick={() => router.push(getBackPath())}>
           <ArrowLeft className="h-4 w-4 mr-2" />
           Back
         </Button>
@@ -367,7 +377,7 @@ export default function FeatureDetailPage() {
     <div className="space-y-6">
       {/* Header with back button */}
       <div className="flex items-center gap-4">
-        <Button variant="ghost" size="sm" onClick={() => router.push(`/w/${workspaceSlug}/plan`)}>
+        <Button variant="ghost" size="sm" onClick={() => router.push(getBackPath())}>
           <ArrowLeft className="h-4 w-4 mr-2" />
           Back
         </Button>

--- a/src/components/features/FeaturesList.tsx
+++ b/src/components/features/FeaturesList.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useRef, forwardRef, useImperativeHandle, useMemo } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useDebounce } from "@/hooks/useDebounce";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
@@ -122,6 +122,7 @@ function FeatureRow({
 const FeaturesListComponent = forwardRef<{ triggerCreate: () => void }, FeaturesListProps>(
   function FeaturesList({ workspaceId }, ref) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { slug: workspaceSlug } = useWorkspace();
 
   // Fetch workspace members (no system assignees for features)
@@ -135,6 +136,18 @@ const FeaturesListComponent = forwardRef<{ triggerCreate: () => void }, Features
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(false);
   const [totalPages, setTotalPages] = useState(1);
+
+  // Read page from URL on mount
+  useEffect(() => {
+    const pageParam = searchParams?.get("page");
+    if (pageParam) {
+      const pageNum = parseInt(pageParam, 10);
+      if (!isNaN(pageNum) && pageNum > 0) {
+        setPage(pageNum);
+      }
+    }
+  }, []); // Only run on mount
+  // eslint-disable-next-line react-hooks/exhaustive-deps
 
   // Filter and sort state with localStorage persistence
   const [statusFilters, setStatusFilters] = useState<string[]>(() => {
@@ -915,7 +928,7 @@ const FeaturesListComponent = forwardRef<{ triggerCreate: () => void }, Features
                       onPriorityUpdate={handleUpdatePriority}
                       onAssigneeUpdate={handleUpdateAssignee}
                       onDelete={handleDeleteFeature}
-                      onClick={() => router.push(`/w/${workspaceSlug}/plan/${feature.id}`)}
+                      onClick={() => router.push(`/w/${workspaceSlug}/plan/${feature.id}?page=${page}`)}
                     />
                   ))
                 )}


### PR DESCRIPTION
fix: preserve pagination state when deleting features

- Add URL query parameter to track current page number
- Update FeaturesList to read and apply page parameter from URL
- Modify feature detail page to include page param in navigation
- Update delete and back navigation to return to correct page
- Ensures users return to the same page after deleting a feature