### PR TITLE
Harden workspace IDOR on github callback/webhook/orgs (Phase B #20, #21, #23)

### DIFF
--- a/docs/plans/workspace-idor-hardening.md
+++ b/docs/plans/workspace-idor-hardening.md
@@ -112,7 +112,34 @@ tackled in a follow-up effort.
     message, or calling the Stakwork bounty API; the bare
     `sourceWorkspaceSlug === "hive"` string check is no longer the
     real auth gate.
-  - Remaining Phase B items (#20, #21, #23) — not started.
+  - **Github callback / webhook / orgs cluster (#20, #21, #23) —
+    DONE** on branch `ef/idor-fixes-3`. `/api/github/app/callback` now
+    verifies an HMAC-signed `state` (new helper
+    `src/lib/auth/github-app-state.ts`, signed in `/api/github/app/install`
+    with `NEXTAUTH_SECRET`), re-checks that the state is bound to the
+    caller's `session.githubState`, and requires `canAdmin` on the
+    workspace slug *before* the token exchange or any
+    `workspace.sourceControlOrgId` rewire — the legacy unsigned base64
+    state is now rejected as malformed. `/api/github/webhook/ensure`
+    requires `canWrite` on the body-supplied `workspaceId` before
+    `ensureRepoWebhook` so a non-member can no longer overwrite a
+    victim's `githubWebhookId` / `githubWebhookSecret`.
+    `/api/orgs/[githubLogin]/connections` GET now requires the caller
+    to belong to at least one workspace under the org before the
+    `db.connection.findMany`, and DELETE additionally requires
+    OWNER/ADMIN — both paths return a unified 404 on failure so org
+    existence isn't leaked. Tests: new `github-app-state` unit suite
+    (13 tests), five new IDOR-hardening integration tests on
+    `github-app-callback.test.ts` (legacy-state rejection,
+    session-binding replay, non-admin member, non-member slug
+    takeover, tampered signature), the existing callback tests were
+    updated to use a `signStateFor` helper that binds the signed
+    state to the user's DB session (plus a `mockReset` fix to stop
+    stale `mockResolvedValueOnce` queues bleeding between tests),
+    the install-route tests were updated to parse the new
+    `<base64url>.<hex>` format, and three new IDOR test blocks on the
+    webhook-ensure unit suite + eleven new integration tests on the
+    org-connections route.
 - **Phase C (Medium #26–30)** — not started.
 - **Phase D (shared-secret S1–S3)** — not started.
 - **"also" items** (public-viewer 7-day → 1-hour presigned URLs;
@@ -504,6 +531,33 @@ proof-of-exploit, and suggested fix.
   incoming state; and require
   `validateWorkspaceAccess(workspaceSlug, userId)` with `canAdmin`
   before mutating `workspace.sourceControlOrgId`.
+- **Status**: ✅ Fixed on `ef/idor-fixes-3`. New helper
+  `src/lib/auth/github-app-state.ts` signs the state payload with
+  HMAC-SHA256 (format: `<base64url-json>.<hex-sig>`) and re-validates
+  on the callback side with a constant-time compare, a 1h expiry
+  window, and a structural `workspaceSlug`/`randomState`/`timestamp`
+  check. The install route (`/api/github/app/install`) now emits the
+  signed state; the callback route now (a) rejects unsigned/legacy
+  states outright, (b) re-checks `session.findFirst({userId,
+  githubState: state})` so a signed state issued to one user can't
+  be replayed by another, and (c) runs `validateWorkspaceAccess`
+  with `canAdmin` before the token exchange or any
+  `workspace.updateMany({sourceControlOrgId})` write — non-admins
+  see `error=workspace_access_denied` with no side-effects. Tests:
+  new `src/__tests__/unit/lib/github-app-state.test.ts` (13 tests
+  covering sign/verify happy-path, body tampering, signature
+  tampering, secret rotation, expiry, missing fields, legacy-format
+  rejection) and five new IDOR integration tests on
+  `github-app-callback.test.ts` (legacy base64 rejection, signed
+  state replayed to the wrong user, non-admin member, completely
+  non-member, tampered signature) — all five assert `mockFetch`
+  was never called and the victim's `sourceControlOrgId` was left
+  untouched. Existing `github-app-callback.test.ts` was swept to
+  use a new `signStateFor` helper (signs + binds to a real
+  `Session` row per call) and `github-app-install.test.ts` was
+  updated to parse the new signed format. Also swapped the suite's
+  `beforeEach` from `mockClear` to `mockReset` to stop stale
+  `mockResolvedValueOnce` queues from bleeding between tests.
 
 #### 21. `src/app/api/github/webhook/ensure/route.ts` — POST
 - **Bug**: `db.repository.findUnique({ where: { id: repositoryId } })`
@@ -515,6 +569,19 @@ proof-of-exploit, and suggested fix.
   callbacks under the new attacker-known secret.
 - **Fix**: `validateWorkspaceAccessById(workspaceId, userId)` with
   `canWrite` before `ensureRepoWebhook`.
+- **Status**: ✅ Fixed on `ef/idor-fixes-3`. The `canWrite`
+  membership check now runs immediately after the missing-fields
+  400 and before the `repository.findUnique` lookup, callback URL
+  construction, and `WebhookService.ensureRepoWebhook` call —
+  returns the unified 404 on failure so repository existence isn't
+  leaked either. Also added the ordering guarantee that auth
+  precedes the `repositoryId → url` lookup so an attacker can't use
+  the endpoint as a probe for arbitrary repository ids. Tests:
+  three new IDOR unit tests on
+  `src/__tests__/unit/api/github/webhook-ensure-route.test.ts`
+  (non-member → 404 + no webhook side-effects, VIEWER → 404,
+  check-before-lookup ordering) plus a stubbed
+  `@/services/workspace` mock so the 34 existing tests still pass.
 
 #### 22. `src/app/api/workspaces/[slug]/workflows/[workflowId]/versions/route.ts` — GET
 - **Bug**: fetches workspace with `members: { where: { userId } }` but
@@ -549,6 +616,23 @@ proof-of-exploit, and suggested fix.
   workspace under `org.id` (pattern used in
   `orgs/[githubLogin]/workspaces/route.ts`). DELETE additionally
   requires ADMIN/OWNER.
+- **Status**: ✅ Fixed on `ef/idor-fixes-3`. A new private helper
+  `resolveAuthorizedOrgId(githubLogin, userId, requireAdmin)` in
+  the route file resolves the org id only when the caller owns or
+  is an active member of at least one workspace under it — for
+  DELETE we pass `requireAdmin: true`, which narrows the match to
+  OWNER or WorkspaceRole.ADMIN. GET now uses the resolved org id
+  to scope `db.connection.findMany`; DELETE first uses it to scope
+  the existence lookup, then only deletes when found. Unknown
+  `githubLogin` and non-qualifying callers both get the unified
+  404 "Organization not found" so org existence isn't leaked.
+  Tests: new integration suite
+  `src/__tests__/integration/api/orgs-connections.test.ts` with 11
+  tests covering GET (unauth → 401, non-member attacker → 404
+  with no payload leakage, unknown org → 404, owner happy-path,
+  plain DEVELOPER member happy-path) and DELETE (unauth → 401,
+  non-member → 404 with no write, DEVELOPER → 404 with no write,
+  OWNER deletes, ADMIN deletes, missing connectionId → 400).
 
 #### 24. `src/app/api/bounty-request/route.ts` — POST
 - **Bug**: only a `sourceWorkspaceSlug === "hive"` string check — no
@@ -682,7 +766,7 @@ require session auth + workspace admin.
    - Pool manager (#19) ✅ on `ef/idor-fixes-2`.
    - Workflows/versions (#22) ✅ on `ef/idor-fixes-2`.
    - Bounty request (#24) ✅ on `ef/idor-fixes-2`.
-   - Remaining (#20, #21, #23) still open.
+   - Github cluster (#20, #21, #23) ✅ on `ef/idor-fixes-3`.
 3. **Phase C — medium (#26–30)**: one cleanup PR.
 4. **Phase D — shared-secret endpoints (S1–S3)**: design work on
    per-resource tokens, then migrate webhooks to the new scheme.

--- a/src/__tests__/integration/api/github-app-callback.test.ts
+++ b/src/__tests__/integration/api/github-app-callback.test.ts
@@ -17,6 +17,52 @@ import { createTestUser } from "@/__tests__/support/factories/user.factory";
 import { createTestWorkspace } from "@/__tests__/support/factories/workspace.factory";
 import { db } from "@/lib/db";
 import { EncryptionService } from "@/lib/encryption";
+import { signGithubAppState } from "@/lib/auth/github-app-state";
+
+// Ensure NEXTAUTH_SECRET is set before signGithubAppState runs. The
+// integration test env sets this, but we assert it defensively here so
+// that running this suite in isolation fails loudly instead of minting
+// unsigned state that the handler will reject.
+if (!process.env.NEXTAUTH_SECRET) {
+  process.env.NEXTAUTH_SECRET = "test-nextauth-secret-for-integration-tests";
+}
+
+/**
+ * Signs a state payload and optionally mirrors it onto the user's
+ * NextAuth session row (so the handler's "state bound to session"
+ * check passes).
+ */
+async function signStateFor(
+  user: { id: string },
+  data: { workspaceSlug: string; repositoryUrl?: string; timestamp?: number },
+  { bindToSession = true }: { bindToSession?: boolean } = {},
+): Promise<string> {
+  // Use a NEW random value per call so even within a single test every
+  // signed state is unique. Previously the fixed `randomState` caused
+  // later calls to compute the same signature, and `signStateFor` for
+  // user A would collide on `session.findFirst({userId:A})` with a
+  // prior test's leftover session row that had a stale `githubState`.
+  const state = signGithubAppState({
+    workspaceSlug: data.workspaceSlug,
+    repositoryUrl: data.repositoryUrl,
+    randomState: `test-random-${Math.random().toString(36).slice(2)}`,
+    timestamp: data.timestamp ?? Date.now(),
+  });
+  if (bindToSession) {
+    // Always create a brand-new session row rather than mutating any
+    // existing one. The handler only cares that *some* session for
+    // this user has `githubState === state`.
+    await db.session.create({
+      data: {
+        userId: user.id,
+        sessionToken: `sess-${user.id}-${Date.now()}-${Math.random()}`,
+        expires: new Date(Date.now() + 24 * 60 * 60 * 1000),
+        githubState: state,
+      },
+    });
+  }
+  return state;
+}
 
 // Mock next-auth for session management
 vi.mock("next-auth/next");
@@ -43,8 +89,12 @@ global.fetch = mockFetch;
 
 describe("GitHub App Callback API Integration Tests", () => {
   beforeEach(async () => {
-    vi.clearAllMocks();
-    mockFetch.mockClear();
+    // `mockClear` keeps the `mockResolvedValueOnce` queue around, which
+    // caused leftover mocks from earlier tests to bleed into later ones.
+    // `mockReset` clears both the call history AND any queued
+    // implementations, which is what we actually want between tests.
+    vi.resetAllMocks();
+    mockFetch.mockReset();
   });
 
   describe("GET /api/github/app/callback", () => {
@@ -66,7 +116,7 @@ describe("GitHub App Callback API Integration Tests", () => {
           workspaceSlug: workspace.slug,
           timestamp: Date.now(),
         };
-        const state = Buffer.from(JSON.stringify(stateData)).toString("base64");
+        const state = await signStateFor(testUser, stateData);
 
         // Mock GitHub token exchange
         mockFetch.mockResolvedValueOnce({
@@ -221,7 +271,7 @@ describe("GitHub App Callback API Integration Tests", () => {
           workspaceSlug: workspace.slug,
           timestamp: Date.now(),
         };
-        const state = Buffer.from(JSON.stringify(stateData)).toString("base64");
+        const state = await signStateFor(testUser, stateData);
 
         // Mock token exchange
         mockFetch.mockResolvedValueOnce({
@@ -294,7 +344,7 @@ describe("GitHub App Callback API Integration Tests", () => {
           workspaceSlug: workspace.slug,
           timestamp: Date.now(),
         };
-        const state = Buffer.from(JSON.stringify(stateData)).toString("base64");
+        const state = await signStateFor(testUser, stateData);
 
         // Mock token exchange
         mockFetch.mockResolvedValueOnce({
@@ -374,7 +424,7 @@ describe("GitHub App Callback API Integration Tests", () => {
           workspaceSlug: workspace.slug,
           timestamp: Date.now(),
         };
-        const state = Buffer.from(JSON.stringify(stateData)).toString("base64");
+        const state = await signStateFor(testUser, stateData);
 
         // Mock token exchange
         mockFetch.mockResolvedValueOnce({
@@ -448,7 +498,7 @@ describe("GitHub App Callback API Integration Tests", () => {
           workspaceSlug: workspace.slug,
           timestamp: Date.now(),
         };
-        const state = Buffer.from(JSON.stringify(stateData)).toString("base64");
+        const state = await signStateFor(testUser, stateData);
 
         // Mock token exchange
         mockFetch.mockResolvedValueOnce({
@@ -510,17 +560,13 @@ describe("GitHub App Callback API Integration Tests", () => {
       test("should redirect to /auth for unauthenticated user", async () => {
         getMockedSession().mockResolvedValue(mockUnauthenticatedSession());
 
-        const stateData = {
-          workspaceSlug: "test-workspace",
-          timestamp: Date.now(),
-        };
-        const state = Buffer.from(JSON.stringify(stateData)).toString("base64");
-
+        // Auth check runs before state verification, so the state value
+        // doesn't matter here — any non-empty string works.
         const request = createGetRequest(
           "http://localhost:3000/api/github/app/callback",
           {
             code: "test_code",
-            state,
+            state: "irrelevant-state-auth-fails-first",
           }
         );
 
@@ -538,17 +584,11 @@ describe("GitHub App Callback API Integration Tests", () => {
           expires: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
         });
 
-        const stateData = {
-          workspaceSlug: "test-workspace",
-          timestamp: Date.now(),
-        };
-        const state = Buffer.from(JSON.stringify(stateData)).toString("base64");
-
         const request = createGetRequest(
           "http://localhost:3000/api/github/app/callback",
           {
             code: "test_code",
-            state,
+            state: "irrelevant-state-auth-fails-first",
           }
         );
 
@@ -592,7 +632,7 @@ describe("GitHub App Callback API Integration Tests", () => {
           workspaceSlug: "test-workspace",
           timestamp: Date.now(),
         };
-        const state = Buffer.from(JSON.stringify(stateData)).toString("base64");
+        const state = await signStateFor(testUser, stateData);
 
         const request = createGetRequest(
           "http://localhost:3000/api/github/app/callback",
@@ -620,7 +660,7 @@ describe("GitHub App Callback API Integration Tests", () => {
           workspaceSlug: "test-workspace",
           timestamp: Date.now() - 2 * 60 * 60 * 1000, // 2 hours ago
         };
-        const state = Buffer.from(JSON.stringify(stateData)).toString("base64");
+        const state = await signStateFor(testUser, stateData);
 
         // Mock successful token exchange (so we can reach state validation)
         mockFetch.mockResolvedValueOnce({
@@ -712,7 +752,7 @@ describe("GitHub App Callback API Integration Tests", () => {
           workspaceSlug: workspace.slug,
           timestamp: Date.now(),
         };
-        const state = Buffer.from(JSON.stringify(stateData)).toString("base64");
+        const state = await signStateFor(testUser, stateData);
 
         // Mock failed token exchange
         mockFetch.mockResolvedValueOnce({
@@ -750,7 +790,7 @@ describe("GitHub App Callback API Integration Tests", () => {
           workspaceSlug: workspace.slug,
           timestamp: Date.now(),
         };
-        const state = Buffer.from(JSON.stringify(stateData)).toString("base64");
+        const state = await signStateFor(testUser, stateData);
 
         // Mock token exchange returning no access_token
         mockFetch.mockResolvedValueOnce({
@@ -792,7 +832,7 @@ describe("GitHub App Callback API Integration Tests", () => {
           workspaceSlug: workspace.slug,
           timestamp: Date.now(),
         };
-        const state = Buffer.from(JSON.stringify(stateData)).toString("base64");
+        const state = await signStateFor(testUser, stateData);
 
         // Mock successful token exchange
         mockFetch.mockResolvedValueOnce({
@@ -838,7 +878,7 @@ describe("GitHub App Callback API Integration Tests", () => {
           workspaceSlug: workspace.slug,
           timestamp: Date.now(),
         };
-        const state = Buffer.from(JSON.stringify(stateData)).toString("base64");
+        const state = await signStateFor(testUser, stateData);
 
         // Mock network error
         mockFetch.mockRejectedValue(new Error("Network error"));
@@ -903,7 +943,7 @@ describe("GitHub App Callback API Integration Tests", () => {
           workspaceSlug: workspace.slug,
           timestamp: Date.now(),
         };
-        const state = Buffer.from(JSON.stringify(stateData)).toString("base64");
+        const state = await signStateFor(testUser, stateData);
 
         // Mock token exchange
         mockFetch.mockResolvedValueOnce({
@@ -989,7 +1029,7 @@ describe("GitHub App Callback API Integration Tests", () => {
           workspaceSlug: workspace.slug,
           timestamp: Date.now(),
         };
-        const state = Buffer.from(JSON.stringify(stateData)).toString("base64");
+        const state = await signStateFor(testUser, stateData);
 
         // Mock token exchange
         mockFetch.mockResolvedValueOnce({
@@ -1058,7 +1098,7 @@ describe("GitHub App Callback API Integration Tests", () => {
           workspaceSlug: workspace.slug,
           timestamp: Date.now(),
         };
-        const state = Buffer.from(JSON.stringify(stateData)).toString("base64");
+        const state = await signStateFor(testUser, stateData);
 
         // Mock token exchange
         mockFetch.mockResolvedValueOnce({
@@ -1162,7 +1202,7 @@ describe("GitHub App Callback API Integration Tests", () => {
           workspaceSlug: workspace.slug,
           timestamp: Date.now(),
         };
-        const state = Buffer.from(JSON.stringify(stateData)).toString("base64");
+        const state = await signStateFor(testUser, stateData);
 
         const beforeTime = Date.now();
 
@@ -1260,7 +1300,7 @@ describe("GitHub App Callback API Integration Tests", () => {
           workspaceSlug: workspace.slug,
           timestamp: Date.now(),
         };
-        const state = Buffer.from(JSON.stringify(stateData)).toString("base64");
+        const state = await signStateFor(testUser, stateData);
 
         // Mock token exchange
         mockFetch.mockResolvedValueOnce({
@@ -1291,6 +1331,221 @@ describe("GitHub App Callback API Integration Tests", () => {
           where: { id: workspace.id },
         });
         expect(updatedWorkspace?.sourceControlOrgId).toBeNull();
+      });
+    });
+
+    describe("IDOR hardening (Plan finding #20)", () => {
+      test("rejects legacy unsigned base64 state without any side-effects", async () => {
+        // The old `state` format (plain base64-encoded JSON) is now
+        // considered forgeable. The handler must reject these outright,
+        // even when the caller is otherwise authenticated as a workspace
+        // admin — otherwise a logged-in attacker who only knows a victim
+        // workspace's slug can mint a state themselves.
+        const testUser = await createTestUser({ name: "legacy-state-user" });
+        const workspace = await createTestWorkspace({
+          ownerId: testUser.id,
+          slug: "legacy-state-workspace",
+        });
+
+        getMockedSession().mockResolvedValue(
+          createAuthenticatedSession(testUser)
+        );
+
+        const stateData = {
+          workspaceSlug: workspace.slug,
+          timestamp: Date.now(),
+        };
+        const legacyState = Buffer.from(JSON.stringify(stateData)).toString(
+          "base64"
+        );
+
+        const request = createGetRequest(
+          "http://localhost:3000/api/github/app/callback",
+          {
+            code: "legacy_code",
+            state: legacyState,
+          }
+        );
+
+        const response = await GET(request);
+
+        expect(response.status).toBe(307);
+        const location = response.headers.get("location");
+        expect(location).toContain("error=invalid_state");
+
+        // No token exchange, no GitHub API calls — the handler must
+        // bail before any side-effects. This is the whole point of the
+        // IDOR fix.
+        expect(mockFetch).not.toHaveBeenCalled();
+
+        // And the workspace must not have been relinked.
+        const unchanged = await db.workspace.findUnique({
+          where: { id: workspace.id },
+        });
+        expect(unchanged?.sourceControlOrgId).toBe(workspace.sourceControlOrgId);
+      });
+
+      test("rejects a signed state that isn't bound to this user's session", async () => {
+        // An attacker who steals a signed state issued to another user
+        // (e.g. via log exfil) must not be able to replay it — the
+        // handler requires session.githubState to match.
+        const victim = await createTestUser({ name: "session-bind-victim" });
+        const attacker = await createTestUser({ name: "session-bind-attacker" });
+        const workspace = await createTestWorkspace({
+          ownerId: victim.id,
+          slug: "session-bind-workspace",
+        });
+
+        // Sign a state and bind it to the victim's session. Do NOT bind
+        // it to the attacker's session.
+        const state = await signStateFor(
+          victim,
+          { workspaceSlug: workspace.slug, timestamp: Date.now() },
+          { bindToSession: true },
+        );
+
+        // Attacker's session exists but has no matching `githubState`.
+        getMockedSession().mockResolvedValue(
+          createAuthenticatedSession(attacker)
+        );
+
+        const request = createGetRequest(
+          "http://localhost:3000/api/github/app/callback",
+          {
+            code: "replay_code",
+            state,
+          }
+        );
+
+        const response = await GET(request);
+
+        expect(response.status).toBe(307);
+        const location = response.headers.get("location");
+        expect(location).toContain("error=invalid_state");
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+
+      test("rejects when caller is not an admin on the workspace named in state", async () => {
+        // A plain workspace member (DEVELOPER) signs a state for a
+        // victim workspace they co-own. The rewire must be blocked
+        // because only OWNER/ADMIN should be able to re-point
+        // `sourceControlOrgId`.
+        const owner = await createTestUser({ name: "nonadmin-owner" });
+        const developer = await createTestUser({ name: "nonadmin-dev" });
+        const workspace = await createTestWorkspace({
+          ownerId: owner.id,
+          slug: "nonadmin-workspace",
+        });
+
+        await db.workspaceMember.create({
+          data: {
+            workspaceId: workspace.id,
+            userId: developer.id,
+            role: "DEVELOPER",
+            joinedAt: new Date(),
+          },
+        });
+
+        const state = await signStateFor(
+          developer,
+          { workspaceSlug: workspace.slug, timestamp: Date.now() },
+          { bindToSession: true },
+        );
+
+        getMockedSession().mockResolvedValue(
+          createAuthenticatedSession(developer)
+        );
+
+        const request = createGetRequest(
+          "http://localhost:3000/api/github/app/callback",
+          {
+            code: "nonadmin_code",
+            state,
+          }
+        );
+
+        const response = await GET(request);
+
+        expect(response.status).toBe(307);
+        const location = response.headers.get("location");
+        expect(location).toContain("error=workspace_access_denied");
+
+        // No token exchange, no rewire.
+        expect(mockFetch).not.toHaveBeenCalled();
+        const unchanged = await db.workspace.findUnique({
+          where: { id: workspace.id },
+        });
+        expect(unchanged?.sourceControlOrgId).toBe(workspace.sourceControlOrgId);
+      });
+
+      test("rejects when state names a workspace the caller doesn't belong to at all", async () => {
+        const owner = await createTestUser({ name: "idor-owner" });
+        const attacker = await createTestUser({ name: "idor-attacker" });
+        const workspace = await createTestWorkspace({
+          ownerId: owner.id,
+          slug: "idor-victim-workspace",
+        });
+
+        const state = await signStateFor(
+          attacker,
+          { workspaceSlug: workspace.slug, timestamp: Date.now() },
+          { bindToSession: true },
+        );
+
+        getMockedSession().mockResolvedValue(
+          createAuthenticatedSession(attacker)
+        );
+
+        const request = createGetRequest(
+          "http://localhost:3000/api/github/app/callback",
+          {
+            code: "idor_code",
+            state,
+          }
+        );
+
+        const response = await GET(request);
+
+        expect(response.status).toBe(307);
+        const location = response.headers.get("location");
+        expect(location).toContain("error=workspace_access_denied");
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+
+      test("rejects a state with a tampered signature", async () => {
+        const testUser = await createTestUser({ name: "tamper-user" });
+        const workspace = await createTestWorkspace({
+          ownerId: testUser.id,
+          slug: "tamper-workspace",
+        });
+
+        const state = await signStateFor(
+          testUser,
+          { workspaceSlug: workspace.slug, timestamp: Date.now() },
+          { bindToSession: true },
+        );
+
+        // Flip the last character of the signature.
+        const tampered = state.replace(/.$/, (c) => (c === "a" ? "b" : "a"));
+
+        getMockedSession().mockResolvedValue(
+          createAuthenticatedSession(testUser)
+        );
+
+        const request = createGetRequest(
+          "http://localhost:3000/api/github/app/callback",
+          {
+            code: "tamper_code",
+            state: tampered,
+          }
+        );
+
+        const response = await GET(request);
+
+        expect(response.status).toBe(307);
+        const location = response.headers.get("location");
+        expect(location).toContain("error=invalid_state");
+        expect(mockFetch).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/__tests__/integration/api/github-app-install.test.ts
+++ b/src/__tests__/integration/api/github-app-install.test.ts
@@ -265,8 +265,20 @@ describe("GitHub App Install API Integration Tests", () => {
         expect(data.data.state).toBeDefined();
         expect(typeof data.data.state).toBe("string");
 
-        // Verify state token was generated and is base64 encoded
-        expect(() => Buffer.from(data.data.state, "base64")).not.toThrow();
+        // State is now signed: `<base64url-json>.<hex-sig>`. Both halves
+        // must be present and the body must decode to valid JSON.
+        const [body, signature] = data.data.state.split(".");
+        expect(body).toBeTruthy();
+        expect(signature).toMatch(/^[0-9a-f]+$/i);
+        // Ensure the payload body decodes without blowing up (base64url
+        // variant — hyphen/underscore instead of +/ and no padding).
+        const padded =
+          body + "=".repeat((4 - (body.length % 4)) % 4);
+        const decodedJson = Buffer.from(
+          padded.replace(/-/g, "+").replace(/_/g, "/"),
+          "base64",
+        ).toString("utf-8");
+        expect(() => JSON.parse(decodedJson)).not.toThrow();
       });
 
       test("should generate installation URL with target_type=User for user repositories", async () => {
@@ -802,9 +814,14 @@ describe("GitHub App Install API Integration Tests", () => {
         const response = await POST(request);
         const data = await expectSuccess(response);
 
-        // Decode state token
+        // Decode signed state: `<base64url-json>.<hex-sig>`
+        const [body] = data.data.state.split(".");
+        const padded = body + "=".repeat((4 - (body.length % 4)) % 4);
         const stateData = JSON.parse(
-          Buffer.from(data.data.state, "base64").toString()
+          Buffer.from(
+            padded.replace(/-/g, "+").replace(/_/g, "/"),
+            "base64",
+          ).toString("utf-8"),
         );
 
         expect(stateData.workspaceSlug).toBe(workspace.slug);

--- a/src/__tests__/integration/api/orgs-connections.test.ts
+++ b/src/__tests__/integration/api/orgs-connections.test.ts
@@ -1,0 +1,406 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  addMiddlewareHeaders,
+  createAuthenticatedGetRequest,
+  createDeleteRequest,
+  createGetRequest,
+  generateUniqueId,
+} from "@/__tests__/support/helpers";
+import { createTestUser } from "@/__tests__/support/factories";
+import { db } from "@/lib/db";
+import { GET, DELETE } from "@/app/api/orgs/[githubLogin]/connections/route";
+import { WorkspaceRole } from "@prisma/client";
+import type { NextResponse } from "next/server";
+
+async function expectJson<T = unknown>(res: NextResponse | Response, status = 200): Promise<T> {
+  const r = res as Response;
+  expect(r.status).toBe(status);
+  return r.json() as Promise<T>;
+}
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+let installationIdCounter = 900000;
+function nextInstallationId() {
+  return installationIdCounter++;
+}
+
+async function createOrg(githubLogin: string) {
+  return db.sourceControlOrg.create({
+    data: {
+      githubLogin,
+      githubInstallationId: nextInstallationId(),
+      type: "ORG",
+      name: githubLogin,
+    },
+  });
+}
+
+async function createWorkspaceInOrg(ownerId: string, orgId: string) {
+  const slug = `conn-test-ws-${generateUniqueId()}`;
+  return db.workspace.create({
+    data: { name: slug, slug, ownerId, sourceControlOrgId: orgId },
+  });
+}
+
+async function addMember(workspaceId: string, userId: string, role: WorkspaceRole = WorkspaceRole.DEVELOPER) {
+  return db.workspaceMember.create({
+    data: { workspaceId, userId, role, joinedAt: new Date() },
+  });
+}
+
+async function createConnection(orgId: string, createdBy: string, slug?: string) {
+  return db.connection.create({
+    data: {
+      slug: slug ?? `connection-${generateUniqueId()}`,
+      name: "Test Connection",
+      summary: "victim summary content",
+      diagram: "victim diagram",
+      architecture: "victim architecture",
+      openApiSpec: "victim openapi",
+      createdBy,
+      orgId,
+    },
+  });
+}
+
+function makeParams(githubLogin: string) {
+  return Promise.resolve({ githubLogin });
+}
+
+function authedDeleteRequest(
+  url: string,
+  user: { id: string; email: string | null; name: string | null },
+  body: object,
+) {
+  const base = createDeleteRequest(url, body);
+  return addMiddlewareHeaders(base, {
+    id: user.id,
+    email: user.email || "",
+    name: user.name || "",
+  });
+}
+
+// ─── cleanup tracking ───────────────────────────────────────────────────────
+
+const createdOrgIds: string[] = [];
+const createdWorkspaceIds: string[] = [];
+const createdConnectionIds: string[] = [];
+const createdUserIds: string[] = [];
+
+afterEach(async () => {
+  if (createdConnectionIds.length > 0) {
+    await db.connection.deleteMany({ where: { id: { in: createdConnectionIds } } });
+    createdConnectionIds.length = 0;
+  }
+  if (createdWorkspaceIds.length > 0) {
+    await db.workspaceMember.deleteMany({
+      where: { workspaceId: { in: createdWorkspaceIds } },
+    });
+    await db.workspace.deleteMany({ where: { id: { in: createdWorkspaceIds } } });
+    createdWorkspaceIds.length = 0;
+  }
+  if (createdOrgIds.length > 0) {
+    await db.sourceControlOrg.deleteMany({ where: { id: { in: createdOrgIds } } });
+    createdOrgIds.length = 0;
+  }
+  if (createdUserIds.length > 0) {
+    await db.user.deleteMany({ where: { id: { in: createdUserIds } } });
+    createdUserIds.length = 0;
+  }
+});
+
+// ─── GET ────────────────────────────────────────────────────────────────────
+
+describe("GET /api/orgs/[githubLogin]/connections - IDOR hardening", () => {
+  it("returns 401 for unauthenticated requests", async () => {
+    const req = createGetRequest("/api/orgs/some-org/connections");
+    const res = await GET(req, { params: makeParams("some-org") });
+    await expectJson(res, 401);
+  });
+
+  it("returns 404 for a signed-in user with no workspace under the org (non-member IDOR)", async () => {
+    const owner = await createTestUser({
+      email: `conn-owner-${generateUniqueId()}@example.com`,
+      idempotent: false,
+    });
+    const attacker = await createTestUser({
+      email: `conn-attacker-${generateUniqueId()}@example.com`,
+      idempotent: false,
+    });
+    createdUserIds.push(owner.id, attacker.id);
+
+    const login = `conn-victim-${generateUniqueId()}`;
+    const org = await createOrg(login);
+    createdOrgIds.push(org.id);
+
+    const ws = await createWorkspaceInOrg(owner.id, org.id);
+    createdWorkspaceIds.push(ws.id);
+
+    const connection = await createConnection(org.id, owner.id);
+    createdConnectionIds.push(connection.id);
+
+    const req = createAuthenticatedGetRequest(
+      `/api/orgs/${login}/connections`,
+      attacker,
+    );
+    const res = await GET(req, { params: makeParams(login) });
+    const data = await expectJson<{ error: string }>(res, 404);
+
+    expect(data.error).toBe("Organization not found");
+    // Make sure the attacker never received the victim's connection payload.
+    expect(JSON.stringify(data)).not.toContain("victim summary content");
+    expect(JSON.stringify(data)).not.toContain("victim diagram");
+  });
+
+  it("returns 404 for an unknown org without leaking existence", async () => {
+    const user = await createTestUser({
+      email: `conn-unknown-${generateUniqueId()}@example.com`,
+      idempotent: false,
+    });
+    createdUserIds.push(user.id);
+
+    const req = createAuthenticatedGetRequest(
+      `/api/orgs/nonexistent-login-${generateUniqueId()}/connections`,
+      user,
+    );
+    const res = await GET(req, {
+      params: makeParams(`nonexistent-login-${generateUniqueId()}`),
+    });
+    await expectJson(res, 404);
+  });
+
+  it("returns connections when caller owns a workspace under the org", async () => {
+    const owner = await createTestUser({
+      email: `conn-ok-owner-${generateUniqueId()}@example.com`,
+      idempotent: false,
+    });
+    createdUserIds.push(owner.id);
+
+    const login = `conn-ok-org-${generateUniqueId()}`;
+    const org = await createOrg(login);
+    createdOrgIds.push(org.id);
+
+    const ws = await createWorkspaceInOrg(owner.id, org.id);
+    createdWorkspaceIds.push(ws.id);
+
+    const connection = await createConnection(org.id, owner.id);
+    createdConnectionIds.push(connection.id);
+
+    const req = createAuthenticatedGetRequest(
+      `/api/orgs/${login}/connections`,
+      owner,
+    );
+    const res = await GET(req, { params: makeParams(login) });
+    const data = await expectJson<{ id: string; summary: string }[]>(res);
+
+    expect(data).toHaveLength(1);
+    expect(data[0].id).toBe(connection.id);
+    expect(data[0].summary).toBe("victim summary content");
+  });
+
+  it("returns connections for a plain DEVELOPER member", async () => {
+    const owner = await createTestUser({
+      email: `conn-o-${generateUniqueId()}@example.com`,
+      idempotent: false,
+    });
+    const member = await createTestUser({
+      email: `conn-m-${generateUniqueId()}@example.com`,
+      idempotent: false,
+    });
+    createdUserIds.push(owner.id, member.id);
+
+    const login = `conn-member-org-${generateUniqueId()}`;
+    const org = await createOrg(login);
+    createdOrgIds.push(org.id);
+
+    const ws = await createWorkspaceInOrg(owner.id, org.id);
+    createdWorkspaceIds.push(ws.id);
+    await addMember(ws.id, member.id, WorkspaceRole.DEVELOPER);
+
+    const connection = await createConnection(org.id, owner.id);
+    createdConnectionIds.push(connection.id);
+
+    const req = createAuthenticatedGetRequest(
+      `/api/orgs/${login}/connections`,
+      member,
+    );
+    const res = await GET(req, { params: makeParams(login) });
+    const data = await expectJson<unknown[]>(res);
+
+    expect(data).toHaveLength(1);
+  });
+});
+
+// ─── DELETE ─────────────────────────────────────────────────────────────────
+
+describe("DELETE /api/orgs/[githubLogin]/connections - IDOR hardening", () => {
+  it("returns 401 for unauthenticated requests", async () => {
+    const req = createDeleteRequest("/api/orgs/some-org/connections", {
+      connectionId: "abc",
+    });
+    const res = await DELETE(req, { params: makeParams("some-org") });
+    await expectJson(res, 401);
+  });
+
+  it("returns 404 when caller is not a member of any workspace under the org", async () => {
+    const owner = await createTestUser({
+      email: `conn-del-o-${generateUniqueId()}@example.com`,
+      idempotent: false,
+    });
+    const attacker = await createTestUser({
+      email: `conn-del-a-${generateUniqueId()}@example.com`,
+      idempotent: false,
+    });
+    createdUserIds.push(owner.id, attacker.id);
+
+    const login = `conn-del-victim-${generateUniqueId()}`;
+    const org = await createOrg(login);
+    createdOrgIds.push(org.id);
+
+    const ws = await createWorkspaceInOrg(owner.id, org.id);
+    createdWorkspaceIds.push(ws.id);
+
+    const connection = await createConnection(org.id, owner.id);
+    createdConnectionIds.push(connection.id);
+
+    const req = authedDeleteRequest(
+      `/api/orgs/${login}/connections`,
+      attacker,
+      { connectionId: connection.id },
+    );
+    const res = await DELETE(req, { params: makeParams(login) });
+    await expectJson(res, 404);
+
+    // Verify the connection still exists — no write happened.
+    const stillThere = await db.connection.findUnique({
+      where: { id: connection.id },
+    });
+    expect(stillThere).not.toBeNull();
+  });
+
+  it("returns 404 when caller is a plain DEVELOPER member (admin required for DELETE)", async () => {
+    const owner = await createTestUser({
+      email: `conn-dev-o-${generateUniqueId()}@example.com`,
+      idempotent: false,
+    });
+    const developer = await createTestUser({
+      email: `conn-dev-d-${generateUniqueId()}@example.com`,
+      idempotent: false,
+    });
+    createdUserIds.push(owner.id, developer.id);
+
+    const login = `conn-dev-org-${generateUniqueId()}`;
+    const org = await createOrg(login);
+    createdOrgIds.push(org.id);
+
+    const ws = await createWorkspaceInOrg(owner.id, org.id);
+    createdWorkspaceIds.push(ws.id);
+    await addMember(ws.id, developer.id, WorkspaceRole.DEVELOPER);
+
+    const connection = await createConnection(org.id, owner.id);
+    createdConnectionIds.push(connection.id);
+
+    const req = authedDeleteRequest(
+      `/api/orgs/${login}/connections`,
+      developer,
+      { connectionId: connection.id },
+    );
+    const res = await DELETE(req, { params: makeParams(login) });
+    await expectJson(res, 404);
+
+    const stillThere = await db.connection.findUnique({
+      where: { id: connection.id },
+    });
+    expect(stillThere).not.toBeNull();
+  });
+
+  it("allows workspace OWNER to delete a connection", async () => {
+    const owner = await createTestUser({
+      email: `conn-del-ok-o-${generateUniqueId()}@example.com`,
+      idempotent: false,
+    });
+    createdUserIds.push(owner.id);
+
+    const login = `conn-del-ok-${generateUniqueId()}`;
+    const org = await createOrg(login);
+    createdOrgIds.push(org.id);
+
+    const ws = await createWorkspaceInOrg(owner.id, org.id);
+    createdWorkspaceIds.push(ws.id);
+
+    const connection = await createConnection(org.id, owner.id);
+    // Don't push to createdConnectionIds — the delete under test will remove it.
+
+    const req = authedDeleteRequest(
+      `/api/orgs/${login}/connections`,
+      owner,
+      { connectionId: connection.id },
+    );
+    const res = await DELETE(req, { params: makeParams(login) });
+    await expectJson(res, 200);
+
+    const deleted = await db.connection.findUnique({
+      where: { id: connection.id },
+    });
+    expect(deleted).toBeNull();
+  });
+
+  it("allows ADMIN member to delete a connection", async () => {
+    const owner = await createTestUser({
+      email: `conn-del-adm-o-${generateUniqueId()}@example.com`,
+      idempotent: false,
+    });
+    const admin = await createTestUser({
+      email: `conn-del-adm-a-${generateUniqueId()}@example.com`,
+      idempotent: false,
+    });
+    createdUserIds.push(owner.id, admin.id);
+
+    const login = `conn-del-adm-${generateUniqueId()}`;
+    const org = await createOrg(login);
+    createdOrgIds.push(org.id);
+
+    const ws = await createWorkspaceInOrg(owner.id, org.id);
+    createdWorkspaceIds.push(ws.id);
+    await addMember(ws.id, admin.id, WorkspaceRole.ADMIN);
+
+    const connection = await createConnection(org.id, owner.id);
+
+    const req = authedDeleteRequest(
+      `/api/orgs/${login}/connections`,
+      admin,
+      { connectionId: connection.id },
+    );
+    const res = await DELETE(req, { params: makeParams(login) });
+    await expectJson(res, 200);
+
+    const deleted = await db.connection.findUnique({
+      where: { id: connection.id },
+    });
+    expect(deleted).toBeNull();
+  });
+
+  it("returns 400 when connectionId is missing", async () => {
+    const owner = await createTestUser({
+      email: `conn-del-400-${generateUniqueId()}@example.com`,
+      idempotent: false,
+    });
+    createdUserIds.push(owner.id);
+
+    const login = `conn-del-400-${generateUniqueId()}`;
+    const org = await createOrg(login);
+    createdOrgIds.push(org.id);
+
+    const ws = await createWorkspaceInOrg(owner.id, org.id);
+    createdWorkspaceIds.push(ws.id);
+
+    const req = authedDeleteRequest(
+      `/api/orgs/${login}/connections`,
+      owner,
+      {},
+    );
+    const res = await DELETE(req, { params: makeParams(login) });
+    await expectJson(res, 400);
+  });
+});

--- a/src/__tests__/unit/api/github/webhook-ensure-route.test.ts
+++ b/src/__tests__/unit/api/github/webhook-ensure-route.test.ts
@@ -32,17 +32,23 @@ vi.mock("@/lib/auth/nextauth", () => ({
   authOptions: {},
 }));
 
+vi.mock("@/services/workspace", () => ({
+  validateWorkspaceAccessById: vi.fn(),
+}));
+
 // Import mocked modules
 import { db } from "@/lib/db";
 import { WebhookService } from "@/services/github/WebhookService";
 import { getGithubWebhookCallbackUrl } from "@/lib/url";
 import { getServiceConfig } from "@/config/services";
+import { validateWorkspaceAccessById } from "@/services/workspace";
 
 const mockGetServerSession = getServerSession as Mock;
 const mockDbRepositoryFindUnique = db.repository.findUnique as Mock;
 const mockWebhookService = WebhookService as Mock;
 const mockGetGithubWebhookCallbackUrl = getGithubWebhookCallbackUrl as Mock;
 const mockGetServiceConfig = getServiceConfig as Mock;
+const mockValidateWorkspaceAccessById = validateWorkspaceAccessById as Mock;
 
 // Test Data Factories
 const TestDataFactory = {
@@ -162,6 +168,51 @@ const TestHelpers = {
 const MockSetup = {
   reset: () => {
     vi.clearAllMocks();
+    // Default: caller has write access. IDOR-specific tests override this.
+    mockValidateWorkspaceAccessById.mockResolvedValue({
+      hasAccess: true,
+      canRead: true,
+      canWrite: true,
+      canAdmin: false,
+      userRole: "DEVELOPER",
+      workspace: {
+        id: "workspace-123",
+        name: "ws",
+        description: null,
+        slug: "ws",
+        ownerId: "owner-1",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+  },
+
+  setupNonMember: () => {
+    mockValidateWorkspaceAccessById.mockResolvedValue({
+      hasAccess: false,
+      canRead: false,
+      canWrite: false,
+      canAdmin: false,
+    });
+  },
+
+  setupReaderOnly: () => {
+    mockValidateWorkspaceAccessById.mockResolvedValue({
+      hasAccess: true,
+      canRead: true,
+      canWrite: false,
+      canAdmin: false,
+      userRole: "VIEWER",
+      workspace: {
+        id: "workspace-123",
+        name: "ws",
+        description: null,
+        slug: "ws",
+        ownerId: "owner-1",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
   },
 
   setupSuccessfulWebhookCreation: (webhookId: number = 123456789) => {
@@ -811,6 +862,71 @@ describe("POST /api/github/webhook/ensure - Integration Tests", () => {
           userId: differentUserId,
         })
       );
+    });
+  });
+
+  describe("IDOR hardening", () => {
+    beforeEach(() => {
+      TestHelpers.setupAuthenticatedUser();
+    });
+
+    test("returns 404 and skips webhook writes when caller is not a member", async () => {
+      MockSetup.setupNonMember();
+      MockSetup.setupSuccessfulWebhookCreation();
+
+      const request = TestHelpers.createMockRequest({
+        workspaceId: "victim-workspace-id",
+        repositoryUrl: "https://github.com/victim-org/victim-repo",
+      });
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(404);
+      const data = await response.json();
+      expect(data).toEqual({
+        success: false,
+        message: "Workspace not found or access denied",
+      });
+      expect(mockValidateWorkspaceAccessById).toHaveBeenCalledWith(
+        "victim-workspace-id",
+        "user-123",
+      );
+      // No webhook side-effects — no callback URL built, no service instantiated,
+      // and therefore no repo update of githubWebhookId / githubWebhookSecret.
+      expect(mockGetGithubWebhookCallbackUrl).not.toHaveBeenCalled();
+      expect(mockWebhookService).not.toHaveBeenCalled();
+      expect(mockDbRepositoryFindUnique).not.toHaveBeenCalled();
+    });
+
+    test("returns 404 when caller is a reader but not a writer (VIEWER)", async () => {
+      MockSetup.setupReaderOnly();
+      MockSetup.setupSuccessfulWebhookCreation();
+
+      const request = TestHelpers.createMockRequest({
+        workspaceId: "workspace-123",
+        repositoryUrl: "https://github.com/test-org/test-repo",
+      });
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(404);
+      expect(mockWebhookService).not.toHaveBeenCalled();
+    });
+
+    test("authorization check runs BEFORE the repositoryId → url lookup", async () => {
+      // If we ever flip the order, a non-member could at least confirm
+      // the existence of arbitrary repository ids. Lock the order down.
+      MockSetup.setupNonMember();
+
+      const request = TestHelpers.createMockRequest({
+        workspaceId: "victim-workspace-id",
+        repositoryId: "some-repo-id",
+      });
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(404);
+      expect(mockDbRepositoryFindUnique).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/__tests__/unit/lib/github-app-state.test.ts
+++ b/src/__tests__/unit/lib/github-app-state.test.ts
@@ -1,0 +1,196 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import {
+  signGithubAppState,
+  verifyGithubAppState,
+} from "@/lib/auth/github-app-state";
+
+const ORIGINAL_SECRET = process.env.NEXTAUTH_SECRET;
+
+describe("github-app-state", () => {
+  beforeEach(() => {
+    process.env.NEXTAUTH_SECRET = "test-secret-for-github-app-state-hmac";
+  });
+
+  afterEach(() => {
+    process.env.NEXTAUTH_SECRET = ORIGINAL_SECRET;
+  });
+
+  describe("signGithubAppState", () => {
+    test("produces a `<body>.<signature>` token", () => {
+      const state = signGithubAppState({
+        workspaceSlug: "my-workspace",
+        randomState: "random-abc",
+        timestamp: Date.now(),
+      });
+
+      expect(typeof state).toBe("string");
+      const parts = state.split(".");
+      expect(parts).toHaveLength(2);
+      expect(parts[0]).toMatch(/^[A-Za-z0-9_-]+$/); // base64url
+      expect(parts[1]).toMatch(/^[0-9a-f]+$/); // hex
+    });
+
+    test("includes optional repositoryUrl in the payload", () => {
+      const state = signGithubAppState({
+        workspaceSlug: "my-workspace",
+        repositoryUrl: "https://github.com/acme/repo",
+        randomState: "random-abc",
+        timestamp: Date.now(),
+      });
+
+      const result = verifyGithubAppState(state);
+      expect(result.ok).toBe(true);
+      expect(result.payload?.repositoryUrl).toBe(
+        "https://github.com/acme/repo",
+      );
+    });
+
+    test("throws when NEXTAUTH_SECRET is missing", () => {
+      delete process.env.NEXTAUTH_SECRET;
+      expect(() =>
+        signGithubAppState({
+          workspaceSlug: "ws",
+          randomState: "r",
+          timestamp: Date.now(),
+        }),
+      ).toThrow(/NEXTAUTH_SECRET is required/);
+    });
+  });
+
+  describe("verifyGithubAppState", () => {
+    test("accepts a freshly-signed state", () => {
+      const state = signGithubAppState({
+        workspaceSlug: "ws",
+        randomState: "r",
+        timestamp: Date.now(),
+      });
+      const result = verifyGithubAppState(state);
+      expect(result.ok).toBe(true);
+      expect(result.payload?.workspaceSlug).toBe("ws");
+    });
+
+    test("rejects a tampered body (signature no longer matches)", () => {
+      const state = signGithubAppState({
+        workspaceSlug: "original-ws",
+        randomState: "r",
+        timestamp: Date.now(),
+      });
+      const [, sig] = state.split(".");
+      // Swap the body to one representing a different workspace but
+      // keep the original signature.
+      const forgedBody = Buffer.from(
+        JSON.stringify({
+          workspaceSlug: "victim-ws",
+          randomState: "r",
+          timestamp: Date.now(),
+        }),
+      )
+        .toString("base64")
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/g, "");
+      const forged = `${forgedBody}.${sig}`;
+
+      const result = verifyGithubAppState(forged);
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe("bad_signature");
+    });
+
+    test("rejects a tampered signature", () => {
+      const state = signGithubAppState({
+        workspaceSlug: "ws",
+        randomState: "r",
+        timestamp: Date.now(),
+      });
+      const tampered = state.replace(/.$/, (c) => (c === "a" ? "b" : "a"));
+      const result = verifyGithubAppState(tampered);
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe("bad_signature");
+    });
+
+    test("rejects state signed with a different secret", () => {
+      const state = signGithubAppState({
+        workspaceSlug: "ws",
+        randomState: "r",
+        timestamp: Date.now(),
+      });
+      process.env.NEXTAUTH_SECRET = "a-different-secret";
+      const result = verifyGithubAppState(state);
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe("bad_signature");
+    });
+
+    test("rejects an expired state (older than 1h)", () => {
+      const state = signGithubAppState({
+        workspaceSlug: "ws",
+        randomState: "r",
+        timestamp: Date.now() - 2 * 60 * 60 * 1000, // 2 hours ago
+      });
+      const result = verifyGithubAppState(state);
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe("expired");
+    });
+
+    test("rejects a state with a future timestamp", () => {
+      const state = signGithubAppState({
+        workspaceSlug: "ws",
+        randomState: "r",
+        timestamp: Date.now() + 10 * 60 * 1000, // 10 min in the future
+      });
+      const result = verifyGithubAppState(state);
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe("expired");
+    });
+
+    test("rejects malformed input (missing dot)", () => {
+      expect(verifyGithubAppState("no-dot-here").ok).toBe(false);
+      expect(verifyGithubAppState("no-dot-here").reason).toBe("malformed");
+    });
+
+    test("rejects null, undefined and empty string", () => {
+      expect(verifyGithubAppState(null).ok).toBe(false);
+      expect(verifyGithubAppState(undefined).ok).toBe(false);
+      expect(verifyGithubAppState("").ok).toBe(false);
+    });
+
+    test("rejects legacy plain-base64 state", () => {
+      // The old format was base64 JSON with no signature. The new
+      // verifier must reject these outright rather than falling back.
+      const legacy = Buffer.from(
+        JSON.stringify({
+          workspaceSlug: "ws",
+          randomState: "r",
+          timestamp: Date.now(),
+        }),
+      ).toString("base64");
+
+      const result = verifyGithubAppState(legacy);
+      expect(result.ok).toBe(false);
+      // Legacy format has no `.` — rejected as malformed.
+      expect(result.reason).toBe("malformed");
+    });
+
+    test("rejects a payload missing required fields", async () => {
+      // Hand-sign a payload that omits `workspaceSlug`.
+      const badPayload = Buffer.from(
+        JSON.stringify({ randomState: "r", timestamp: Date.now() }),
+      )
+        .toString("base64")
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/g, "");
+
+      // Compute a valid signature for the bad body.
+      const crypto = await import("crypto");
+      const sig = crypto
+        .createHmac("sha256", process.env.NEXTAUTH_SECRET!)
+        .update(badPayload)
+        .digest("hex");
+
+      const state = `${badPayload}.${sig}`;
+      const result = verifyGithubAppState(state);
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe("invalid_payload");
+    });
+  });
+});

--- a/src/app/api/github/app/callback/route.ts
+++ b/src/app/api/github/app/callback/route.ts
@@ -5,6 +5,11 @@ import { config, optionalEnvVars } from "@/config/env";
 import { serviceConfigs } from "@/config/services";
 import { checkRepositoryAccess } from "@/lib/github-oauth-repository-access";
 import { getPrimaryRepository } from "@/lib/helpers/repository";
+import {
+  verifyGithubAppState,
+  type GithubAppStatePayload,
+} from "@/lib/auth/github-app-state";
+import { validateWorkspaceAccess } from "@/services/workspace";
 import { getServerSession } from "next-auth/next";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -81,18 +86,59 @@ export async function GET(request: NextRequest) {
       return NextResponse.redirect(new URL("/auth", request.url));
     }
 
-    // Get the user's session to validate the GitHub state
-    // const userSession = await db.session.findFirst({
-    //   where: {
-    //     userId: session.user.id as string,
-    //     githubState: state,
-    //   },
-    // });
+    // IDOR hardening: verify the signed state BEFORE any side-effects
+    // (token exchange, installation lookup, workspace mutations). The
+    // state is HMAC-signed with NEXTAUTH_SECRET so an attacker who only
+    // knows a victim workspace slug can no longer forge a callback that
+    // rewires `workspace.sourceControlOrgId`.
+    const stateResult = verifyGithubAppState(state);
+    if (!stateResult.ok || !stateResult.payload) {
+      console.error("GitHub App callback rejected state:", stateResult.reason);
+      const errorCode =
+        stateResult.reason === "expired" ? "state_expired" : "invalid_state";
+      return NextResponse.redirect(new URL(`/?error=${errorCode}`, request.url));
+    }
+    const statePayload: GithubAppStatePayload = stateResult.payload;
 
-    // if (!userSession) {
-    //   console.error("Invalid or expired GitHub state for user:", session.user.id);
-    //   return NextResponse.redirect(new URL("/?error=invalid_state", request.url));
-    // }
+    // Additionally bind the state to this user's session. The install
+    // handler stores the signed state on `session.githubState`, so even
+    // if an attacker somehow replayed a valid signed state issued to
+    // another user (e.g. via log exfil), it won't match this user's
+    // session and the rewire will be rejected.
+    const userSession = await db.session.findFirst({
+      where: {
+        userId: session.user.id as string,
+        githubState: state,
+      },
+      select: { id: true },
+    });
+    if (!userSession) {
+      console.error(
+        "GitHub App callback: state not bound to user session",
+        session.user.id,
+      );
+      return NextResponse.redirect(
+        new URL("/?error=invalid_state", request.url),
+      );
+    }
+
+    // Authorization: the caller must be an admin (OWNER/ADMIN) of the
+    // workspace named in the state BEFORE we perform the token exchange
+    // or mutate `workspace.sourceControlOrgId`. Plain members and non-
+    // members see a generic "invalid_state" and no side-effects run.
+    const workspaceAccess = await validateWorkspaceAccess(
+      statePayload.workspaceSlug,
+      session.user.id as string,
+    );
+    if (!workspaceAccess.hasAccess || !workspaceAccess.canAdmin) {
+      console.error(
+        "GitHub App callback: caller lacks admin on workspace",
+        statePayload.workspaceSlug,
+      );
+      return NextResponse.redirect(
+        new URL("/?error=workspace_access_denied", request.url),
+      );
+    }
 
     const { userAccessToken, userRefreshToken } = await getAccessToken(code, state);
 
@@ -117,22 +163,8 @@ export async function GET(request: NextRequest) {
 
     const githubUser = await userResponse.json();
 
-    // Decode the state to get workspace information FIRST
-    let workspaceSlug: string;
-    try {
-      const stateData = JSON.parse(Buffer.from(state, "base64").toString());
-      workspaceSlug = stateData.workspaceSlug;
-
-      // Optional: Validate timestamp (e.g., state not older than 1 hour)
-      const stateAge = Date.now() - stateData.timestamp;
-      if (stateAge > 60 * 60 * 1000) {
-        // 1 hour
-        return NextResponse.redirect(new URL(`/?error=state_expired`, request.url));
-      }
-    } catch (error) {
-      console.error("Failed to decode state:", error);
-      return NextResponse.redirect(new URL("/?error=invalid_state", request.url));
-    }
+    // Workspace slug was already extracted from the signed state above.
+    const workspaceSlug = statePayload.workspaceSlug;
 
     // Get installation info if available
     let githubOwner: string;
@@ -380,15 +412,10 @@ export async function GET(request: NextRequest) {
         }
       }
 
-      // If no swarm yet, try to reconstruct from the state data
+      // If no swarm yet, fall back to the repositoryUrl embedded in the
+      // (already-verified) signed state payload.
       if (!targetRepositoryUrl) {
-        try {
-          const stateData = JSON.parse(Buffer.from(state, "base64").toString());
-          // If we stored repositoryUrl in state, use it (we should enhance the install route to include this)
-          targetRepositoryUrl = stateData.repositoryUrl;
-        } catch (error) {
-          console.log("Could not extract repository URL from state", error);
-        }
+        targetRepositoryUrl = statePayload.repositoryUrl;
       }
 
       if (targetRepositoryUrl) {

--- a/src/app/api/github/app/install/route.ts
+++ b/src/app/api/github/app/install/route.ts
@@ -3,6 +3,7 @@ import { db } from "@/lib/db";
 import { config } from "@/config/env";
 import { serviceConfigs } from "@/config/services";
 import { getUserAppTokens } from "@/lib/githubApp";
+import { signGithubAppState } from "@/lib/auth/github-app-state";
 import { randomBytes } from "crypto";
 import { getServerSession } from "next-auth/next";
 import { NextRequest, NextResponse } from "next/server";
@@ -29,15 +30,16 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: false, message: "Workspace slug is required" }, { status: 400 });
     }
 
-    // Generate state
+    // Generate state. The state is signed with NEXTAUTH_SECRET (HMAC-SHA256)
+    // so an attacker can't forge a callback against a victim workspace's
+    // slug. See `@/lib/auth/github-app-state` for the rationale.
     const randomState = randomBytes(32).toString("hex");
-    const stateData = {
+    const state = signGithubAppState({
       workspaceSlug,
       repositoryUrl, // Include repository URL in state for callback
       randomState,
       timestamp: Date.now(),
-    };
-    const state = Buffer.from(JSON.stringify(stateData)).toString("base64");
+    });
 
     // Store the GitHub state in the user's session
     await db.session.updateMany({

--- a/src/app/api/github/webhook/ensure/route.ts
+++ b/src/app/api/github/webhook/ensure/route.ts
@@ -5,6 +5,7 @@ import { db } from "@/lib/db";
 import { WebhookService } from "@/services/github/WebhookService";
 import { getServiceConfig } from "@/config/services";
 import { getGithubWebhookCallbackUrl } from "@/lib/url";
+import { validateWorkspaceAccessById } from "@/services/workspace";
 
 export const runtime = "nodejs";
 
@@ -31,6 +32,25 @@ export async function POST(request: NextRequest) {
             "Missing required fields: workspaceId and repositoryUrl or repositoryId",
         },
         { status: 400 },
+      );
+    }
+
+    // IDOR hardening: verify the caller is a writer on the workspace
+    // BEFORE touching the repository or minting/storing a webhook secret.
+    // Without this, a signed-in non-member could overwrite a victim
+    // workspace's githubWebhookId / githubWebhookSecret and then forge
+    // webhook callbacks under the new attacker-known secret.
+    const access = await validateWorkspaceAccessById(
+      workspaceId,
+      session.user.id as string,
+    );
+    if (!access.hasAccess || !access.canWrite) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: "Workspace not found or access denied",
+        },
+        { status: 404 },
       );
     }
 

--- a/src/app/api/orgs/[githubLogin]/connections/route.ts
+++ b/src/app/api/orgs/[githubLogin]/connections/route.ts
@@ -1,6 +1,55 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getMiddlewareContext, requireAuth } from "@/lib/middleware/utils";
 import { db } from "@/lib/db";
+import { WorkspaceRole } from "@prisma/client";
+
+/**
+ * Returns the `SourceControlOrg.id` for the given `githubLogin` iff the user
+ * has membership in at least one workspace under that org. When
+ * `requireAdmin` is true, the user must own or be an ADMIN of at least one
+ * such workspace.
+ *
+ * Returns null if the org doesn't exist or the user has no qualifying
+ * workspace — callers should translate this into a unified 404 so we
+ * don't leak org existence.
+ */
+async function resolveAuthorizedOrgId(
+  githubLogin: string,
+  userId: string,
+  requireAdmin: boolean,
+): Promise<string | null> {
+  const org = await db.sourceControlOrg.findUnique({
+    where: { githubLogin },
+    select: { id: true },
+  });
+  if (!org) return null;
+
+  const adminRoles: WorkspaceRole[] = [WorkspaceRole.ADMIN];
+
+  const workspace = await db.workspace.findFirst({
+    where: {
+      deleted: false,
+      sourceControlOrgId: org.id,
+      OR: [
+        // Owners always qualify — including for admin-gated actions.
+        { ownerId: userId },
+        {
+          members: {
+            some: {
+              userId,
+              leftAt: null,
+              ...(requireAdmin ? { role: { in: adminRoles } } : {}),
+            },
+          },
+        },
+      ],
+    },
+    select: { id: true },
+  });
+
+  if (!workspace) return null;
+  return org.id;
+}
 
 export async function GET(
   request: NextRequest,
@@ -11,19 +60,22 @@ export async function GET(
   if (userOrResponse instanceof NextResponse) return userOrResponse;
 
   const { githubLogin } = await params;
+  const userId = userOrResponse.id;
 
   try {
-    const org = await db.sourceControlOrg.findUnique({
-      where: { githubLogin },
-      select: { id: true },
-    });
-
-    if (!org) {
-      return NextResponse.json({ error: "Organization not found" }, { status: 404 });
+    // IDOR hardening: require caller to belong to at least one workspace
+    // under the org. Connection rows include summary/diagram/architecture/
+    // openApiSpec which would otherwise leak across tenants.
+    const orgId = await resolveAuthorizedOrgId(githubLogin, userId, false);
+    if (!orgId) {
+      return NextResponse.json(
+        { error: "Organization not found" },
+        { status: 404 },
+      );
     }
 
     const connections = await db.connection.findMany({
-      where: { orgId: org.id },
+      where: { orgId },
       orderBy: { updatedAt: "desc" },
       select: {
         id: true,
@@ -54,6 +106,7 @@ export async function DELETE(
   if (userOrResponse instanceof NextResponse) return userOrResponse;
 
   const { githubLogin } = await params;
+  const userId = userOrResponse.id;
 
   try {
     const { connectionId } = await request.json();
@@ -61,18 +114,19 @@ export async function DELETE(
       return NextResponse.json({ error: "connectionId is required" }, { status: 400 });
     }
 
-    const org = await db.sourceControlOrg.findUnique({
-      where: { githubLogin },
-      select: { id: true },
-    });
-
-    if (!org) {
-      return NextResponse.json({ error: "Organization not found" }, { status: 404 });
+    // IDOR hardening: deletion is gated on ADMIN/OWNER of at least one
+    // workspace under the org. Plain members can read but not delete.
+    const orgId = await resolveAuthorizedOrgId(githubLogin, userId, true);
+    if (!orgId) {
+      return NextResponse.json(
+        { error: "Organization not found" },
+        { status: 404 },
+      );
     }
 
     // Ensure the connection belongs to this org
     const connection = await db.connection.findFirst({
-      where: { id: connectionId, orgId: org.id },
+      where: { id: connectionId, orgId },
     });
 
     if (!connection) {

--- a/src/lib/auth/github-app-state.ts
+++ b/src/lib/auth/github-app-state.ts
@@ -1,0 +1,132 @@
+import crypto from "crypto";
+
+/**
+ * Signed-state utilities for the GitHub App install → callback handshake.
+ *
+ * The callback at `/api/github/app/callback` trusts the `workspaceSlug`
+ * encoded into the `state` query parameter to decide which workspace to
+ * rewire to a `SourceControlOrg`. Historically `state` was just base64-
+ * encoded JSON — any attacker who knew a victim workspace slug could
+ * forge a `state`, walk through the OAuth flow, and hijack the victim
+ * workspace's `sourceControlOrgId` (or unlink it via `setup_action=uninstall`),
+ * routing all subsequent webhook / PR traffic through an attacker-
+ * controlled installation.
+ *
+ * We now sign the state payload with `NEXTAUTH_SECRET` using HMAC-SHA256
+ * so forging it requires server-side key compromise. `verifyState` is
+ * constant-time and treats malformed / expired / unsigned values as
+ * invalid rather than falling back to the legacy unsigned path.
+ *
+ * Format: `<base64url(json)>.<hex(hmac-sha256)>`
+ */
+
+export interface GithubAppStatePayload {
+  workspaceSlug: string;
+  repositoryUrl?: string;
+  randomState: string;
+  timestamp: number;
+}
+
+const MAX_STATE_AGE_MS = 60 * 60 * 1000; // 1 hour — matches the callback's pre-existing timestamp check
+
+function getSecret(): string {
+  const secret = process.env.NEXTAUTH_SECRET;
+  if (!secret) {
+    throw new Error(
+      "NEXTAUTH_SECRET is required for GitHub App state signing",
+    );
+  }
+  return secret;
+}
+
+function base64url(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+function fromBase64url(value: string): Buffer {
+  const pad = value.length % 4 === 0 ? "" : "=".repeat(4 - (value.length % 4));
+  return Buffer.from(
+    value.replace(/-/g, "+").replace(/_/g, "/") + pad,
+    "base64",
+  );
+}
+
+export function signGithubAppState(payload: GithubAppStatePayload): string {
+  const json = JSON.stringify(payload);
+  const body = base64url(Buffer.from(json, "utf-8"));
+  const signature = crypto
+    .createHmac("sha256", getSecret())
+    .update(body)
+    .digest("hex");
+  return `${body}.${signature}`;
+}
+
+export interface VerifyResult {
+  ok: boolean;
+  reason?:
+    | "malformed"
+    | "bad_signature"
+    | "invalid_json"
+    | "expired"
+    | "invalid_payload";
+  payload?: GithubAppStatePayload;
+}
+
+export function verifyGithubAppState(state: string | null | undefined): VerifyResult {
+  if (!state || typeof state !== "string") {
+    return { ok: false, reason: "malformed" };
+  }
+
+  const parts = state.split(".");
+  if (parts.length !== 2) return { ok: false, reason: "malformed" };
+
+  const [body, signature] = parts;
+  if (!body || !signature) return { ok: false, reason: "malformed" };
+
+  let expectedSignature: string;
+  try {
+    expectedSignature = crypto
+      .createHmac("sha256", getSecret())
+      .update(body)
+      .digest("hex");
+  } catch {
+    return { ok: false, reason: "bad_signature" };
+  }
+
+  // Constant-time compare. Lengths differ → immediately invalid.
+  if (signature.length !== expectedSignature.length) {
+    return { ok: false, reason: "bad_signature" };
+  }
+  const a = Buffer.from(signature, "hex");
+  const b = Buffer.from(expectedSignature, "hex");
+  if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) {
+    return { ok: false, reason: "bad_signature" };
+  }
+
+  let payload: GithubAppStatePayload;
+  try {
+    payload = JSON.parse(fromBase64url(body).toString("utf-8"));
+  } catch {
+    return { ok: false, reason: "invalid_json" };
+  }
+
+  if (
+    !payload ||
+    typeof payload.workspaceSlug !== "string" ||
+    typeof payload.randomState !== "string" ||
+    typeof payload.timestamp !== "number"
+  ) {
+    return { ok: false, reason: "invalid_payload" };
+  }
+
+  const age = Date.now() - payload.timestamp;
+  if (age > MAX_STATE_AGE_MS || age < 0) {
+    return { ok: false, reason: "expired" };
+  }
+
+  return { ok: true, payload };
+}


### PR DESCRIPTION
## Summary

Completes the three remaining Phase B findings from `docs/plans/workspace-idor-hardening.md`. All are High-severity IDORs affecting the GitHub App handshake, webhook setup, and org connections endpoints.

- **#20 `/api/github/app/callback`** — `state` was base64-encoded JSON with no signature, so any signed-in user who knew a victim workspace slug could forge a callback that rewired `workspace.sourceControlOrgId` to an attacker-controlled `SourceControlOrg`, hijacking all subsequent GitHub App webhook / PR traffic.
- **#21 `/api/github/webhook/ensure`** — no membership check before `WebhookService.ensureRepoWebhook` overwrote the repository's `githubWebhookId` / `githubWebhookSecret`, letting a signed-in user with GitHub App tokens forge webhook callbacks under the new attacker-known secret.
- **#23 `/api/orgs/[githubLogin]/connections`** — any signed-in user could read (and DELETE) every `Connection` record (`summary`, `diagram`, `architecture`, `openApiSpec`) for any GitHub org login.

## Fixes

### #20 Signed state + admin check
- New helper `src/lib/auth/github-app-state.ts` signs the state payload with HMAC-SHA256 keyed on `NEXTAUTH_SECRET` (format: `<base64url-json>.<hex-sig>`), verifies with a constant-time compare, a 1h expiry window, and a structural check on `workspaceSlug` / `randomState` / `timestamp`.
- `/api/github/app/install` now emits the signed state.
- `/api/github/app/callback` now (a) rejects unsigned / legacy / tampered / expired state outright, (b) re-checks that the state is bound to the caller's `session.githubState` so a signed state issued to one user can't be replayed by another, and (c) runs `validateWorkspaceAccess` with `canAdmin` **before** the token exchange or any `workspace.updateMany({sourceControlOrgId})` write.

### #21 Membership check
- `validateWorkspaceAccessById(workspaceId, userId)` with `canWrite` now runs immediately after the missing-fields 400, **before** the `repository.findUnique` lookup, callback URL construction, and `ensureRepoWebhook` call. Returns unified 404 so repo existence isn't leaked either.

### #23 Org-membership check
- New private helper `resolveAuthorizedOrgId(githubLogin, userId, requireAdmin)` in the route file resolves the org id only when the caller owns or is an active member of at least one workspace under it. DELETE passes `requireAdmin: true`, narrowing the match to OWNER or `WorkspaceRole.ADMIN`.
- Unknown `githubLogin` and non-qualifying callers both get the unified 404 \"Organization not found\".

## Tests

- **New unit suite** `src/__tests__/unit/lib/github-app-state.test.ts` — 13 tests covering sign/verify happy-path, body tampering, signature tampering, secret rotation, expiry, future timestamps, missing fields, legacy-format rejection.
- **New callback IDOR integration tests** (5) on `github-app-callback.test.ts` — legacy base64 rejection, signed state replayed to the wrong user, non-admin member, completely non-member, tampered signature. All five assert `mockFetch` was never called and `sourceControlOrgId` was untouched.
- **New webhook-ensure IDOR unit tests** (3) — non-member -> 404 + no webhook side-effects, VIEWER -> 404, check-before-lookup ordering.
- **New org-connections integration suite** `orgs-connections.test.ts` — 11 tests covering GET (unauth -> 401, non-member -> 404 with no payload leakage, unknown org -> 404, owner happy-path, DEVELOPER member happy-path) and DELETE (unauth -> 401, non-member -> 404 with no write, DEVELOPER -> 404 with no write, OWNER deletes, ADMIN deletes, missing connectionId -> 400).
- Existing callback tests updated to use a `signStateFor` helper that signs + binds to a real `Session` row per call; install-route tests updated to parse the new `<base64url>.<hex>` format.

### Test infra incidentally fixed
Swapped the callback suite's `beforeEach` from `mockClear` to `mockReset` to stop stale `mockResolvedValueOnce` queues from bleeding between tests.

## Status after this PR

Phase A (Critical #1-5) done. Phase B (High #6-25) **done**. Remaining work:
- Phase C (Medium #26-30)
- Phase D (shared-secret S1-S3) — needs design work on per-resource tokens
- "also" items — public-viewer 7-day -> 1-hour presigned URLs, `jarvis/nodes` call reduction

## Test plan

- [x] `npm run test:integration -- github-app-callback.test.ts github-app-install.test.ts orgs-connections.test.ts orgs.test.ts` -> 76 passed / 1 skipped
- [x] `npx vitest run webhook-ensure-route.test.ts github-app-state.test.ts` -> 50 passed
- [x] `tsc --noEmit` clean on changed files
- [x] `eslint` clean on changed files