### PR TITLE
making pid optional / undefined

### DIFF
--- a/src/types/pod-repair.ts
+++ b/src/types/pod-repair.ts
@@ -11,7 +11,7 @@ export const STAKLINK_PROXY_PROCESS = "staklink-proxy" as const;
 
 // jlist endpoint response types
 export interface JlistProcess {
-  pid: number | null;
+  pid?: number | null;
   name: string;
   status: string;
   pm_uptime?: number | null;
@@ -21,7 +21,7 @@ export interface JlistProcess {
 
 export const JlistResponseSchema = z.array(
   z.object({
-    pid: z.number().nullable(),
+    pid: z.number().nullable().optional(),
     name: z.string(),
     status: z.string(),
     pm_uptime: z.number().nullable().optional(),


### PR DESCRIPTION
If even one process in the jlist had pid: undefined instead of pid: null, the entire jlist validation failed, and the pod repair cron would skip that pod completely - meaning failed processes on that pod wouldn't be
  detected or repaired.