### PR TITLE
fix: improve dependency graph collision detection spacing

### DIFF
--- a/src/components/features/DependencyGraph/index.tsx
+++ b/src/components/features/DependencyGraph/index.tsx
@@ -16,8 +16,10 @@ import { getLayoutedElements } from "./layouts/dagre";
 import type { DependencyGraphProps, GraphEntity } from "./types";
 import { Empty, EmptyHeader, EmptyTitle, EmptyDescription } from "@/components/ui/empty";
 
-const DEFAULT_NODE_WIDTH = 250;
-const DEFAULT_NODE_HEIGHT = 80;
+// Account for actual rendered size including padding, borders, and shadows
+// The RoadmapTaskNode has min-w-[250px] but renders larger with content
+const DEFAULT_NODE_WIDTH = 300;
+const DEFAULT_NODE_HEIGHT = 100;
 
 export function DependencyGraph<T extends GraphEntity>({
   entities,
@@ -66,8 +68,8 @@ export function DependencyGraph<T extends GraphEntity>({
       nodeWidth: DEFAULT_NODE_WIDTH,
       nodeHeight: DEFAULT_NODE_HEIGHT,
       direction,
-      ranksep: 100,
-      nodesep: 50,
+      ranksep: 200,
+      nodesep: 150,
     });
   }, [entities, getDependencies, direction]);
 

--- a/src/components/features/DependencyGraph/layouts/dagre.ts
+++ b/src/components/features/DependencyGraph/layouts/dagre.ts
@@ -3,9 +3,9 @@ import { Node, Edge, Position } from "@xyflow/react";
 import type { LayoutConfig, LayoutResult } from "../types";
 import { detectCollisions } from "./collisionDetection";
 
-const MAX_LAYOUT_ATTEMPTS = 3;
-const RANKSEP_INCREMENT = 50;
-const NODESEP_INCREMENT = 25;
+const MAX_LAYOUT_ATTEMPTS = 5;
+const RANKSEP_INCREMENT = 100;
+const NODESEP_INCREMENT = 75;
 
 export function getLayoutedElements(
   nodes: Node[],
@@ -16,8 +16,8 @@ export function getLayoutedElements(
     nodeWidth,
     nodeHeight,
     direction = "TB",
-    ranksep: initialRanksep = 100,
-    nodesep: initialNodesep = 50,
+    ranksep: initialRanksep = 200,
+    nodesep: initialNodesep = 100,
   } = config;
 
   let currentRanksep = initialRanksep;
@@ -70,7 +70,7 @@ export function getLayoutedElements(
       layoutedNodes,
       nodeWidth,
       nodeHeight,
-      25 // minSpacing for collision detection
+      50 // minSpacing for collision detection (buffer on each side)
     );
 
     // If no collisions, return the result


### PR DESCRIPTION
Increase node dimensions and spacing parameters to prevent overlapping task cards in the dependency graph view.