### PR TITLE
fix: remove podId gate from live mode chat input

### DIFF
--- a/src/app/w/[slug]/task/[...taskParams]/page.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/page.tsx
@@ -1141,7 +1141,7 @@ export default function TaskChatPage() {
     isLoading ||
     !isConnected ||
     isTerminalState ||
-    (taskMode !== "agent" && taskMode !== "workflow_editor" && (!podId || !liveModeSendAllowed));
+    (taskMode !== "agent" && taskMode !== "workflow_editor" && !liveModeSendAllowed);
 
   return (
     <AnimatePresence mode="wait">


### PR DESCRIPTION
Allow sending messages in live mode without a pod, relying on workflow state (liveModeSendAllowed) instead.