### PR TITLE
Harden workspace IDOR on 17 Phase B handlers

### DIFF
--- a/docs/plans/workspace-idor-hardening.md
+++ b/docs/plans/workspace-idor-hardening.md
@@ -92,7 +92,12 @@ tackled in a follow-up effort.
     the caller can no longer name arbitrary @-aliases. Integration
     tests for `/invite` were updated to enrol each test invitee as a
     workspace member.
-  - Remaining Phase B items (#12, #19–24) — not started.
+  - **Agent logs #12 — DONE** on `ef/idor-fixes-2`. agent-logs GET
+    now requires `canRead` membership on the `workspace_id` query
+    param before the `db.agentLog.findMany` and the per-log
+    `fetchBlobContent` search loop. Unit test updated to stub
+    `@/services/workspace`.
+  - Remaining Phase B items (#19–24) — not started.
 - **Phase C (Medium #26–30)** — not started.
 - **Phase D (shared-secret S1–S3)** — not started.
 - **"also" items** (public-viewer 7-day → 1-hour presigned URLs;
@@ -370,6 +375,12 @@ proof-of-exploit, and suggested fix.
   contents for any workspace.
 - **Fix**: `validateWorkspaceAccessById(workspaceId, userId)` with
   `canRead` before the query.
+- **Status**: ✅ Fixed on `ef/idor-fixes-2`. `canRead` membership
+  check now runs immediately after the `workspace_id` validation and
+  before both the `findMany` and the `fetchBlobContent` loop.
+  Returns unified 404. The existing unit test was updated to stub
+  `@/services/workspace` so it stays focused on the pagination and
+  keyword-search paths it actually covers.
 
 #### 13. `src/app/api/swarm/stakgraph/ingest/route.ts` — POST, GET
 - **Bug**: loads swarm by `workspaceId` with no membership check; POST
@@ -623,7 +634,8 @@ require session auth + workspace admin.
    - Tests cluster (#17–18) ✅ on `ef/idor-fixes-2`.
    - Upload (#25) ✅ on `ef/idor-fixes-2`.
    - Misc (#6, #7) ✅ on `ef/idor-fixes-2`.
-   - Remaining (#12, #19–24) still open.
+   - Agent logs (#12) ✅ on `ef/idor-fixes-2`.
+   - Remaining (#19–24) still open.
 3. **Phase C — medium (#26–30)**: one cleanup PR.
 4. **Phase D — shared-secret endpoints (S1–S3)**: design work on
    per-resource tokens, then migrate webhooks to the new scheme.

--- a/docs/plans/workspace-idor-hardening.md
+++ b/docs/plans/workspace-idor-hardening.md
@@ -77,7 +77,13 @@ tackled in a follow-up effort.
     writes (previously the 403 fired *after* the writes persisted)
     and upgraded from a 403 to the unified 404. Two existing
     integration tests were updated to the new 404.
-  - Remaining Phase B items (#6, #7, #12, #19–25) — not started.
+  - **Upload #25 — DONE** on `ef/idor-fixes-2`. upload/image now
+    authorizes the caller as a `canWrite` member of
+    `feature.workspaceId` before minting either the presigned upload
+    URL or the long-lived presigned download URL, and also validates
+    `session.user.id` (401 otherwise). No test churn — the existing
+    integration test file was already `describe.skip`ed.
+  - Remaining Phase B items (#6, #7, #12, #19–24) — not started.
 - **Phase C (Medium #26–30)** — not started.
 - **Phase D (shared-secret S1–S3)** — not started.
 - **"also" items** (public-viewer 7-day → 1-hour presigned URLs;
@@ -495,6 +501,15 @@ proof-of-exploit, and suggested fix.
   victim's S3 prefix.
 - **Fix**: `validateWorkspaceAccessById(feature.workspaceId, userId)`
   with `canWrite` before issuing any presigned URL.
+- **Status**: ✅ Fixed on `ef/idor-fixes-2`. The handler now also
+  requires a non-empty `session.user.id` (401 otherwise), folds the
+  "feature not found" path into the unified 404, and runs the
+  `canWrite` membership check on `feature.workspaceId` before either
+  the upload or download presigned URL is generated. The integration
+  test suite for this route is `describe.skip`ed; no test churn.
+  (Note: the "604800 seconds ≈ 1 year" comment in the handler is
+  actually 7 days — not tackled here; the "also" item in this plan
+  already flags public-viewer 7-day URLs for follow-up.)
 
 ---
 
@@ -581,7 +596,8 @@ require session auth + workspace admin.
    - Swarm cluster (#13–16) ✅ on `ef/idor-fixes-2` (commit
      `7b5a2fa78`).
    - Tests cluster (#17–18) ✅ on `ef/idor-fixes-2`.
-   - Remaining (#6, #7, #12, #19–25) still open.
+   - Upload (#25) ✅ on `ef/idor-fixes-2`.
+   - Remaining (#6, #7, #12, #19–24) still open.
 3. **Phase C — medium (#26–30)**: one cleanup PR.
 4. **Phase D — shared-secret endpoints (S1–S3)**: design work on
    per-resource tokens, then migrate webhooks to the new scheme.

--- a/docs/plans/workspace-idor-hardening.md
+++ b/docs/plans/workspace-idor-hardening.md
@@ -37,7 +37,47 @@ tackled in a follow-up effort.
   access denied"` and that no credentialed side-effects (Stakwork
   calls, pool deletion, S3 presigning, LiveKit/MCP JWT signing,
   stakgraph polling / env-var writes) run on their behalf.
-- **Phase B (High #6–25)** — not started.
+- **Phase B (High #6–25) — partial.**
+  - **Agent cluster #8–11 — DONE** on branch `ef/idor-fixes-2`
+    (commit `3d39db806`). /api/agent now runs the workspace
+    membership check before `claimPodForTask` / credential writes;
+    /api/agent/commit and /api/agent/diff derive the authorized
+    workspaceId from `task.workspaceId` (rejecting mismatched body
+    `workspaceId` with the unified 404) so a caller can't pair a
+    victim's `taskId` with their own `workspaceId`; /api/agent/branch
+    resolves `task.workspace` and rejects non-members before invoking
+    `generateCommitMessage`, so the AI-summary path no longer leaks
+    chat history. Existing integration tests were updated from the
+    "security-gap documentation" shape to assert the new 404 + no-AI-
+    call behavior; these routes are also currently gated behind the
+    `TASK_AGENT_MODE` feature flag, which is why new targeted tests
+    weren't added.
+  - **Swarm cluster #13–16 — DONE** on `ef/idor-fixes-2` (commit
+    `7b5a2fa78`). stakgraph/ingest POST requires `canWrite` on the
+    body workspaceId before the CAS flag flip, repo→PENDING update,
+    stakgraph trigger, or GitHub webhook registration; stakgraph/
+    ingest GET requires `canRead` before fetching swarm creds and
+    polling stakgraph; stakgraph/services and stakgraph/sync now
+    authorize against `swarm.workspaceId` (not the body-supplied
+    `workspaceId`/`swarmId`) and require `canWrite` before the
+    decrypted credentialed side-effects run; jarvis/search-by-types
+    requires a `workspaceId` query param plus `canRead` before the
+    swarm lookup so non-members can't exfiltrate the code-graph
+    (which contains presigned S3 media URLs). Test adjustments:
+    promoted the `@/lib/constants` mock in two integration suites to
+    a partial `importOriginal` variant so `WORKSPACE_PERMISSION_LEVELS`
+    is still available to `validateWorkspaceAccessById`, reworded one
+    jarvis test to match the unified 404, and stubbed
+    `@/services/workspace` in the stakgraph-ingest unit test.
+  - **Tests cluster #17–18 — DONE** on `ef/idor-fixes-2`. tests/
+    coverage now requires `canWrite` before the primary-repo
+    ignoreDirs / unitGlob / integrationGlob / e2eGlob writes and
+    before decrypting `swarmApiKey`; tests/nodes had its pre-existing
+    `validateWorkspaceAccessById` call moved above the same repo
+    writes (previously the 403 fired *after* the writes persisted)
+    and upgraded from a 403 to the unified 404. Two existing
+    integration tests were updated to the new 404.
+  - Remaining Phase B items (#6, #7, #12, #19–25) — not started.
 - **Phase C (Medium #26–30)** — not started.
 - **Phase D (shared-secret S1–S3)** — not started.
 - **"also" items** (public-viewer 7-day → 1-hour presigned URLs;
@@ -244,6 +284,11 @@ proof-of-exploit, and suggested fix.
   task thread.
 - **Fix**: load the task with `workspace.ownerId` + `workspace.members { where: { userId } }`
   and reject non-members. Pattern exists already on `prototype-push`.
+- **Status**: ✅ Fixed on `ef/idor-fixes-2` (commit `3d39db806`). The
+  task lookup now pulls `workspace.ownerId` + filtered `members` and
+  returns the unified 404 for non-members *before* `claimPodForTask`,
+  any credential write, or `saveUserMessage`. Added the missing
+  `userId` session check (401 instead of 500 on malformed sessions).
 
 #### 9. `src/app/api/agent/commit/route.ts` — POST
 - **Bug**: body carries both `taskId` and `workspaceId` independently;
@@ -256,6 +301,11 @@ proof-of-exploit, and suggested fix.
 - **Fix**: derive `workspaceId` from `task.workspaceId` — never trust
   two independent body fields. Or at minimum assert
   `task.workspaceId === workspaceId`.
+- **Status**: ✅ Fixed on `ef/idor-fixes-2` (commit `3d39db806`). The
+  task load now returns both `podId` and `workspaceId`; the handler
+  rejects mismatched body `workspaceId` with the unified 404 and runs
+  the membership check against `task.workspaceId` only. Existing
+  integration tests updated from 403 → 404.
 
 #### 10. `src/app/api/agent/diff/route.ts` — POST
 - **Bug**: identical task↔workspace decoupling to #9; calls
@@ -263,6 +313,9 @@ proof-of-exploit, and suggested fix.
   pod and writes an assistant `ChatMessage` + `DIFF` `Artifact` onto
   the victim's task.
 - **Fix**: same as #9 — tie `workspaceId` to `task.workspaceId`.
+- **Status**: ✅ Fixed on `ef/idor-fixes-2` (commit `3d39db806`).
+  Same pattern as #9 applied. Duplicate access check that ran after
+  the mock branch was collapsed into the single pre-mock gate.
 
 #### 11. `src/app/api/agent/branch/route.ts` — POST
 - **Bug**: `generateCommitMessage(taskId, ...)` queries the task's full
@@ -271,6 +324,12 @@ proof-of-exploit, and suggested fix.
   history as an AI-generated summary.
 - **Fix**: verify caller is owner/member of `task.workspaceId` before
   calling `generateCommitMessage`.
+- **Status**: ✅ Fixed on `ef/idor-fixes-2` (commit `3d39db806`). The
+  handler now loads `task.workspace.{ownerId, members}` and returns
+  the unified 404 for non-members *before* `generateCommitMessage`,
+  so the AI summarizer never sees the victim's chat. Also added the
+  missing `userId` session check. The "SECURITY GAP documentation"
+  test was flipped to assert the new secure behavior.
 
 #### 12. `src/app/api/agent-logs/route.ts` — GET
 - **Bug**: `db.agentLog.findMany({ where: { workspaceId, ... } })` and
@@ -291,6 +350,10 @@ proof-of-exploit, and suggested fix.
   exfiltrate ingest progress.
 - **Fix**: `validateWorkspaceAccessById(workspaceId, userId)` — write
   for POST, read for GET.
+- **Status**: ✅ Fixed on `ef/idor-fixes-2` (commit `7b5a2fa78`).
+  POST requires `canWrite` before the CAS flip, repo→PENDING updates,
+  stakgraph trigger, and webhook registration; GET requires `canRead`
+  before the credentialed poll. Failure returns the unified 404.
 
 #### 14. `src/app/api/swarm/stakgraph/services/route.ts` — GET
 - **Bug**: loads swarm by body `swarmId` / `workspaceId` with no
@@ -299,6 +362,10 @@ proof-of-exploit, and suggested fix.
   / `agentStatus` / `services` / `environmentVariables`.
 - **Fix**: `validateWorkspaceAccessById(swarm.workspaceId, userId)`
   after loading the swarm.
+- **Status**: ✅ Fixed on `ef/idor-fixes-2` (commit `7b5a2fa78`). The
+  membership check runs against `swarm.workspaceId` (not any body
+  field) and requires `canWrite` before the services_agent call or
+  any writes to `swarm.agentRequestId` / `services` / env vars.
 
 #### 15. `src/app/api/swarm/stakgraph/sync/route.ts` — POST
 - **Bug**: loads swarm by body `swarmId` / `workspaceId` with no
@@ -307,6 +374,10 @@ proof-of-exploit, and suggested fix.
   webhook callback URL pointing at an attacker-controlled host.
 - **Fix**: `validateWorkspaceAccessById(swarm.workspaceId, userId)`
   with `canWrite` before the writes.
+- **Status**: ✅ Fixed on `ef/idor-fixes-2` (commit `7b5a2fa78`).
+  `canWrite` membership check on `swarm.workspaceId` runs immediately
+  after the swarm lookup, before the repo→PENDING write, the
+  `triggerAsyncSync` call, and the `ingestRefId` update.
 
 #### 16. `src/app/api/swarm/jarvis/search-by-types/route.ts` — POST
 - **Bug**: `db.swarm.findFirst({ where: { workspaceId } })` with
@@ -316,6 +387,10 @@ proof-of-exploit, and suggested fix.
   presigned S3 media URLs).
 - **Fix**: `validateWorkspaceAccessById(workspaceId, userId)` before
   the swarm lookup.
+- **Status**: ✅ Fixed on `ef/idor-fixes-2` (commit `7b5a2fa78`). The
+  `id` query param is now required (400 if missing) and gated by
+  `canRead` before the swarm lookup, so non-members can't touch the
+  jarvis graph even in the mock-response branch.
 
 #### 17. `src/app/api/tests/coverage/route.ts` — GET
 - **Bug**: `getPrimaryRepository(workspaceId)` and then
@@ -327,6 +402,10 @@ proof-of-exploit, and suggested fix.
   data through victim's decrypted API key.
 - **Fix**: `validateWorkspaceAccessById(workspaceId, userId)` with
   `canWrite` before any repo update or swarm fetch.
+- **Status**: ✅ Fixed on `ef/idor-fixes-2`. The `canWrite` membership
+  check runs immediately after parsing query params and before any
+  `getPrimaryRepository` / `db.repository.update` / `db.swarm.findFirst`
+  call. Returns unified 404 on failure.
 
 #### 18. `src/app/api/tests/nodes/route.ts` — GET
 - **Bug**: `db.repository.update` at L213-244 writes globs BEFORE the
@@ -334,6 +413,11 @@ proof-of-exploit, and suggested fix.
   the writes already persisted.
 - **Fix**: move `validateWorkspaceAccessById` above
   `getPrimaryRepository` and before any repo update.
+- **Status**: ✅ Fixed on `ef/idor-fixes-2`. Moved the existing
+  `validateWorkspaceAccessById` call up to run immediately after param
+  parsing — before `getPrimaryRepository` and the four `db.repository.
+  update` calls — and upgraded the response from 403 to the unified
+  404. Two integration tests that asserted the old 403 were updated.
 
 #### 19. `src/app/api/pool-manager/create-pool/route.ts` — POST
 - **Bug**: `saveOrUpdateSwarm({ containerFiles })` writes to the
@@ -492,6 +576,12 @@ require session auth + workspace admin.
    github, upload, misc). 3–4 follow-up PRs. Consider factoring the
    `apiTokenAuth ? requireAuthOrApiToken(...) : resolveWorkspaceAccess(...)`
    pattern into a shared helper to keep new handlers honest.
+   - Agent cluster (#8–11) ✅ on `ef/idor-fixes-2` (commit
+     `3d39db806`).
+   - Swarm cluster (#13–16) ✅ on `ef/idor-fixes-2` (commit
+     `7b5a2fa78`).
+   - Tests cluster (#17–18) ✅ on `ef/idor-fixes-2`.
+   - Remaining (#6, #7, #12, #19–25) still open.
 3. **Phase C — medium (#26–30)**: one cleanup PR.
 4. **Phase D — shared-secret endpoints (S1–S3)**: design work on
    per-resource tokens, then migrate webhooks to the new scheme.

--- a/docs/plans/workspace-idor-hardening.md
+++ b/docs/plans/workspace-idor-hardening.md
@@ -83,7 +83,16 @@ tackled in a follow-up effort.
     URL or the long-lived presigned download URL, and also validates
     `session.user.id` (401 otherwise). No test churn — the existing
     integration test file was already `describe.skip`ed.
-  - Remaining Phase B items (#6, #7, #12, #19–24) — not started.
+  - **Misc #6 + #7 — DONE** on `ef/idor-fixes-2`. tasks/create-
+    from-transcript now requires `canWrite` via `validateWorkspaceAccess`
+    before extracting the transcript or firing the live Stakwork
+    workflow; features/[featureId]/invite requires `canWrite` on the
+    feature's workspace AND narrows the invitee lookup to users who
+    own the workspace or have an active `workspaceMembers` row, so
+    the caller can no longer name arbitrary @-aliases. Integration
+    tests for `/invite` were updated to enrol each test invitee as a
+    workspace member.
+  - Remaining Phase B items (#12, #19–24) — not started.
 - **Phase C (Medium #26–30)** — not started.
 - **Phase D (shared-secret S1–S3)** — not started.
 - **"also" items** (public-viewer 7-day → 1-hour presigned URLs;
@@ -268,6 +277,12 @@ proof-of-exploit, and suggested fix.
 - **Fix**: `validateWorkspaceAccess(workspaceSlug, userId)` (or
   `resolveWorkspaceAccess` + `requireMemberAccess`) before
   `extractTaskFromTranscript` / `createTaskWithStakworkWorkflow`.
+- **Status**: ✅ Fixed on `ef/idor-fixes-2`. Replaced the bare
+  slug→id lookup with `validateWorkspaceAccess` requiring `canWrite`
+  and return the unified 404 on failure. The live Stakwork workflow
+  and the transcript-to-AI extractor now only run after membership
+  is confirmed. No existing test needed updating (this route has no
+  integration test).
 
 #### 7. `src/app/api/features/[featureId]/invite/route.ts` — POST
 - **Bug**: loads feature + workspace (with Sphinx creds) by `featureId`
@@ -279,6 +294,16 @@ proof-of-exploit, and suggested fix.
   `validateWorkspaceAccessById(feature.workspace.id, userId)` with
   `canWrite`; also verify each `inviteeUserId` is a member of the same
   workspace.
+- **Status**: ✅ Fixed on `ef/idor-fixes-2`. Added both the caller
+  membership check (`canWrite` on `feature.workspace.id`, return 404
+  before decrypting `sphinxBotSecret` or calling `sendToSphinx`) and
+  the invitee-membership check (the `db.user.findMany` query now
+  requires each invitee to own the workspace or be an active member
+  via `workspaceMembers { some: { workspaceId, leftAt: null } }`).
+  Also added a missing `session.user.id` check (401 otherwise).
+  Integration tests updated: each invitee is now enrolled as a
+  `DEVELOPER` workspace member before the invite call, and one
+  error-message assertion was adjusted to the new copy.
 
 #### 8. `src/app/api/agent/route.ts` — POST
 - **Bug**: loads `db.task.findUnique({ where: { id: taskId } })` with
@@ -597,7 +622,8 @@ require session auth + workspace admin.
      `7b5a2fa78`).
    - Tests cluster (#17–18) ✅ on `ef/idor-fixes-2`.
    - Upload (#25) ✅ on `ef/idor-fixes-2`.
-   - Remaining (#6, #7, #12, #19–24) still open.
+   - Misc (#6, #7) ✅ on `ef/idor-fixes-2`.
+   - Remaining (#12, #19–24) still open.
 3. **Phase C — medium (#26–30)**: one cleanup PR.
 4. **Phase D — shared-secret endpoints (S1–S3)**: design work on
    per-resource tokens, then migrate webhooks to the new scheme.

--- a/docs/plans/workspace-idor-hardening.md
+++ b/docs/plans/workspace-idor-hardening.md
@@ -101,7 +101,12 @@ tackled in a follow-up effort.
     owner/member check above the `saveOrUpdateSwarm({ containerFiles })`
     write, so a non-member can no longer poison the victim's swarm
     container-file config before the auth check fires.
-  - Remaining Phase B items (#20–24) — not started.
+  - **Workflows/versions #22 — DONE** on `ef/idor-fixes-2`. Added
+    the missing `members.length / ownerId` check after the workspace
+    load so a signed-in non-member can no longer read any workspace's
+    `workflow_version` graph nodes (which include raw `workflow_json`)
+    via the victim's decrypted `swarmApiKey`.
+  - Remaining Phase B items (#20, #21, #23, #24) — not started.
 - **Phase C (Medium #26–30)** — not started.
 - **Phase D (shared-secret S1–S3)** — not started.
 - **"also" items** (public-viewer 7-day → 1-hour presigned URLs;
@@ -515,6 +520,17 @@ proof-of-exploit, and suggested fix.
   workspace slug.
 - **Fix**: replace with `resolveWorkspaceAccess(request, { slug })` +
   `requireMemberAccess` (require admin since swarm creds are used).
+- **Status**: ✅ Fixed on `ef/idor-fixes-2`. Added the missing
+  `members.length / ownerId` check right after the workspace load,
+  also filtering `members` by `leftAt: null` to match the codebase
+  pattern. Any active workspace member suffices (consistent with
+  other swarm-reading endpoints — the plan's "require admin" note
+  was dropped because every other `canRead` swarm endpoint we've
+  hardened treats swarm-cred decryption as reader-level, not admin).
+  Returns the unified 404. Updated two existing integration tests
+  (the "workspace does not exist" message + the "not a member" test
+  which previously only asserted `not.toBe(403)` — now properly
+  asserts 404 and the unified error copy).
 
 #### 23. `src/app/api/orgs/[githubLogin]/connections/route.ts` — GET, DELETE
 - **Bug**: `db.sourceControlOrg.findUnique` by path-supplied
@@ -648,7 +664,8 @@ require session auth + workspace admin.
    - Misc (#6, #7) ✅ on `ef/idor-fixes-2`.
    - Agent logs (#12) ✅ on `ef/idor-fixes-2`.
    - Pool manager (#19) ✅ on `ef/idor-fixes-2`.
-   - Remaining (#20–24) still open.
+   - Workflows/versions (#22) ✅ on `ef/idor-fixes-2`.
+   - Remaining (#20, #21, #23, #24) still open.
 3. **Phase C — medium (#26–30)**: one cleanup PR.
 4. **Phase D — shared-secret endpoints (S1–S3)**: design work on
    per-resource tokens, then migrate webhooks to the new scheme.

--- a/docs/plans/workspace-idor-hardening.md
+++ b/docs/plans/workspace-idor-hardening.md
@@ -106,7 +106,13 @@ tackled in a follow-up effort.
     load so a signed-in non-member can no longer read any workspace's
     `workflow_version` graph nodes (which include raw `workflow_json`)
     via the victim's decrypted `swarmApiKey`.
-  - Remaining Phase B items (#20, #21, #23, #24) — not started.
+  - **Bounty request #24 — DONE** on `ef/idor-fixes-2`. The bounty
+    handler now authorizes against `task.workspaceId` with `canWrite`
+    before decrypting `agentPassword`, creating the BOUNTY chat
+    message, or calling the Stakwork bounty API; the bare
+    `sourceWorkspaceSlug === "hive"` string check is no longer the
+    real auth gate.
+  - Remaining Phase B items (#20, #21, #23) — not started.
 - **Phase C (Medium #26–30)** — not started.
 - **Phase D (shared-secret S1–S3)** — not started.
 - **"also" items** (public-viewer 7-day → 1-hour presigned URLs;
@@ -554,6 +560,16 @@ proof-of-exploit, and suggested fix.
   via Pusher), records attacker as `sourceUserId`.
 - **Fix**: `validateWorkspaceAccessById(task.workspaceId, userId)`
   with `canWrite`; tighten or remove the hard-coded slug check.
+- **Status**: ✅ Fixed on `ef/idor-fixes-2`. The task lookup now also
+  returns `workspaceId`; the handler authorizes the caller as a
+  `canWrite` member of `task.workspaceId` (never the body-supplied
+  slug) before generating the bounty code, writing the `BOUNTY`
+  chat message, decrypting `agentPassword`, or calling the Stakwork
+  bounty API. The "Source task not found" response was folded into
+  the unified 404 so we don't leak task existence. The hardcoded
+  `sourceWorkspaceSlug === "hive"` 403 check is left in place as a
+  belt-and-braces guard; the real authorization is now the membership
+  check. No existing tests.
 
 #### 25. `src/app/api/upload/image/route.ts` — POST
 - **Bug**: `db.feature.findFirst({ where: { id: featureId } })` with
@@ -665,7 +681,8 @@ require session auth + workspace admin.
    - Agent logs (#12) ✅ on `ef/idor-fixes-2`.
    - Pool manager (#19) ✅ on `ef/idor-fixes-2`.
    - Workflows/versions (#22) ✅ on `ef/idor-fixes-2`.
-   - Remaining (#20, #21, #23, #24) still open.
+   - Bounty request (#24) ✅ on `ef/idor-fixes-2`.
+   - Remaining (#20, #21, #23) still open.
 3. **Phase C — medium (#26–30)**: one cleanup PR.
 4. **Phase D — shared-secret endpoints (S1–S3)**: design work on
    per-resource tokens, then migrate webhooks to the new scheme.

--- a/docs/plans/workspace-idor-hardening.md
+++ b/docs/plans/workspace-idor-hardening.md
@@ -97,7 +97,11 @@ tackled in a follow-up effort.
     param before the `db.agentLog.findMany` and the per-log
     `fetchBlobContent` search loop. Unit test updated to stub
     `@/services/workspace`.
-  - Remaining Phase B items (#19–24) — not started.
+  - **Pool manager #19 — DONE** on `ef/idor-fixes-2`. Moved the
+    owner/member check above the `saveOrUpdateSwarm({ containerFiles })`
+    write, so a non-member can no longer poison the victim's swarm
+    container-file config before the auth check fires.
+  - Remaining Phase B items (#20–24) — not started.
 - **Phase C (Medium #26–30)** — not started.
 - **Phase D (shared-secret S1–S3)** — not started.
 - **"also" items** (public-viewer 7-day → 1-hour presigned URLs;
@@ -468,6 +472,14 @@ proof-of-exploit, and suggested fix.
   on victim's swarm before the access check returns 403.
 - **Fix**: move the ownership check immediately after
   `db.swarm.findFirst` and before any `saveOrUpdateSwarm` call.
+- **Status**: ✅ Fixed on `ef/idor-fixes-2`. Ownership check now
+  runs immediately after the swarm lookup and before the container-
+  files generation / `saveOrUpdateSwarm` write that previously
+  persisted attacker-controlled content on the victim's swarm. Also
+  filtered the `workspace.members` query to `leftAt: null` to match
+  the rest of the codebase. Response upgraded from 403 → unified 404.
+  Existing "403 when user is not owner or member" test updated to
+  the new 404 status + message.
 
 #### 20. `src/app/api/github/app/callback/route.ts` — GET
 - **Bug**: `state` is base64-encoded JSON, NOT signed. Caller-supplied
@@ -635,7 +647,8 @@ require session auth + workspace admin.
    - Upload (#25) ✅ on `ef/idor-fixes-2`.
    - Misc (#6, #7) ✅ on `ef/idor-fixes-2`.
    - Agent logs (#12) ✅ on `ef/idor-fixes-2`.
-   - Remaining (#19–24) still open.
+   - Pool manager (#19) ✅ on `ef/idor-fixes-2`.
+   - Remaining (#20–24) still open.
 3. **Phase C — medium (#26–30)**: one cleanup PR.
 4. **Phase D — shared-secret endpoints (S1–S3)**: design work on
    per-resource tokens, then migrate webhooks to the new scheme.

--- a/src/__tests__/integration/api/agent-branch.test.ts
+++ b/src/__tests__/integration/api/agent-branch.test.ts
@@ -36,18 +36,11 @@ describe("POST /api/agent/branch Integration Tests", () => {
       await expectUnauthorized(response);
     });
 
-    // VALIDATION GAP: This test documents current behavior where missing user.id causes 500 instead of 401
-    // The route should validate user.id exists before proceeding (like /api/agent/commit does)
-    test("VALIDATION GAP: currently returns 500 when user session has no id (should be 401)", async () => {
+    test("returns 401 when user session has no id", async () => {
       getMockedSession().mockResolvedValue({
         user: { email: "test@example.com", name: "Test User" },
         expires: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
       } as any);
-
-      const { generateCommitMessage } = await import("@/lib/ai/commit-msg");
-      vi.mocked(generateCommitMessage).mockRejectedValue(
-        new Error("Cannot process request with invalid user session")
-      );
 
       const request = createPostRequest("http://localhost:3000/api/agent/branch", {
         taskId: "test-task-id",
@@ -55,11 +48,9 @@ describe("POST /api/agent/branch Integration Tests", () => {
 
       const response = await POST(request);
 
-      // Current behavior: returns 500 due to missing userId validation
-      // Expected behavior: should return 401 with explicit userId check (see /api/agent/commit)
-      expect(response.status).toBe(500);
+      expect(response.status).toBe(401);
       const data = await response.json();
-      expect(data.error).toBeTruthy();
+      expect(data.error).toBe("Invalid user session");
     });
   });
 
@@ -108,14 +99,14 @@ describe("POST /api/agent/branch Integration Tests", () => {
       expect(data.error).toBe("No conversation history found for this task");
     });
 
-    test("should return 500 when task does not exist", async () => {
+    test("should return 404 when task does not exist", async () => {
+      // IDOR guard: we resolve the task's workspace and check membership
+      // before calling generateCommitMessage, so a missing task returns
+      // the unified 404 and never touches the AI summarizer.
       const user = await createTestUser();
       getMockedSession().mockResolvedValue(createAuthenticatedSession(user));
 
       const { generateCommitMessage } = await import("@/lib/ai/commit-msg");
-      vi.mocked(generateCommitMessage).mockRejectedValue(
-        new Error("Task not found")
-      );
 
       const request = createPostRequest("http://localhost:3000/api/agent/branch", {
         taskId: "non-existent-task-id",
@@ -123,14 +114,20 @@ describe("POST /api/agent/branch Integration Tests", () => {
 
       const response = await POST(request);
 
-      expect(response.status).toBe(500);
+      expect(response.status).toBe(404);
       const data = await response.json();
-      expect(data.error).toContain("Task not found");
+      expect(data.error).toContain("Workspace not found or access denied");
+      expect(vi.mocked(generateCommitMessage)).not.toHaveBeenCalled();
     });
   });
 
-  describe("Authorization Tests (Security Gap Documentation)", () => {
-    test("SECURITY GAP: currently allows any authenticated user to generate branch names for any task", async () => {
+  describe("Authorization Tests (IDOR hardening)", () => {
+    test("returns 404 and does not call generateCommitMessage for non-member attacker", async () => {
+      // Previously this route had no workspace membership check: any
+      // signed-in user could read another workspace's task chat history
+      // as an AI-generated summary. The IDOR fix resolves the task's
+      // workspace first and returns the unified 404 for non-members
+      // before ever calling the AI summarizer.
       const owner = await createTestUser({ name: "Owner" });
       const unauthorizedUser = await createTestUser({ name: "Unauthorized User" });
 
@@ -168,15 +165,13 @@ describe("POST /api/agent/branch Integration Tests", () => {
 
       const response = await POST(request);
 
-      // SECURITY GAP: Currently returns 200 for unauthorized users
-      // EXPECTED: Should return 403 with proper workspace authorization
-      const data = await expectSuccess(response, 200);
-      expect(data.success).toBe(true);
-      expect(data.data.branch_name).toBe("feat/implement-feature-x");
+      expect(response.status).toBe(404);
+      const data = await response.json();
+      expect(data.error).toContain("Workspace not found or access denied");
+      expect(vi.mocked(generateCommitMessage)).not.toHaveBeenCalled();
     });
 
-    // TODO: Implement workspace authorization using validateWorkspaceAccess()
-    // These tests document expected secure behavior after authorization is implemented
+    // Legacy skipped placeholders describing the fix now live above.
     test.skip("EXPECTED BEHAVIOR: should return 403 when user lacks workspace access", async () => {
       const owner = await createTestUser({ name: "Owner" });
       const unauthorizedUser = await createTestUser({ name: "Unauthorized User" });

--- a/src/__tests__/integration/api/agent-commit.test.ts
+++ b/src/__tests__/integration/api/agent-commit.test.ts
@@ -9,7 +9,6 @@ import {
   expectSuccess,
   expectError,
   expectUnauthorized,
-  expectForbidden,
   expectNotFound,
   generateUniqueId,
   generateUniqueSlug,
@@ -306,8 +305,9 @@ describe("POST /api/agent/commit Integration Tests", () => {
   });
 
   describe("Authorization Tests", () => {
-    test("should return 404 when workspace not found", async () => {
-      // Create a task with podId so we can test workspace not found
+    test("should return 404 when body workspaceId does not match task.workspaceId", async () => {
+      // Attacker passes a victim's taskId paired with their own workspaceId —
+      // the mismatch check rejects before any pod write.
       const { task } = await createTestDataWithCommitCapabilities({ podId: "test-pod-id" });
       const user = await createTestUser();
       getMockedSession().mockResolvedValue(createAuthenticatedSession(user));
@@ -320,10 +320,10 @@ describe("POST /api/agent/commit Integration Tests", () => {
       });
 
       const response = await POST(request);
-      await expectNotFound(response, "Workspace not found");
+      await expectNotFound(response, "Workspace not found or access denied");
     });
 
-    test("should return 403 when user is not workspace owner or member", async () => {
+    test("should return 404 when user is not workspace owner or member (IDOR)", async () => {
       const { workspace, task } = await createTestDataWithCommitCapabilities({ podId: "test-pod-id" });
       const unauthorizedUser = await createTestUser({ name: "Unauthorized User" });
 
@@ -337,7 +337,7 @@ describe("POST /api/agent/commit Integration Tests", () => {
       });
 
       const response = await POST(request);
-      await expectForbidden(response);
+      await expectNotFound(response, "Workspace not found or access denied");
     });
 
     test("should allow workspace owner to commit", async () => {

--- a/src/__tests__/integration/api/agent-diff.test.ts
+++ b/src/__tests__/integration/api/agent-diff.test.ts
@@ -9,7 +9,6 @@ import {
   expectSuccess,
   expectError,
   expectUnauthorized,
-  expectForbidden,
   expectNotFound,
   generateUniqueSlug,
   createPostRequest,
@@ -199,8 +198,9 @@ describe("POST /api/agent/diff Integration Tests", () => {
   });
 
   describe("Authorization Tests", () => {
-    test("returns 404 when workspace not found", async () => {
-      // Create a task with podId in a workspace the user doesn't have access to
+    test("returns 404 when body workspaceId does not match task.workspaceId", async () => {
+      // Attacker passes a victim's taskId paired with a workspaceId they
+      // control; the mismatch check rejects before any pod read.
       const { task } = await createTestDataWithDiffCapabilities({ podId: "test-pod-id" });
       const user = await createTestUser();
       getMockedSession().mockResolvedValue(createAuthenticatedSession(user));
@@ -211,10 +211,10 @@ describe("POST /api/agent/diff Integration Tests", () => {
       });
 
       const response = await POST(request);
-      await expectNotFound(response, "Workspace not found");
+      await expectNotFound(response, "Workspace not found or access denied");
     });
 
-    test("returns 403 when user is not workspace owner or member", async () => {
+    test("returns 404 when user is not workspace owner or member (IDOR)", async () => {
       const { workspace, task } = await createTestDataWithDiffCapabilities({ podId: "test-pod-id" });
       const unauthorizedUser = await createTestUser({ name: "Unauthorized User" });
 
@@ -226,7 +226,7 @@ describe("POST /api/agent/diff Integration Tests", () => {
       });
 
       const response = await POST(request);
-      await expectForbidden(response);
+      await expectNotFound(response, "Workspace not found or access denied");
     });
 
     test("allows workspace owner to fetch diff", async () => {

--- a/src/__tests__/integration/api/features-invite.test.ts
+++ b/src/__tests__/integration/api/features-invite.test.ts
@@ -18,12 +18,20 @@ vi.mock("@/lib/auth/nextauth", () => ({
   authOptions: {},
 }));
 
-// Mock environment config
-vi.mock("@/config/env", () => ({
-  config: {
-    SPHINX_API_URL: "http://localhost:3000/api/mock/sphinx/action",
-  },
-}));
+// Mock environment config. Extend the real module (via importOriginal)
+// so that downstream callers like @/config/services still see
+// optionalEnvVars / USE_MOCKS / MOCK_BASE when this test file imports
+// @/services/workspace (pulled in by the route's IDOR fix).
+vi.mock("@/config/env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/config/env")>();
+  return {
+    ...actual,
+    config: {
+      ...actual.config,
+      SPHINX_API_URL: "http://localhost:3000/api/mock/sphinx/action",
+    },
+  };
+});
 
 // Mock fetch for Sphinx API calls
 global.fetch = vi.fn();
@@ -154,6 +162,12 @@ describe("POST /api/features/[featureId]/invite Integration Tests", () => {
       // No sphinxAlias set
     });
 
+    // Invitee must be an active workspace member for the IDOR-hardened
+    // route to let them through to the sphinxAlias check.
+    await db.workspaceMember.create({
+      data: { userId: invitee.id, workspaceId: workspace.id, role: "DEVELOPER" },
+    });
+
     const feature = await db.feature.create({
       data: {
         title: "Test Feature",
@@ -171,9 +185,9 @@ describe("POST /api/features/[featureId]/invite Integration Tests", () => {
 
     const response = await POST(request, { params: Promise.resolve({ featureId: feature.id }) });
     expect(response.status).toBe(400);
-    
+
     const data = await response.json();
-    expect(data.error).toContain("does not have a Sphinx alias");
+    expect(data.error).toContain("lacks a Sphinx alias");
   });
 
   test("successfully sends invite when all conditions are met", async () => {
@@ -198,6 +212,10 @@ describe("POST /api/features/[featureId]/invite Integration Tests", () => {
       name: "Invitee User",
       sphinxAlias: "invitee_sphinx",
       lightningPubkey: "test-pubkey-123",
+    });
+
+    await db.workspaceMember.create({
+      data: { userId: invitee.id, workspaceId: workspace.id, role: "DEVELOPER" },
     });
 
     const feature = await db.feature.create({
@@ -262,6 +280,13 @@ describe("POST /api/features/[featureId]/invite Integration Tests", () => {
       createTestUser({ email: `bob-${generateUniqueId()}@example.com`, name: "Bob", sphinxAlias: "bob", lightningPubkey: "pk-bob" }),
     ]);
 
+    await db.workspaceMember.createMany({
+      data: [
+        { userId: alice.id, workspaceId: workspace.id, role: "DEVELOPER" },
+        { userId: bob.id, workspaceId: workspace.id, role: "DEVELOPER" },
+      ],
+    });
+
     const feature = await db.feature.create({
       data: { title: "Multi-User Feature", workspaceId: workspace.id, createdById: owner.id, updatedById: owner.id },
     });
@@ -307,6 +332,14 @@ describe("POST /api/features/[featureId]/invite Integration Tests", () => {
       createTestUser({ email: `bob-${generateUniqueId()}@example.com`, name: "Bob", sphinxAlias: "bob", lightningPubkey: "pk-bob" }),
       createTestUser({ email: `charlie-${generateUniqueId()}@example.com`, name: "Charlie", sphinxAlias: "charlie", lightningPubkey: "pk-charlie" }),
     ]);
+
+    await db.workspaceMember.createMany({
+      data: [
+        { userId: alice.id, workspaceId: workspace.id, role: "DEVELOPER" },
+        { userId: bob.id, workspaceId: workspace.id, role: "DEVELOPER" },
+        { userId: charlie.id, workspaceId: workspace.id, role: "DEVELOPER" },
+      ],
+    });
 
     const feature = await db.feature.create({
       data: { title: "Three-User Feature", workspaceId: workspace.id, createdById: owner.id, updatedById: owner.id },
@@ -364,6 +397,10 @@ describe("POST /api/features/[featureId]/invite Integration Tests", () => {
       name: "Invitee User",
       sphinxAlias: "invitee_sphinx",
       lightningPubkey: "test-pubkey-123",
+    });
+
+    await db.workspaceMember.create({
+      data: { userId: invitee.id, workspaceId: workspace.id, role: "DEVELOPER" },
     });
 
     const feature = await db.feature.create({

--- a/src/__tests__/integration/api/pool-manager/create-pool.test.ts
+++ b/src/__tests__/integration/api/pool-manager/create-pool.test.ts
@@ -7,7 +7,6 @@ import {
   expectUnauthorized,
   expectError,
   expectNotFound,
-  expectForbidden,
   createPostRequest,
   generateUniqueId,
 } from "@/__tests__/support/helpers";
@@ -166,7 +165,12 @@ describe("POST /api/pool-manager/create-pool", () => {
       await expectNotFound(response, "Swarm not found");
     });
 
-    test("returns 403 when user is not owner or member", async () => {
+    test("returns 404 when user is not owner or member (IDOR)", async () => {
+      // The owner/member check was moved above the saveOrUpdateSwarm
+      // (containerFiles) write so a non-member no longer gets the chance
+      // to poison the victim's swarm containerFiles before the 403 fires.
+      // Response now uses the unified 404 "Workspace not found or access
+      // denied" convention.
       const nonMember = await createTestUser({ email: "nonmember@test.com" });
       getMockedSession().mockResolvedValue(createAuthenticatedSession(nonMember));
 
@@ -176,7 +180,7 @@ describe("POST /api/pool-manager/create-pool", () => {
       );
       const response = await POST(request);
 
-      await expectForbidden(response, "Access denied");
+      await expectNotFound(response, "Workspace not found or access denied");
     });
 
     test("allows workspace owner to create pool", async () => {

--- a/src/__tests__/integration/api/swarm-jarvis-search-by-types.test.ts
+++ b/src/__tests__/integration/api/swarm-jarvis-search-by-types.test.ts
@@ -20,9 +20,13 @@ vi.mock("@/services/s3", () => ({
   getS3Service: vi.fn(),
 }));
 
-vi.mock("@/lib/constants", () => ({
-  getSwarmVanityAddress: vi.fn((name: string) => `${name}.sphinx.chat`),
-}));
+vi.mock("@/lib/constants", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/constants")>();
+  return {
+    ...actual,
+    getSwarmVanityAddress: vi.fn((name: string) => `${name}.sphinx.chat`),
+  };
+});
 
 vi.mock("@/lib/auth/nextauth", () => ({
   authOptions: {},
@@ -465,7 +469,10 @@ describe("POST /api/swarm/jarvis/search-by-types", () => {
   });
 
   describe("Swarm Configuration", () => {
-    test("returns 404 when workspace not found", async () => {
+    test("returns 404 when workspace not found or caller lacks access", async () => {
+      // IDOR fix: the membership check now runs before the swarm lookup,
+      // so unknown-workspace and no-access cases collapse into the
+      // unified 'Workspace not found or access denied' message.
       const nonExistentWorkspaceId = "non-existent-workspace-id";
 
       const response = await createAuthenticatedPostRequest(
@@ -477,7 +484,7 @@ describe("POST /api/swarm/jarvis/search-by-types", () => {
       expect(response.status).toBe(404);
       const data = await response.json();
       expect(data.success).toBe(false);
-      expect(data.message).toBe("Workspace not found");
+      expect(data.message).toBe("Workspace not found or access denied");
     });
 
     test("returns mock response when swarm is not configured", async () => {

--- a/src/__tests__/integration/api/swarm-stakgraph-ingest.test.ts
+++ b/src/__tests__/integration/api/swarm-stakgraph-ingest.test.ts
@@ -34,9 +34,17 @@ vi.mock("@/config/services", () => ({
   })),
 }));
 
-vi.mock("@/lib/constants", () => ({
-  getSwarmVanityAddress: vi.fn((name: string) => `${name}.sphinx.chat`),
-}));
+vi.mock("@/lib/constants", async (importOriginal) => {
+  // Partial mock: stub getSwarmVanityAddress so tests don't hit the real
+  // vanity resolver, but keep the rest of the module (WORKSPACE_PERMISSION_LEVELS,
+  // workspace slug constants, etc.) intact since workspace-access helpers
+  // read them.
+  const actual = await importOriginal<typeof import("@/lib/constants")>();
+  return {
+    ...actual,
+    getSwarmVanityAddress: vi.fn((name: string) => `${name}.sphinx.chat`),
+  };
+});
 
 vi.mock("@/lib/url", () => ({
   getGithubWebhookCallbackUrl: vi.fn(() => "https://app.example.com/api/github/webhook"),

--- a/src/__tests__/integration/api/tests/nodes.test.ts
+++ b/src/__tests__/integration/api/tests/nodes.test.ts
@@ -177,9 +177,11 @@ describe("GET /api/tests/nodes Integration Tests", () => {
       );
 
       const response = await GET(request);
-      
-      // Check actual response structure  
-      expect(response.status).toBe(403);
+
+      // The access check now runs before any primary-repo glob writes
+      // and returns the unified 404 rather than a 403 that fired after
+      // the writes had already landed (see plan Phase B #18).
+      expect(response.status).toBe(404);
       const data = await response.json();
       expect(data.success).toBe(false);
       expect(data.message).toContain("Workspace not found or access denied");
@@ -666,7 +668,7 @@ describe("GET /api/tests/nodes Integration Tests", () => {
 
     test("should return 404 for non-existent workspace", async () => {
       const user = await createTestUser();
-      
+
       getMockedSession().mockResolvedValue(createAuthenticatedSession(user));
 
       const request = createGetRequest(
@@ -675,9 +677,10 @@ describe("GET /api/tests/nodes Integration Tests", () => {
       );
 
       const response = await GET(request);
-      
-      // Check actual response structure  
-      expect(response.status).toBe(403);
+
+      // Unified 404 for "unknown workspace" and "no access" — the check
+      // now runs before any repo write (plan Phase B #18).
+      expect(response.status).toBe(404);
       const data = await response.json();
       expect(data.success).toBe(false);
       expect(data.message).toContain("Workspace not found or access denied");
@@ -715,7 +718,11 @@ describe("GET /api/tests/nodes Integration Tests", () => {
       }
     });
 
-    test("should prioritize swarmId over workspaceId when both provided", async () => {
+    test("rejects body-supplied workspaceId that caller lacks access to, even when swarmId is also present", async () => {
+      // The access check now runs based on the body workspaceId and
+      // fires before the swarm lookup, so a non-member combining a
+      // victim's workspaceId with some swarmId they know can no longer
+      // slip through. Unified 404.
       const { user, swarm } = await createTestWorkspaceWithSwarm();
       const otherUser = await createTestUser({ name: "Other User" });
       const otherWorkspace = await createTestWorkspace({
@@ -733,25 +740,18 @@ describe("GET /api/tests/nodes Integration Tests", () => {
 
       const request = createGetRequest(
         "http://localhost/api/tests/nodes",
-        { 
+        {
           workspaceId: otherWorkspace.id, // Different workspace (user has no access)
-          swarmId: swarm.id // But valid swarm
+          swarmId: swarm.id, // But valid swarm
         }
       );
 
       const response = await GET(request);
-      
+
+      expect(response.status).toBe(404);
       const data = await response.json();
-      // API may not have auth checks for swarmId - check actual behavior
-      if (response.status === 403) {
-        // If auth check still applies when swarmId is present
-        expect(data.message).toContain("Workspace not found or access denied");
-      } else if (response.status === 404) {
-        expect(data.message).toContain("Swarm not found");  
-      } else {
-        expect(response.status).toBe(200);
-        expect(data.success).toBe(true);
-      }
+      expect(data.success).toBe(false);
+      expect(data.message).toContain("Workspace not found or access denied");
     });
   });
 });

--- a/src/__tests__/integration/api/workflow-versions.test.ts
+++ b/src/__tests__/integration/api/workflow-versions.test.ts
@@ -151,13 +151,18 @@ describe("GET /api/workspaces/[slug]/workflows/[workflowId]/versions", () => {
       expect(response.status).toBe(404);
       const data = await response.json();
       expect(data.success).toBe(false);
-      expect(data.error).toBe("Workspace not found");
+      expect(data.error).toBe("Workspace not found or access denied");
     });
 
-    test("returns 404 when user is not a workspace member (workspace not visible)", async () => {
+    test("returns 404 when user is not a workspace member (IDOR hardening)", async () => {
+      // Previously this handler loaded `members` filtered by userId
+      // but never consulted `members.length` or `ownerId`, so any
+      // signed-in user could read workflow_version nodes (including
+      // raw workflow_json) from any workspace slug. The fix enforces
+      // active ownership/membership and returns the unified 404 so
+      // we don't leak workspace existence either.
       const { workspace } = await createTestFixtures();
 
-      // Create a different user who is not a member
       const nonMember = await createTestUser({
         id: generateUniqueId(),
         email: `nonmember-${Date.now()}@example.com`,
@@ -174,9 +179,10 @@ describe("GET /api/workspaces/[slug]/workflows/[workflowId]/versions", () => {
         params: Promise.resolve({ slug: workspace.slug, workflowId: "123" }),
       });
 
-      // Without membership check, workspace is still found so it proceeds
-      // The request will fail at the swarm/graph level
-      expect(response.status).not.toBe(403);
+      expect(response.status).toBe(404);
+      const data = await response.json();
+      expect(data.success).toBe(false);
+      expect(data.error).toContain("Workspace not found or access denied");
     });
   });
 

--- a/src/__tests__/unit/api/agent-logs.test.ts
+++ b/src/__tests__/unit/api/agent-logs.test.ts
@@ -21,6 +21,20 @@ vi.mock("@/lib/utils/blob-fetch", () => ({
   fetchBlobContent: vi.fn(),
 }));
 
+// Stub the workspace-access validator so this unit stays focused on the
+// agent-logs pagination/search paths. Integration coverage owns the
+// real membership check.
+vi.mock("@/services/workspace", () => ({
+  validateWorkspaceAccessById: vi.fn(async () => ({
+    hasAccess: true,
+    canRead: true,
+    canWrite: true,
+    canAdmin: true,
+    userRole: "OWNER",
+    workspace: { id: "ws-1" },
+  })),
+}));
+
 import { GET } from "@/app/api/agent-logs/route";
 import { db } from "@/lib/db";
 import { fetchBlobContent } from "@/lib/utils/blob-fetch";

--- a/src/__tests__/unit/api/agent-rollback-logging.test.ts
+++ b/src/__tests__/unit/api/agent-rollback-logging.test.ts
@@ -82,7 +82,9 @@ describe("POST /api/agent — claimPodForTask rollback logging", () => {
     repositories: [],
   };
 
-  // Task with no podId so the claim path is taken; mode must be "agent"
+  // Task with no podId so the claim path is taken; mode must be "agent".
+  // Includes the nested `workspace` selector the handler uses for the
+  // IDOR membership check (user-1 is the workspace owner).
   const mockTask = {
     id: "task-1",
     workspaceId: "workspace-1",
@@ -92,6 +94,10 @@ describe("POST /api/agent — claimPodForTask rollback logging", () => {
     agentWebhookSecret: null,
     mode: "agent",
     model: null,
+    workspace: {
+      ownerId: "user-1",
+      members: [],
+    },
   };
 
   // Empty portMappings → controlUrl will be undefined → throws "Pod control port not available"

--- a/src/__tests__/unit/api/swarm-stakgraph-ingest-route.test.ts
+++ b/src/__tests__/unit/api/swarm-stakgraph-ingest-route.test.ts
@@ -26,6 +26,18 @@ vi.mock("@/lib/helpers/repository");
 vi.mock("@/services/swarm/stakgraph-actions");
 vi.mock("@/services/swarm/api/swarm");
 vi.mock("@/services/swarm/db");
+// Stub the workspace-access validator so this unit test stays focused on
+// the ingest flow. Integration tests cover the real membership check.
+vi.mock("@/services/workspace", () => ({
+  validateWorkspaceAccessById: vi.fn(async () => ({
+    hasAccess: true,
+    canRead: true,
+    canWrite: true,
+    canAdmin: true,
+    userRole: "OWNER",
+    workspace: { id: "workspace-123" },
+  })),
+}));
 vi.mock("@/lib/encryption", () => ({
   EncryptionService: {
     getInstance: vi.fn(() => ({

--- a/src/app/api/agent-logs/route.ts
+++ b/src/app/api/agent-logs/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getMiddlewareContext, requireAuth } from "@/lib/middleware/utils";
 import { db } from "@/lib/db";
 import { fetchBlobContent } from "@/lib/utils/blob-fetch";
+import { validateWorkspaceAccessById } from "@/services/workspace";
 
 /**
  * GET /api/agent-logs
@@ -46,6 +47,18 @@ export async function GET(request: NextRequest) {
       return NextResponse.json(
         { error: "workspace_id is required" },
         { status: 400 }
+      );
+    }
+
+    // IDOR guard: previously any signed-in user could read agent log
+    // metadata for any workspace, and with `search=...` also surface
+    // matching blob contents. Require an active workspace member (any
+    // role — this endpoint is read-only) before the findMany.
+    const access = await validateWorkspaceAccessById(workspaceId, userOrResponse.id);
+    if (!access.hasAccess || !access.canRead) {
+      return NextResponse.json(
+        { error: "Workspace not found or access denied" },
+        { status: 404 },
       );
     }
 

--- a/src/app/api/agent/branch/route.ts
+++ b/src/app/api/agent/branch/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth/nextauth";
+import { db } from "@/lib/db";
 import { generateCommitMessage } from "@/lib/ai/commit-msg";
 
 export async function POST(request: NextRequest) {
@@ -11,11 +12,45 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
+    const userId = (session.user as { id?: string })?.id;
+    if (!userId) {
+      return NextResponse.json({ error: "Invalid user session" }, { status: 401 });
+    }
+
     const body = await request.json();
     const { taskId } = body;
 
     if (!taskId) {
       return NextResponse.json({ error: "Missing required field: taskId" }, { status: 400 });
+    }
+
+    // IDOR guard: generateCommitMessage reads the full chat history for
+    // the task and returns an AI summary. Without a membership check any
+    // signed-in user can exfiltrate any task's private conversation.
+    // Resolve the task's workspace and verify the caller is an owner or
+    // active member before invoking the AI summarizer.
+    const task = await db.task.findUnique({
+      where: { id: taskId },
+      select: {
+        workspace: {
+          select: {
+            ownerId: true,
+            members: {
+              where: { userId, leftAt: null },
+              select: { userId: true },
+            },
+          },
+        },
+      },
+    });
+
+    const isOwner = task?.workspace.ownerId === userId;
+    const isMember = (task?.workspace.members.length ?? 0) > 0;
+    if (!task || (!isOwner && !isMember)) {
+      return NextResponse.json(
+        { error: "Workspace not found or access denied" },
+        { status: 404 },
+      );
     }
 
     console.log(">>> Generating commit message and branch name for task:", taskId);

--- a/src/app/api/agent/commit/route.ts
+++ b/src/app/api/agent/commit/route.ts
@@ -39,25 +39,37 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Missing required field: branchName" }, { status: 400 });
     }
 
-    // Fetch podId from task record
+    // Fetch task + podId. Derive workspace from task.workspaceId — NEVER
+    // trust the body-supplied workspaceId independently of the task, or
+    // an attacker can combine a victim's taskId with their own workspace
+    // to pass the membership check while writing to the victim's pod.
     const task = await db.task.findUnique({
       where: { id: taskId },
-      select: { podId: true },
+      select: { podId: true, workspaceId: true },
     });
 
     if (!task?.podId) {
       return NextResponse.json({ error: "No pod assigned to this task" }, { status: 400 });
     }
 
+    // Reject mismatched workspaceId to fail loudly on buggy callers, but
+    // authorize only against the task's workspace.
+    if (task.workspaceId !== workspaceId) {
+      return NextResponse.json(
+        { error: "Workspace not found or access denied" },
+        { status: 404 },
+      );
+    }
+
     const podId = task.podId;
 
-    // Verify user has access to the workspace
+    // Verify user has access to the task's workspace
     const workspace = await db.workspace.findFirst({
-      where: { id: workspaceId },
+      where: { id: task.workspaceId },
       include: {
         owner: true,
         members: {
-          where: { userId },
+          where: { userId, leftAt: null },
           select: { role: true },
         },
         swarm: true,
@@ -73,7 +85,21 @@ export async function POST(request: NextRequest) {
     });
 
     if (!workspace) {
-      return NextResponse.json({ error: "Workspace not found" }, { status: 404 });
+      return NextResponse.json(
+        { error: "Workspace not found or access denied" },
+        { status: 404 },
+      );
+    }
+
+    // Unified IDOR guard: non-members cannot see whether the workspace
+    // or task exists.
+    const isOwner = workspace.ownerId === userId;
+    const isMember = workspace.members.length > 0;
+    if (!isOwner && !isMember) {
+      return NextResponse.json(
+        { error: "Workspace not found or access denied" },
+        { status: 404 },
+      );
     }
 
     if (process.env.MOCK_BROWSER_URL) {
@@ -94,13 +120,6 @@ export async function POST(request: NextRequest) {
         },
         { status: 200 },
       );
-    }
-
-    const isOwner = workspace.ownerId === userId;
-    const isMember = workspace.members.length > 0;
-
-    if (!isOwner && !isMember) {
-      return NextResponse.json({ error: "Access denied" }, { status: 403 });
     }
 
     // Check if workspace has a swarm

--- a/src/app/api/agent/diff/route.ts
+++ b/src/app/api/agent/diff/route.ts
@@ -38,10 +38,13 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Missing required field: taskId" }, { status: 400 });
     }
 
-    // Fetch podId from task record
+    // Fetch podId + workspaceId from the task. Derive the authorized
+    // workspace from task.workspaceId — never trust the body-supplied
+    // workspaceId independently, or a caller can combine a victim's
+    // taskId with their own workspaceId and read diffs from the victim's pod.
     const task = await db.task.findUnique({
       where: { id: taskId },
-      select: { podId: true },
+      select: { podId: true, workspaceId: true },
     });
 
     if (!task?.podId) {
@@ -49,16 +52,24 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "No pod assigned to this task" }, { status: 400 });
     }
 
+    if (task.workspaceId !== workspaceId) {
+      console.log(">>> [DIFF] Body workspaceId does not match task.workspaceId");
+      return NextResponse.json(
+        { error: "Workspace not found or access denied" },
+        { status: 404 },
+      );
+    }
+
     const podId = task.podId;
     console.log(">>> [DIFF] Found podId from task:", podId);
 
-    // Verify user has access to the workspace
+    // Verify user has access to the task's workspace
     const workspace = await db.workspace.findFirst({
-      where: { id: workspaceId },
+      where: { id: task.workspaceId },
       include: {
         owner: true,
         members: {
-          where: { userId },
+          where: { userId, leftAt: null },
           select: { role: true },
         },
         swarm: true,
@@ -66,8 +77,22 @@ export async function POST(request: NextRequest) {
     });
 
     if (!workspace) {
-      console.log(">>> [DIFF] Workspace not found:", workspaceId);
-      return NextResponse.json({ error: "Workspace not found" }, { status: 404 });
+      console.log(">>> [DIFF] Workspace not found:", task.workspaceId);
+      return NextResponse.json(
+        { error: "Workspace not found or access denied" },
+        { status: 404 },
+      );
+    }
+
+    const isOwner = workspace.ownerId === userId;
+    const isMember = workspace.members.length > 0;
+    console.log(">>> [DIFF] Access check:", { isOwner, isMember });
+    if (!isOwner && !isMember) {
+      console.log(">>> [DIFF] Access denied");
+      return NextResponse.json(
+        { error: "Workspace not found or access denied" },
+        { status: 404 },
+      );
     }
 
     console.log(">>> [DIFF] Workspace found:", { id: workspace.id, hasSwarm: !!workspace.swarm });
@@ -119,15 +144,6 @@ index 1234567..abcdefg 100644
       };
 
       return NextResponse.json({ success: true, message: mockMessage }, { status: 200 });
-    }
-
-    const isOwner = workspace.ownerId === userId;
-    const isMember = workspace.members.length > 0;
-    console.log(">>> [DIFF] Access check:", { isOwner, isMember });
-
-    if (!isOwner && !isMember) {
-      console.log(">>> [DIFF] Access denied");
-      return NextResponse.json({ error: "Access denied" }, { status: 403 });
     }
 
     // Check if workspace has a swarm

--- a/src/app/api/agent/route.ts
+++ b/src/app/api/agent/route.ts
@@ -417,6 +417,11 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
+  const userId = (session.user as { id?: string })?.id;
+  if (!userId) {
+    return NextResponse.json({ error: "Invalid user session" }, { status: 401 });
+  }
+
   // 1a. Gate agent mode behind feature flag
   if (!canAccessServerFeature(FEATURE_FLAGS.TASK_AGENT_MODE)) {
     return NextResponse.json({ error: "Agent mode is not enabled" }, { status: 403 });
@@ -426,7 +431,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "taskId is required" }, { status: 400 });
   }
 
-  // 2. Load task and message count
+  // 2. Load task (with workspace membership) and message count
   const [task, messageCount] = await Promise.all([
     db.task.findUnique({
       where: { id: taskId },
@@ -438,6 +443,15 @@ export async function POST(request: NextRequest) {
         agentWebhookSecret: true,
         mode: true,
         model: true,
+        workspace: {
+          select: {
+            ownerId: true,
+            members: {
+              where: { userId, leftAt: null },
+              select: { userId: true },
+            },
+          },
+        },
       },
     }),
     db.chatMessage.count({
@@ -445,8 +459,15 @@ export async function POST(request: NextRequest) {
     }),
   ]);
 
-  if (!task) {
-    return NextResponse.json({ error: "Task not found" }, { status: 404 });
+  // IDOR guard: treat "task exists but caller is not a workspace member"
+  // identically to "task does not exist" so we don't leak task existence.
+  const isOwner = task?.workspace.ownerId === userId;
+  const isMember = (task?.workspace.members.length ?? 0) > 0;
+  if (!task || (!isOwner && !isMember)) {
+    return NextResponse.json(
+      { error: "Workspace not found or access denied" },
+      { status: 404 },
+    );
   }
 
   if (task.mode !== "agent") {

--- a/src/app/api/bounty-request/route.ts
+++ b/src/app/api/bounty-request/route.ts
@@ -4,6 +4,7 @@ import { ensureUniqueBountyCode } from "@/lib/bounty-code";
 import { getGithubUsernameAndPAT } from "@/lib/auth/nextauth";
 import { EncryptionService } from "@/lib/encryption";
 import { callStakworkBountyAPI } from "@/services/task-workflow";
+import { validateWorkspaceAccessById } from "@/services/workspace";
 import { getServerSession } from "next-auth/next";
 import { NextRequest, NextResponse } from "next/server";
 import { ChatRole, ChatStatus, ArtifactType, Prisma } from "@prisma/client";
@@ -50,21 +51,42 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Bounty requests are only available for the hive workspace" }, { status: 403 });
     }
 
-    // Generate a unique bounty code
-    const bountyCode = await ensureUniqueBountyCode();
-
-    // Look up source task to get podId and agentPassword
+    // Look up the source task first so we can authorize against its
+    // real workspaceId (NOT the body-supplied sourceWorkspaceSlug/Id —
+    // the existing `=== "hive"` string check is not a membership check).
     const sourceTask = await db.task.findUnique({
       where: { id: sourceTaskId },
       select: {
         podId: true,
         agentPassword: true,
+        workspaceId: true,
       },
     });
 
     if (!sourceTask) {
-      return NextResponse.json({ error: "Source task not found" }, { status: 404 });
+      return NextResponse.json(
+        { error: "Workspace not found or access denied" },
+        { status: 404 },
+      );
     }
+
+    // IDOR guard: before this check any signed-in user could pass a
+    // victim's sourceTaskId (from the hardcoded "hive" workspace) and
+    // get the handler to decrypt that task's agentPassword + inject a
+    // BOUNTY-artifact chat message broadcast via Pusher, with the
+    // attacker recorded as `sourceUserId`. Require canWrite membership
+    // on the source task's actual workspace before any decryption or
+    // chat write runs.
+    const access = await validateWorkspaceAccessById(sourceTask.workspaceId, userId);
+    if (!access.hasAccess || !access.canWrite) {
+      return NextResponse.json(
+        { error: "Workspace not found or access denied" },
+        { status: 404 },
+      );
+    }
+
+    // Generate a unique bounty code
+    const bountyCode = await ensureUniqueBountyCode();
 
     // Create PENDING bounty artifact
     const bountyContent: BountyContent = {

--- a/src/app/api/features/[featureId]/invite/route.ts
+++ b/src/app/api/features/[featureId]/invite/route.ts
@@ -5,6 +5,7 @@ import { db } from "@/lib/db";
 import { EncryptionService } from "@/lib/encryption";
 import { sendToSphinx } from "@/lib/sphinx/daily-pr-summary";
 import type { SphinxConfig } from "@/lib/sphinx/daily-pr-summary";
+import { validateWorkspaceAccessById } from "@/services/workspace";
 
 export const runtime = "nodejs";
 
@@ -18,6 +19,11 @@ export async function POST(
     const session = await getServerSession(authOptions);
     if (!session?.user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const userId = (session.user as { id?: string }).id;
+    if (!userId) {
+      return NextResponse.json({ error: "Invalid user session" }, { status: 401 });
     }
 
     const { featureId } = await params;
@@ -60,10 +66,27 @@ export async function POST(
     });
 
     if (!feature) {
-      return NextResponse.json({ error: "Feature not found" }, { status: 404 });
+      return NextResponse.json(
+        { error: "Workspace not found or access denied" },
+        { status: 404 },
+      );
     }
 
     const workspace = feature.workspace;
+
+    // IDOR guard: before this check any signed-in user could broadcast
+    // attacker-controlled invite messages into the victim workspace's
+    // Sphinx channel using the victim's bot credentials, naming
+    // arbitrary users as invitees. Require an active workspace member
+    // with `canWrite` before decrypting `sphinxBotSecret` or calling
+    // `sendToSphinx`.
+    const access = await validateWorkspaceAccessById(workspace.id, userId);
+    if (!access.hasAccess || !access.canWrite) {
+      return NextResponse.json(
+        { error: "Workspace not found or access denied" },
+        { status: 404 },
+      );
+    }
 
     // Validate Sphinx config
     if (
@@ -78,20 +101,34 @@ export async function POST(
       );
     }
 
-    // Fetch all invitees in one query, then restore the caller's order
+    // Fetch all invitees in one query, then restore the caller's order.
+    // Also require each invitee to be an active member of this workspace
+    // (or the workspace owner) so the caller can't name arbitrary
+    // @-aliases into the Sphinx message.
     const inviteesRaw = await db.user.findMany({
-      where: { id: { in: ids } },
+      where: {
+        id: { in: ids },
+        OR: [
+          { ownedWorkspaces: { some: { id: workspace.id } } },
+          {
+            workspaceMembers: {
+              some: { workspaceId: workspace.id, leftAt: null },
+            },
+          },
+        ],
+      },
       select: { id: true, sphinxAlias: true },
     });
     const invitees = ids
       .map((id) => inviteesRaw.find((u) => u.id === id))
       .filter((u): u is NonNullable<typeof u> => u !== undefined);
 
-    // Validate that every requested invitee exists and has a Sphinx alias
+    // Validate that every requested invitee exists, is a workspace member,
+    // and has a Sphinx alias configured.
     const missingAlias = invitees.find((u) => !u.sphinxAlias);
     if (missingAlias || invitees.length < ids.length) {
       return NextResponse.json(
-        { error: "One or more invitees does not have a Sphinx alias configured" },
+        { error: "One or more invitees is not a workspace member or lacks a Sphinx alias" },
         { status: 400 }
       );
     }

--- a/src/app/api/pool-manager/create-pool/route.ts
+++ b/src/app/api/pool-manager/create-pool/route.ts
@@ -101,7 +101,7 @@ export async function POST(request: NextRequest) {
             slug: true,
             ownerId: true,
             members: {
-              where: { userId },
+              where: { userId, leftAt: null },
               select: { role: true },
             },
           },
@@ -111,6 +111,27 @@ export async function POST(request: NextRequest) {
 
     if (!swarm) {
       return NextResponse.json({ error: "Swarm not found" }, { status: 404 });
+    }
+
+    // IDOR guard: previously the owner/member check ran further down,
+    // AFTER the handler had already called `saveOrUpdateSwarm({ containerFiles })`
+    // with attacker-controlled content. Run the authz check immediately
+    // after the swarm lookup so no swarm row or secret decryption work
+    // happens on behalf of a non-member.
+    if (!swarm.workspace) {
+      return NextResponse.json(
+        { error: "Workspace not found or access denied" },
+        { status: 404 },
+      );
+    }
+
+    const isOwner = swarm.workspace.ownerId === userId;
+    const isMember = swarm.workspace.members.length > 0;
+    if (!isOwner && !isMember) {
+      return NextResponse.json(
+        { error: "Workspace not found or access denied" },
+        { status: 404 },
+      );
     }
 
     // Get poolApiKey from swarm
@@ -231,21 +252,6 @@ export async function POST(request: NextRequest) {
         containerFiles: finalContainerFiles,
       });
       console.log("Generated and saved new container files to database");
-    }
-
-    if (!swarm) {
-      return NextResponse.json({ error: "Swarm not found" }, { status: 404 });
-    }
-
-    if (!swarm.workspace) {
-      return NextResponse.json({ error: "Workspace not found" }, { status: 404 });
-    }
-
-    const isOwner = swarm.workspace.ownerId === userId;
-    const isMember = swarm.workspace.members.length > 0;
-
-    if (!isOwner && !isMember) {
-      return NextResponse.json({ error: "Access denied" }, { status: 403 });
     }
 
     // Validate required fields

--- a/src/app/api/swarm/jarvis/search-by-types/route.ts
+++ b/src/app/api/swarm/jarvis/search-by-types/route.ts
@@ -3,6 +3,7 @@ import { getSwarmVanityAddress } from "@/lib/constants";
 import { db } from "@/lib/db";
 import { getS3Service } from "@/services/s3";
 import { swarmApiRequest } from "@/services/swarm/api/swarm";
+import { validateWorkspaceAccessById } from "@/services/workspace";
 import type { JarvisNode, JarvisResponse, SearchByTypesRequest } from "@/types/jarvis";
 import { getServerSession } from "next-auth/next";
 import { NextRequest, NextResponse } from "next/server";
@@ -102,10 +103,25 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const where: Record<string, string> = {};
-    if (workspaceId) where.workspaceId = workspaceId;
+    if (!workspaceId) {
+      return NextResponse.json(
+        { success: false, message: "Missing required query parameter: id" },
+        { status: 400 },
+      );
+    }
 
-    const swarm = await db.swarm.findFirst({ where });
+    // IDOR guard: a non-member could previously run arbitrary graph
+    // queries against the victim's swarm using its decrypted swarmApiKey,
+    // exfiltrating functions / files / presigned S3 media URLs.
+    const access = await validateWorkspaceAccessById(workspaceId, session.user.id);
+    if (!access.hasAccess || !access.canRead) {
+      return NextResponse.json(
+        { success: false, message: "Workspace not found or access denied" },
+        { status: 404 },
+      );
+    }
+
+    const swarm = await db.swarm.findFirst({ where: { workspaceId } });
 
     // Return mock data if swarm is not configured (for development/testing)
     if (!swarm || !swarm.swarmUrl || !swarm.swarmApiKey) {

--- a/src/app/api/swarm/stakgraph/ingest/route.ts
+++ b/src/app/api/swarm/stakgraph/ingest/route.ts
@@ -10,6 +10,7 @@ import { WebhookService } from "@/services/github/WebhookService";
 import { swarmApiRequest } from "@/services/swarm/api/swarm";
 import { saveOrUpdateSwarm } from "@/services/swarm/db";
 import { triggerIngestAsync, checkStakgraphAvailability, SyncOptions } from "@/services/swarm/stakgraph-actions";
+import { validateWorkspaceAccessById } from "@/services/workspace";
 import { RepositoryStatus } from "@prisma/client";
 import { getServerSession } from "next-auth/next";
 import { NextRequest, NextResponse } from "next/server";
@@ -44,6 +45,19 @@ export async function POST(request: NextRequest) {
     if (!workspaceId) {
       console.log(`[STAKGRAPH_INGEST] No workspaceId provided`);
       return NextResponse.json({ success: false, message: "Workspace ID is required" }, { status: 400 });
+    }
+
+    // IDOR guard: a non-member could previously trigger a real stakgraph
+    // ingest against the victim's swarm (burning credits, attacker-PAT
+    // cloning victim repos) and flip repos to PENDING. Require an active
+    // member with write permission before any swarm read or DB write.
+    const access = await validateWorkspaceAccessById(workspaceId, session.user.id);
+    if (!access.hasAccess || !access.canWrite) {
+      console.log(`[STAKGRAPH_INGEST] Access denied for user ${session.user.id} on workspace ${workspaceId}`);
+      return NextResponse.json(
+        { success: false, message: "Workspace not found or access denied" },
+        { status: 404 },
+      );
     }
 
     console.log(`[STAKGRAPH_INGEST] Looking up swarm for workspace: ${workspaceId}`);
@@ -377,6 +391,18 @@ export async function GET(request: NextRequest) {
       return NextResponse.json(
         { success: false, message: "Missing required fields: id, workspaceId" },
         { status: 400 },
+      );
+    }
+
+    // IDOR guard: reading ingest status via the victim's decrypted
+    // swarmApiKey is not free (it leaks progress + indirectly the shape
+    // of the ingest). Require active membership on the workspace.
+    const access = await validateWorkspaceAccessById(workspaceId, session.user.id);
+    if (!access.hasAccess || !access.canRead) {
+      console.log(`[STAKGRAPH_STATUS] Access denied for user ${session.user.id} on workspace ${workspaceId}`);
+      return NextResponse.json(
+        { success: false, message: "Workspace not found or access denied" },
+        { status: 404 },
       );
     }
 

--- a/src/app/api/swarm/stakgraph/services/route.ts
+++ b/src/app/api/swarm/stakgraph/services/route.ts
@@ -7,6 +7,7 @@ import { swarmApiRequestAuth } from "@/services/swarm/api/swarm";
 import { saveOrUpdateSwarm, ServiceConfig } from "@/services/swarm/db";
 import { checkStakgraphAvailability } from "@/services/swarm/stakgraph-actions";
 import { fetchStakgraphServices } from "@/services/swarm/stakgraph-services";
+import { validateWorkspaceAccessById } from "@/services/workspace";
 import { parseGithubOwnerRepo } from "@/utils/repositoryParser";
 import { getServerSession } from "next-auth/next";
 import { NextRequest, NextResponse } from "next/server";
@@ -55,6 +56,19 @@ export async function GET(request: NextRequest) {
 
     if (!swarm) {
       return NextResponse.json({ success: false, message: "Swarm not found" }, { status: 404 });
+    }
+
+    // IDOR guard: a non-member could previously drive the services_agent
+    // against the victim's swarm using its decrypted swarmApiKey and
+    // overwrite agentRequestId / services / environmentVariables on the
+    // victim's swarm row. Authorize against the swarm's actual workspace,
+    // not the body-supplied workspaceId.
+    const access = await validateWorkspaceAccessById(swarm.workspaceId, session.user.id);
+    if (!access.hasAccess || !access.canWrite) {
+      return NextResponse.json(
+        { success: false, message: "Workspace not found or access denied" },
+        { status: 404 },
+      );
     }
 
     if (!swarm.swarmUrl || !swarm.swarmApiKey) {

--- a/src/app/api/swarm/stakgraph/sync/route.ts
+++ b/src/app/api/swarm/stakgraph/sync/route.ts
@@ -4,6 +4,7 @@ import { db } from "@/lib/db";
 import { getStakgraphWebhookCallbackUrl } from "@/lib/url";
 import { saveOrUpdateSwarm } from "@/services/swarm/db";
 import { AsyncSyncResult, triggerAsyncSync } from "@/services/swarm/stakgraph-actions";
+import { validateWorkspaceAccessById } from "@/services/workspace";
 import { RepositoryStatus } from "@prisma/client";
 import { getServerSession } from "next-auth/next";
 import { NextRequest, NextResponse } from "next/server";
@@ -36,6 +37,20 @@ export async function POST(request: NextRequest) {
       console.error("[Sync] Swarm not found or misconfigured", { workspaceId, swarmId });
       return NextResponse.json({ success: false, message: "Swarm not found or misconfigured" }, { status: 400 });
     }
+
+    // IDOR guard: a non-member could previously force a sync (flipping
+    // repos to PENDING/FAILED, overwriting ingestRefId, and registering
+    // a webhook callback URL pointing at an attacker-controlled host
+    // when combined with request spoofing). Authorize against the
+    // swarm's actual workspace, not any body-supplied id.
+    const access = await validateWorkspaceAccessById(swarm.workspaceId, session.user.id);
+    if (!access.hasAccess || !access.canWrite) {
+      return NextResponse.json(
+        { success: false, message: "Workspace not found or access denied" },
+        { status: 404 },
+      );
+    }
+
     const primaryRepo = await getPrimaryRepository(swarm.workspaceId);
     const repositoryUrl = primaryRepo?.repositoryUrl;
 

--- a/src/app/api/tasks/create-from-transcript/route.ts
+++ b/src/app/api/tasks/create-from-transcript/route.ts
@@ -2,8 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { type ModelMessage } from "ai";
 import { getMiddlewareContext, requireAuth } from "@/lib/middleware/utils";
 import { extractTaskFromTranscript } from "@/lib/ai/extract-task";
-import { db } from "@/lib/db";
 import { createTaskWithStakworkWorkflow } from "@/services/task-workflow";
+import { validateWorkspaceAccess } from "@/services/workspace";
 import { Priority } from "@prisma/client";
 
 export async function POST(request: NextRequest) {
@@ -33,14 +33,20 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Get workspace ID from slug
-    const workspace = await db.workspace.findUnique({
-      where: { slug: workspaceSlug },
-      select: { id: true },
-    });
-
-    if (!workspace) {
-      return NextResponse.json({ error: "Workspace not found" }, { status: 404 });
+    // IDOR guard: without a membership check any signed-in user could
+    // pass another workspace's slug and fire a live Stakwork workflow
+    // (burning victim credits) against the victim's swarm, leaking the
+    // attacker-supplied transcript into the victim's AI pipeline and
+    // dropping a task + chat messages into the victim's workspace.
+    // Resolve the workspace through `validateWorkspaceAccess` so the
+    // membership + role check runs before `extractTaskFromTranscript`
+    // or `createTaskWithStakworkWorkflow`.
+    const access = await validateWorkspaceAccess(workspaceSlug, userOrResponse.id);
+    if (!access.hasAccess || !access.canWrite || !access.workspace) {
+      return NextResponse.json(
+        { error: "Workspace not found or access denied" },
+        { status: 404 },
+      );
     }
 
     console.log("🎤 Creating task from voice transcript:", {
@@ -57,7 +63,7 @@ export async function POST(request: NextRequest) {
     const result = await createTaskWithStakworkWorkflow({
       title: extractedTask.title,
       description: extractedTask.description,
-      workspaceId: workspace.id,
+      workspaceId: access.workspace.id,
       priority: Priority.HIGH, // HIGH priority for voice-created tasks
       sourceType: "USER",
       userId: userOrResponse.id,

--- a/src/app/api/tests/coverage/route.ts
+++ b/src/app/api/tests/coverage/route.ts
@@ -4,6 +4,7 @@ import { swarmApiRequest } from "@/services/swarm/api/swarm";
 import { EncryptionService } from "@/lib/encryption";
 import { convertGlobsToRegex } from "@/lib/utils/glob";
 import { getPrimaryRepository } from "@/lib/helpers/repository";
+import { validateWorkspaceAccessById } from "@/services/workspace";
 import { getServerSession } from "next-auth/next";
 import { NextRequest, NextResponse } from "next/server";
 import { TestCoverageData } from "@/types/test-coverage";
@@ -35,6 +36,22 @@ export async function GET(request: NextRequest) {
     let finalUnitGlob = unitGlobParam;
     let finalIntegrationGlob = integrationGlobParam;
     let finalE2eGlob = e2eGlobParam;
+
+    // IDOR guard: before this check the handler happily accepted a
+    // body-supplied `workspaceId` and overwrote the primary repo's
+    // ignoreDirs / unitGlob / integrationGlob / e2eGlob fields (poisoning
+    // the victim's future test runs) and decrypted the victim's
+    // swarmApiKey. Authorize the caller as a write-capable member of
+    // the target workspace before any repo update or swarm fetch.
+    if (workspaceId) {
+      const access = await validateWorkspaceAccessById(workspaceId, session.user.id);
+      if (!access.hasAccess || !access.canWrite) {
+        return NextResponse.json(
+          { success: false, message: "Workspace not found or access denied" },
+          { status: 404 },
+        );
+      }
+    }
 
     if (workspaceId && !swarmId) {
       const primaryRepo = await getPrimaryRepository(workspaceId);

--- a/src/app/api/tests/nodes/route.ts
+++ b/src/app/api/tests/nodes/route.ts
@@ -204,6 +204,21 @@ export async function GET(request: NextRequest) {
     let finalIntegrationGlob = integrationGlobParam;
     let finalE2eGlob = e2eGlobParam;
 
+    // IDOR guard: previously this check ran AFTER the primary-repo
+    // ignoreDirs / unitGlob / integrationGlob / e2eGlob writes below,
+    // so a non-member could poison the victim's repo glob config and
+    // only then receive a 403. Authorize before any write. Require
+    // canWrite because the repo fields are mutated from query params.
+    if (workspaceId) {
+      const access = await validateWorkspaceAccessById(workspaceId, session.user.id);
+      if (!access.hasAccess || !access.canWrite) {
+        return NextResponse.json(
+          { success: false, message: "Workspace not found or access denied" },
+          { status: 404 },
+        );
+      }
+    }
+
     if (workspaceId && !swarmId) {
       const primaryRepo = await getPrimaryRepository(workspaceId);
       if (primaryRepo) {
@@ -272,13 +287,6 @@ export async function GET(request: NextRequest) {
         { success: false, message: "Missing required parameter: workspaceId or swarmId" },
         { status: 400 },
       );
-    }
-
-    if (workspaceId) {
-      const workspaceAccess = await validateWorkspaceAccessById(workspaceId, session.user.id);
-      if (!workspaceAccess.hasAccess) {
-        return NextResponse.json({ success: false, message: "Workspace not found or access denied" }, { status: 403 });
-      }
     }
 
     const where: Record<string, string> = {};

--- a/src/app/api/upload/image/route.ts
+++ b/src/app/api/upload/image/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth/next'
 import { authOptions } from '@/lib/auth/nextauth'
 import { getS3Service } from '@/services/s3'
 import { db } from '@/lib/db'
+import { validateWorkspaceAccessById } from '@/services/workspace'
 import { z } from 'zod'
 
 const uploadRequestSchema = z.object({
@@ -23,10 +24,18 @@ export async function POST(request: NextRequest) {
       )
     }
 
+    const userId = (session.user as { id?: string }).id
+    if (!userId) {
+      return NextResponse.json(
+        { error: 'Invalid user session' },
+        { status: 401 }
+      )
+    }
+
     const body = await request.json()
     const validatedData = uploadRequestSchema.parse(body)
     const { filename, contentType, size, featureId } = validatedData
-    
+
     // Get feature with workspace information
     const feature = await db.feature.findFirst({
       where: {
@@ -47,16 +56,30 @@ export async function POST(request: NextRequest) {
         },
       },
     })
-    
+
     if (!feature) {
       return NextResponse.json(
-        { error: 'Feature not found' },
+        { error: 'Workspace not found or access denied' },
         { status: 404 }
       )
     }
-    
+
     const workspaceId = feature.workspace.id
     const swarmId = feature.workspace.swarm?.id || 'default'
+
+    // IDOR guard: previously any signed-in user could pass another
+    // workspace's `featureId` and receive a write-capable presigned
+    // upload URL + a long-lived presigned download URL under that
+    // workspace's S3 prefix. Require an active workspace member with
+    // write permission before issuing either URL. Return the unified
+    // 404 so we don't leak whether the feature exists.
+    const access = await validateWorkspaceAccessById(workspaceId, userId)
+    if (!access.hasAccess || !access.canWrite) {
+      return NextResponse.json(
+        { error: 'Workspace not found or access denied' },
+        { status: 404 }
+      )
+    }
 
     // Validate file type
     if (!getS3Service().validateFileType(contentType)) {

--- a/src/app/api/workspaces/[slug]/workflows/[workflowId]/versions/route.ts
+++ b/src/app/api/workspaces/[slug]/workflows/[workflowId]/versions/route.ts
@@ -48,7 +48,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       include: {
         owner: true,
         members: {
-          where: { userId },
+          where: { userId, leftAt: null },
           select: { role: true },
         },
         swarm: true,
@@ -57,7 +57,25 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     });
 
     if (!workspace) {
-      return NextResponse.json({ success: false, error: "Workspace not found" }, { status: 404 });
+      return NextResponse.json(
+        { success: false, error: "Workspace not found or access denied" },
+        { status: 404 },
+      );
+    }
+
+    // IDOR guard: the handler loaded `members` filtered by userId but
+    // never checked `members.length` or `ownerId`, so any signed-in
+    // user could read workflow_version nodes (including raw
+    // workflow_json) from any workspace slug via the victim's
+    // decrypted swarmApiKey. Require active ownership or membership
+    // before decrypting credentials or calling the graph API.
+    const isOwner = workspace.ownerId === userId;
+    const isMember = workspace.members.length > 0;
+    if (!isOwner && !isMember) {
+      return NextResponse.json(
+        { success: false, error: "Workspace not found or access denied" },
+        { status: 404 },
+      );
     }
 
     // Validate workflowId is a valid number


### PR DESCRIPTION
## Summary

Lands Phase B of the [workspace IDOR hardening plan](docs/plans/workspace-idor-hardening.md) — 17 of the 20 High-severity findings (#6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #22, #24, #25). Remaining Phase B items (#20 github/app/callback signed state, #21 github/webhook/ensure, #23 orgs/connections) and Phases C/D stay open for follow-up PRs.

Every fixed handler now runs the workspace membership check **before** any credentialed side-effect (swarm API key decryption, pod credential write, Stakwork/Sphinx/LiveKit/Pusher call, presigned-URL minting, repo config mutation) and returns the unified `404 "Workspace not found or access denied"` so task/workspace existence isn't leaked.

## Clusters

| Commit | Findings | Handlers |
|---|---|---|
| `3d39db80` | #8, #9, #10, #11 | /api/agent, /api/agent/commit, /api/agent/diff, /api/agent/branch |
| `7b5a2fa7` | #13, #14, #15, #16 | stakgraph/ingest (POST+GET), stakgraph/services, stakgraph/sync, jarvis/search-by-types |
| `5d51bcd5` | #17, #18 | tests/coverage, tests/nodes |
| `9b3af87c` | #25 | upload/image |
| `44f28a27` | #6, #7 | tasks/create-from-transcript, features/[featureId]/invite |
| `90146994` | #12 | agent-logs |
| `80f8b0f0` | #19 | pool-manager/create-pool |
| `1d710668` | #22 | workspaces/[slug]/workflows/[workflowId]/versions |
| `510224bf` | #24 | bounty-request |

## Notable patterns used

- **Task↔workspace decoupling fix (#9, #10, #24):** Derive the authorized `workspaceId` from `task.workspaceId` and reject mismatched body `workspaceId`. Closes the "victim taskId + attacker workspaceId" bypass.
- **Access check above writes (#18, #19):** Moved pre-existing checks up past primary-repo / swarm container-file writes so a non-member can no longer poison config before the 403.
- **Invitee-membership check (#7):** Narrow `db.user.findMany` for invitees to users who own the workspace or have an active `workspaceMembers` row — caller can't name arbitrary @-aliases into Sphinx.
- **Unified 404 convention:** All fixed handlers return `404 "Workspace not found or access denied"` per the plan; existing tests flipped from 403 → 404 where applicable.

## Testing

- All 7699 unit tests pass.
- All 3760 integration tests pass.
- Lint clean on every modified file; no new TypeScript errors.
- Existing tests updated where the fix changed response shape (see per-cluster commit messages).
- No new tests added for /api/agent/* (feature-flagged behind `TASK_AGENT_MODE` and not live in prod per owner request) or for routes with only `describe.skip`ed suites; every other fix re-used the existing integration coverage.

## Plan doc

`docs/plans/workspace-idor-hardening.md` is updated with a per-finding Status section and a progress summary so the next PR can pick up where this leaves off.