### PR TITLE
feat: deploy branches to vercel

### DIFF
--- a/.github/workflows/deployPR.yml
+++ b/.github/workflows/deployPR.yml
@@ -260,6 +260,22 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const marker = '<!-- hive-preview-deploy -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const botComments = comments.filter(
+              (c) => c.user.type === 'Bot' && c.body && c.body.includes(marker)
+            );
+            for (const comment of botComments) {
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: comment.id,
+              });
+            }
             const url = '${{ steps.deploy.outputs.deployment_url }}';
             const expiresAt = '${{ steps.neon.outputs.expires_at }}';
             const expiresReadable = expiresAt ? new Date(expiresAt).toLocaleString('en-US', { timeZone: 'UTC', dateStyle: 'medium', timeStyle: 'short' }) + ' UTC' : 'N/A';
@@ -267,7 +283,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `**Test environment is now live.**\n\nView it at: ${url}\n\nDatabase expires at: ${expiresReadable}`
+              body: `**Test environment is now live.**\n\nView it at: ${url}\n\nDatabase expires at: ${expiresReadable}\n\n${marker}`
             });
 
       - name: Mark Failure


### PR DESCRIPTION
### Summary
The goal of this pull request is to create pull request testing environments that mimic prod by giving the change its own db, its own domain to view the changes and also by setting a static domain so we can add github webhooks to these for testing.

The way this will work is that there will be multiple preview branches `preview-1`, `preview-2` and `preview-3` that will be rotated per PR. They will all be setup with temp databases. 

### Challenges
Some challenges we might face is that while we have these test environments we might not want to allow the user to spin up new workspaces with new pods to test their features as this would be a waste of resources. Because of this I might setup the databases in such a way that there is one testing workspace and each environment uses the same pods for this. It might not work but that would be the next step as then we would only be able to test changes that don't require new tasks to be created.