### PR TITLE
fix: handle double-encoded phases in task generation results

### DIFF
--- a/src/components/features/TicketsList/index.tsx
+++ b/src/components/features/TicketsList/index.tsx
@@ -262,6 +262,10 @@ export function TicketsList({ featureId, feature, onUpdate, onDecisionMade }: Ti
     ) {
       try {
         const parsed = JSON.parse(latestRun.result);
+        // Handle double-encoded phases from Stakwork API
+        if (typeof parsed.phases === "string") {
+          parsed.phases = JSON.parse(parsed.phases);
+        }
         aiGeneration.setContent(latestRun.result, "deep", latestRun.id);
         setGeneratedContent(parsed);
       } catch (error) {

--- a/src/services/stakwork-run.ts
+++ b/src/services/stakwork-run.ts
@@ -850,6 +850,10 @@ async function applyAcceptResult(
 
     case StakworkRunType.TASK_GENERATION: {
       const tasksData = JSON.parse(run.result);
+      // Handle double-encoded phases from Stakwork API
+      if (typeof tasksData.phases === "string") {
+        tasksData.phases = JSON.parse(tasksData.phases);
+      }
 
       const featureWithPhase = await db.feature.findUnique({
         where: { id: run.featureId },


### PR DESCRIPTION
Stakwork API returns phases as a JSON string instead of an array, causing task preview to render empty and accept to create zero tasks.