### PR TITLE
fix: hide "show more" button when janitors are disabled on recommendatio

### DIFF
--- a/src/components/insights/RecommendationsSection/index.tsx
+++ b/src/components/insights/RecommendationsSection/index.tsx
@@ -169,7 +169,7 @@ export function RecommendationsSection() {
           </div>
         )}
 
-        {!loading && recommendations.length > 3 && !showAll && (
+        {!loading && hasEnabledJanitors && recommendations.length > 3 && !showAll && (
           <div className="pt-2 text-center">
             <Button
               variant="ghost"


### PR DESCRIPTION
fix: hide "show more" button when janitors are disabled on recommendations page

---

_View task here [cmkwzqu4y0006l1047pudsz4g](https://hive.sphinx.chat/w/hive/task/cmkwzqu4y0006l1047pudsz4g)_