### PR TITLE
Fix plan mode model selector and add admin defaults

### DIFF
--- a/prisma/migrations/20260414104541_add_model_to_feature/migration.sql
+++ b/prisma/migrations/20260414104541_add_model_to_feature/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "features" ADD COLUMN     "model" TEXT;

--- a/prisma/migrations/20260414105821_add_plan_task_defaults_to_llm_model/migration.sql
+++ b/prisma/migrations/20260414105821_add_plan_task_defaults_to_llm_model/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "llm_models" ADD COLUMN     "is_plan_default" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "is_task_default" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -675,6 +675,7 @@ model Feature {
   workflowStatus      WorkflowStatus?       @default(PENDING) @map("workflow_status")
   isFastTrack         Boolean               @default(false) @map("is_fast_track")
   planUpdatedAt       DateTime?             @map("plan_updated_at")
+  model               String?
   agentLogs           AgentLog[]
   chatMessages        ChatMessage[]
   assignee            User?                 @relation("FeatureAssignee", fields: [assigneeId], references: [id])
@@ -1301,6 +1302,8 @@ model LlmModel {
   outputPricePer1M Float       @map("output_price_per_1m")
   dateStart        DateTime?   @map("date_start")
   dateEnd          DateTime?   @map("date_end")
+  isPlanDefault    Boolean     @default(false) @map("is_plan_default")
+  isTaskDefault    Boolean     @default(false) @map("is_task_default")
   createdAt        DateTime    @default(now()) @map("created_at")
   updatedAt        DateTime    @updatedAt @map("updated_at")
 

--- a/src/__tests__/unit/components/plan/PlanChatView.test.tsx
+++ b/src/__tests__/unit/components/plan/PlanChatView.test.tsx
@@ -473,7 +473,7 @@ describe("PlanChatView", () => {
 
         expect(sendMessageCall).toBeDefined();
         const body = JSON.parse(sendMessageCall![1].body);
-        expect(body).toEqual({
+        expect(body).toMatchObject({
           message: "Test answer",
           replyId: "test-message-id",
         });

--- a/src/__tests__/unit/services/roadmap/features.test.ts
+++ b/src/__tests__/unit/services/roadmap/features.test.ts
@@ -647,6 +647,7 @@ describe("createFeature", () => {
           priority: FeaturePriority.LOW,
           assigneeId: null,
           isFastTrack: false,
+          model: null,
           createdById: mockUserId,
           updatedById: mockUserId,
           phases: {

--- a/src/app/admin/llm-models/LlmModelsTable.tsx
+++ b/src/app/admin/llm-models/LlmModelsTable.tsx
@@ -20,6 +20,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
 import type { LlmModel, LlmProvider } from "@prisma/client";
 
 const PROVIDERS: LlmProvider[] = ["GOOGLE", "ANTHROPIC", "OPENAI", "AWS_BEDROCK", "OTHER"];
@@ -54,6 +55,8 @@ interface FormState {
   outputPricePer1M: string;
   dateStart: string;
   dateEnd: string;
+  isPlanDefault: boolean;
+  isTaskDefault: boolean;
 }
 
 const emptyForm: FormState = {
@@ -64,6 +67,8 @@ const emptyForm: FormState = {
   outputPricePer1M: "",
   dateStart: "",
   dateEnd: "",
+  isPlanDefault: false,
+  isTaskDefault: false,
 };
 
 function modelToForm(model: LlmModel): FormState {
@@ -79,6 +84,8 @@ function modelToForm(model: LlmModel): FormState {
     dateEnd: model.dateEnd
       ? new Date(model.dateEnd).toISOString().split("T")[0]
       : "",
+    isPlanDefault: model.isPlanDefault,
+    isTaskDefault: model.isTaskDefault,
   };
 }
 
@@ -133,6 +140,8 @@ export default function LlmModelsTable({ initialData }: LlmModelsTableProps) {
         outputPricePer1M: parseFloat(form.outputPricePer1M),
         dateStart: form.dateStart || null,
         dateEnd: form.dateEnd || null,
+        isPlanDefault: form.isPlanDefault,
+        isTaskDefault: form.isTaskDefault,
       };
 
       const url = editingModel
@@ -195,6 +204,7 @@ export default function LlmModelsTable({ initialData }: LlmModelsTableProps) {
               <th className="pb-3 pr-4 font-medium">Output / 1M</th>
               <th className="pb-3 pr-4 font-medium">Date Start</th>
               <th className="pb-3 pr-4 font-medium">Date End</th>
+              <th className="pb-3 pr-4 font-medium">Defaults</th>
               <th className="pb-3 pr-4 font-medium">Status</th>
               <th className="pb-3 font-medium">Actions</th>
             </tr>
@@ -202,7 +212,7 @@ export default function LlmModelsTable({ initialData }: LlmModelsTableProps) {
           <tbody>
             {models.length === 0 && (
               <tr>
-                <td colSpan={8} className="py-8 text-center text-muted-foreground">
+                <td colSpan={9} className="py-8 text-center text-muted-foreground">
                   No LLM models found. Add one to get started.
                 </td>
               </tr>
@@ -219,6 +229,16 @@ export default function LlmModelsTable({ initialData }: LlmModelsTableProps) {
                 <td className="py-3 pr-4">{formatPrice(model.outputPricePer1M)}</td>
                 <td className="py-3 pr-4">{formatDate(model.dateStart)}</td>
                 <td className="py-3 pr-4">{formatDate(model.dateEnd)}</td>
+                <td className="py-3 pr-4">
+                  <div className="flex gap-1">
+                    {model.isPlanDefault && (
+                      <Badge className="bg-blue-100 text-blue-800 hover:bg-blue-100">Plan</Badge>
+                    )}
+                    {model.isTaskDefault && (
+                      <Badge className="bg-purple-100 text-purple-800 hover:bg-purple-100">Task</Badge>
+                    )}
+                  </div>
+                </td>
                 <td className="py-3 pr-4">
                   {isActive(model.dateEnd) ? (
                     <Badge className="bg-green-100 text-green-800 hover:bg-green-100">Active</Badge>
@@ -344,6 +364,24 @@ export default function LlmModelsTable({ initialData }: LlmModelsTableProps) {
                   value={form.dateEnd}
                   onChange={(e) => setForm((f) => ({ ...f, dateEnd: e.target.value }))}
                 />
+              </div>
+            </div>
+            <div className="flex items-center gap-4">
+              <div className="flex items-center gap-2">
+                <Switch
+                  id="llm-plan-default"
+                  checked={form.isPlanDefault}
+                  onCheckedChange={(checked) => setForm((f) => ({ ...f, isPlanDefault: checked }))}
+                />
+                <Label htmlFor="llm-plan-default">Plan default</Label>
+              </div>
+              <div className="flex items-center gap-2">
+                <Switch
+                  id="llm-task-default"
+                  checked={form.isTaskDefault}
+                  onCheckedChange={(checked) => setForm((f) => ({ ...f, isTaskDefault: checked }))}
+                />
+                <Label htmlFor="llm-task-default">Task default</Label>
               </div>
             </div>
           </div>

--- a/src/app/api/admin/llm-models/[id]/route.ts
+++ b/src/app/api/admin/llm-models/[id]/route.ts
@@ -20,7 +20,14 @@ export async function PATCH(
     }
 
     const body = await request.json();
-    const { name, provider, providerLabel, inputPricePer1M, outputPricePer1M, dateStart, dateEnd } = body;
+    const { name, provider, providerLabel, inputPricePer1M, outputPricePer1M, dateStart, dateEnd, isPlanDefault, isTaskDefault } = body;
+
+    if (isPlanDefault) {
+      await db.llmModel.updateMany({ where: { isPlanDefault: true, id: { not: id } }, data: { isPlanDefault: false } });
+    }
+    if (isTaskDefault) {
+      await db.llmModel.updateMany({ where: { isTaskDefault: true, id: { not: id } }, data: { isTaskDefault: false } });
+    }
 
     const model = await db.llmModel.update({
       where: { id },
@@ -32,6 +39,8 @@ export async function PATCH(
         ...(outputPricePer1M !== undefined && { outputPricePer1M: Number(outputPricePer1M) }),
         ...(dateStart !== undefined && { dateStart: dateStart ? new Date(dateStart) : null }),
         ...(dateEnd !== undefined && { dateEnd: dateEnd ? new Date(dateEnd) : null }),
+        ...(isPlanDefault !== undefined && { isPlanDefault }),
+        ...(isTaskDefault !== undefined && { isTaskDefault }),
       },
     });
 

--- a/src/app/api/admin/llm-models/route.ts
+++ b/src/app/api/admin/llm-models/route.ts
@@ -31,13 +31,20 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json();
-    const { name, provider, providerLabel, inputPricePer1M, outputPricePer1M, dateStart, dateEnd } = body;
+    const { name, provider, providerLabel, inputPricePer1M, outputPricePer1M, dateStart, dateEnd, isPlanDefault, isTaskDefault } = body;
 
     if (!name || !provider || inputPricePer1M == null || outputPricePer1M == null) {
       return NextResponse.json(
         { error: "name, provider, inputPricePer1M, and outputPricePer1M are required" },
         { status: 400 }
       );
+    }
+
+    if (isPlanDefault) {
+      await db.llmModel.updateMany({ where: { isPlanDefault: true }, data: { isPlanDefault: false } });
+    }
+    if (isTaskDefault) {
+      await db.llmModel.updateMany({ where: { isTaskDefault: true }, data: { isTaskDefault: false } });
     }
 
     const model = await db.llmModel.create({
@@ -49,6 +56,8 @@ export async function POST(request: NextRequest) {
         outputPricePer1M: Number(outputPricePer1M),
         dateStart: dateStart ? new Date(dateStart) : null,
         dateEnd: dateEnd ? new Date(dateEnd) : null,
+        isPlanDefault: isPlanDefault ?? false,
+        isTaskDefault: isTaskDefault ?? false,
       },
     });
 

--- a/src/app/api/llm-models/route.ts
+++ b/src/app/api/llm-models/route.ts
@@ -23,6 +23,8 @@ export async function GET(request: NextRequest) {
       name: true,
       provider: true,
       providerLabel: true,
+      isPlanDefault: true,
+      isTaskDefault: true,
     },
     orderBy: { createdAt: "desc" },
   });

--- a/src/app/w/[slug]/plan/[featureId]/components/PlanChatView.tsx
+++ b/src/app/w/[slug]/plan/[featureId]/components/PlanChatView.tsx
@@ -24,6 +24,7 @@ import { ClipboardList } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { useRouter, useSearchParams } from "next/navigation";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { getModelValue } from "@/lib/ai/models";
 import { DiffToken, PlanData, PlanSection, SectionHighlights } from "./PlanArtifact";
 
 function generateUniqueId(): string {
@@ -101,7 +102,7 @@ export function PlanChatView({ featureId, workspaceSlug, workspaceId }: PlanChat
   const [sphinxReady, setSphinxReady] = useState(false);
   const [showPreview, setShowPreview] = useState(false);
   const [isRetrying, setIsRetrying] = useState(false);
-  const [llmModels, setLlmModels] = useState<{ id: string; name: string; provider: string; providerLabel: string | null }[]>([]);
+  const [llmModels, setLlmModels] = useState<{ id: string; name: string; provider: string; providerLabel: string | null; isPlanDefault: boolean; isTaskDefault: boolean }[]>([]);
   const [selectedModel, setSelectedModel] = useState<string>("");
   const { streamContext, onMessage: onStreamMessage, onWorkflowStatusUpdate: onStreamStatusUpdate } = useStreamContext();
 
@@ -283,8 +284,9 @@ export function PlanChatView({ featureId, workspaceSlug, workspaceId }: PlanChat
           const data = await response.json();
           const models = data.models ?? [];
           setLlmModels(models);
-          if (models.length > 0) {
-            setSelectedModel(`${models[0].provider.toLowerCase()}/${models[0].name}`);
+          if (!selectedModel && models.length > 0) {
+            const defaultModel = models.find((m: { isPlanDefault: boolean }) => m.isPlanDefault);
+            setSelectedModel(getModelValue(defaultModel ?? models[0]));
           }
         }
       } catch (error) {
@@ -292,7 +294,14 @@ export function PlanChatView({ featureId, workspaceSlug, workspaceId }: PlanChat
       }
     };
     fetchLlmModels();
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Initialize selectedModel from persisted feature.model
+  useEffect(() => {
+    if (feature?.model && !selectedModel) {
+      setSelectedModel(feature.model);
+    }
+  }, [feature?.model]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Refetch on tab visibility change
   useEffect(() => {
@@ -405,7 +414,7 @@ export function PlanChatView({ featureId, workspaceSlug, workspaceId }: PlanChat
         setIsLoading(false);
       }
     },
-    [featureId, session, clearLogs],
+    [featureId, session, clearLogs, selectedModel],
   );
 
   const handleArtifactAction = useCallback(
@@ -437,6 +446,7 @@ export function PlanChatView({ featureId, workspaceSlug, workspaceId }: PlanChat
           body: JSON.stringify({
             message: action.optionResponse,
             replyId: messageId,
+            model: selectedModel,
           }),
         });
 
@@ -466,7 +476,7 @@ export function PlanChatView({ featureId, workspaceSlug, workspaceId }: PlanChat
         setIsLoading(false);
       }
     },
-    [featureId, session, clearLogs],
+    [featureId, session, clearLogs, selectedModel],
   );
 
   const allArtifacts = useMemo(() => (Array.isArray(messages) ? messages.flatMap((m) => m.artifacts || []) : []), [messages]);
@@ -554,7 +564,14 @@ export function PlanChatView({ featureId, workspaceSlug, workspaceId }: PlanChat
     streamContext,
     isSuperAdmin,
     selectedModel,
-    onModelChange: setSelectedModel,
+    onModelChange: (model: string) => {
+      setSelectedModel(model);
+      fetch(`/api/features/${featureId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model }),
+      }).catch(() => {});
+    },
     llmModels,
     hasMessages,
   };

--- a/src/app/w/[slug]/plan/new/components/PlanStartInput.tsx
+++ b/src/app/w/[slug]/plan/new/components/PlanStartInput.tsx
@@ -15,14 +15,7 @@ import { useSpeechRecognition } from "@/hooks/useSpeechRecognition";
 import { useControlKeyHold } from "@/hooks/useControlKeyHold";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { cn } from "@/lib/utils";
-
-
-interface LlmModelOption {
-  id: string;
-  name: string;
-  provider: string;
-  providerLabel: string | null;
-}
+import { getModelValue, type LlmModelOption } from "@/lib/ai/models";
 
 interface PlanStartInputProps {
   onSubmit: (message: string, options?: { isPrototype: boolean; selectedRepoId: string | null; model: string }) => void;
@@ -78,7 +71,8 @@ export function PlanStartInput({ onSubmit, isLoading = false }: PlanStartInputPr
           const models: LlmModelOption[] = data.models ?? [];
           setLlmModels(models);
           if (models.length > 0) {
-            setSelectedModel(`${models[0].provider.toLowerCase()}/${models[0].name}`);
+            const defaultModel = models.find((m: { isPlanDefault: boolean }) => m.isPlanDefault);
+            setSelectedModel(getModelValue(defaultModel ?? models[0]));
           }
         }
       } catch (error) {
@@ -294,16 +288,16 @@ export function PlanStartInput({ onSubmit, isLoading = false }: PlanStartInputPr
 
             {llmModels.length > 0 && (
               <Select value={selectedModel} onValueChange={(v) => setSelectedModel(v)}>
-                <SelectTrigger className="w-[120px] h-8 text-xs rounded-lg shadow-sm" data-testid="model-selector">
+                <SelectTrigger className="w-auto h-8 text-xs rounded-lg shadow-sm whitespace-nowrap" data-testid="model-selector">
                   <div className="flex items-center gap-2">
-                    <Sparkles className="h-4 w-4" />
-                    <span>{selectedModel ? (llmModels.find(m => `${m.provider.toLowerCase()}/${m.name}` === selectedModel)?.providerLabel || selectedModel) : "Model"}</span>
+                    <Sparkles className="h-4 w-4 shrink-0" />
+                    <span>{selectedModel ? (llmModels.find(m => getModelValue(m) === selectedModel)?.name || selectedModel) : "Model"}</span>
                   </div>
                 </SelectTrigger>
                 <SelectContent>
                   {llmModels.map((m) => (
-                    <SelectItem key={m.id} value={`${m.provider.toLowerCase()}/${m.name}`}>
-                      {m.providerLabel || m.name}
+                    <SelectItem key={m.id} value={getModelValue(m)}>
+                      {m.name}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/src/app/w/[slug]/plan/new/page.tsx
+++ b/src/app/w/[slug]/plan/new/page.tsx
@@ -61,7 +61,7 @@ export default function NewPlanPage() {
       const featureRes = await fetch("/api/features", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ title: message.slice(0, 100), workspaceId }),
+        body: JSON.stringify({ title: message.slice(0, 100), workspaceId, model: options?.model }),
       });
 
       if (!featureRes.ok) {

--- a/src/app/w/[slug]/task/[...taskParams]/components/ChatArea.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/components/ChatArea.tsx
@@ -60,7 +60,7 @@ interface ChatAreaProps {
   isSuperAdmin?: boolean;
   selectedModel?: string;
   onModelChange?: (m: string) => void;
-  llmModels?: { id: string; name: string; provider: string; providerLabel: string | null }[];
+  llmModels?: { id: string; name: string; provider: string; providerLabel: string | null; isPlanDefault: boolean; isTaskDefault: boolean }[];
   hasMessages?: boolean;
 }
 

--- a/src/app/w/[slug]/task/[...taskParams]/components/ChatInput.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/components/ChatInput.tsx
@@ -8,7 +8,7 @@ import { Command, CommandItem, CommandList } from "@/components/ui/command";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Mic, MicOff, ArrowUp, Image as ImageIcon, X, Loader2, RefreshCw, Sparkles } from "lucide-react";
 import { Select, SelectContent, SelectItem, SelectTrigger } from "@/components/ui/select";
-import type { ModelName } from "@/lib/ai/models";
+import { getModelValue, type ModelName } from "@/lib/ai/models";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { cn } from "@/lib/utils";
@@ -60,7 +60,7 @@ interface ChatInputProps {
   isSuperAdmin?: boolean;
   selectedModel?: string;
   onModelChange?: (m: string) => void;
-  llmModels?: { id: string; name: string; provider: string; providerLabel: string | null }[];
+  llmModels?: { id: string; name: string; provider: string; providerLabel: string | null; isPlanDefault: boolean; isTaskDefault: boolean }[];
   hasMessages?: boolean;
 }
 
@@ -689,16 +689,16 @@ export function ChatInput({
         <div className="flex gap-2 shrink-0">
           {isPlanChat && !hasMessages && onModelChange && llmModels.length > 0 && (
             <Select value={selectedModel} onValueChange={(v) => onModelChange(v)}>
-              <SelectTrigger className="w-[120px] h-8 text-xs rounded-lg shadow-sm">
+              <SelectTrigger className="w-auto h-8 text-xs rounded-lg shadow-sm whitespace-nowrap">
                 <div className="flex items-center gap-2">
-                  <Sparkles className="h-4 w-4" />
-                  <span>{selectedModel ? (llmModels.find(m => `${m.provider.toLowerCase()}/${m.name}` === selectedModel)?.providerLabel || selectedModel) : "Model"}</span>
+                  <Sparkles className="h-4 w-4 shrink-0" />
+                  <span>{selectedModel ? (llmModels.find(m => getModelValue(m) === selectedModel)?.name || selectedModel) : "Model"}</span>
                 </div>
               </SelectTrigger>
               <SelectContent>
                 {llmModels.map((m) => (
-                  <SelectItem key={m.id} value={`${m.provider.toLowerCase()}/${m.name}`}>
-                    <span>{m.providerLabel || m.name}</span>
+                  <SelectItem key={m.id} value={getModelValue(m)}>
+                    {m.name}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/src/components/features/CompactTasksList/index.tsx
+++ b/src/components/features/CompactTasksList/index.tsx
@@ -20,7 +20,7 @@ import { PRStatusBadge } from "@/components/tasks/PRStatusBadge";
 import { DeploymentStatusBadge } from "@/components/tasks/DeploymentStatusBadge";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { useRoadmapTaskMutations } from "@/hooks/useRoadmapTaskMutations";
-import { getModelValue } from "@/lib/ai/models";
+import { getModelValue, type LlmModelOption } from "@/lib/ai/models";
 import { usePusherConnection, type TaskTitleUpdateEvent, type DeploymentStatusChangeEvent } from "@/hooks/usePusherConnection";
 import type { FeatureDetail, PrArtifact } from "@/types/roadmap";
 import type { TaskStatus, WorkflowStatus } from "@prisma/client";
@@ -81,12 +81,6 @@ function MiniToggle({
   );
 }
 
-interface LlmModelOption {
-  id: string;
-  name: string;
-  provider: string;
-  providerLabel: string | null;
-}
 
 export function CompactTasksList({ featureId, feature, onUpdate, isGenerating }: CompactTasksListProps) {
   const router = useRouter();

--- a/src/components/features/CompactTasksList/index.tsx
+++ b/src/components/features/CompactTasksList/index.tsx
@@ -20,6 +20,7 @@ import { PRStatusBadge } from "@/components/tasks/PRStatusBadge";
 import { DeploymentStatusBadge } from "@/components/tasks/DeploymentStatusBadge";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { useRoadmapTaskMutations } from "@/hooks/useRoadmapTaskMutations";
+import { getModelValue } from "@/lib/ai/models";
 import { usePusherConnection, type TaskTitleUpdateEvent, type DeploymentStatusChangeEvent } from "@/hooks/usePusherConnection";
 import type { FeatureDetail, PrArtifact } from "@/types/roadmap";
 import type { TaskStatus, WorkflowStatus } from "@prisma/client";
@@ -705,8 +706,8 @@ export function CompactTasksList({ featureId, feature, onUpdate, isGenerating }:
                       </SelectTrigger>
                       <SelectContent>
                         {llmModels.map((m) => (
-                          <SelectItem key={m.id} value={`${m.provider.toLowerCase()}/${m.name}`} className="text-xs">
-                            {m.providerLabel || m.name}
+                          <SelectItem key={m.id} value={getModelValue(m)} className="text-xs">
+                            {m.name}
                           </SelectItem>
                         ))}
                       </SelectContent>

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -29,8 +29,30 @@ export const PROVIDER_API_KEY_ENV_VARS: Record<string, string | null> = {
   OPENAI: "OPENAI_API_KEY",
   GOOGLE: "GOOGLE_API_KEY",
   AWS_BEDROCK: "AWS_BEDROCK_API_KEY",
+  OPENROUTER: "OPENROUTER_API_KEY",
   OTHER: null,
 };
+
+export interface LlmModelOption {
+  id: string;
+  name: string;
+  provider: string;
+  providerLabel: string | null;
+  isPlanDefault: boolean;
+  isTaskDefault: boolean;
+}
+
+/**
+ * Build the model value string sent to Stakwork.
+ * For OTHER providers with a providerLabel, uses the label as prefix.
+ * For standard providers, uses the enum lowercase.
+ */
+export function getModelValue(m: LlmModelOption): string {
+  if (m.provider === "OTHER" && m.providerLabel) {
+    return `${m.providerLabel.toLowerCase().replace(/\s+/g, "")}/${m.name}`;
+  }
+  return `${m.provider.toLowerCase()}/${m.name}`;
+}
 
 export function getApiKeyForModel(model: ModelName | string): string | undefined {
   if (model.includes("/")) {

--- a/src/services/roadmap/feature-chat.ts
+++ b/src/services/roadmap/feature-chat.ts
@@ -201,6 +201,7 @@ export async function sendFeatureChatMessage({
     select: {
       ...FEATURE_SELECT_FOR_CHAT,
       workflowStatus: true,
+      model: true,
     },
   });
 
@@ -367,7 +368,7 @@ export async function sendFeatureChatMessage({
       isPrototype: isPrototype && isFirstMessage,
       subAgents: extraSwarms,
       attachments: attachmentUrls,
-      taskModel: model,
+      taskModel: model || feature.model || undefined,
     });
 
     // Only update workflow status when Stakwork confirms a project was created

--- a/src/services/roadmap/features.ts
+++ b/src/services/roadmap/features.ts
@@ -256,6 +256,7 @@ export async function createFeature(
     architecture?: string;
     personas?: string[];
     isFastTrack?: boolean;
+    model?: string | null;
   }
 ) {
   const workspaceAccess = await validateWorkspaceAccessById(data.workspaceId, userId);
@@ -303,6 +304,7 @@ export async function createFeature(
       priority: data.priority || FeaturePriority.LOW,
       assigneeId: data.assigneeId || null,
       isFastTrack: data.isFastTrack ?? false,
+      model: data.model ?? null,
       createdById: userId,
       updatedById: userId,
       phases: {
@@ -354,6 +356,7 @@ export async function updateFeature(
     requirements?: string | null;
     architecture?: string | null;
     personas?: string[];
+    model?: string | null;
   }
 ) {
   // Validates access and throws specific "Feature not found" or "Access denied" errors
@@ -409,6 +412,9 @@ export async function updateFeature(
     } else {
       updateData.assignee = { connect: { id: data.assigneeId } };
     }
+  }
+  if (data.model !== undefined) {
+    updateData.model = data.model;
   }
 
   // Stamp planUpdatedAt only when user explicitly edits plan content

--- a/src/types/roadmap.tsx
+++ b/src/types/roadmap.tsx
@@ -189,6 +189,7 @@ export type FeatureDetail = Prisma.FeatureGetPayload<{
     priority: true;
     workflowStatus: true;
     stakworkProjectId: true;
+    model: true;
     createdAt: true;
     updatedAt: true;
     assignee: {
@@ -373,6 +374,7 @@ export interface CreateFeatureRequest {
   priority?: FeaturePriority;
   assigneeId?: string;
   isFastTrack?: boolean;
+  model?: string | null;
 }
 
 export interface UpdateFeatureRequest {


### PR DESCRIPTION
## Summary
- Fix model selector displaying provider label ("OpenRouter") instead of model name
- Fix stale closure causing subsequent plan messages to revert to default model
- Persist selected model on Feature record so it survives page refreshes
- Use providerLabel as Stakwork prefix for OTHER providers (sends `openrouter/` instead of `other/`)
- Add `isPlanDefault` / `isTaskDefault` fields to LlmModel with admin UI toggles for configurable defaults
- Widen selector component to prevent text wrapping on longer model names

## Test plan
- [ ] Verify model selector shows model names (e.g. `claude-sonnet-4-6`) not provider labels
- [ ] Select a model, send a plan message, send a second message — confirm same model is used
- [ ] Refresh the plan page — confirm previously selected model is restored
- [ ] In admin, set a model as Plan default — confirm new plans default to it
- [ ] In admin, set a model as Task default — confirm task selectors reflect it
- [ ] Verify Kimi model sends `openrouter/moonshotai/kimi-k2.5` to Stakwork (not `other/...`)