### PR TITLE
fix: set podState to COMPLETED in mock setup to remove "Validating.

### DIFF
--- a/src/utils/mockSetup.ts
+++ b/src/utils/mockSetup.ts
@@ -1,6 +1,7 @@
 import { db } from "@/lib/db";
 import { EncryptionService } from "@/lib/encryption";
 import {
+  PodState,
   PoolState,
   RepositoryStatus,
   SourceControlOrgType,
@@ -180,6 +181,7 @@ export async function ensureMockWorkspaceForUser(
         agentStatus: null,
         containerFilesSetUp: true, // Enable for E2E tests to show dashboard immediately
         poolState: PoolState.COMPLETE, // Skip "Launch Pods" step for mock users
+        podState: PodState.COMPLETED, // Skip "Validating..." message for mock users
         poolName: "mock-pool",
         poolApiKey: encryptedPoolApiKey, // Mock pool API key for Pool Manager mock
       },


### PR DESCRIPTION
fix: set podState to COMPLETED in mock setup to remove "Validating..." message

When running locally with mock authentication, the "Validating..." message 
was appearing because mockSetup.ts created swarms with poolState set to 
COMPLETE but left podState at the default NOT_STARTED value.

Changes:
- Added PodState import to mockSetup.ts
- Set podState: PodState.COMPLETED in swarm creation for mock users
- Prevents pool status widget from showing "Validating..." on mock accounts