### PR TITLE
fix: handle MockNodesLayer fetch errors gracefully to prevent page crash

### DIFF
--- a/src/components/knowledge-graph/Universe/Graph/HighlightedNodes/MockNodesLayer.tsx
+++ b/src/components/knowledge-graph/Universe/Graph/HighlightedNodes/MockNodesLayer.tsx
@@ -39,7 +39,7 @@ export const MockNodesLayer = memo<MockNodesLayerProps>(({ radius = DEFAULT_CIRC
   }, [nodeTypes])
 
   const fetchMockData = useCallback(async () => {
-    if (!workspaceId || hasFetchedMocks) {
+    if (!workspaceId?.trim() || hasFetchedMocks) {
       return
     }
 
@@ -66,13 +66,19 @@ export const MockNodesLayer = memo<MockNodesLayerProps>(({ radius = DEFAULT_CIRC
       const response = await fetch(url)
 
       if (!response.ok) {
-        throw new Error(`Failed to fetch Mock data: ${response.statusText}`)
+        console.warn(`[MockNodesLayer] Failed to fetch Mock data: ${response.status} ${response.statusText}`)
+        setMockNodes([])
+        setHasFetchedMocks(true)
+        return
       }
 
       const result = await response.json()
 
       if (!result.success || !result.data) {
-        throw new Error(`API returned unsuccessful response for Mock data`)
+        console.warn(`[MockNodesLayer] API returned unsuccessful response for Mock data`)
+        setMockNodes([])
+        setHasFetchedMocks(true)
+        return
       }
 
       const fetchedNodes = result.data.nodes || []


### PR DESCRIPTION
fix: handle MockNodesLayer fetch errors gracefully to prevent page crash

Replace throw statements with console.warn and proper state cleanup in MockNodesLayer.tsx to prevent console errors from crashing the main hive page during initial load. When the mock nodes API fails or returns errors, the component now logs a warning and sets empty state instead of throwing, allowing the page to render normally.

---

_View task here [cmlea6pvf0003l804yzggyll7](https://hive.sphinx.chat/w/hive/task/cmlea6pvf0003l804yzggyll7)_