### PR TITLE
Add multi-repo support to janitor recommendations

### DIFF
--- a/prisma/migrations/20260220161101_add_repository_id_to_janitor_recommendation/migration.sql
+++ b/prisma/migrations/20260220161101_add_repository_id_to_janitor_recommendation/migration.sql
@@ -1,0 +1,16 @@
+-- AlterTable
+ALTER TABLE "janitor_recommendations" ADD COLUMN     "repository_id" TEXT;
+
+-- CreateIndex
+CREATE INDEX "janitor_recommendations_repository_id_idx" ON "janitor_recommendations"("repository_id");
+
+-- AddForeignKey
+ALTER TABLE "janitor_recommendations" ADD CONSTRAINT "janitor_recommendations_repository_id_fkey" FOREIGN KEY ("repository_id") REFERENCES "repositories"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Backfill: copy repository_id from the parent janitor_run
+UPDATE "janitor_recommendations" rec
+SET "repository_id" = jr."repository_id"
+FROM "janitor_runs" jr
+WHERE rec."janitor_run_id" = jr."id"
+  AND jr."repository_id" IS NOT NULL
+  AND rec."repository_id" IS NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -478,9 +478,10 @@ model Repository {
   workspace   Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
 
   // Tasks can be linked to repositories
-  tasks       Task[]
-  deployments Deployment[]
-  janitorRuns JanitorRun[]
+  tasks           Task[]
+  deployments     Deployment[]
+  janitorRuns     JanitorRun[]
+  recommendations JanitorRecommendation[]
 
   @@unique([repositoryUrl, workspaceId], name: "repositoryUrl_workspaceId")
   @@index([workspaceId])
@@ -798,6 +799,7 @@ model JanitorRecommendation {
   id           String  @id @default(cuid())
   janitorRunId String? @map("janitor_run_id")
   workspaceId  String  @map("workspace_id")
+  repositoryId String? @map("repository_id")
 
   // Recommendation details
   title       String
@@ -815,13 +817,15 @@ model JanitorRecommendation {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
-  janitorRun  JanitorRun? @relation(fields: [janitorRunId], references: [id], onDelete: Cascade)
-  workspace   Workspace   @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
-  acceptedBy  User?       @relation("RecommendationAcceptor", fields: [acceptedById], references: [id])
-  dismissedBy User?       @relation("RecommendationDismissor", fields: [dismissedById], references: [id])
+  janitorRun  JanitorRun?  @relation(fields: [janitorRunId], references: [id], onDelete: Cascade)
+  workspace   Workspace    @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  repository  Repository?  @relation(fields: [repositoryId], references: [id], onDelete: SetNull)
+  acceptedBy  User?        @relation("RecommendationAcceptor", fields: [acceptedById], references: [id])
+  dismissedBy User?        @relation("RecommendationDismissor", fields: [dismissedById], references: [id])
 
   @@index([janitorRunId])
   @@index([workspaceId])
+  @@index([repositoryId])
   @@index([status])
   @@index([priority])
   @@index([createdAt])

--- a/src/__tests__/support/factories/janitor.factory.ts
+++ b/src/__tests__/support/factories/janitor.factory.ts
@@ -124,6 +124,7 @@ export async function createJanitorRecommendation(
   workspaceId: string,
   overrides: Partial<{
     janitorRunId: string;
+    repositoryId: string;
     title: string;
     description: string;
     priority: "LOW" | "MEDIUM" | "HIGH" | "CRITICAL";

--- a/src/__tests__/support/helpers/service-mocks/janitor-mocks.ts
+++ b/src/__tests__/support/helpers/service-mocks/janitor-mocks.ts
@@ -29,6 +29,7 @@ export interface MockJanitorRunOptions {
   status?: JanitorStatus;
   triggeredBy?: JanitorTrigger;
   stakworkProjectId?: number | null;
+  repositoryId?: string | null;
   startedAt?: Date | null;
   completedAt?: Date | null;
   error?: string | null;
@@ -39,7 +40,8 @@ export interface MockJanitorRunOptions {
 
 export interface MockJanitorRecommendationOptions {
   id?: string;
-  janitorRunId?: string;
+  janitorRunId?: string | null;
+  repositoryId?: string | null;
   title?: string;
   description?: string;
   priority?: Priority;
@@ -83,6 +85,7 @@ export const janitorMocks = {
       status: overrides.status || ("PENDING" as JanitorStatus),
       triggeredBy: overrides.triggeredBy || ("MANUAL" as JanitorTrigger),
       stakworkProjectId: overrides.stakworkProjectId === undefined ? null : overrides.stakworkProjectId,
+      repositoryId: overrides.repositoryId === undefined ? null : overrides.repositoryId,
       startedAt: overrides.startedAt === undefined ? null : overrides.startedAt,
       completedAt: overrides.completedAt === undefined ? null : overrides.completedAt,
       error: overrides.error === undefined ? null : overrides.error,
@@ -95,7 +98,8 @@ export const janitorMocks = {
   createMockRecommendation(overrides: MockJanitorRecommendationOptions = {}) {
     return {
       id: overrides.id || "rec-1",
-      janitorRunId: overrides.janitorRunId || "run-1",
+      janitorRunId: overrides.janitorRunId === undefined ? "run-1" : overrides.janitorRunId,
+      repositoryId: overrides.repositoryId === undefined ? null : overrides.repositoryId,
       title: overrides.title || "Add unit tests for authentication",
       description: overrides.description || "Authentication logic lacks unit test coverage",
       priority: overrides.priority || ("MEDIUM" as Priority),

--- a/src/app/api/workspaces/[slug]/janitors/recommendations/route.ts
+++ b/src/app/api/workspaces/[slug]/janitors/recommendations/route.ts
@@ -3,7 +3,7 @@ import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth/nextauth";
 import { getJanitorRecommendations } from "@/services/janitor";
 import { parseJanitorType, parseRecommendationStatus, parsePriority, validatePaginationParams } from "@/lib/helpers/janitor-validation";
-import { JanitorType, RecommendationStatus, Priority } from "@prisma/client";
+import type { JanitorRecommendationFilters } from "@/types/janitor";
 
 export async function GET(
   request: NextRequest,
@@ -23,19 +23,17 @@ export async function GET(
     const statusParam = searchParams.get("status");
     const janitorTypeParam = searchParams.get("janitorType");
     const priorityParam = searchParams.get("priority");
+    const repositoryIdParam = searchParams.get("repositoryId");
     const { limit, page } = validatePaginationParams(
       searchParams.get("limit"),
       searchParams.get("page")
     );
 
+    const filters: JanitorRecommendationFilters = { limit, page };
 
-    const filters: {
-      status?: RecommendationStatus;
-      janitorType?: JanitorType;
-      priority?: Priority;
-      limit: number;
-      page: number;
-    } = { limit, page };
+    if (repositoryIdParam) {
+      filters.repositoryId = repositoryIdParam;
+    }
 
     if (statusParam) {
       try {
@@ -77,6 +75,7 @@ export async function GET(
         createdAt: rec.createdAt,
         updatedAt: rec.updatedAt,
         janitorRun: rec.janitorRun,
+        repository: rec.repository,
         acceptedBy: rec.acceptedBy,
         dismissedBy: rec.dismissedBy,
       })),

--- a/src/components/insights/RecommendationsSection/index.tsx
+++ b/src/components/insights/RecommendationsSection/index.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { CheckCircle2, Loader2, Sparkles, Clock, User } from "lucide-react";
+import { CheckCircle2, GitBranch, Loader2, Sparkles, Clock, User } from "lucide-react";
 import { toast } from "sonner";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { useInsightsStore } from "@/stores/useInsightsStore";
@@ -129,6 +129,12 @@ export function RecommendationsSection() {
                       <Badge className="gap-1 px-1.5 py-0.5 text-xs bg-purple-100 text-purple-800 border-purple-200" data-testid="recommendation-review-badge">
                         <User className="w-3 h-3" />
                         Review Required
+                      </Badge>
+                    )}
+                    {recommendation.repository && (
+                      <Badge variant="outline" className="gap-1 px-1.5 py-0.5 text-xs" data-testid="recommendation-repo-badge">
+                        <GitBranch className="w-3 h-3" />
+                        {recommendation.repository.name}
                       </Badge>
                     )}
                     {getPriorityBadge(recommendation.priority as Priority)}

--- a/src/services/janitor-cron.ts
+++ b/src/services/janitor-cron.ts
@@ -162,11 +162,12 @@ export async function shouldSkipJanitorRun(
     return true;
   }
 
-  // Check for pending recommendations
+  // Check for pending recommendations for this specific repo
   const pendingRecommendation = await db.janitorRecommendation.findFirst({
     where: {
       workspaceId,
       status: "PENDING",
+      repositoryId,
       janitorRun: {
         janitorType,
       },
@@ -317,7 +318,7 @@ export async function executeScheduledJanitorRuns(): Promise<CronExecutionResult
               );
               result.errors.push({
                 workspaceSlug: slug,
-                janitorType: janitorType,
+                janitorType,
                 repositoryId: repository.id,
                 error: errorMessage,
               });

--- a/src/stores/useInsightsStore.ts
+++ b/src/stores/useInsightsStore.ts
@@ -14,8 +14,11 @@ interface Recommendation {
     status: string;
     createdAt: string;
   };
+  repository?: {
+    id: string;
+    name: string;
+  } | null;
 }
-
 
 const initialState = {
   recommendations: [],
@@ -25,7 +28,6 @@ const initialState = {
   showAll: false,
   runningJanitors: new Set<string>(),
   workspaceSlug: null as string | null,
-  taskCoordinatorEnabled: false,
   recommendationSweepEnabled: false,
   ticketSweepEnabled: false,
 };

--- a/src/types/janitor.ts
+++ b/src/types/janitor.ts
@@ -70,29 +70,9 @@ export interface JanitorRecommendationFilters {
   status?: RecommendationStatus;
   janitorType?: JanitorType;
   priority?: Priority;
+  repositoryId?: string;
   limit?: number;
   page?: number;
-}
-
-export interface CronExecutionResult {
-  success: boolean;
-  workspacesProcessed: number;
-  runsCreated: number;
-  skipped: number; // Number of janitor runs skipped due to active tasks
-  errorCount: number;
-  errors: Array<{
-    workspaceSlug: string;
-    janitorType: JanitorType;
-    error: string;
-  }>;
-  timestamp: string;
-}
-
-export interface CronHealthCheck {
-  enabled: boolean;
-  schedule: string;
-  scheduleSource: string;
-  timestamp: string;
 }
 
 export { JanitorType, JanitorStatus, JanitorTrigger, RecommendationStatus };


### PR DESCRIPTION
Thread repositoryId from JanitorRun through to recommendations, task creation, and the skip-check so each repo is tracked and gated independently. Add repo filter to API and repo badge to UI.