### PR TITLE
feat: change Create PR button to Open PR after PR creation

### DIFF
--- a/src/app/w/[slug]/task/[...taskParams]/components/AgentChatArea.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/components/AgentChatArea.tsx
@@ -34,6 +34,7 @@ interface AgentChatAreaProps {
   podId?: string | null;
   onReleasePod?: () => Promise<void>;
   isReleasingPod?: boolean;
+  prUrl?: string | null;
 }
 
 export function AgentChatArea({
@@ -56,6 +57,7 @@ export function AgentChatArea({
   podId,
   onReleasePod,
   isReleasingPod = false,
+  prUrl = null,
 }: AgentChatAreaProps) {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
@@ -196,17 +198,28 @@ export function AgentChatArea({
                 </TooltipProvider>
               )}
 
-              {/* Create PR Button */}
+              {/* Create PR / Open PR Button */}
               {onCommit && (
-                <Button
-                  size="sm"
-                  onClick={onCommit}
-                  disabled={isCommitting}
-                  className="flex-shrink-0 gap-1 bg-green-600 hover:bg-green-700 text-white"
-                >
-                  <Github className="w-3 h-3" />
-                  {isCommitting ? "Creating..." : "Create PR"}
-                </Button>
+                prUrl ? (
+                  <Button
+                    size="sm"
+                    onClick={() => window.open(prUrl, '_blank')}
+                    className="flex-shrink-0 gap-1 bg-blue-600 hover:bg-blue-700 text-white"
+                  >
+                    <Github className="w-3 h-3" />
+                    Open PR
+                  </Button>
+                ) : (
+                  <Button
+                    size="sm"
+                    onClick={onCommit}
+                    disabled={isCommitting}
+                    className="flex-shrink-0 gap-1 bg-green-600 hover:bg-green-700 text-white"
+                  >
+                    <Github className="w-3 h-3" />
+                    {isCommitting ? "Creating..." : "Create PR"}
+                  </Button>
+                )
               )}
             </div>
           </motion.div>

--- a/src/app/w/[slug]/task/[...taskParams]/page.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/page.tsx
@@ -1036,6 +1036,14 @@ export default function TaskChatPage() {
 
   const hasNonFormArtifacts = artifactsWithoutOldDiffs.some((a) => a.type !== "FORM" && a.type !== "LONGFORM");
   const browserArtifact = artifactsWithoutOldDiffs.find((a) => a.type === "BROWSER");
+  
+  // Extract PR URL from PULL_REQUEST artifacts (get the first one if multiple exist)
+  const prArtifact = messages
+    .slice()
+    .reverse()
+    .find((msg) => msg.artifacts?.some((artifact) => artifact.type === "PULL_REQUEST"));
+  const prUrl = prArtifact?.artifacts?.find((a) => a.type === "PULL_REQUEST")?.content as PullRequestContent | undefined;
+  const prLink = prUrl?.url || null;
 
   const isTerminalState =
     workflowStatus === WorkflowStatus.HALTED ||
@@ -1121,6 +1129,7 @@ export default function TaskChatPage() {
                     podId={podId}
                     onReleasePod={handleReleasePod}
                     isReleasingPod={isReleasingPod}
+                    prUrl={prLink}
                   />
                 )}
               </div>
@@ -1145,6 +1154,7 @@ export default function TaskChatPage() {
                       podId={podId}
                       onReleasePod={handleReleasePod}
                       isReleasingPod={isReleasingPod}
+                      prUrl={prLink}
                     />
                   </div>
                 </ResizablePanel>
@@ -1180,6 +1190,7 @@ export default function TaskChatPage() {
                 podId={podId}
                 onReleasePod={handleReleasePod}
                 isReleasingPod={isReleasingPod}
+                prUrl={prLink}
               />
             </div>
           ) : hasNonFormArtifacts ? (


### PR DESCRIPTION
feat: change Create PR button to Open PR after PR creation

- Add prUrl prop to AgentChatArea component
- Implement conditional rendering to show "Open PR" button when PR exists
- Extract PR URL from PULL_REQUEST artifacts in messages
- Change button color from green to blue when PR is created
- Open PR in new tab when clicking "Open PR" button