### PR TITLE
Unify stop flow into useStakworkGeneration hook

### DIFF
--- a/src/components/features/DeepResearchProgress/index.tsx
+++ b/src/components/features/DeepResearchProgress/index.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { Brain, StopCircle } from "lucide-react";
+import { Brain } from "lucide-react";
 import { useProjectLogWebSocket } from "@/hooks/useProjectLogWebSocket";
-import { ConfirmDialog } from "@/components/ui/confirm-dialog";
-import { Spinner } from "@/components/ui/spinner";
 
 const MIN_DISPLAY_TIME = 1500; // Minimum time each log is shown (ms)
 const DEFAULT_MESSAGE = "Processing...";
@@ -12,15 +10,11 @@ const DEFAULT_MESSAGE = "Processing...";
 interface DeepResearchProgressProps {
   projectId: number | null;
   runId: string;
-  onStop: () => Promise<void>;
-  isStopping?: boolean;
 }
 
-export function DeepResearchProgress({ 
-  projectId, 
-  runId, 
-  onStop, 
-  isStopping = false 
+export function DeepResearchProgress({
+  projectId,
+  runId: _runId,
 }: DeepResearchProgressProps) {
   const { logs } = useProjectLogWebSocket(
     projectId ? String(projectId) : null
@@ -28,8 +22,6 @@ export function DeepResearchProgress({
 
   const [displayedMessage, setDisplayedMessage] = useState(DEFAULT_MESSAGE);
   const [processedCount, setProcessedCount] = useState(0);
-  const [showStopDialog, setShowStopDialog] = useState(false);
-  const [isHovered, setIsHovered] = useState(false);
   const lastDisplayTimeRef = useRef<number>(Date.now());
 
   // Process new logs with minimum display time
@@ -60,62 +52,20 @@ export function DeepResearchProgress({
   }, [logs, processedCount]);
 
   return (
-    <>
-      <div 
-        className="group relative rounded-md border border-border bg-muted/50 animate-in fade-in slide-in-from-top-2 duration-300"
-        onMouseEnter={() => !isStopping && setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-      >
-        <div className="flex flex-col items-center justify-center py-16 px-4">
-          <div className="relative mb-4">
-            <Brain className="h-8 w-8 text-purple-600 animate-pulse" />
-          </div>
-
-          <h3 className="text-sm font-medium text-foreground mb-2">
-            Deep Research
-          </h3>
-
-          <p className="text-sm text-muted-foreground text-center max-w-md min-h-[20px] transition-all duration-300">
-            {displayedMessage}
-          </p>
+    <div className="rounded-md border border-border bg-muted/50 animate-in fade-in slide-in-from-top-2 duration-300">
+      <div className="flex flex-col items-center justify-center py-16 px-4">
+        <div className="relative mb-4">
+          <Brain className="h-8 w-8 text-purple-600 animate-pulse" />
         </div>
 
-        {/* Stop icon overlay on hover */}
-        {isHovered && !isStopping && (
-          <div 
-            className="absolute inset-0 flex items-center justify-center bg-black/50 cursor-pointer rounded-md"
-            onClick={(e) => {
-              e.stopPropagation();
-              setShowStopDialog(true);
-            }}
-          >
-            <StopCircle className="h-12 w-12 text-white" />
-          </div>
-        )}
+        <h3 className="text-sm font-medium text-foreground mb-2">
+          Deep Research
+        </h3>
 
-        {/* Spinner overlay when stopping */}
-        {isStopping && (
-          <div className="absolute inset-0 flex items-center justify-center bg-black/50 rounded-md">
-            <Spinner className="h-8 w-8 text-white" />
-          </div>
-        )}
+        <p className="text-sm text-muted-foreground text-center max-w-md min-h-[20px] transition-all duration-300">
+          {displayedMessage}
+        </p>
       </div>
-
-      {/* Confirmation dialog */}
-      <ConfirmDialog
-        open={showStopDialog}
-        onOpenChange={setShowStopDialog}
-        title="Stop Deep Research?"
-        description="This will stop the research in progress and discard all partial results. You can start a new research immediately."
-        confirmText="Stop Research"
-        cancelText="Cancel"
-        variant="destructive"
-        onConfirm={async () => {
-          await onStop();
-          setShowStopDialog(false);
-        }}
-        testId="stop-research-dialog"
-      />
-    </>
+    </div>
   );
 }

--- a/src/components/features/GenerationControls/index.tsx
+++ b/src/components/features/GenerationControls/index.tsx
@@ -1,14 +1,20 @@
-import { Brain, Loader2, FileImage } from "lucide-react";
+"use client";
+
+import { useState } from "react";
+import { Brain, Loader2, FileImage, CircleStop } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import type { WorkflowStatus } from "@prisma/client";
 
 interface GenerationControlsProps {
   onQuickGenerate: () => void;
   onDeepThink: () => void;
   onRetry?: () => void;
+  onStop?: () => Promise<void>;
   status?: WorkflowStatus | null;
   isLoading?: boolean;
   isQuickGenerating?: boolean;
+  isStopping?: boolean;
   disabled?: boolean;
   showDeepThink?: boolean;
   showGenerateDiagram?: boolean;
@@ -20,52 +26,110 @@ export function GenerationControls({
   onQuickGenerate: _onQuickGenerate,
   onDeepThink,
   onRetry,
+  onStop,
   status,
   isLoading = false,
   isQuickGenerating = false,
+  isStopping = false,
   disabled = false,
   showDeepThink = true,
   showGenerateDiagram = false,
   onGenerateDiagram,
   isGeneratingDiagram = false,
 }: GenerationControlsProps) {
+  const [showStopDialog, setShowStopDialog] = useState(false);
+  const [hovered, setHovered] = useState(false);
+
   const isErrorState =
     status && ["FAILED", "ERROR", "HALTED"].includes(status);
   const isLoadingState =
     status && ["PENDING", "IN_PROGRESS"].includes(status);
 
+  const handleButtonClick = () => {
+    if (isStopping) return;
+    if (isLoadingState && onStop) {
+      setShowStopDialog(true);
+      return;
+    }
+    if (isErrorState) {
+      onRetry?.();
+      return;
+    }
+    onDeepThink();
+  };
+
   return (
     <div className="flex items-center gap-2">
       {showDeepThink && (
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={isErrorState ? onRetry : onDeepThink}
-          disabled={
-            isLoading ||
-            isLoadingState ||
-            isQuickGenerating ||
-            disabled
-          }
-          className={isErrorState ? "border-yellow-600/50 bg-yellow-50 hover:bg-yellow-100 dark:bg-yellow-950/30 dark:hover:bg-yellow-950/50" : ""}
-        >
-          {isLoadingState ? (
-            <>
-              <Loader2 className="h-3.5 w-3.5 animate-spin text-purple-500" />
-              <span className="ml-1.5">Researching...</span>
-            </>
-          ) : isErrorState ? (
-            <>
-              <Brain className="h-3.5 w-3.5 text-yellow-700 dark:text-yellow-500" />
-              <span className="ml-1.5 text-yellow-700 dark:text-yellow-500">Retry</span>
-            </>
-          ) : (
-            <>
-              <Brain className="h-3.5 w-3.5 text-purple-600" />
-              <span className="ml-1.5">Deep Research</span>
-            </>
-          )}
-        </Button>
+        <>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={handleButtonClick}
+            onMouseEnter={() => setHovered(true)}
+            onMouseLeave={() => setHovered(false)}
+            disabled={
+              isStopping ||
+              isLoading ||
+              isQuickGenerating ||
+              disabled ||
+              (!!isLoadingState && !onStop)
+            }
+            className={
+              isStopping
+                ? "border-red-600/50 bg-red-50 dark:bg-red-950/30"
+                : isLoadingState && onStop && hovered
+                  ? "border-foreground/30"
+                  : isErrorState
+                    ? "border-yellow-600/50 bg-yellow-50 hover:bg-yellow-100 dark:bg-yellow-950/30 dark:hover:bg-yellow-950/50"
+                    : ""
+            }
+          >
+            {isStopping ? (
+              <>
+                <Loader2 className="h-3.5 w-3.5 animate-spin text-red-500" />
+                <span className="ml-1.5 text-red-600 dark:text-red-400">Stopping...</span>
+              </>
+            ) : isLoadingState && hovered && onStop ? (
+              <>
+                <CircleStop className="h-3.5 w-3.5 text-muted-foreground" />
+                <span className="ml-1.5">Stop</span>
+              </>
+            ) : isLoadingState ? (
+              <>
+                <Loader2 className="h-3.5 w-3.5 animate-spin text-purple-500" />
+                <span className="ml-1.5">Researching...</span>
+              </>
+            ) : isErrorState ? (
+              <>
+                <Brain className="h-3.5 w-3.5 text-yellow-700 dark:text-yellow-500" />
+                <span className="ml-1.5 text-yellow-700 dark:text-yellow-500">Retry</span>
+              </>
+            ) : (
+              <>
+                <Brain className="h-3.5 w-3.5 text-purple-600" />
+                <span className="ml-1.5">Deep Research</span>
+              </>
+            )}
+          </Button>
+
+          <ConfirmDialog
+            open={showStopDialog}
+            onOpenChange={setShowStopDialog}
+            title="Stop Deep Research?"
+            description="This will stop the research in progress and discard all partial results. You can start a new research immediately."
+            confirmText="Stop Research"
+            cancelText="Cancel"
+            variant="destructive"
+            onConfirm={async () => {
+              if (onStop) {
+                await onStop();
+              }
+              setShowStopDialog(false);
+            }}
+            testId="stop-research-dialog"
+          />
+        </>
       )}
       {showGenerateDiagram && onGenerateDiagram && (
         <Button

--- a/src/services/stakwork/index.ts
+++ b/src/services/stakwork/index.ts
@@ -185,7 +185,7 @@ export class StakworkService extends BaseServiceClass {
    */
   async stopProject(projectId: number): Promise<void> {
     try {
-      const endpoint = `${config.STAKWORK_BASE_URL}/projects/${projectId}/stop`;
+      const endpoint = `/projects/${projectId}/stop`;
 
       const headers = {
         "Content-Type": "application/json",


### PR DESCRIPTION
Move duplicated stop fetch logic from TicketsList and AITextareaSection into a shared stopRun method on the hook. Replace red hover tint on GenerationControls with CircleStop icon swap on hover. Simplify DeepResearchProgress by removing its stop overlay.