### PR TITLE
Add undo toast for task archive action

### DIFF
--- a/src/components/tasks/TasksList.tsx
+++ b/src/components/tasks/TasksList.tsx
@@ -193,6 +193,7 @@ export function TasksList({ workspaceId, workspaceSlug }: TasksListProps) {
                         task={task}
                         workspaceSlug={workspaceSlug}
                         isArchived={false}
+                        onUndoArchive={refetch}
                       />
                     ))}
 
@@ -256,6 +257,7 @@ export function TasksList({ workspaceId, workspaceSlug }: TasksListProps) {
                     task={task}
                     workspaceSlug={workspaceSlug}
                     isArchived={activeTab === "archived"}
+                    onUndoArchive={refetch}
                   />
                 )}
                 sortItems={(a, b) => {

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -14,6 +14,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
       theme={theme as ToasterProps["theme"]}
       className="toaster group"
       position="top-right"
+      visibleToasts={3}
       toastOptions={{
         classNames: {
           toast:


### PR DESCRIPTION
Show a toast with undo button when archiving a task. Undo calls the PATCH API to unarchive and refetches the task list. Limits visible toasts to 3 and clamps description to 2 lines.