### PR TITLE
Fix pod release overlay incorrectly showing for user journey testing

### DIFF
--- a/src/app/w/[slug]/task/[...taskParams]/artifacts/browser.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/artifacts/browser.tsx
@@ -477,10 +477,10 @@ export function BrowserArtifactPanel({
                     </div>
                   </div>
                 )}
-                {isActive && isUrlReady && !podId && (
+                {isActive && isUrlReady && !podId && !onUserJourneySave && (
                   <div className="absolute inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm">
                     <div className="flex flex-col items-center gap-3">
-                      <p className="text-sm text-muted-foreground">Development environment has been released</p>
+                      <p className="text-sm text-muted-foreground">Pod has been released</p>
                     </div>
                   </div>
                 )}


### PR DESCRIPTION
The overlay condition now checks for onUserJourneySave prop to distinguish between regular agent tasks (where podId becomes null on release) and user journey testing (where podId is never passed but onUserJourneySave is provided).

Also updated the message from "Development environment has been released" to "Pod has been released".