### PR TITLE
Reset pod repair attempt counter on COMPLETED

### DIFF
--- a/prisma/migrations/20260217030435_add_pod_completed_at/migration.sql
+++ b/prisma/migrations/20260217030435_add_pod_completed_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "swarms" ADD COLUMN     "pod_completed_at" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -350,6 +350,7 @@ model Swarm {
   // Stakgraph configuration fields
   poolState            PoolState @default(NOT_STARTED) @map("pool_state")
   podState             PodState  @default(NOT_STARTED) @map("pod_state")
+  podCompletedAt       DateTime? @map("pod_completed_at")
   poolName             String?   @map("pool_name")
   poolApiKey           String?   @map("pool_api_key") // Pool API Key for Pool Manager
   poolCpu              String?   @map("pool_cpu") // CPU allocation for pool tasks

--- a/src/services/swarm/db.ts
+++ b/src/services/swarm/db.ts
@@ -65,6 +65,7 @@ export const select = {
   poolMemory: true,
   poolState: true,
   podState: true,
+  podCompletedAt: true,
   services: true,
   swarmSecretAlias: true,
   swarmId: true,


### PR DESCRIPTION
## Problem

The pod repair cron has a `MAX_REPAIR_ATTEMPTS` (default 10) that counts **all-time** `POD_REPAIR` StakworkRuns for a workspace. Once a workspace exhausts its 10 attempts — even if the pod was successfully repaired and reached COMPLETED — it is permanently locked out of future repairs. Any new, unrelated failure (service crash, new repo added) can never be auto-repaired.

## Fix

Add a `podCompletedAt` timestamp to the Swarm model. Each time the pod reaches `COMPLETED`, this timestamp is set. The repair attempt counter now only counts runs **since the last `podCompletedAt`**, effectively resetting on every successful repair cycle.

If `podCompletedAt` is null (pod has never been healthy), all attempts are counted — same as current behavior.

## Example scenarios

**Pod failure → repair → new failure:**
1. Pod has 8 failed repair attempts, then attempt 9 succeeds → `podCompletedAt` is set
2. A week later a service crashes → counter starts from 0 again (no runs after `podCompletedAt`)
3. Pod gets a fresh 10 attempts to resolve the new issue

**Pod completed → add new repo (multi-repo):**
1. Workspace has a healthy pod (`COMPLETED`, `podCompletedAt` set) with repo A
2. User adds repo B, triggering a pending repair via `pendingRepairTrigger`
3. Repair runs count from 0 since the pod was last healthy, so the workspace is never blocked by stale history

## Changes

- `prisma/schema.prisma` — Add `podCompletedAt` field to Swarm
- `src/services/pod-repair-cron.ts` — Set `podCompletedAt` on COMPLETED, scope `getRepairAttemptCount` to runs after it
- `src/services/swarm/db.ts` — Include `podCompletedAt` in select