### PR TITLE
feat: exclude completed features from needs input filter

### DIFF
--- a/src/services/roadmap/features.ts
+++ b/src/services/roadmap/features.ts
@@ -86,6 +86,7 @@ export async function listFeatures({
   }
 
   // Handle needsAttention filter - features with pending StakworkRuns awaiting user decision
+  // Exclude features that are already COMPLETED
   if (needsAttention) {
     whereClause.stakworkRuns = {
       some: {
@@ -94,6 +95,17 @@ export async function listFeatures({
         type: { in: ["ARCHITECTURE", "REQUIREMENTS", "TASK_GENERATION", "USER_STORIES"] },
       },
     };
+    // If status filter is already set, merge with COMPLETED exclusion
+    // Otherwise, just exclude COMPLETED status
+    if (whereClause.status && whereClause.status.in) {
+      // Filter out COMPLETED from the status list if present
+      const filteredStatuses = whereClause.status.in.filter((s: string) => s !== "COMPLETED");
+      whereClause.status = { in: filteredStatuses };
+    } else {
+      whereClause.status = {
+        not: "COMPLETED",
+      };
+    }
   }
 
   // Build orderBy clause


### PR DESCRIPTION
feat: exclude completed features from needs input filter

Add logic to filter out COMPLETED features when the "Needs input" 
filter is active on Build: Plan: Tasks Feature table. The implementation 
intelligently handles both standalone and combined status filtering 
scenarios to prevent completed features from appearing in the needs 
input view.

- Modified features.ts to check feature status
- Added smart merging logic for status filters
- Excludes COMPLETED status when needs input filter is active
- Maintains backward compatibility with existing filters

---

_View task here [cmkvb3wno0001l404l8vaplvv](https://hive.sphinx.chat/w/hive/task/cmkvb3wno0001l404l8vaplvv)_