### PR TITLE
fix: clarifying questions crash when comparison table cells are strings

### DIFF
--- a/src/components/features/ClarifyingQuestionsPreview/artifacts/ComparisonTable.tsx
+++ b/src/components/features/ClarifyingQuestionsPreview/artifacts/ComparisonTable.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/lib/utils";
 interface ComparisonRow {
   label: string;
   description?: string;
-  cells: Record<string, string[]>; // keyed by column name
+  cells: Record<string, string | string[]>; // keyed by column name
 }
 
 interface ComparisonTableData {
@@ -102,7 +102,8 @@ export function ComparisonTable({ data, className }: ComparisonTableProps) {
               {columns.map((col, colIdx) => {
                 const colType = getColumnType(col);
                 const config = colConfig[colType];
-                const cellItems = row.cells[col] || [];
+                const raw = row.cells[col];
+                const cellItems: string[] = Array.isArray(raw) ? raw : raw ? [raw] : [];
                 return (
                   <td
                     key={colIdx}

--- a/src/components/features/ClarifyingQuestionsPreview/index.tsx
+++ b/src/components/features/ClarifyingQuestionsPreview/index.tsx
@@ -58,7 +58,8 @@ function isValidComparisonTableArtifact(artifact: QuestionArtifact | undefined):
     const cells = r.cells as Record<string, unknown>;
     for (const key of Object.keys(cells)) {
       const value = cells[key];
-      // Each cell value must be an array of strings
+      // Each cell value must be a string or an array of strings
+      if (typeof value === "string") continue;
       if (!Array.isArray(value)) return false;
       if (!value.every((item) => typeof item === "string")) return false;
     }
@@ -153,11 +154,15 @@ export function ClarifyingQuestionsPreview({
   isLoading = false,
 }: ClarifyingQuestionsPreviewProps) {
   const validQuestions = useMemo(
-    () => questions.filter((q) => !shouldSkipQuestion(q)),
+    () => questions.filter((q) => q && !shouldSkipQuestion(q)),
     [questions]
   );
 
   const [currentIndex, setCurrentIndex] = useState(0);
+
+  if (validQuestions.length === 0) {
+    return null;
+  }
   const [answers, setAnswers] = useState<Record<number, Answer>>({});
   const [showReview, setShowReview] = useState(false);
 

--- a/src/types/stakwork.ts
+++ b/src/types/stakwork.ts
@@ -180,12 +180,25 @@ export interface ClarifyingQuestionsResponse {
 export function isClarifyingQuestions(
   result: unknown
 ): result is ClarifyingQuestionsResponse {
+  if (
+    typeof result !== "object" ||
+    result === null ||
+    !("tool_use" in result) ||
+    (result as Record<string, unknown>).tool_use !== "ask_clarifying_questions" ||
+    !("content" in result)
+  ) {
+    return false;
+  }
+  const content = (result as Record<string, unknown>).content;
   return (
-    typeof result === "object" &&
-    result !== null &&
-    "tool_use" in result &&
-    (result as Record<string, unknown>).tool_use === "ask_clarifying_questions" &&
-    "content" in result &&
-    Array.isArray((result as Record<string, unknown>).content)
+    Array.isArray(content) &&
+    content.length > 0 &&
+    content.every(
+      (item) =>
+        typeof item === "object" &&
+        item !== null &&
+        "question" in item &&
+        typeof (item as Record<string, unknown>).question === "string"
+    )
   );
 }


### PR DESCRIPTION
The AI returns comparison table cell values as strings but the validator expected string arrays only, causing all questions to be skipped and crashing on undefined access to .question property.