### PR TITLE
Fix back button navigating to tasks list from plan chat

### DIFF
--- a/src/app/w/[slug]/task/[...taskParams]/components/ChatArea.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/components/ChatArea.tsx
@@ -167,8 +167,8 @@ export function ChatArea({
                   title={taskTitle}
                   data-testid="task-title"
                 >
-                  {/* Inline Breadcrumbs */}
-                  {workspaceSlug && (
+                  {/* Inline Breadcrumbs - only show in task chat context */}
+                  {workspaceSlug && taskId && (
                     <TaskBreadcrumbs
                       featureId={featureId ?? null}
                       featureTitle={featureTitle ?? null}


### PR DESCRIPTION
Use featureId to determine fallback route — navigate to /plan for feature chats instead of always falling back to /tasks.