### PR TITLE
feat: add pod repair observability section to stakgraph page

### DIFF
--- a/prisma/migrations/20260218154809_add_swarm_description/migration.sql
+++ b/prisma/migrations/20260218154809_add_swarm_description/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "swarms" ADD COLUMN     "description" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -348,6 +348,8 @@ model Swarm {
   createdAt    DateTime    @default(now()) @map("created_at")
   updatedAt    DateTime    @updatedAt @map("updated_at")
 
+  description  String?
+
   // Stakgraph configuration fields
   poolState            PoolState @default(NOT_STARTED) @map("pool_state")
   podState             PodState  @default(NOT_STARTED) @map("pod_state")

--- a/src/app/api/w/[slug]/pool/repair/route.ts
+++ b/src/app/api/w/[slug]/pool/repair/route.ts
@@ -1,0 +1,108 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getMiddlewareContext, requireAuth } from "@/lib/middleware/utils";
+import { getWorkspaceBySlug } from "@/services/workspace";
+import { isRepairInProgress, triggerPodRepair } from "@/services/pod-repair-cron";
+import { poolManagerService } from "@/lib/service-factory";
+import { db } from "@/lib/db";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  try {
+    const context = getMiddlewareContext(request);
+    const userOrResponse = requireAuth(context);
+    if (userOrResponse instanceof NextResponse) return userOrResponse;
+
+    const { slug } = await params;
+
+    if (!slug) {
+      return NextResponse.json(
+        { error: "Workspace slug is required" },
+        { status: 400 }
+      );
+    }
+
+    const workspace = await getWorkspaceBySlug(slug, userOrResponse.id);
+
+    if (!workspace) {
+      return NextResponse.json(
+        { error: "Workspace not found or access denied" },
+        { status: 404 }
+      );
+    }
+
+    if (workspace.userRole !== "OWNER" && workspace.userRole !== "ADMIN") {
+      return NextResponse.json(
+        { error: "Insufficient permissions" },
+        { status: 403 }
+      );
+    }
+
+    const swarm = await db.swarm.findFirst({
+      where: { workspaceId: workspace.id },
+      select: {
+        id: true,
+        poolApiKey: true,
+        description: true,
+      },
+    });
+
+    if (!swarm?.poolApiKey) {
+      return NextResponse.json(
+        { error: "Pool not configured for this workspace" },
+        { status: 404 }
+      );
+    }
+
+    const alreadyRunning = await isRepairInProgress(workspace.id);
+    if (alreadyRunning) {
+      return NextResponse.json(
+        { error: "A repair is already in progress" },
+        { status: 409 }
+      );
+    }
+
+    const poolService = poolManagerService();
+    const poolData = await poolService.getPoolWorkspaces(
+      swarm.id,
+      swarm.poolApiKey
+    );
+
+    const pod = poolData.workspaces.find(
+      (vm) =>
+        vm.usage_status !== "used" && vm.state.toLowerCase() === "running"
+    );
+
+    if (!pod) {
+      return NextResponse.json(
+        { error: "No available running pods found" },
+        { status: 404 }
+      );
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const message = typeof body.message === "string" ? body.message : undefined;
+
+    const { runId, projectId } = await triggerPodRepair(
+      workspace.id,
+      slug,
+      pod.subdomain,
+      pod.password || "",
+      [],
+      message,
+      swarm.description || undefined
+    );
+
+    return NextResponse.json({ success: true, runId, projectId });
+  } catch (error) {
+    console.error("Error in pool repair endpoint:", error);
+    return NextResponse.json(
+      {
+        success: false,
+        message: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/workspaces/[slug]/stakgraph/route.ts
+++ b/src/app/api/workspaces/[slug]/stakgraph/route.ts
@@ -210,7 +210,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       message: "Pool settings retrieved successfully",
       data: {
         name: swarm.name || "",
-        description: "",
+        description: swarm.description || "",
         repositories: repositories.length > 0 ? repositories : [],
         swarmUrl: swarm.swarmUrl || "",
         swarmSecretAlias: swarm.swarmSecretAlias || "",
@@ -565,6 +565,7 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
       services: syncResult.services,
       environmentVariables: settings.environmentVariables,
       containerFiles: syncResult.containerFiles,
+      description: settings.description,
     });
 
     const swarm = (await db.swarm.findUnique({
@@ -737,7 +738,7 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
       data: {
         id: typedSwarm.id,
         name: typedSwarm.name || "",
-        description: settings.description || "",
+        description: typedSwarm.description || "",
         repositories: updatedRepositories,
         swarmUrl: typedSwarm.swarmUrl,
         poolName: typedSwarm.poolName,

--- a/src/app/w/[slug]/stakgraph/page.tsx
+++ b/src/app/w/[slug]/stakgraph/page.tsx
@@ -2,6 +2,7 @@
 
 import { EnvironmentForm, ProjectInfoForm, RepositoryForm, ServicesForm, SwarmForm } from "@/components/stakgraph";
 import { FileTabs } from "@/components/stakgraph/forms/EditFilesForm";
+import { PodRepairSection } from "@/components/pod-repair";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PageHeader } from "@/components/ui/page-header";
@@ -132,101 +133,107 @@ export default function StakgraphPage() {
       </div>
       <PageHeader title="Pool Status" description="Configure your pool settings for development environment" />
 
-      <Card className="max-w-2xl">
-        <CardHeader className="flex flex-row items-center justify-between">
-          <CardTitle>Pool Settings</CardTitle>
-          <div className="flex gap-2">
-            {!formData.webhookEnsured && formData.repositories?.[0]?.repositoryUrl ? (
-              <Button type="button" variant="default" onClick={handleEnsureWebhooks}>
-                <Webhook className="mr-2 h-4 w-4" />
-                Add Github Webhooks
-              </Button>
-            ) : null}
-          </div>
-        </CardHeader>
-        <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-6">
-            {errors.general && (
-              <div className="p-3 rounded-md bg-destructive/10 border border-destructive/20">
-                <p className="text-sm text-destructive">{errors.general}</p>
-              </div>
-            )}
-
-            {saved && (
-              <div className="p-3 rounded-md bg-green-50 border border-green-200">
-                <p className="text-sm text-green-700">Configuration saved successfully!</p>
-              </div>
-            )}
-
-            <div className="space-y-6">
-              <ProjectInfoForm
-                data={{
-                  name: formData.name,
-                  description: formData.description,
-                }}
-                errors={errors}
-                loading={loading}
-                onChange={handleProjectInfoChange}
-              />
-
-              <RepositoryForm
-                data={{
-                  repositories: formData.repositories || [{ repositoryUrl: "", branch: "main", name: "" }],
-                }}
-                errors={errors}
-                loading={loading}
-                onChange={handleRepositoryChange}
-              />
-
-              <SwarmForm
-                data={{
-                  swarmUrl: formData.swarmUrl,
-                  swarmApiKey: formData.swarmApiKey || "",
-                  swarmSecretAlias: formData.swarmSecretAlias,
-                }}
-                errors={errors}
-                loading={loading}
-                onChange={handleSwarmChange}
-              />
-
-              <EnvironmentForm
-                data={{
-                  poolName: formData.poolName,
-                  poolCpu: formData.poolCpu || "2",
-                  poolMemory: formData.poolMemory || "8Gi",
-                  environmentVariables: formData.environmentVariables,
-                }}
-                errors={errors}
-                loading={loading}
-                onChange={handleEnvironmentChange}
-                onEnvVarsChange={handleEnvVarsChange}
-              />
-
-              <ServicesForm data={formData.services} loading={loading} onChange={handleServicesChange} />
-
-              <FileTabs
-                fileContents={formData.containerFiles}
-                originalContents={formData.containerFiles}
-                onChange={handleFileChange}
-              />
+      <div className="flex flex-col lg:flex-row gap-6 items-start">
+        <Card className="w-full lg:max-w-2xl">
+          <CardHeader className="flex flex-row items-center justify-between">
+            <CardTitle>Pool Settings</CardTitle>
+            <div className="flex gap-2">
+              {!formData.webhookEnsured && formData.repositories?.[0]?.repositoryUrl ? (
+                <Button type="button" variant="default" onClick={handleEnsureWebhooks}>
+                  <Webhook className="mr-2 h-4 w-4" />
+                  Add Github Webhooks
+                </Button>
+              ) : null}
             </div>
-
-            <Button type="submit" disabled={loading}>
-              {loading ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Saving...
-                </>
-              ) : (
-                <>
-                  <Save className="mr-2 h-4 w-4" />
-                  Save
-                </>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-6">
+              {errors.general && (
+                <div className="p-3 rounded-md bg-destructive/10 border border-destructive/20">
+                  <p className="text-sm text-destructive">{errors.general}</p>
+                </div>
               )}
-            </Button>
-          </form>
-        </CardContent>
-      </Card>
+
+              {saved && (
+                <div className="p-3 rounded-md bg-green-50 border border-green-200">
+                  <p className="text-sm text-green-700">Configuration saved successfully!</p>
+                </div>
+              )}
+
+              <div className="space-y-6">
+                <ProjectInfoForm
+                  data={{
+                    name: formData.name,
+                    description: formData.description,
+                  }}
+                  errors={errors}
+                  loading={loading}
+                  onChange={handleProjectInfoChange}
+                />
+
+                <RepositoryForm
+                  data={{
+                    repositories: formData.repositories || [{ repositoryUrl: "", branch: "main", name: "" }],
+                  }}
+                  errors={errors}
+                  loading={loading}
+                  onChange={handleRepositoryChange}
+                />
+
+                <SwarmForm
+                  data={{
+                    swarmUrl: formData.swarmUrl,
+                    swarmApiKey: formData.swarmApiKey || "",
+                    swarmSecretAlias: formData.swarmSecretAlias,
+                  }}
+                  errors={errors}
+                  loading={loading}
+                  onChange={handleSwarmChange}
+                />
+
+                <EnvironmentForm
+                  data={{
+                    poolName: formData.poolName,
+                    poolCpu: formData.poolCpu || "2",
+                    poolMemory: formData.poolMemory || "8Gi",
+                    environmentVariables: formData.environmentVariables,
+                  }}
+                  errors={errors}
+                  loading={loading}
+                  onChange={handleEnvironmentChange}
+                  onEnvVarsChange={handleEnvVarsChange}
+                />
+
+                <ServicesForm data={formData.services} loading={loading} onChange={handleServicesChange} />
+
+                <FileTabs
+                  fileContents={formData.containerFiles}
+                  originalContents={formData.containerFiles}
+                  onChange={handleFileChange}
+                />
+              </div>
+
+              <Button type="submit" disabled={loading}>
+                {loading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Saving...
+                  </>
+                ) : (
+                  <>
+                    <Save className="mr-2 h-4 w-4" />
+                    Save
+                  </>
+                )}
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+
+        <div className="w-full lg:w-[420px] lg:shrink-0 lg:sticky lg:top-6">
+          <PodRepairSection />
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/pod-repair/index.tsx
+++ b/src/components/pod-repair/index.tsx
@@ -1,0 +1,295 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { Textarea } from "@/components/ui/textarea";
+import { useWorkspace } from "@/hooks/useWorkspace";
+import { useStakgraphStore } from "@/stores/useStakgraphStore";
+import { formatRelativeOrDate } from "@/lib/date-utils";
+import { toast } from "sonner";
+import {
+  Bot,
+  Circle,
+  ExternalLink,
+  Loader2,
+  Pencil,
+  Play,
+  Wrench,
+} from "lucide-react";
+
+interface StakworkRun {
+  id: string;
+  projectId: number | null;
+  createdAt: string;
+}
+
+type PodState = "COMPLETED" | "FAILED" | "NOT_STARTED" | "VALIDATING";
+
+const podStateConfig: Record<PodState, { label: string; dotClassName: string }> = {
+  COMPLETED: { label: "Healthy", dotClassName: "fill-green-500 text-green-500" },
+  FAILED: { label: "Failed", dotClassName: "fill-red-500 text-red-500" },
+  VALIDATING: { label: "Validating", dotClassName: "fill-yellow-500 text-yellow-500" },
+  NOT_STARTED: { label: "Not Started", dotClassName: "fill-muted-foreground text-muted-foreground" },
+};
+
+function PodStateInline({ state, repoCount }: { state: PodState; repoCount: number }) {
+  const c = podStateConfig[state] || podStateConfig.NOT_STARTED;
+  return (
+    <div className="flex items-center gap-1.5 text-xs text-muted-foreground mt-0.5">
+      <Circle className={`h-1.5 w-1.5 ${c.dotClassName}`} />
+      <span>{c.label}</span>
+      <span>&middot;</span>
+      <span>{repoCount} {repoCount === 1 ? "repo" : "repos"}</span>
+    </div>
+  );
+}
+
+export function PodRepairSection() {
+  const { slug, id: workspaceId, workspace, isOwner, isAdmin } = useWorkspace();
+  const { formData, handleProjectInfoChange, saveSettings } = useStakgraphStore();
+
+  const [runs, setRuns] = useState<StakworkRun[]>([]);
+  const [runsLoading, setRunsLoading] = useState(false);
+  const [showPrompt, setShowPrompt] = useState(false);
+  const [message, setMessage] = useState("");
+  const [triggering, setTriggering] = useState(false);
+  const [editingDescription, setEditingDescription] = useState(false);
+  const [descriptionDraft, setDescriptionDraft] = useState("");
+  const [savingDescription, setSavingDescription] = useState(false);
+
+  const isPoolActive = workspace?.poolState === "COMPLETE";
+  const canTrigger = isOwner || isAdmin;
+  const podState = (workspace?.podState || "NOT_STARTED") as PodState;
+  const repoCount = formData.repositories?.filter((r) => r.repositoryUrl).length || 0;
+
+  const fetchRuns = useCallback(async () => {
+    if (!workspaceId) return;
+    setRunsLoading(true);
+    try {
+      const res = await fetch(
+        `/api/stakwork/runs?workspaceId=${workspaceId}&type=POD_REPAIR&limit=5`
+      );
+      const data = await res.json();
+      if (data.success) {
+        setRuns(data.runs || []);
+      }
+    } catch {
+      // silently fail
+    } finally {
+      setRunsLoading(false);
+    }
+  }, [workspaceId]);
+
+  useEffect(() => {
+    if (isPoolActive) {
+      fetchRuns();
+    }
+  }, [isPoolActive, fetchRuns]);
+
+  const handleTriggerRepair = async () => {
+    if (!slug) return;
+    setTriggering(true);
+    try {
+      const res = await fetch(`/api/w/${slug}/pool/repair`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: message.trim() || undefined }),
+      });
+      const data = await res.json();
+
+      if (!res.ok) {
+        toast.error("Repair failed", {
+          description: data.error || data.message || "Unknown error",
+        });
+        return;
+      }
+
+      toast.success("Repair triggered", {
+        description: data.projectId
+          ? `Stakwork project #${data.projectId}`
+          : "Repair workflow started",
+      });
+      setMessage("");
+      setShowPrompt(false);
+      fetchRuns();
+    } catch {
+      toast.error("Repair failed", {
+        description: "Could not reach the server",
+      });
+    } finally {
+      setTriggering(false);
+    }
+  };
+
+  const handleStartEditDescription = () => {
+    setDescriptionDraft(formData.description || "");
+    setEditingDescription(true);
+  };
+
+  const handleSaveDescription = async () => {
+    if (!slug) return;
+    setSavingDescription(true);
+    handleProjectInfoChange({ description: descriptionDraft });
+    await saveSettings(slug);
+    setSavingDescription(false);
+    setEditingDescription(false);
+  };
+
+  const handleCancelEditDescription = () => {
+    setEditingDescription(false);
+    setDescriptionDraft("");
+  };
+
+  if (!isPoolActive) return null;
+
+  return (
+    <Card className="py-5 gap-0">
+      <CardContent className="space-y-4">
+        {/* Header */}
+        <div className="flex items-center gap-3">
+          <Bot className="h-5 w-5 shrink-0" />
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium">Pod Agent</p>
+            <PodStateInline state={podState} repoCount={repoCount} />
+          </div>
+          {canTrigger && !showPrompt && (
+            <Button size="sm" variant="outline" onClick={() => setShowPrompt(true)}>
+              <Play className="h-3.5 w-3.5 mr-1.5" />
+              Repair
+            </Button>
+          )}
+        </div>
+
+        {/* Setup description */}
+        {editingDescription ? (
+          <div className="space-y-2">
+            <Textarea
+              value={descriptionDraft}
+              onChange={(e) => setDescriptionDraft(e.target.value)}
+              placeholder="Describe your project setup..."
+              rows={3}
+              className="resize-none text-sm"
+              autoFocus
+            />
+            <div className="flex gap-2">
+              <Button
+                size="sm"
+                onClick={handleSaveDescription}
+                disabled={savingDescription}
+              >
+                {savingDescription ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
+                ) : null}
+                Save
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={handleCancelEditDescription}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div
+            className="group flex items-start gap-2 cursor-pointer rounded-md -mx-2 px-2 py-1 hover:bg-muted/50 transition-colors"
+            onClick={handleStartEditDescription}
+          >
+            <p className="text-sm text-muted-foreground leading-relaxed flex-1">
+              {formData.description || "Add a project description..."}
+            </p>
+            <Pencil className="h-3.5 w-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity mt-0.5 shrink-0" />
+          </div>
+        )}
+
+        <Separator />
+
+        {/* Recent runs */}
+        <div className="space-y-1.5">
+          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+            History
+          </p>
+          {runsLoading ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              Loading...
+            </div>
+          ) : runs.length > 0 ? (
+            <div className="space-y-0.5">
+              {runs.map((run) => (
+                <div
+                  key={run.id}
+                  className="flex items-center justify-between py-1.5 text-sm"
+                >
+                  <span className="text-muted-foreground">
+                    {formatRelativeOrDate(run.createdAt)}
+                  </span>
+                  {run.projectId && (
+                    <a
+                      href={`https://jobs.stakwork.com/admin/projects/${run.projectId}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
+                    >
+                      #{run.projectId}
+                      <ExternalLink className="h-3 w-3" />
+                    </a>
+                  )}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">No runs yet.</p>
+          )}
+        </div>
+
+        {/* Expandable repair prompt */}
+        {showPrompt && (
+          <>
+            <Separator />
+            <div className="rounded-md border border-border bg-muted/30 p-3 space-y-2">
+              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                Repair Instructions
+              </p>
+              <Textarea
+                placeholder="Describe what needs fixing..."
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
+                rows={2}
+                className="resize-none text-sm bg-background"
+                autoFocus
+              />
+              <div className="flex items-center justify-end gap-2">
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => {
+                    setShowPrompt(false);
+                    setMessage("");
+                  }}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={handleTriggerRepair}
+                  disabled={triggering}
+                >
+                  {triggering ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
+                  ) : (
+                    <Wrench className="h-3.5 w-3.5 mr-1.5" />
+                  )}
+                  Run Repair
+                </Button>
+              </div>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/stakgraph/forms/ProjectInfoForm.tsx
+++ b/src/components/stakgraph/forms/ProjectInfoForm.tsx
@@ -31,20 +31,6 @@ export default function ProjectInfoForm({
         )}
       </div>
 
-      <div className="space-y-2">
-        <Label htmlFor="description">Description</Label>
-        <Input
-          id="description"
-          placeholder="Short description of the project"
-          value={data.description}
-          onChange={(e) => handleInputChange("description", e.target.value)}
-          className={errors.description ? "border-destructive" : ""}
-          disabled={loading}
-        />
-        {errors.description && (
-          <p className="text-sm text-destructive">{errors.description}</p>
-        )}
-      </div>
     </div>
   );
 }

--- a/src/services/pod-repair-cron.ts
+++ b/src/services/pod-repair-cron.ts
@@ -59,6 +59,7 @@ export async function getEligibleWorkspaces() {
           poolState: true,
           podState: true,
           pendingRepairTrigger: true,
+          description: true,
         },
       },
     },
@@ -320,7 +321,8 @@ export async function triggerPodRepair(
   podId: string,
   podPassword: string,
   failedServices: string[],
-  message?: string
+  message?: string,
+  description?: string
 ): Promise<{ runId: string; projectId: number | null }> {
   const baseUrl = getBaseUrl();
   const webhookUrl = `${baseUrl}/api/webhook/stakwork/response?type=POD_REPAIR&workspace_id=${workspaceId}`;
@@ -367,6 +369,7 @@ export async function triggerPodRepair(
               history,
               failedServices,
               message: message || null,
+              description: description || null,
               searchApiKey: process.env.EXA_API_KEY,
             },
           },
@@ -487,7 +490,8 @@ export async function executePodRepairRuns(): Promise<PodRepairCronResult> {
             readyPod.subdomain,
             readyPod.password || "",
             [], // No specific failed services - this is a setup repair
-            `Repository added: ${pending.repoName}. If this new repo is connected or integrated with the existing repo(s), see if anything needs to be changed in the configs to properly connect the repos. If nothing needs to be changed then simply do not return any changed files!`
+            `Repository added: ${pending.repoName}. If this new repo is connected or integrated with the existing repo(s), see if anything needs to be changed in the configs to properly connect the repos. If nothing needs to be changed then simply do not return any changed files!`,
+            workspace.swarm?.description || undefined
           );
           
           // Clear the pending trigger
@@ -664,7 +668,8 @@ export async function executePodRepairRuns(): Promise<PodRepairCronResult> {
             pod.subdomain,
             pod.password || "",
             servicesToRepair,
-            frontendError || undefined
+            frontendError || undefined,
+            workspace.swarm?.description || undefined
           );
           result.repairsTriggered++;
           continue;
@@ -695,7 +700,8 @@ export async function executePodRepairRuns(): Promise<PodRepairCronResult> {
             pod.subdomain,
             pod.password || "",
             [PROCESS_NAMES.FRONTEND],
-            validationResult.message
+            validationResult.message,
+            workspace.swarm?.description || undefined
           );
           result.validationsFailedWithRepair++;
           result.repairsTriggered++;

--- a/src/services/swarm/db.ts
+++ b/src/services/swarm/db.ts
@@ -45,6 +45,7 @@ interface SaveOrUpdateSwarmParams {
   podState?: PodState;
   ingestRequestInProgress?: boolean;
   autoLearnEnabled?: boolean;
+  description?: string;
 }
 
 export const select = {
@@ -80,6 +81,7 @@ export const select = {
   minimumVms: true,
   webhookUrl: true,
   pendingRepairTrigger: true,
+  description: true,
 };
 
 export async function saveOrUpdateSwarm(params: SaveOrUpdateSwarmParams) {
@@ -119,6 +121,7 @@ export async function saveOrUpdateSwarm(params: SaveOrUpdateSwarmParams) {
   if (params.ingestRefId !== undefined) data.ingestRefId = params.ingestRefId;
   if (params.ingestRequestInProgress !== undefined) data.ingestRequestInProgress = params.ingestRequestInProgress;
   if (params.autoLearnEnabled !== undefined) data.autoLearnEnabled = params.autoLearnEnabled;
+  if (params.description !== undefined) data.description = params.description;
   data.updatedAt = new Date();
 
   if (swarm) {

--- a/src/types/swarm.ts
+++ b/src/types/swarm.ts
@@ -60,6 +60,7 @@ export interface SwarmSelectResult {
   environmentVariables: Record<string, string>[];
   services: ServicesConfig[] | string; // string if not parsed yet
   containerFiles: Record<string, string>;
+  description: string | null;
 }
 
 export interface ServicesConfig {


### PR DESCRIPTION
- Add PodRepairSection component with status, editable description, repair history, and manual repair trigger
- Add manual repair API endpoint (POST /api/w/[slug]/pool/repair)
- Add description field to Swarm model for project setup context
- Persist and load description in stakgraph settings GET/PUT
- Pass description to Stakwork workflow in both manual and cron repairs
- Two-column layout on stakgraph page (form left, pod agent right)
- Remove description from ProjectInfoForm (now in PodRepairSection)