### PR TITLE
feat: add API token auth to workspace creation endpoint

### DIFF
--- a/src/app/api/workspaces/route.ts
+++ b/src/app/api/workspaces/route.ts
@@ -1,7 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth/nextauth";
-import { createWorkspace, getUserWorkspaces, softDeleteWorkspace } from "@/services/workspace";
+import {
+  createWorkspace,
+  ensureUniqueSlug,
+  extractRepoNameFromUrl,
+  getUserWorkspaces,
+  softDeleteWorkspace,
+} from "@/services/workspace";
+import { findUserByGitHubUsername } from "@/lib/helpers/workspace-member-queries";
 import { db } from "@/lib/db";
 import { getErrorMessage } from "@/lib/utils/error";
 
@@ -19,25 +26,64 @@ export async function GET() {
 }
 
 export async function POST(request: NextRequest) {
-  const session = await getServerSession(authOptions);
-  if (!session?.user || !(session.user as { id?: string }).id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-  const userId = (session.user as { id: string }).id;
+  const apiToken = request.headers.get("x-api-token");
   const body = await request.json();
-  const { name, description, slug, repositoryUrl } = body;
-  if (!name || !slug) {
-    return NextResponse.json(
-      { error: "Missing required fields" },
-      { status: 400 },
-    );
+  let ownerId: string;
+
+  if (apiToken) {
+    if (apiToken !== process.env.API_TOKEN) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (!body.githubUsername) {
+      return NextResponse.json(
+        { error: "githubUsername required for API key auth" },
+        { status: 400 },
+      );
+    }
+    const githubAuth = await findUserByGitHubUsername(body.githubUsername);
+    if (!githubAuth) {
+      return NextResponse.json(
+        { error: "User not found. They must sign up to Hive first." },
+        { status: 404 },
+      );
+    }
+    ownerId = githubAuth.userId;
+  } else {
+    const session = await getServerSession(authOptions);
+    if (!session?.user || !(session.user as { id?: string }).id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    ownerId = (session.user as { id: string }).id;
   }
+
+  const { name, description, slug, repositoryUrl } = body;
+  let finalName = name;
+  let finalSlug = slug;
+
+  // Auto-generate from repositoryUrl if not provided
+  if (repositoryUrl && (!finalSlug || !finalName)) {
+    const repoName = extractRepoNameFromUrl(repositoryUrl);
+    if (!repoName) {
+      return NextResponse.json({ error: "Invalid repository URL" }, { status: 400 });
+    }
+    if (!finalSlug) {
+      finalSlug = await ensureUniqueSlug(repoName);
+    }
+    if (!finalName) {
+      finalName = repoName.replace(/-/g, " ").replace(/\b\w/g, (c: string) => c.toUpperCase());
+    }
+  }
+
+  if (!finalName || !finalSlug) {
+    return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
+  }
+
   try {
     const workspace = await createWorkspace({
-      name,
+      name: finalName,
       description,
-      slug,
-      ownerId: userId,
+      slug: finalSlug,
+      ownerId,
       repositoryUrl,
     });
     return NextResponse.json({ workspace }, { status: 201 });

--- a/src/app/onboarding/workspace/wizard/wizard-steps/welcome-step/index.tsx
+++ b/src/app/onboarding/workspace/wizard/wizard-steps/welcome-step/index.tsx
@@ -6,6 +6,7 @@ import { Separator } from "@/components/ui/separator";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { SupportedLanguages } from "@/lib/constants";
+import { extractRepoNameFromUrl, nextIndexedName } from "@/lib/utils/slug";
 import { AlertCircle, ArrowRight, Loader2 } from "lucide-react";
 import Image from "next/image";
 import { signOut, useSession } from "next-auth/react";
@@ -14,35 +15,6 @@ import { useState, useRef } from "react";
 
 interface WelcomeStepProps {
   onNext: (repositoryUrl?: string) => void;
-}
-
-const escapeRegex = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-
-function nextIndexedName(base: string, pool: string[]) {
-  const re = new RegExp(`^${escapeRegex(base)}(?:-(\\d+))?$`, "i");
-  let max = -1;
-  for (const name of pool) {
-    const m = name.match(re);
-    if (!m) continue;
-    const idx = m[1] ? Number(m[1]) : 0; // plain "base" => 0
-    if (idx > max) max = idx;
-  }
-  const next = max + 1;
-  return next === 0 ? base : `${base}-${next}`;
-}
-
-function extractRepoNameFromUrl(url: string): string | null {
-  try {
-    // Handle various GitHub URL formats
-    const githubMatch = url.match(/github\.com[\/:]([^\/]+)\/([^\/\.]+)(?:\.git)?/);
-    if (githubMatch) {
-      return githubMatch[2]; // Return the repository name
-    }
-    return null;
-  } catch (error) {
-    console.error("Error extracting repo name from URL:", error);
-    return null;
-  }
 }
 
 export const WelcomeStep = ({}: WelcomeStepProps) => {

--- a/src/lib/utils/slug.ts
+++ b/src/lib/utils/slug.ts
@@ -1,0 +1,27 @@
+/**
+ * Extracts repo name from a GitHub repository URL
+ */
+export function extractRepoNameFromUrl(url: string): string | null {
+  const match = url.match(/github\.com[\/:]([^\/]+)\/([^\/\.]+)(?:\.git)?/);
+  return match ? match[2].toLowerCase() : null;
+}
+
+/**
+ * Finds the next available indexed name from a pool of existing names.
+ * E.g., if "repo" and "repo-1" exist, returns "repo-2"
+ */
+export function nextIndexedName(base: string, pool: string[]): string {
+  const escaped = base.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`^${escaped}(?:-(\\d+))?$`, "i");
+
+  let max = -1;
+  for (const name of pool) {
+    const m = name.match(re);
+    if (!m) continue;
+    const idx = m[1] ? Number(m[1]) : 0;
+    if (idx > max) max = idx;
+  }
+
+  const next = max + 1;
+  return next === 0 ? base : `${base}-${next}`;
+}

--- a/src/services/workspace.ts
+++ b/src/services/workspace.ts
@@ -894,6 +894,22 @@ export async function recoverWorkspace(
   };
 }
 
+// Re-export from shared utility
+export { extractRepoNameFromUrl } from "@/lib/utils/slug";
+import { nextIndexedName } from "@/lib/utils/slug";
+
+/**
+ * Ensures a slug is unique by finding max index and adding 1
+ */
+export async function ensureUniqueSlug(baseSlug: string): Promise<string> {
+  const workspaces = await db.workspace.findMany({
+    where: { deleted: false },
+    select: { slug: true },
+  });
+  const slugs = workspaces.map((w) => w.slug.toLowerCase());
+  return nextIndexedName(baseSlug, slugs);
+}
+
 /**
  * Validates a workspace slug against reserved words and format requirements
  */


### PR DESCRIPTION
Support external workspace creation via x-api-token header using existing API_TOKEN. Auto-generates slug and name from repositoryUrl if not provided.

Extracts slug utilities to shared lib/utils/slug.ts for reuse by frontend.