### PR TITLE
fix: trigger Pusher events when workflowStatus changes to IN_PROGRESS

### DIFF
--- a/src/__tests__/unit/api/api-chat-message.test.ts
+++ b/src/__tests__/unit/api/api-chat-message.test.ts
@@ -496,6 +496,11 @@ describe("POST /api/chat/message", () => {
           workflowStartedAt: expect.any(Date),
           stakworkProjectId: 123,
         },
+        select: {
+          workflowStartedAt: true,
+          workflowCompletedAt: true,
+          featureId: true,
+        },
       });
     });
 
@@ -516,6 +521,11 @@ describe("POST /api/chat/message", () => {
         where: { id: mockTaskId },
         data: {
           workflowStatus: WorkflowStatus.FAILED,
+        },
+        select: {
+          workflowStartedAt: true,
+          workflowCompletedAt: true,
+          featureId: true,
         },
       });
     });

--- a/src/__tests__/unit/api/chat/message/call-stakwork.test.ts
+++ b/src/__tests__/unit/api/chat/message/call-stakwork.test.ts
@@ -236,6 +236,11 @@ describe("callStakwork Function - Chat Message Processing", () => {
             workflowStartedAt: expect.any(Date),
             stakworkProjectId: 67890,
           },
+          select: {
+            workflowStartedAt: true,
+            workflowCompletedAt: true,
+            featureId: true,
+          },
         });
       });
 
@@ -287,12 +292,17 @@ describe("callStakwork Function - Chat Message Processing", () => {
         const response = await POST(request);
 
         expect(response.status).toBe(201); // Message still created
-        
+
         // Verify task was marked as FAILED
         expect(vi.mocked(db.task.update)).toHaveBeenCalledWith({
           where: { id: mockTaskId },
           data: {
             workflowStatus: WorkflowStatus.FAILED,
+          },
+          select: {
+            workflowStartedAt: true,
+            workflowCompletedAt: true,
+            featureId: true,
           },
         });
       });
@@ -1098,6 +1108,11 @@ describe("callStakwork Function - Chat Message Processing", () => {
           where: { id: mockTaskId },
           data: {
             workflowStatus: WorkflowStatus.FAILED,
+          },
+          select: {
+            workflowStartedAt: true,
+            workflowCompletedAt: true,
+            featureId: true,
           },
         });
       });

--- a/src/__tests__/unit/api/chat/message/route.test.ts
+++ b/src/__tests__/unit/api/chat/message/route.test.ts
@@ -1053,6 +1053,11 @@ describe("POST /api/chat/message - callStakwork Unit Tests", () => {
         data: {
           workflowStatus: WorkflowStatus.FAILED,
         },
+        select: {
+          workflowStartedAt: true,
+          workflowCompletedAt: true,
+          featureId: true,
+        },
       });
     });
 
@@ -1080,6 +1085,11 @@ describe("POST /api/chat/message - callStakwork Unit Tests", () => {
         where: { id: mockTaskId },
         data: {
           workflowStatus: WorkflowStatus.FAILED,
+        },
+        select: {
+          workflowStartedAt: true,
+          workflowCompletedAt: true,
+          featureId: true,
         },
       });
     });
@@ -1237,6 +1247,11 @@ describe("POST /api/chat/message - callStakwork Unit Tests", () => {
           workflowStartedAt: expect.any(Date),
           stakworkProjectId: 12345,
         },
+        select: {
+          workflowStartedAt: true,
+          workflowCompletedAt: true,
+          featureId: true,
+        },
       });
     });
 
@@ -1267,6 +1282,11 @@ describe("POST /api/chat/message - callStakwork Unit Tests", () => {
           workflowStatus: WorkflowStatus.IN_PROGRESS,
           workflowStartedAt: expect.any(Date),
           stakworkProjectId: 67890,
+        },
+        select: {
+          workflowStartedAt: true,
+          workflowCompletedAt: true,
+          featureId: true,
         },
       });
     });
@@ -1303,6 +1323,11 @@ describe("POST /api/chat/message - callStakwork Unit Tests", () => {
         data: {
           workflowStatus: WorkflowStatus.IN_PROGRESS,
           workflowStartedAt: expect.any(Date),
+        },
+        select: {
+          workflowStartedAt: true,
+          workflowCompletedAt: true,
+          featureId: true,
         },
       });
     });

--- a/src/__tests__/unit/services/release-stale-task-pods.test.ts
+++ b/src/__tests__/unit/services/release-stale-task-pods.test.ts
@@ -326,6 +326,11 @@ describe("releaseStaleTaskPods", () => {
         workflowStatus: "HALTED",
         workflowCompletedAt: expect.any(Date),
       },
+      select: {
+        workflowStartedAt: true,
+        workflowCompletedAt: true,
+        featureId: true,
+      },
     });
 
     // Verify result
@@ -572,6 +577,11 @@ describe("haltTask", () => {
         workflowStatus: "HALTED",
         workflowCompletedAt: expect.any(Date),
       },
+      select: {
+        workflowStartedAt: true,
+        workflowCompletedAt: true,
+        featureId: true,
+      },
     });
   });
 
@@ -589,6 +599,11 @@ describe("haltTask", () => {
         agentUrl: null,
         agentPassword: null,
       },
+      select: {
+        workflowStartedAt: true,
+        workflowCompletedAt: true,
+        featureId: true,
+      },
     });
   });
 
@@ -602,6 +617,11 @@ describe("haltTask", () => {
       data: {
         workflowStatus: "HALTED",
         workflowCompletedAt: expect.any(Date),
+      },
+      select: {
+        workflowStartedAt: true,
+        workflowCompletedAt: true,
+        featureId: true,
       },
     });
   });

--- a/src/lib/helpers/workflow-status.ts
+++ b/src/lib/helpers/workflow-status.ts
@@ -1,0 +1,81 @@
+import { db } from "@/lib/db";
+import { WorkflowStatus } from "@prisma/client";
+import { pusherServer, getTaskChannelName, PUSHER_EVENTS } from "@/lib/pusher";
+import { updateFeatureStatusFromTasks } from "@/services/roadmap/feature-status-sync";
+
+interface UpdateWorkflowStatusOptions {
+  taskId: string;
+  workflowStatus: WorkflowStatus;
+  workflowStartedAt?: Date;
+  workflowCompletedAt?: Date;
+  additionalData?: Record<string, unknown>;
+  skipPusher?: boolean;
+}
+
+interface UpdateWorkflowStatusResult {
+  workflowStartedAt: Date | null;
+  workflowCompletedAt: Date | null;
+  featureId: string | null;
+}
+
+/**
+ * Updates a task's workflow status and broadcasts to Pusher for real-time UI updates.
+ * Centralizes workflowStatus updates to ensure consistent Pusher notifications.
+ */
+export async function updateTaskWorkflowStatus(
+  options: UpdateWorkflowStatusOptions
+): Promise<UpdateWorkflowStatusResult> {
+  const {
+    taskId,
+    workflowStatus,
+    workflowStartedAt,
+    workflowCompletedAt,
+    additionalData,
+    skipPusher,
+  } = options;
+
+  const updatedTask = await db.task.update({
+    where: { id: taskId },
+    data: {
+      workflowStatus,
+      ...(workflowStartedAt && { workflowStartedAt }),
+      ...(workflowCompletedAt && { workflowCompletedAt }),
+      ...additionalData,
+    },
+    select: {
+      workflowStartedAt: true,
+      workflowCompletedAt: true,
+      featureId: true,
+    },
+  });
+
+  // Sync feature status if task belongs to a feature
+  if (updatedTask.featureId) {
+    try {
+      await updateFeatureStatusFromTasks(updatedTask.featureId);
+    } catch (error) {
+      console.error("Failed to sync feature status:", error);
+    }
+  }
+
+  // Broadcast to task channel for real-time UI updates
+  if (!skipPusher) {
+    try {
+      await pusherServer.trigger(
+        getTaskChannelName(taskId),
+        PUSHER_EVENTS.WORKFLOW_STATUS_UPDATE,
+        {
+          taskId,
+          workflowStatus,
+          workflowStartedAt: updatedTask.workflowStartedAt,
+          workflowCompletedAt: updatedTask.workflowCompletedAt,
+          timestamp: new Date(),
+        }
+      );
+    } catch (error) {
+      console.error("Error broadcasting workflow status to Pusher:", error);
+    }
+  }
+
+  return updatedTask;
+}


### PR DESCRIPTION
Add updateTaskWorkflowStatus helper that updates the database and triggers a Pusher WORKFLOW_STATUS_UPDATE event. Previously, the event was only triggered by the Stakwork webhook callback, causing the frontend to show stale status until page refresh.