### PR TITLE
Harden workspace IDOR on 5 critical handlers (plan Phase A)

### DIFF
--- a/docs/plans/workspace-idor-hardening.md
+++ b/docs/plans/workspace-idor-hardening.md
@@ -26,6 +26,23 @@ remaining findings pre-date this branch and are out of scope for the
 current PR — this document captures a remediation plan so they can be
 tackled in a follow-up effort.
 
+## Progress
+
+- **Phase A (Critical #1–5) — DONE** on branch `ef/idor-fixes-1`
+  (commit `03d836163`, "Harden workspace IDOR on 5 critical handlers").
+  See the per-finding "Status" notes under each Critical entry below.
+  Both the source handlers and the MCP JWT verifier were updated, and
+  targeted unit + integration tests were added asserting that a
+  signed-in non-member receives a unified `404 "Workspace not found or
+  access denied"` and that no credentialed side-effects (Stakwork
+  calls, pool deletion, S3 presigning, LiveKit/MCP JWT signing,
+  stakgraph polling / env-var writes) run on their behalf.
+- **Phase B (High #6–25)** — not started.
+- **Phase C (Medium #26–30)** — not started.
+- **Phase D (shared-secret S1–S3)** — not started.
+- **"also" items** (public-viewer 7-day → 1-hour presigned URLs;
+  jarvis/nodes call reduction) — not started.
+
 ## Guiding principles
 
 - **Membership check must run before any DB write and before any
@@ -99,6 +116,13 @@ proof-of-exploit, and suggested fix.
 - **Fix**: `validateWorkspaceAccessById(workspaceId, userId)` with
   `canAdmin: true` before the customer create or the `stakworkApiKey`
   write.
+- **Status**: ✅ Fixed on `ef/idor-fixes-1`. Handler now rejects
+  missing/null/empty `workspaceId` with 400 and rejects non-admins
+  with 404 before calling `createCustomer` or writing `stakworkApiKey`.
+  Tests: `src/__tests__/integration/api/stakwork-create-customer.test.ts`
+  (non-member → 404, DEVELOPER member → 404) +
+  `src/__tests__/unit/api/stakwork/create-customer-route.test.ts`
+  (`validateWorkspaceAccessById` mocked, IDOR branch asserted).
 
 #### 2. `src/app/api/pool-manager/delete-pool/route.ts` — DELETE
 - **Bug**: only `getServerSession` is checked; `poolManagerService().deletePool({ name })`
@@ -109,6 +133,13 @@ proof-of-exploit, and suggested fix.
 - **Fix**: look up the swarm whose id matches `name`, then
   `validateWorkspaceAccessById(swarm.workspaceId, userId)` requiring
   admin. Reject otherwise.
+- **Status**: ✅ Fixed on `ef/idor-fixes-1`. Handler now does
+  `db.swarm.findUnique({ where: { id: name } })` → admin check on
+  `swarm.workspaceId` before `deletePool`. Missing swarm and non-admin
+  both return the unified 404. Tests:
+  `src/__tests__/integration/api/pool-manager/delete-pool.test.ts`
+  (unknown `name` → 404, non-member attacker → 404; pre-existing
+  tests refactored to create a real swarm so `name === swarm.id`).
 
 #### 3. `src/app/api/upload/presigned-url/route.ts` — POST, GET
 - **Bug (POST)**: returns a presigned upload URL scoped to the victim's
@@ -123,6 +154,17 @@ proof-of-exploit, and suggested fix.
   `Attachment` / `Artifact` / `Feature` row carrying `workspaceId`),
   then require membership. Alternative: restrict to a user-specific
   prefix (e.g. `users/<userId>/*`).
+- **Status**: ✅ Fixed on `ef/idor-fixes-1`.
+  - POST: adds `validateWorkspaceAccessById(task.workspaceId, userId)`
+    with `canWrite` before issuing the upload URL.
+  - GET: parses the owning `workspaceId` out of the `s3Key` with an
+    allow-list of known prefixes (`uploads/`, `workspace-logos/`,
+    `whiteboards/`, `screenshots/`, `features/`, `diagrams/`) and
+    requires `canRead` membership before minting the download URL.
+    Unknown prefixes return 404.
+  - Tests: `src/__tests__/integration/api/upload-presigned-url.test.ts`
+    — IDOR suite covers POST non-member, GET non-member, GET unknown
+    prefix, and GET owner happy-path (redirect to presigned URL).
 
 #### 4. `src/app/api/livekit-token/route.ts` — POST
 - **Bug**: signs a 4-hour JWT containing body-supplied `slug` which
@@ -133,6 +175,16 @@ proof-of-exploit, and suggested fix.
 - **Fix**: before signing, `validateWorkspaceAccess(slug, userId)` → 403
   on failure. Embed `userId` in the JWT claims and have `verifyJwt`
   re-validate membership at use time.
+- **Status**: ✅ Fixed on `ef/idor-fixes-1`.
+  - `/api/livekit-token` calls `validateWorkspaceAccess(slug, userId)`
+    before signing and returns 404 on failure (no JWT is minted).
+  - The minted JWT now carries both `slug` and `userId` claims.
+  - `src/lib/mcp/handler.ts` `verifyJwt` rejects legacy JWTs missing
+    `userId` and re-checks `ownerId` / `workspaceMember` at use time,
+    so a revoked membership invalidates the token immediately.
+  - Tests: `src/__tests__/integration/api/livekit-token.test.ts`
+    covers unauth/400/owner-happy-path/non-member attacker/unknown
+    slug; `toJwt()` is asserted to not be called on the error paths.
 
 #### 5. `src/app/api/swarm/stakgraph/agent-stream/route.ts` — GET
 - **Bug**: loads swarm by body/query `swarmId` with no membership check,
@@ -143,6 +195,18 @@ proof-of-exploit, and suggested fix.
   victim credentials and overwrites victim's swarm env vars.
 - **Fix**: `validateWorkspaceAccessById(swarm.workspaceId, userId)` with
   `canAdmin` before the poll and writes.
+- **Status**: ✅ Fixed on `ef/idor-fixes-1`. The swarm lookup and
+  admin check now run **before** the SSE stream is opened — so there
+  is no opportunity to decrypt `swarmApiKey`, poll stakgraph, or
+  write `environment_variables` / `swarm` rows for a non-admin.
+  Failure returns a plain 404 (not an SSE error event). Tests:
+  new `describe("GET /api/swarm/stakgraph/agent-stream - IDOR hardening")`
+  suite in `src/__tests__/integration/api/swarm-stakgraph-agent-stream.test.ts`
+  covering unauth/missing-swarm/non-member/non-admin member — all
+  four assert no stream is opened and `pollAgentProgress` is never
+  called. (The pre-existing `describe.skip` block is left skipped
+  due to unrelated zombie-polling issues; the new IDOR tests do not
+  depend on the polling loop so they run.)
 
 ---
 
@@ -420,8 +484,10 @@ require session auth + workspace admin.
 
 ## Suggested rollout
 
-1. **Phase A — critical handlers (#1–5)**: single focused PR. Include
-   integration tests that sign in as a non-member and assert 403/404.
+1. **Phase A — critical handlers (#1–5)**: ✅ landed on
+   `ef/idor-fixes-1` (commit `03d836163`). Unit + integration tests
+   assert non-members get 404 and that no credentialed side-effects
+   run on their behalf.
 2. **Phase B — high-severity (#6–25)**: group by area (agent, swarm,
    github, upload, misc). 3–4 follow-up PRs. Consider factoring the
    `apiTokenAuth ? requireAuthOrApiToken(...) : resolveWorkspaceAccess(...)`

--- a/src/__tests__/integration/api/livekit-token.test.ts
+++ b/src/__tests__/integration/api/livekit-token.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { POST } from "@/app/api/livekit-token/route";
+import { db } from "@/lib/db";
+import {
+  createAuthenticatedPostRequest,
+  createPostRequest,
+  generateUniqueId,
+  generateUniqueSlug,
+} from "@/__tests__/support/helpers";
+
+// Mock the LiveKit SDK to avoid signing real AccessTokens during the test
+// run. We only care that our route validates workspace access *before*
+// calling into LiveKit — so a stub that tracks invocations is enough.
+const mockAddGrant = vi.fn();
+const mockToJwt = vi.fn(async () => "fake-livekit-jwt");
+
+vi.mock("livekit-server-sdk", () => {
+  return {
+    AccessToken: vi.fn().mockImplementation(() => ({
+      addGrant: mockAddGrant,
+      toJwt: mockToJwt,
+      metadata: "",
+    })),
+  };
+});
+
+async function createOwnerAndWorkspace() {
+  const owner = await db.user.create({
+    data: {
+      id: generateUniqueId("lk-owner"),
+      email: `lk-owner-${generateUniqueId()}@example.com`,
+      name: "LK Owner",
+    },
+  });
+  const workspace = await db.workspace.create({
+    data: {
+      id: generateUniqueId("lk-ws"),
+      name: "LK Workspace",
+      slug: generateUniqueSlug("lk-ws"),
+      ownerId: owner.id,
+    },
+  });
+  return { owner, workspace };
+}
+
+describe("POST /api/livekit-token", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Provide the env the route expects; tests are hermetic so overwriting
+    // is safe.
+    process.env.LIVEKIT_API_KEY = "test-livekit-key";
+    process.env.LIVEKIT_API_SECRET = "test-livekit-secret";
+    process.env.JWT_SECRET = "test-jwt-secret";
+  });
+
+  it("returns 401 when request is unauthenticated", async () => {
+    const req = createPostRequest("http://localhost:3000/api/livekit-token", {
+      slug: "anything",
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(401);
+    expect(mockToJwt).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when slug is missing", async () => {
+    const { owner } = await createOwnerAndWorkspace();
+
+    const req = createAuthenticatedPostRequest(
+      "http://localhost:3000/api/livekit-token",
+      owner,
+      {},
+    );
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("slug is required");
+    expect(mockToJwt).not.toHaveBeenCalled();
+  });
+
+  it("signs a token when caller owns the workspace", async () => {
+    const { owner, workspace } = await createOwnerAndWorkspace();
+
+    const req = createAuthenticatedPostRequest(
+      "http://localhost:3000/api/livekit-token",
+      owner,
+      { slug: workspace.slug },
+    );
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.token).toBe("fake-livekit-jwt");
+    expect(json.roomName).toMatch(new RegExp(`^hive-${workspace.slug}-\\d+$`));
+    expect(mockToJwt).toHaveBeenCalledTimes(1);
+  });
+
+  describe("IDOR hardening", () => {
+    it("returns 404 when caller is not a member of the workspace", async () => {
+      const { workspace } = await createOwnerAndWorkspace();
+
+      // Attacker knows the victim's slug but is not a member.
+      const attacker = await db.user.create({
+        data: {
+          id: generateUniqueId("lk-attacker"),
+          email: `lk-attacker-${generateUniqueId()}@example.com`,
+          name: "Attacker",
+        },
+      });
+
+      const req = createAuthenticatedPostRequest(
+        "http://localhost:3000/api/livekit-token",
+        attacker,
+        { slug: workspace.slug },
+      );
+
+      const res = await POST(req);
+
+      expect(res.status).toBe(404);
+      const json = await res.json();
+      expect(json.error).toBe("Workspace not found or access denied");
+      // JWT must never be signed for non-members — otherwise they could
+      // drive MCP against the victim's swarm.
+      expect(mockToJwt).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 for a slug that does not resolve to any workspace", async () => {
+      const user = await db.user.create({
+        data: {
+          id: generateUniqueId("lk-user"),
+          email: `lk-user-${generateUniqueId()}@example.com`,
+          name: "User",
+        },
+      });
+
+      const req = createAuthenticatedPostRequest(
+        "http://localhost:3000/api/livekit-token",
+        user,
+        { slug: "no-such-slug-exists" },
+      );
+
+      const res = await POST(req);
+
+      expect(res.status).toBe(404);
+      expect(mockToJwt).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/__tests__/integration/api/pool-manager/delete-pool.test.ts
+++ b/src/__tests__/integration/api/pool-manager/delete-pool.test.ts
@@ -9,7 +9,11 @@ import {
   expectError,
   createDeleteRequest,
 } from "@/__tests__/support/helpers";
-import { createTestUser } from "@/__tests__/support/fixtures";
+import {
+  createTestUser,
+  createTestWorkspace,
+  createTestSwarm,
+} from "@/__tests__/support/fixtures";
 import { poolManagerService } from "@/lib/service-factory";
 
 // Mock the Pool Manager service
@@ -21,26 +25,30 @@ vi.mock("@/lib/service-factory", () => ({
   }),
 }));
 
+/**
+ * Create an owner, workspace, and swarm. Returns the swarm.id so callers
+ * can use it as the pool `name` (matching the pool_name convention in
+ * create-pool: `pool_name: swarm.id`).
+ */
+async function setupOwnedPool() {
+  const user = await createTestUser();
+  const workspace = await createTestWorkspace({ ownerId: user.id });
+  const swarm = await createTestSwarm({ workspaceId: workspace.id });
+  return { user, workspace, swarm };
+}
+
 describe("DELETE /api/pool-manager/delete-pool", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  /**
-   * SECURITY NOTE: This endpoint has a security gap - there is no ownership validation.
-   * Any authenticated user can delete any pool by name. This should be addressed
-   * by adding ownership checks (verify pool.owner_id === session.user.id) or
-   * role-based authorization in the future.
-   */
-
   describe("Successful Deletion", () => {
-    test("successfully deletes pool when authenticated with valid name", async () => {
+    test("successfully deletes pool when caller owns the swarm's workspace", async () => {
       // Arrange
-      const user = await createTestUser();
-      const session = createAuthenticatedSession(user);
-      getMockedSession().mockResolvedValue(session);
-      
-      const poolName = "test-pool";
+      const { user, swarm } = await setupOwnedPool();
+      getMockedSession().mockResolvedValue(createAuthenticatedSession(user));
+
+      const poolName = swarm.id;
       const mockResponse = {
         id: "pool-123",
         name: poolName,
@@ -49,7 +57,7 @@ describe("DELETE /api/pool-manager/delete-pool", () => {
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
       };
-      
+
       mockDeletePool.mockResolvedValue(mockResponse);
 
       // Act
@@ -66,6 +74,46 @@ describe("DELETE /api/pool-manager/delete-pool", () => {
       expect(data.pool.status).toBe("deleted");
       expect(mockDeletePool).toHaveBeenCalledWith({ name: poolName });
       expect(mockDeletePool).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("IDOR hardening", () => {
+    test("returns 404 when the pool name does not match any swarm", async () => {
+      const user = await createTestUser();
+      getMockedSession().mockResolvedValue(createAuthenticatedSession(user));
+
+      const request = createDeleteRequest(
+        "http://localhost/api/pool-manager/delete-pool",
+        { name: "does-not-exist" }
+      );
+      const response = await DELETE(request);
+
+      expect(response.status).toBe(404);
+      const json = await response.json();
+      expect(json.error).toBe("Workspace not found or access denied");
+      expect(mockDeletePool).not.toHaveBeenCalled();
+    });
+
+    test("returns 404 when caller is not a member of the swarm's workspace", async () => {
+      // Victim: owns a pool
+      const { swarm } = await setupOwnedPool();
+
+      // Attacker: signed-in but not a member of victim's workspace
+      const attacker = await createTestUser();
+      getMockedSession().mockResolvedValue(
+        createAuthenticatedSession(attacker),
+      );
+
+      const request = createDeleteRequest(
+        "http://localhost/api/pool-manager/delete-pool",
+        { name: swarm.id }
+      );
+      const response = await DELETE(request);
+
+      expect(response.status).toBe(404);
+      const json = await response.json();
+      expect(json.error).toBe("Workspace not found or access denied");
+      expect(mockDeletePool).not.toHaveBeenCalled();
     });
   });
 
@@ -162,36 +210,34 @@ describe("DELETE /api/pool-manager/delete-pool", () => {
   describe("Service Error Handling", () => {
     test("handles 404 pool not found error from service", async () => {
       // Arrange
-      const user = await createTestUser();
-      const session = createAuthenticatedSession(user);
-      getMockedSession().mockResolvedValue(session);
-      
+      const { user, swarm } = await setupOwnedPool();
+      getMockedSession().mockResolvedValue(createAuthenticatedSession(user));
+
       const apiError = {
         status: 404,
         service: "pool-manager",
         message: "Pool not found",
-        details: { poolName: "nonexistent-pool" },
+        details: { poolName: swarm.id },
       };
       mockDeletePool.mockRejectedValue(apiError);
 
       // Act
       const request = createDeleteRequest(
         "http://localhost/api/pool-manager/delete-pool",
-        { name: "nonexistent-pool" }
+        { name: swarm.id }
       );
       const response = await DELETE(request);
 
       // Assert
       await expectError(response, "Pool not found", 404);
-      expect(mockDeletePool).toHaveBeenCalledWith({ name: "nonexistent-pool" });
+      expect(mockDeletePool).toHaveBeenCalledWith({ name: swarm.id });
     });
 
     test("handles 403 forbidden error from service", async () => {
       // Arrange
-      const user = await createTestUser();
-      const session = createAuthenticatedSession(user);
-      getMockedSession().mockResolvedValue(session);
-      
+      const { user, swarm } = await setupOwnedPool();
+      getMockedSession().mockResolvedValue(createAuthenticatedSession(user));
+
       const apiError = {
         status: 403,
         service: "pool-manager",
@@ -202,7 +248,7 @@ describe("DELETE /api/pool-manager/delete-pool", () => {
       // Act
       const request = createDeleteRequest(
         "http://localhost/api/pool-manager/delete-pool",
-        { name: "protected-pool" }
+        { name: swarm.id }
       );
       const response = await DELETE(request);
 
@@ -212,10 +258,9 @@ describe("DELETE /api/pool-manager/delete-pool", () => {
 
     test("handles 500 service unavailable error", async () => {
       // Arrange
-      const user = await createTestUser();
-      const session = createAuthenticatedSession(user);
-      getMockedSession().mockResolvedValue(session);
-      
+      const { user, swarm } = await setupOwnedPool();
+      getMockedSession().mockResolvedValue(createAuthenticatedSession(user));
+
       const apiError = {
         status: 500,
         service: "pool-manager",
@@ -226,7 +271,7 @@ describe("DELETE /api/pool-manager/delete-pool", () => {
       // Act
       const request = createDeleteRequest(
         "http://localhost/api/pool-manager/delete-pool",
-        { name: "test-pool" }
+        { name: swarm.id }
       );
       const response = await DELETE(request);
 
@@ -236,10 +281,9 @@ describe("DELETE /api/pool-manager/delete-pool", () => {
 
     test("handles 401 invalid API key error from service", async () => {
       // Arrange
-      const user = await createTestUser();
-      const session = createAuthenticatedSession(user);
-      getMockedSession().mockResolvedValue(session);
-      
+      const { user, swarm } = await setupOwnedPool();
+      getMockedSession().mockResolvedValue(createAuthenticatedSession(user));
+
       const apiError = {
         status: 401,
         service: "pool-manager",
@@ -250,7 +294,7 @@ describe("DELETE /api/pool-manager/delete-pool", () => {
       // Act
       const request = createDeleteRequest(
         "http://localhost/api/pool-manager/delete-pool",
-        { name: "test-pool" }
+        { name: swarm.id }
       );
       const response = await DELETE(request);
 
@@ -260,17 +304,16 @@ describe("DELETE /api/pool-manager/delete-pool", () => {
 
     test("handles generic errors from service without ApiError structure", async () => {
       // Arrange
-      const user = await createTestUser();
-      const session = createAuthenticatedSession(user);
-      getMockedSession().mockResolvedValue(session);
-      
+      const { user, swarm } = await setupOwnedPool();
+      getMockedSession().mockResolvedValue(createAuthenticatedSession(user));
+
       // Generic error without ApiError structure
       mockDeletePool.mockRejectedValue(new Error("Network timeout"));
 
       // Act
       const request = createDeleteRequest(
         "http://localhost/api/pool-manager/delete-pool",
-        { name: "test-pool" }
+        { name: swarm.id }
       );
       const response = await DELETE(request);
 
@@ -329,11 +372,10 @@ describe("DELETE /api/pool-manager/delete-pool", () => {
   describe("Service Invocation", () => {
     test("calls service with exact parameters", async () => {
       // Arrange
-      const user = await createTestUser();
-      const session = createAuthenticatedSession(user);
-      getMockedSession().mockResolvedValue(session);
-      
-      const poolName = "my-specific-pool-name";
+      const { user, swarm } = await setupOwnedPool();
+      getMockedSession().mockResolvedValue(createAuthenticatedSession(user));
+
+      const poolName = swarm.id;
       mockDeletePool.mockResolvedValue({
         id: "pool-456",
         name: poolName,
@@ -353,7 +395,7 @@ describe("DELETE /api/pool-manager/delete-pool", () => {
       // Assert
       expect(mockDeletePool).toHaveBeenCalledWith({ name: poolName });
       expect(mockDeletePool).toHaveBeenCalledTimes(1);
-      
+
       // Verify exact call signature
       const callArgs = mockDeletePool.mock.calls[0][0];
       expect(callArgs).toEqual({ name: poolName });

--- a/src/__tests__/integration/api/stakwork-create-customer.test.ts
+++ b/src/__tests__/integration/api/stakwork-create-customer.test.ts
@@ -112,22 +112,20 @@ describe("POST /api/stakwork/create-customer", () => {
       expect(mockCreateCustomer).not.toHaveBeenCalled();
     });
 
-    it("returns error when workspaceId is missing from request body", async () => {
+    it("returns 400 when workspaceId is missing from request body", async () => {
       const req = createPostRequest("http://localhost:3000/api/stakwork/create-customer", {});
 
       const res = await POST(req);
 
-      // The endpoint will try to create customer with undefined workspaceId
-      expect(mockCreateCustomer).toHaveBeenCalledWith(undefined);
+      // IDOR hardening: reject requests missing workspaceId instead of
+      // letting them pass through to Stakwork.
+      expect(res?.status).toBe(400);
+      expect(mockCreateCustomer).not.toHaveBeenCalled();
     });
   });
 
   describe("database validation errors", () => {
-    it("handles workspace not found gracefully", async () => {
-      mockCreateCustomer.mockResolvedValueOnce({
-        data: { token: "stak-token-new" },
-      });
-
+    it("returns 404 when workspace does not exist", async () => {
       const nonExistentWorkspaceId = generateUniqueId("nonexistent");
       const req = createPostRequest("http://localhost:3000/api/stakwork/create-customer", {
         workspaceId: nonExistentWorkspaceId,
@@ -135,18 +133,21 @@ describe("POST /api/stakwork/create-customer", () => {
 
       const res = await POST(req);
 
-      // Should still succeed with 201 but not update any workspace
-      expect(res?.status).toBe(201);
+      // IDOR hardening: callers without admin access to the workspace
+      // must get a unified "not found or access denied" response — and
+      // createCustomer must never be invoked on their behalf.
+      expect(res?.status).toBe(404);
       const json = await res.json();
-      expect(json).toEqual({ success: true });
+      expect(json).toEqual({ error: "Workspace not found or access denied" });
 
-      // Verify no workspace was updated
+      // Verify no workspace was created or updated
       const workspace = await db.workspace.findFirst({
         where: { id: nonExistentWorkspaceId },
       });
       expect(workspace).toBeNull();
 
-      // createSecret should never be called
+      // Neither Stakwork API should have been touched
+      expect(mockCreateCustomer).not.toHaveBeenCalled();
       expect(mockCreateSecret).not.toHaveBeenCalled();
     });
 
@@ -195,6 +196,57 @@ describe("POST /api/stakwork/create-customer", () => {
       expect(res?.status).toBe(500);
       const json = await res.json();
       expect(json).toEqual({ error: "Failed to create customer" });
+    });
+  });
+
+  describe("IDOR hardening", () => {
+    it("returns 404 when caller is not a member of the target workspace", async () => {
+      // Attacker: signed-in as a different user with no membership
+      const attacker = await db.user.create({
+        data: createTestUserData(),
+      });
+      getMockedSession().mockResolvedValue(createAuthenticatedSession(attacker));
+
+      const req = createPostRequest(
+        "http://localhost:3000/api/stakwork/create-customer",
+        { workspaceId },
+      );
+
+      const res = await POST(req);
+
+      expect(res?.status).toBe(404);
+      const json = await res.json();
+      expect(json).toEqual({ error: "Workspace not found or access denied" });
+
+      // Neither Stakwork API was touched and stakworkApiKey was not written.
+      expect(mockCreateCustomer).not.toHaveBeenCalled();
+      expect(mockCreateSecret).not.toHaveBeenCalled();
+
+      const workspace = await db.workspace.findFirst({ where: { id: workspaceId } });
+      expect(workspace?.stakworkApiKey).toBeNull();
+    });
+
+    it("returns 404 when caller is a DEVELOPER member (not admin)", async () => {
+      // Viewer/developer membership does not satisfy canAdmin.
+      const developer = await db.user.create({ data: createTestUserData() });
+      await db.workspaceMember.create({
+        data: {
+          workspaceId,
+          userId: developer.id,
+          role: "DEVELOPER",
+        },
+      });
+      getMockedSession().mockResolvedValue(createAuthenticatedSession(developer));
+
+      const req = createPostRequest(
+        "http://localhost:3000/api/stakwork/create-customer",
+        { workspaceId },
+      );
+
+      const res = await POST(req);
+
+      expect(res?.status).toBe(404);
+      expect(mockCreateCustomer).not.toHaveBeenCalled();
     });
   });
 

--- a/src/__tests__/integration/api/swarm-stakgraph-agent-stream.test.ts
+++ b/src/__tests__/integration/api/swarm-stakgraph-agent-stream.test.ts
@@ -1351,3 +1351,134 @@ describe.skip("GET /api/swarm/stakgraph/agent-stream - Integration Tests", () =>
     });
   });
 });
+
+// These tests exercise the synchronous membership check that runs BEFORE
+// the SSE stream is opened, so they don't hit the zombie polling issue
+// that forced the main suite to be skipped.
+describe("GET /api/swarm/stakgraph/agent-stream - IDOR hardening", () => {
+  const enc = EncryptionService.getInstance();
+
+  async function createOwnedSwarm() {
+    const user = await db.user.create({
+      data: {
+        id: generateUniqueId("idor-user"),
+        email: `idor-${generateUniqueId()}@example.com`,
+        name: "IDOR Owner",
+      },
+    });
+    const workspace = await db.workspace.create({
+      data: {
+        name: "IDOR Workspace",
+        slug: generateUniqueSlug("idor-ws"),
+        ownerId: user.id,
+      },
+    });
+    const swarm = await db.swarm.create({
+      data: {
+        workspaceId: workspace.id,
+        name: "idor-swarm",
+        swarmId: generateUniqueId("swarm"),
+        status: "ACTIVE",
+        swarmUrl: "https://idor-swarm.sphinx.chat/api",
+        swarmApiKey: JSON.stringify(enc.encryptField("swarmApiKey", "idor-key")),
+        services: [],
+        agentRequestId: `req-${generateUniqueId()}`,
+        agentStatus: "PROCESSING",
+      },
+    });
+    return { user, workspace, swarm };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const { swarm } = await createOwnedSwarm();
+    getMockedSession().mockResolvedValue(mockUnauthenticatedSession());
+
+    const url = new URL("http://localhost:3000/api/swarm/stakgraph/agent-stream");
+    url.searchParams.set("request_id", swarm.agentRequestId!);
+    url.searchParams.set("swarm_id", swarm.id);
+
+    const response = await GET(new Request(url.toString(), { method: "GET" }) as any);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 404 when swarm does not exist", async () => {
+    const user = await db.user.create({
+      data: {
+        id: generateUniqueId("idor-no-swarm"),
+        email: `idor-no-swarm-${generateUniqueId()}@example.com`,
+        name: "User",
+      },
+    });
+    getMockedSession().mockResolvedValue(createAuthenticatedSession(user));
+
+    const url = new URL("http://localhost:3000/api/swarm/stakgraph/agent-stream");
+    url.searchParams.set("request_id", "req-123");
+    url.searchParams.set("swarm_id", "non-existent-swarm-id");
+
+    const response = await GET(new Request(url.toString(), { method: "GET" }) as any);
+
+    expect(response.status).toBe(404);
+    // Must not be an SSE stream — the access check short-circuits before
+    // the stream is opened.
+    expect(response.headers.get("content-type")).not.toBe("text/event-stream");
+  });
+
+  it("returns 404 when caller is not a member of the swarm's workspace", async () => {
+    const { swarm } = await createOwnedSwarm();
+
+    const attacker = await db.user.create({
+      data: {
+        id: generateUniqueId("idor-attacker"),
+        email: `idor-attacker-${generateUniqueId()}@example.com`,
+        name: "Attacker",
+      },
+    });
+    getMockedSession().mockResolvedValue(createAuthenticatedSession(attacker));
+
+    const url = new URL("http://localhost:3000/api/swarm/stakgraph/agent-stream");
+    url.searchParams.set("request_id", swarm.agentRequestId!);
+    url.searchParams.set("swarm_id", swarm.id);
+
+    const response = await GET(new Request(url.toString(), { method: "GET" }) as any);
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("content-type")).not.toBe("text/event-stream");
+    // The polling fn must never be reached, so the decrypted swarm api key
+    // never leaves the DB.
+    expect(mockPollAgentProgress).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when caller is a non-admin member (lacks canAdmin)", async () => {
+    const { swarm, workspace } = await createOwnedSwarm();
+
+    const viewer = await db.user.create({
+      data: {
+        id: generateUniqueId("idor-viewer"),
+        email: `idor-viewer-${generateUniqueId()}@example.com`,
+        name: "Viewer",
+      },
+    });
+    await db.workspaceMember.create({
+      data: {
+        workspaceId: workspace.id,
+        userId: viewer.id,
+        role: "VIEWER",
+      },
+    });
+    getMockedSession().mockResolvedValue(createAuthenticatedSession(viewer));
+
+    const url = new URL("http://localhost:3000/api/swarm/stakgraph/agent-stream");
+    url.searchParams.set("request_id", swarm.agentRequestId!);
+    url.searchParams.set("swarm_id", swarm.id);
+
+    const response = await GET(new Request(url.toString(), { method: "GET" }) as any);
+
+    expect(response.status).toBe(404);
+    expect(mockPollAgentProgress).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/integration/api/upload-presigned-url.test.ts
+++ b/src/__tests__/integration/api/upload-presigned-url.test.ts
@@ -1,11 +1,12 @@
 import { describe, test, expect, beforeEach, vi } from "vitest";
-import { POST } from "@/app/api/upload/presigned-url/route";
+import { POST, GET } from "@/app/api/upload/presigned-url/route";
 import { db } from "@/lib/db";
 import { WorkflowStatus } from "@prisma/client";
 import {
   generateUniqueId,
   createPostRequest,
   createAuthenticatedPostRequest,
+  createAuthenticatedGetRequest,
 } from "@/__tests__/support/helpers";
 
 // Create mock S3 service methods
@@ -14,6 +15,7 @@ const mockS3Service = {
   validateFileSize: vi.fn(),
   generateS3Path: vi.fn(),
   generatePresignedUploadUrl: vi.fn(),
+  generatePresignedDownloadUrl: vi.fn(),
 };
 
 // Mock S3 service to avoid AWS SDK calls
@@ -732,6 +734,148 @@ describe("POST /api/upload/presigned-url Integration Tests", () => {
         expect.any(String),
         testTask.id,
         longFilename,
+      );
+    });
+  });
+
+  describe("IDOR hardening", () => {
+    async function createVictimSetup() {
+      const victim = await db.user.create({
+        data: {
+          id: generateUniqueId("victim"),
+          email: `victim-${generateUniqueId()}@example.com`,
+          name: "Victim User",
+        },
+      });
+      const workspace = await db.workspace.create({
+        data: {
+          id: generateUniqueId("victim-ws"),
+          name: "Victim Workspace",
+          slug: generateUniqueId("victim-ws"),
+          ownerId: victim.id,
+        },
+      });
+      const task = await db.task.create({
+        data: {
+          id: generateUniqueId("victim-task"),
+          title: "Victim Task",
+          status: "TODO",
+          workspaceId: workspace.id,
+          workflowStatus: WorkflowStatus.PENDING,
+          createdById: victim.id,
+          updatedById: victim.id,
+        },
+      });
+      return { victim, workspace, task };
+    }
+
+    test("POST returns 404 when caller is not a member of the task's workspace", async () => {
+      // Victim owns a task in their workspace
+      const { task } = await createVictimSetup();
+
+      // Attacker: signed-in but not a member of victim's workspace
+      const attacker = await db.user.create({
+        data: {
+          id: generateUniqueId("attacker"),
+          email: `attacker-${generateUniqueId()}@example.com`,
+          name: "Attacker",
+        },
+      });
+
+      const request = createAuthenticatedPostRequest(
+        "http://localhost:3000/api/upload/presigned-url",
+        attacker,
+        {
+          taskId: task.id,
+          filename: "evil.jpg",
+          contentType: "image/jpeg",
+          size: 1024,
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(404);
+      const data = await response.json();
+      expect(data.error).toBe("Workspace not found or access denied");
+      expect(mockS3Service.generatePresignedUploadUrl).not.toHaveBeenCalled();
+    });
+
+    test("GET returns 404 when caller is not a member of the workspace named in s3Key", async () => {
+      const { workspace } = await createVictimSetup();
+
+      const attacker = await db.user.create({
+        data: {
+          id: generateUniqueId("attacker-get"),
+          email: `attacker-get-${generateUniqueId()}@example.com`,
+          name: "Attacker GET",
+        },
+      });
+
+      // Attacker knows/guesses the victim's workspaceId and tries to pull
+      // an arbitrary attachment out of its S3 prefix.
+      const s3Key = `uploads/${workspace.id}/default/some-task/victim-secret.png`;
+
+      const request = createAuthenticatedGetRequest(
+        "http://localhost:3000/api/upload/presigned-url",
+        { id: attacker.id, email: attacker.email, name: attacker.name },
+        { s3Key },
+      );
+
+      const response = await GET(request);
+
+      expect(response.status).toBe(404);
+      const data = await response.json();
+      expect(data.error).toBe("Workspace not found or access denied");
+      expect(mockS3Service.generatePresignedDownloadUrl).not.toHaveBeenCalled();
+    });
+
+    test("GET returns 404 for s3Key with an unrecognized prefix", async () => {
+      const user = await db.user.create({
+        data: {
+          id: generateUniqueId("user"),
+          email: `user-${generateUniqueId()}@example.com`,
+          name: "User",
+        },
+      });
+
+      // Not a known prefix (e.g. `uploads/`, `whiteboards/`, etc.)
+      const s3Key = "arbitrary/path/file.png";
+
+      const request = createAuthenticatedGetRequest(
+        "http://localhost:3000/api/upload/presigned-url",
+        { id: user.id, email: user.email, name: user.name },
+        { s3Key },
+      );
+
+      const response = await GET(request);
+
+      expect(response.status).toBe(404);
+      expect(mockS3Service.generatePresignedDownloadUrl).not.toHaveBeenCalled();
+    });
+
+    test("GET redirects to presigned URL when caller owns the workspace named in s3Key", async () => {
+      const { victim, workspace } = await createVictimSetup();
+
+      mockS3Service.generatePresignedDownloadUrl.mockResolvedValueOnce(
+        "https://test-bucket.s3.us-east-1.amazonaws.com/presigned-download?sig=ok",
+      );
+
+      const s3Key = `uploads/${workspace.id}/default/some-task/image.png`;
+
+      const request = createAuthenticatedGetRequest(
+        "http://localhost:3000/api/upload/presigned-url",
+        { id: victim.id, email: victim.email, name: victim.name },
+        { s3Key },
+      );
+
+      const response = await GET(request);
+
+      // Redirects (3xx) to the presigned URL on success
+      expect([301, 302, 303, 307, 308]).toContain(response.status);
+      expect(mockS3Service.generatePresignedDownloadUrl).toHaveBeenCalledWith(
+        s3Key,
+        300,
       );
     });
   });

--- a/src/__tests__/unit/api/stakwork/create-customer-route.test.ts
+++ b/src/__tests__/unit/api/stakwork/create-customer-route.test.ts
@@ -61,6 +61,22 @@ vi.mock("@/lib/auth/nextauth", () => ({
   authOptions: {},
 }));
 
+// Mock the workspace access helper so these unit tests stay isolated
+// from `getWorkspaceById` DB plumbing. By default, every caller is
+// treated as an admin of the target workspace; IDOR tests override with
+// `mockValidateWorkspaceAccessById.mockResolvedValueOnce(...)`.
+vi.mock("@/services/workspace", () => {
+  const mockValidateWorkspaceAccessById = vi.fn();
+  return {
+    validateWorkspaceAccessById: mockValidateWorkspaceAccessById,
+    __mockValidateWorkspaceAccessById: mockValidateWorkspaceAccessById,
+  };
+});
+
+const workspaceServiceMock = vi.mocked(await import("@/services/workspace"));
+const mockValidateWorkspaceAccessById =
+  workspaceServiceMock.__mockValidateWorkspaceAccessById;
+
 const mockGetServerSession = getServerSession as Mock;
 
 // Test Data Factories
@@ -200,6 +216,15 @@ const MockSetup = {
 describe("POST /api/stakwork/create-customer - Unit Tests", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: caller is an admin of the workspace. Individual tests can
+    // override with `.mockResolvedValueOnce({ hasAccess: false, ... })`.
+    mockValidateWorkspaceAccessById.mockResolvedValue({
+      hasAccess: true,
+      canRead: true,
+      canWrite: true,
+      canAdmin: true,
+      userRole: "OWNER",
+    });
   });
 
   describe("Authentication", () => {
@@ -232,6 +257,29 @@ describe("POST /api/stakwork/create-customer - Unit Tests", () => {
       expect(mockGetServerSession).toHaveBeenCalled();
       expect(mockCreateCustomer).toHaveBeenCalled();
     });
+
+    test("IDOR: returns 404 when caller lacks admin access to the workspace", async () => {
+      TestHelpers.setupAuthenticatedUser();
+      MockSetup.setupSuccessfulCustomerCreation("test-token");
+
+      // Override the default admin grant for this single call.
+      mockValidateWorkspaceAccessById.mockResolvedValueOnce({
+        hasAccess: false,
+        canRead: false,
+        canWrite: false,
+        canAdmin: false,
+      });
+
+      const request = TestHelpers.createMockRequest({ workspaceId: "workspace-123" });
+      const response = await POST(request);
+
+      expect(response.status).toBe(404);
+      const data = await response.json();
+      expect(data).toEqual({ error: "Workspace not found or access denied" });
+      // Stakwork customer creation and workspace write must never run.
+      expect(mockCreateCustomer).not.toHaveBeenCalled();
+      expect(mockWorkspaceUpdate).not.toHaveBeenCalled();
+    });
   });
 
   describe("Request Validation", () => {
@@ -249,23 +297,22 @@ describe("POST /api/stakwork/create-customer - Unit Tests", () => {
       expect(mockCreateCustomer).toHaveBeenCalledWith("workspace-123");
     });
 
-    test("should handle missing workspaceId gracefully", async () => {
-      mockCreateCustomer.mockResolvedValue(TestDataFactory.createStakworkResponse("test-token"));
-      MockSetup.setupSuccessfulCustomerCreation("test-token");
-
+    test("should return 400 when workspaceId is missing", async () => {
       const request = TestHelpers.createMockRequest({});
       const response = await POST(request);
 
-      expect(mockCreateCustomer).toHaveBeenCalledWith(undefined);
+      // IDOR hardening: we no longer forward undefined/null workspaceIds
+      // down to Stakwork — the request is rejected up-front.
+      expect(response.status).toBe(400);
+      expect(mockCreateCustomer).not.toHaveBeenCalled();
     });
 
-    test("should handle null workspaceId", async () => {
-      MockSetup.setupSuccessfulCustomerCreation("test-token");
-
+    test("should return 400 when workspaceId is null", async () => {
       const request = TestHelpers.createMockRequest({ workspaceId: null });
       const response = await POST(request);
 
-      expect(mockCreateCustomer).toHaveBeenCalledWith(null);
+      expect(response.status).toBe(400);
+      expect(mockCreateCustomer).not.toHaveBeenCalled();
     });
   });
 
@@ -647,14 +694,13 @@ describe("POST /api/stakwork/create-customer - Unit Tests", () => {
       TestHelpers.setupAuthenticatedUser();
     });
 
-    test("should handle empty workspaceId string", async () => {
-      MockSetup.setupSuccessfulCustomerCreation("test-token");
-
+    test("should return 400 for empty workspaceId string", async () => {
       const request = TestHelpers.createMockRequest({ workspaceId: "" });
       const response = await POST(request);
 
-      expect(mockCreateCustomer).toHaveBeenCalledWith("");
-      expect(response.status).toBe(201);
+      // IDOR hardening: empty string is not a valid workspaceId.
+      expect(response.status).toBe(400);
+      expect(mockCreateCustomer).not.toHaveBeenCalled();
     });
 
     test("should handle workspace with existing stakworkApiKey", async () => {

--- a/src/app/api/livekit-token/route.ts
+++ b/src/app/api/livekit-token/route.ts
@@ -2,6 +2,7 @@ import { AccessToken } from "livekit-server-sdk";
 import jwt from "jsonwebtoken";
 import { NextRequest, NextResponse } from "next/server";
 import { getMiddlewareContext, requireAuth } from "@/lib/middleware/utils";
+import { validateWorkspaceAccess } from "@/services/workspace";
 
 export async function POST(req: NextRequest) {
   const context = getMiddlewareContext(req);
@@ -11,6 +12,18 @@ export async function POST(req: NextRequest) {
   const { slug } = await req.json();
   if (!slug || typeof slug !== "string") {
     return NextResponse.json({ error: "slug is required" }, { status: 400 });
+  }
+
+  // IDOR hardening: the JWT minted below grants MCP access to the workspace
+  // keyed by `slug` (see `src/lib/mcp/handler.ts` `verifyJwt`). Require the
+  // caller to be a member of that workspace before signing — otherwise any
+  // signed-in user can drive MCP against any workspace they can name.
+  const access = await validateWorkspaceAccess(slug, userOrResponse.id);
+  if (!access.hasAccess || !access.canRead) {
+    return NextResponse.json(
+      { error: "Workspace not found or access denied" },
+      { status: 404 },
+    );
   }
 
   const roomName = `hive-${slug}-${Date.now()}`;
@@ -40,7 +53,13 @@ export async function POST(req: NextRequest) {
   if (!jwtSecret) {
     return NextResponse.json({ error: "JWT secret not configured" }, { status: 500 });
   }
-  const hiveToken = jwt.sign({ slug }, jwtSecret, { expiresIn: "4h" });
+  // Embed the acting user so `verifyJwt` can re-check workspace membership
+  // at use time (memberships can be revoked between mint and use).
+  const hiveToken = jwt.sign(
+    { slug, userId: userOrResponse.id },
+    jwtSecret,
+    { expiresIn: "4h" },
+  );
 
   // Pass MCP server config via participant metadata so the agent can make
   // authenticated MCP calls on behalf of this user's workspace.

--- a/src/app/api/pool-manager/delete-pool/route.ts
+++ b/src/app/api/pool-manager/delete-pool/route.ts
@@ -1,16 +1,20 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth/nextauth";
+import { db } from "@/lib/db";
 import { poolManagerService } from "@/lib/service-factory";
+import { validateWorkspaceAccessById } from "@/services/workspace";
 import { type ApiError } from "@/types";
 
 export async function DELETE(request: NextRequest) {
   try {
     const session = await getServerSession(authOptions);
 
-    if (!session?.user) {
+    if (!session?.user || !(session.user as { id?: string }).id) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
+
+    const userId = (session.user as { id: string }).id;
 
     let body;
     try {
@@ -19,7 +23,7 @@ export async function DELETE(request: NextRequest) {
       // Handle empty body or malformed JSON
       body = {};
     }
-    
+
     const { name } = body;
 
     // Validate required fields
@@ -27,6 +31,30 @@ export async function DELETE(request: NextRequest) {
       return NextResponse.json(
         { error: "Missing required field: name" },
         { status: 400 },
+      );
+    }
+
+    // `name` is the swarm.id (matches pool_name convention in create-pool).
+    // Resolve the owning workspace and require workspace admin before
+    // allowing a pool deletion — otherwise any signed-in user can DoS
+    // any workspace's compute pool (IDOR hardening).
+    const swarm = await db.swarm.findUnique({
+      where: { id: name },
+      select: { workspaceId: true },
+    });
+
+    if (!swarm) {
+      return NextResponse.json(
+        { error: "Workspace not found or access denied" },
+        { status: 404 },
+      );
+    }
+
+    const access = await validateWorkspaceAccessById(swarm.workspaceId, userId);
+    if (!access.hasAccess || !access.canAdmin) {
+      return NextResponse.json(
+        { error: "Workspace not found or access denied" },
+        { status: 404 },
       );
     }
 

--- a/src/app/api/stakwork/create-customer/route.ts
+++ b/src/app/api/stakwork/create-customer/route.ts
@@ -2,6 +2,7 @@ import { authOptions } from "@/lib/auth/nextauth";
 import { db } from "@/lib/db";
 import { EncryptionService } from "@/lib/encryption";
 import { stakworkService } from "@/lib/service-factory";
+import { validateWorkspaceAccessById } from "@/services/workspace";
 import { type ApiError } from "@/types";
 import { getServerSession } from "next-auth/next";
 import { NextRequest, NextResponse } from "next/server";
@@ -13,12 +14,31 @@ const encryptionService: EncryptionService = EncryptionService.getInstance();
 export async function POST(request: NextRequest) {
   try {
     const session = await getServerSession(authOptions);
-    if (!session?.user) {
+    if (!session?.user || !(session.user as { id?: string }).id) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
+    const userId = (session.user as { id: string }).id;
+
     const body = await request.json();
     const { workspaceId } = body;
+
+    if (!workspaceId || typeof workspaceId !== "string") {
+      return NextResponse.json(
+        { error: "workspaceId is required" },
+        { status: 400 },
+      );
+    }
+
+    // Verify the caller is an admin/owner of the workspace before consuming
+    // Stakwork allocation or writing the stakworkApiKey (IDOR hardening).
+    const access = await validateWorkspaceAccessById(workspaceId, userId);
+    if (!access.hasAccess || !access.canAdmin) {
+      return NextResponse.json(
+        { error: "Workspace not found or access denied" },
+        { status: 404 },
+      );
+    }
 
     const customerResponse =
       await stakworkService().createCustomer(workspaceId);

--- a/src/app/api/swarm/stakgraph/agent-stream/route.ts
+++ b/src/app/api/swarm/stakgraph/agent-stream/route.ts
@@ -4,6 +4,7 @@ import { EncryptionService, encryptEnvVars } from "@/lib/encryption";
 import { getPrimaryRepository } from "@/lib/helpers/repository";
 import { saveOrUpdateSwarm } from "@/services/swarm/db";
 import { pollAgentProgress } from "@/services/swarm/stakgraph-services";
+import { validateWorkspaceAccessById } from "@/services/workspace";
 import { devcontainerJsonContent, dockerfileContent, extractEnvVarsFromPM2Config, parsePM2Content } from "@/utils/devContainerUtils";
 import { parseGithubOwnerRepo } from "@/utils/repositoryParser";
 import { getServerSession } from "next-auth/next";
@@ -46,6 +47,32 @@ export async function GET(request: NextRequest) {
       missingParams: { requestId: !requestId, swarmId: !swarmId },
     });
     return new Response("Missing required parameters", { status: 400 });
+  }
+
+  // IDOR hardening: resolve the swarm → workspace and require admin access
+  // BEFORE opening the SSE stream, polling with the decrypted swarmApiKey,
+  // or writing to the swarm / environment_variables tables. Otherwise any
+  // signed-in user could stream progress and mutate env vars on any
+  // workspace's swarm by guessing its id.
+  const swarmForAuth = await db.swarm.findFirst({
+    where: { id: swarmId },
+    select: { workspaceId: true },
+  });
+
+  if (!swarmForAuth) {
+    return new Response("Swarm not found or access denied", { status: 404 });
+  }
+
+  const access = await validateWorkspaceAccessById(
+    swarmForAuth.workspaceId,
+    session.user.id,
+  );
+  if (!access.hasAccess || !access.canAdmin) {
+    console.warn("[agent-stream] Access denied", {
+      ...logContext,
+      workspaceId: swarmForAuth.workspaceId,
+    });
+    return new Response("Swarm not found or access denied", { status: 404 });
   }
 
   // Set up SSE headers

--- a/src/app/api/upload/presigned-url/route.ts
+++ b/src/app/api/upload/presigned-url/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getMiddlewareContext, requireAuth } from '@/lib/middleware/utils'
 import { getS3Service } from '@/services/s3'
 import { db } from '@/lib/db'
+import { validateWorkspaceAccessById } from '@/services/workspace'
 import { z } from 'zod'
 
 const uploadRequestSchema = z.object({
@@ -11,20 +12,71 @@ const uploadRequestSchema = z.object({
   taskId: z.string().min(1, 'Task ID is required'),
 })
 
+/**
+ * Extract the owning workspaceId from a well-known S3 key prefix.
+ *
+ * Returns `null` when the key doesn't match a supported prefix — callers
+ * should treat that as a 404 rather than silently falling through.
+ *
+ * Supported prefixes mirror the generators on `S3Service`:
+ *   - uploads/<workspaceId>/<swarmId>/<taskId>/...
+ *   - workspace-logos/<workspaceId>/...
+ *   - whiteboards/<workspaceId>/...
+ *   - screenshots/<workspaceId>/...
+ *   - features/<workspaceId>/...
+ *   - diagrams/<workspaceId>/...
+ */
+function extractWorkspaceIdFromS3Key(s3Key: string): string | null {
+  const parts = s3Key.split('/').filter(Boolean)
+  if (parts.length < 2) return null
+  const [prefix, workspaceId] = parts
+  const ALLOWED_PREFIXES = new Set([
+    'uploads',
+    'workspace-logos',
+    'whiteboards',
+    'screenshots',
+    'features',
+    'diagrams',
+  ])
+  if (!ALLOWED_PREFIXES.has(prefix)) return null
+  return workspaceId || null
+}
+
 export async function GET(request: NextRequest) {
   try {
     const context = getMiddlewareContext(request)
     const userOrResponse = requireAuth(context)
     if (userOrResponse instanceof NextResponse) return userOrResponse
+    const userId = userOrResponse.id
 
     // Get s3Key from query params
     const { searchParams } = new URL(request.url)
     const s3Key = searchParams.get('s3Key')
-    
+
     if (!s3Key) {
       return NextResponse.json(
         { error: 's3Key parameter is required' },
         { status: 400 }
+      )
+    }
+
+    // IDOR hardening: s3Keys follow a `<prefix>/<workspaceId>/...` layout.
+    // Parse the workspaceId out of the key and require membership before
+    // minting a presigned download URL — otherwise any signed-in user can
+    // exfiltrate any other workspace's attachments/artifacts/feature media.
+    const workspaceId = extractWorkspaceIdFromS3Key(s3Key)
+    if (!workspaceId) {
+      return NextResponse.json(
+        { error: 'Workspace not found or access denied' },
+        { status: 404 }
+      )
+    }
+
+    const access = await validateWorkspaceAccessById(workspaceId, userId)
+    if (!access.hasAccess || !access.canRead) {
+      return NextResponse.json(
+        { error: 'Workspace not found or access denied' },
+        { status: 404 }
       )
     }
 
@@ -51,11 +103,12 @@ export async function POST(request: NextRequest) {
     const context = getMiddlewareContext(request)
     const userOrResponse = requireAuth(context)
     if (userOrResponse instanceof NextResponse) return userOrResponse
+    const userId = userOrResponse.id
 
     const body = await request.json()
     const validatedData = uploadRequestSchema.parse(body)
     const { filename, contentType, size, taskId } = validatedData
-    
+
     // Get task with workspace and swarm information
     const task = await db.task.findFirst({
       where: {
@@ -76,16 +129,26 @@ export async function POST(request: NextRequest) {
         },
       },
     })
-    
+
     if (!task) {
       return NextResponse.json(
         { error: 'Task not found' },
         { status: 404 }
       )
     }
-    
+
     const workspaceId = task.workspace.id
     const swarmId = task.workspace.swarm?.id || 'default'
+
+    // IDOR hardening: require write access to the task's workspace before
+    // issuing an upload URL scoped to its S3 prefix.
+    const access = await validateWorkspaceAccessById(workspaceId, userId)
+    if (!access.hasAccess || !access.canWrite) {
+      return NextResponse.json(
+        { error: 'Workspace not found or access denied' },
+        { status: 404 }
+      )
+    }
 
     // Validate file type
     if (!getS3Service().validateFileType(contentType)) {

--- a/src/lib/mcp/handler.ts
+++ b/src/lib/mcp/handler.ts
@@ -417,17 +417,49 @@ async function verifyJwt(
   if (!jwtSecret) return undefined;
 
   try {
-    const payload = jwt.verify(token, jwtSecret) as { slug?: string };
+    const payload = jwt.verify(token, jwtSecret) as {
+      slug?: string;
+      userId?: string;
+    };
     if (!payload.slug) return undefined;
 
     const workspace = await db.workspace.findFirst({
       where: { slug: payload.slug, deleted: false },
-      select: { id: true, slug: true, name: true },
+      select: { id: true, slug: true, name: true, ownerId: true },
     });
     if (!workspace) {
       console.log("[MCP] JWT workspace not found:", payload.slug);
       return undefined;
     }
+
+    // IDOR hardening: if the JWT carries a userId (minted by
+    // /api/livekit-token), re-validate that the user is still a member of
+    // the workspace at use time. Legacy JWTs without userId are rejected.
+    if (!payload.userId) {
+      console.log("[MCP] JWT missing userId claim — rejecting legacy token");
+      return undefined;
+    }
+
+    const isOwner = workspace.ownerId === payload.userId;
+    if (!isOwner) {
+      const membership = await db.workspaceMember.findUnique({
+        where: {
+          workspaceId_userId: {
+            workspaceId: workspace.id,
+            userId: payload.userId,
+          },
+        },
+        select: { role: true },
+      });
+      if (!membership) {
+        console.log(
+          "[MCP] JWT user is no longer a member of workspace:",
+          workspace.slug,
+        );
+        return undefined;
+      }
+    }
+
     console.log("[MCP] JWT verified for workspace:", workspace.slug);
 
     const swarmAccess = await getSwarmAccessByWorkspaceId(workspace.id);


### PR DESCRIPTION
Enforce workspace membership/admin checks before privileged work on five pre-existing IDOR-vulnerable routes identified in docs/plans/workspace-idor-hardening.md: stakwork/create-customer, pool-manager/delete-pool, upload/presigned-url (POST+GET), livekit-token (plus MCP verifyJwt re-check), and
swarm/stakgraph/agent-stream. Also adds targeted unit+integration tests asserting non-members get a unified 404 and that no credentialed side-effects run on their behalf.