### PR TITLE
Fix PR button styling and visibility in task chat

### DIFF
--- a/src/app/w/[slug]/task/[...taskParams]/components/AgentChatArea.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/components/AgentChatArea.tsx
@@ -204,7 +204,8 @@ export function AgentChatArea({
                   <Button
                     size="sm"
                     onClick={() => window.open(prUrl, '_blank')}
-                    className="flex-shrink-0 gap-1 bg-blue-600 hover:bg-blue-700 text-white"
+                    className="flex-shrink-0 gap-1 text-white hover:opacity-90"
+                    style={{ backgroundColor: "#238636" }}
                   >
                     <Github className="w-3 h-3" />
                     Open PR

--- a/src/app/w/[slug]/task/[...taskParams]/page.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/page.tsx
@@ -1041,6 +1041,9 @@ export default function TaskChatPage() {
   const hasNonFormArtifacts = artifactsWithoutOldDiffs.some((a) => a.type !== "FORM" && a.type !== "LONGFORM");
   const browserArtifact = artifactsWithoutOldDiffs.find((a) => a.type === "BROWSER");
   
+  // Check if code has been created (CODE or DIFF artifacts exist)
+  const hasCodeArtifact = artifactsWithoutOldDiffs.some((a) => a.type === "CODE" || a.type === "DIFF");
+  
   // Extract PR URL from PULL_REQUEST artifacts (get the first one if multiple exist)
   const prArtifact = messages
     .slice()
@@ -1124,7 +1127,7 @@ export default function TaskChatPage() {
                     workflowStatus={workflowStatus}
                     taskTitle={taskTitle}
                     workspaceSlug={slug}
-                    onCommit={handleCommit}
+                    onCommit={hasCodeArtifact ? handleCommit : undefined}
                     isCommitting={isGeneratingCommitInfo || isCommitting}
                     showPreviewToggle={!!browserArtifact}
                     showPreview={showPreview}
@@ -1152,7 +1155,7 @@ export default function TaskChatPage() {
                       workflowStatus={workflowStatus}
                       taskTitle={taskTitle}
                       workspaceSlug={slug}
-                      onCommit={handleCommit}
+                      onCommit={hasCodeArtifact ? handleCommit : undefined}
                       isCommitting={isGeneratingCommitInfo || isCommitting}
                       taskMode={taskMode}
                       podId={podId}
@@ -1188,7 +1191,7 @@ export default function TaskChatPage() {
                 workflowStatus={workflowStatus}
                 taskTitle={taskTitle}
                 workspaceSlug={slug}
-                onCommit={handleCommit}
+                onCommit={hasCodeArtifact ? handleCommit : undefined}
                 isCommitting={isGeneratingCommitInfo || isCommitting}
                 taskMode={taskMode}
                 podId={podId}


### PR DESCRIPTION
Fix PR button styling and visibility in task chat

- Change "Open PR" button color from blue to green (#238636) to match Open PR artifact
- Add hasCodeArtifact check to only show "Create PR" button after code is generated
- Update hover effect to opacity-90 for consistency with artifact styling