### PR TITLE
Increase endpoint nodes limit from 40 to 400 in defaultFilters

### DIFF
--- a/src/stores/useDataStore/index.ts
+++ b/src/stores/useDataStore/index.ts
@@ -9,7 +9,7 @@ export const defaultFilters = {
   depth: '3',
   sort_by: 'score',
   include_properties: 'true',
-  top_node_count: '40',
+  top_node_count: '400',
   includeContent: 'true',
   node_type: [],
   search_method: 'hybrid',


### PR DESCRIPTION
Increase endpoint nodes limit from 40 to 400 in defaultFilters