### PR TITLE
Fix PR merged real-time update on task chat page

### DIFF
--- a/src/hooks/usePusherConnection.ts
+++ b/src/hooks/usePusherConnection.ts
@@ -32,7 +32,9 @@ export interface TaskTitleUpdateEvent {
 export interface PRStatusChangeEvent {
   taskId: string;
   prNumber: number;
-  state: "healthy" | "conflict" | "ci_failure" | "checking";
+  prUrl?: string;
+  state: "healthy" | "conflict" | "ci_failure" | "checking" | "merged" | "closed";
+  artifactStatus?: "IN_PROGRESS" | "DONE" | "CANCELLED";
   problemDetails?: string;
   timestamp: Date;
 }


### PR DESCRIPTION
Send PR_STATUS_CHANGE event to task channel when PR is merged, allowing the task page to update the artifact status without refresh.