### PR TITLE
fix: broadcast FEATURE_UPDATED on feature channel after auto-accept

### DIFF
--- a/src/services/stakwork-run.ts
+++ b/src/services/stakwork-run.ts
@@ -19,6 +19,7 @@ import {
   pusherServer,
   getWorkspaceChannelName,
   getWhiteboardChannelName,
+  getFeatureChannelName,
   PUSHER_EVENTS,
 } from "@/lib/pusher";
 import { mapStakworkStatus } from "@/utils/conversions";
@@ -848,6 +849,17 @@ export async function processStakworkRunWebhook(
         );
       } catch (pusherError) {
         console.error("Error broadcasting auto-accept decision to Pusher:", pusherError);
+      }
+
+      // Also notify feature channel so plan mode listeners refetch
+      try {
+        const featureChannelName = getFeatureChannelName(run.featureId);
+        await pusherServer.trigger(featureChannelName, PUSHER_EVENTS.FEATURE_UPDATED, {
+          featureId: run.featureId,
+          timestamp: new Date().toISOString(),
+        });
+      } catch (pusherError) {
+        console.error("Error broadcasting feature update to Pusher:", pusherError);
       }
     } catch (error) {
       console.error(`Auto-accept failed for run ${run.id}:`, error);


### PR DESCRIPTION
Task generation with autoAccept in plan mode wasn't updating the artifact panel because the webhook only broadcast on the workspace channel. PlanChatView listens on the feature channel, so the feature data was never refetched and the TASKS tab stayed empty.