### PR TITLE
Fix deep research overlay stuck on preparing output

### DIFF
--- a/src/hooks/useStakworkGeneration.ts
+++ b/src/hooks/useStakworkGeneration.ts
@@ -71,9 +71,7 @@ export function useStakworkGeneration({
     }
   }, [enabled, workspace?.id, featureId, type]);
 
-  useEffect(() => {
-    queryLatestRunRef.current = queryLatestRun;
-  }, [queryLatestRun]);
+  queryLatestRunRef.current = queryLatestRun;
 
   useEffect(() => {
     if (!enabled || !workspace?.id) return;
@@ -114,7 +112,6 @@ export function useStakworkGeneration({
     return () => {
       channel.unbind("stakwork-run-update", handleRunUpdate);
       channel.unbind("stakwork-run-decision", handleRunDecision);
-      pusher.unsubscribe(channelName);
     };
   }, [enabled, workspace?.slug, featureId, type]);
 


### PR DESCRIPTION
The feature page's Pusher effect had unstable dependencies (isAutoLaunching, fetchPendingRuns, etc.) causing it to re-run frequently. Each cleanup called pusher.unsubscribe() which destroyed the shared channel, orphaning useStakworkGeneration's event handlers so it never received the COMPLETED status update.

Use refs for volatile dependencies to keep the effect stable, and remove pusher.unsubscribe() from cleanup since the channel is shared across hooks.