### PR TITLE
Increase graph chat answer box height from 50% to 75% viewport height

### DIFF
--- a/src/components/dashboard/DashboardChat/index.tsx
+++ b/src/components/dashboard/DashboardChat/index.tsx
@@ -576,7 +576,7 @@ export function DashboardChat() {
           </div>
           <div className="flex gap-4">
             {/* Message history */}
-            <div className="flex-1 max-h-[300px] overflow-y-auto pb-2">
+            <div className="flex-1 max-h-[calc(75vh-100px)] overflow-y-auto pb-2">
               <div className="space-y-2 px-4">
                 {messages.map((message, index) => {
                   // Only the last message is streaming
@@ -609,7 +609,7 @@ export function DashboardChat() {
 
             {/* Provenance sidebar - only shows when toggled AND data available */}
             {isProvenanceSidebarOpen && provenanceData && (
-              <div className="w-80 overflow-y-auto max-h-[300px] pointer-events-auto">
+              <div className="w-80 overflow-y-auto max-h-[calc(75vh-100px)] pointer-events-auto">
                 <div className="backdrop-blur-md bg-background/20 border border-border/50 rounded-lg p-4 shadow-lg">
                   <ProvenanceTree provenanceData={provenanceData} />
                 </div>


### PR DESCRIPTION
Increase graph chat answer box height from 50% to 75% viewport height

- Updated message history container max height to calc(75vh-100px)
- Updated provenance sidebar max height to calc(75vh-100px)
- Added 100px offset to prevent covering top buttons
- Improves answer visibility without blocking UI controls

---

_View task here [cmlf95awr0001lg04hu13spyt](https://hive.sphinx.chat/w/hive/task/cmlf95awr0001lg04hu13spyt)_