### PR TITLE
Increase workflow zoom out limit to improve visibility

### DIFF
--- a/src/components/workflow/index.tsx
+++ b/src/components/workflow/index.tsx
@@ -1257,7 +1257,7 @@ export default function App(workflowApp: WorkflowAppProps) {
       <ReactFlow
         onInit={onInit}
         ref={ref}
-        minZoom={0.2}
+        minZoom={0.05}
         maxZoom={0.7}
         nodeTypes={nodeTypes}
         nodes={nodes}


### PR DESCRIPTION
Increase workflow zoom out limit to improve visibility

Changed minZoom from 0.2 to 0.05 in workflow component to allow users to zoom out 4x further (from 20% to 5% scale). This enables viewing entire workflows in the task chat panel that previously couldn't fit in the viewport.

---

_View task here [cmld531xn000hl204wayattpg](https://hive.sphinx.chat/w/hive/task/cmld531xn000hl204wayattpg)_