### PR TITLE
fix: Pusher dedup ID swap and broadcast cleanup

### DIFF
--- a/src/app/api/chat/message/route.ts
+++ b/src/app/api/chat/message/route.ts
@@ -282,17 +282,11 @@ export async function POST(request: NextRequest) {
       attachments: chatMessage.attachments || [],
     } as ChatMessage;
 
-    console.log("clientMessage", clientMessage);
-
-    // Broadcast user message to Pusher
+    // Broadcast user message to other connected clients
     try {
-      await pusherServer.trigger(
-        getTaskChannelName(taskId),
-        PUSHER_EVENTS.NEW_MESSAGE,
-        chatMessage.id
-      );
+      await pusherServer.trigger(getTaskChannelName(taskId), PUSHER_EVENTS.NEW_MESSAGE, chatMessage.id);
     } catch (error) {
-      console.error('Error broadcasting user message to Pusher (task):', error);
+      console.error("Error broadcasting user message to Pusher (task):", error);
     }
 
     const useStakwork = config.STAKWORK_API_KEY && config.STAKWORK_BASE_URL && config.STAKWORK_WORKFLOW_ID;

--- a/src/app/api/features/[featureId]/chat/route.ts
+++ b/src/app/api/features/[featureId]/chat/route.ts
@@ -214,15 +214,11 @@ export async function POST(
       })) as Artifact[],
     };
 
-    // Broadcast user message to Pusher
+    // Broadcast user message to other connected clients
     try {
-      await pusherServer.trigger(
-        getFeatureChannelName(featureId),
-        PUSHER_EVENTS.NEW_MESSAGE,
-        chatMessage.id
-      );
+      await pusherServer.trigger(getFeatureChannelName(featureId), PUSHER_EVENTS.NEW_MESSAGE, chatMessage.id);
     } catch (error) {
-      console.error('Error broadcasting user message to Pusher (feature):', error);
+      console.error("Error broadcasting user message to Pusher (feature):", error);
     }
 
     // Call Stakwork workflow


### PR DESCRIPTION
## Summary
- Swap temp message ID to real DB ID after POST so Pusher dedup correctly ignores the sender's own bounced message (without this, sender sees duplicates)
- Clean up broadcast blocks in both chat routes for consistency, remove debug log, rename `handleSSEMessage` → `handleNewMessage`

Follow-up to #3146 which was merged before these commits landed.

## Test plan
- [ ] Open same task page in two browser sessions — message sent in session A appears in session B, no duplicates in either
- [ ] Open same plan page in two sessions — same behavior
- [ ] Sender never sees their own message twice