### PR TITLE
feat: disable chat input during workflow execution in live mode

### DIFF
--- a/src/app/w/[slug]/task/[...taskParams]/page.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/page.tsx
@@ -1035,14 +1035,19 @@ export default function TaskChatPage() {
     workflowStatus === WorkflowStatus.HALTED ||
     workflowStatus === WorkflowStatus.FAILED ||
     workflowStatus === WorkflowStatus.ERROR;
-  const inputDisabled = isLoading || !isConnected || isTerminalState;
-  if (hasActiveChatForm) {
-    // TODO: rm this and only enable if ready below
-  }
-  // const inputDisabled =
-  //   isLoading ||
-  //   !isConnected ||
-  //   (started && messages.length > 0 && !hasActiveChatForm);
+
+  // Live mode: restrict input based on workflow state and pod availability
+  const liveModeSendAllowed =
+    !started || // Fresh task - can send to kick off
+    hasActiveChatForm || // FORM with chat option waiting for response
+    workflowStatus === WorkflowStatus.COMPLETED || // Workflow done, can continue
+    workflowStatus === WorkflowStatus.PENDING; // Not started yet
+
+  const inputDisabled =
+    isLoading ||
+    !isConnected ||
+    isTerminalState ||
+    (taskMode !== "agent" && (!podId || !liveModeSendAllowed));
 
   return (
     <AnimatePresence mode="wait">


### PR DESCRIPTION
## Summary

Adds input control logic for live mode task chat to prevent users from sending messages while workflows are executing. Agent mode behavior remains unchanged.

## Input State Rules (Live Mode)

| Condition | Input State | Reason |
|-----------|-------------|--------|
| No `podId` | 🔒 Disabled | No pod connection available |
| Fresh task (not started) | ✅ Enabled | Can send to kick off workflow |
| Workflow `PENDING` | ✅ Enabled | Ready to start |
| Workflow `IN_PROGRESS` | 🔒 Disabled | Workflow is running |
| Workflow `IN_PROGRESS` + FORM waiting | ✅ Enabled | Form expects user response |
| Workflow `COMPLETED` + `podId` | ✅ Enabled | Can continue conversation |
| Workflow `COMPLETED` + no `podId` | 🔒 Disabled | Pod was released |
| Terminal states (`HALTED`/`FAILED`/`ERROR`) | 🔒 Disabled | Workflow ended |

**Agent mode**: Unchanged (always allows input when connected)

## Real-time Updates

Input state updates automatically via Pusher when:
- Workflow status changes → input enables/disables based on new status
- Pod is released → input becomes disabled

## Test Plan

- [ ] Live mode: new task can send initial message
- [ ] Live mode: input disabled during `IN_PROGRESS`
- [ ] Live mode: input enabled when FORM artifact with chat option arrives
- [ ] Live mode: input enabled when workflow `COMPLETED` (with pod)
- [ ] Live mode: input disabled after pod release
- [ ] Agent mode: input behavior unchanged