### PR TITLE
Hide workflow status and processing indicator when completed

### DIFF
--- a/src/app/w/[slug]/task/[...taskParams]/components/ChatInput.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/components/ChatInput.tsx
@@ -178,7 +178,7 @@ export function ChatInput({
       )}>
         <ModeIcon className="h-4 w-4" />
         <span>{modeConfig.label}</span>
-        {!hasPrArtifact && (
+        {!hasPrArtifact && workflowStatus !== WorkflowStatus.COMPLETED && (
           <>
             <span>|</span>
             <WorkflowStatusBadge status={workflowStatus} />

--- a/src/app/w/[slug]/task/[...taskParams]/page.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/page.tsx
@@ -138,6 +138,10 @@ export default function TaskChatPage() {
 
   const handleWorkflowStatusUpdate = useCallback((update: WorkflowStatusUpdate) => {
     setWorkflowStatus(update.workflowStatus);
+    // Hide processing indicator when workflow finishes
+    if (update.workflowStatus === WorkflowStatus.COMPLETED) {
+      setIsChainVisible(false);
+    }
   }, []);
 
   const handleTaskTitleUpdate = useCallback(


### PR DESCRIPTION
- Don't show "Workflow | Completed" badge in chat input
- Hide processing indicator when workflow status changes to COMPLETED