### PR TITLE
Generated with Hive: Set minimumPods default to 2 in AdminPodScaleControl and Prisma schema

### DIFF
--- a/prisma/migrations/20260416213213_set_minimum_pods_default_2/migration.sql
+++ b/prisma/migrations/20260416213213_set_minimum_pods_default_2/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "swarms" ALTER COLUMN "minimum_pods" SET DEFAULT 2;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -309,7 +309,7 @@ model Swarm {
   podState                PodState              @default(NOT_STARTED) @map("pod_state")
   autoLearnEnabled        Boolean               @default(false) @map("auto_learn_enabled")
   minimumVms              Int                   @default(2) @map("minimum_vms")
-  minimumPods             Int?                  @map("minimum_pods")
+  minimumPods             Int?                  @default(2) @map("minimum_pods")
   deployedPods            Int?                  @map("deployed_pods")
   webhookUrl              String?               @map("webhook_url")
   pendingRepairTrigger    Json?                 @map("pending_repair_trigger")

--- a/src/__tests__/integration/api/pool-config.test.ts
+++ b/src/__tests__/integration/api/pool-config.test.ts
@@ -117,7 +117,7 @@ describe("Pool Config API", () => {
         success: true,
         data: {
           minimumVms: 3,
-          minimumPods: null,
+          minimumPods: 2,
           isSuperAdmin: false,
         },
       });
@@ -145,7 +145,7 @@ describe("Pool Config API", () => {
         success: true,
         data: {
           minimumVms: 3,
-          minimumPods: null,
+          minimumPods: 2,
           isSuperAdmin: true,
         },
       });
@@ -232,7 +232,7 @@ describe("Pool Config API", () => {
         success: true,
         data: {
           minimumVms: 4,
-          minimumPods: null,
+          minimumPods: 2,
           isSuperAdmin: true,
         },
       });

--- a/src/__tests__/unit/app/admin/components/AdminPodScaleControl.test.tsx
+++ b/src/__tests__/unit/app/admin/components/AdminPodScaleControl.test.tsx
@@ -26,6 +26,7 @@ describe("AdminPodScaleControl", () => {
     expect(screen.getByText("Minimum Pods")).toBeInTheDocument();
     const inputs = screen.getAllByRole("spinbutton");
     expect(inputs[0]).toHaveValue(2);
+    expect(inputs[1]).toHaveValue(2);
     expect(screen.getByRole("button", { name: /save/i })).toBeInTheDocument();
   });
 

--- a/src/app/admin/workspaces/[slug]/AdminPodScaleControl.tsx
+++ b/src/app/admin/workspaces/[slug]/AdminPodScaleControl.tsx
@@ -17,11 +17,11 @@ export default function AdminPodScaleControl({
   initialMinimumPods,
 }: AdminPodScaleControlProps) {
   const [pendingVms, setPendingVms] = useState(initialMinimumVms);
-  const [pendingPods, setPendingPods] = useState(initialMinimumPods ?? 1);
+  const [pendingPods, setPendingPods] = useState(initialMinimumPods ?? 2);
   const [saving, setSaving] = useState(false);
 
   const hasChanged =
-    pendingVms !== initialMinimumVms || pendingPods !== (initialMinimumPods ?? 1);
+    pendingVms !== initialMinimumVms || pendingPods !== (initialMinimumPods ?? 2);
 
   const handleSave = async () => {
     setSaving(true);


### PR DESCRIPTION
Set minimumPods default to 2 in AdminPodScaleControl and Prisma schema