### PR TITLE
Hide COMPLETED workflow status badge on task cards

### DIFF
--- a/src/components/tasks/TaskCard.tsx
+++ b/src/components/tasks/TaskCard.tsx
@@ -184,9 +184,9 @@ export function TaskCard({ task, workspaceSlug, hideWorkflowStatus = false, isAr
           </Badge>
         )}
 
-        {/* Workflow Status - hidden when PR artifact exists */}
+        {/* Workflow Status - hidden when PR artifact exists or workflow is completed */}
         {/* Agent tasks show "Running" instead of "Pending" since they're active until completion */}
-        {!hideWorkflowStatus && !task.prArtifact && (
+        {!hideWorkflowStatus && !task.prArtifact && task.workflowStatus !== "COMPLETED" && (
           <div className="px-2 py-0.5 rounded-full border bg-background text-xs">
             <WorkflowStatusBadge
               status={


### PR DESCRIPTION
The workflow status badge showing "Completed" was confusing since it refers to system automation state, not task completion. Now hidden alongside existing logic that hides the badge when a PR artifact exists.