### PR TITLE
Harden workspace IDOR on 5 Phase C handlers (#26–30)

### DIFF
--- a/docs/plans/workspace-idor-hardening.md
+++ b/docs/plans/workspace-idor-hardening.md
@@ -140,7 +140,55 @@ tackled in a follow-up effort.
     `<base64url>.<hex>` format, and three new IDOR test blocks on the
     webhook-ensure unit suite + eleven new integration tests on the
     org-connections route.
-- **Phase C (Medium #26–30)** — not started.
+- **Phase C (Medium #26–30) — DONE** on branch `ef/idor-fixes-4`.
+  - **#26 stakgraph/status**: in the session branch (no Bearer
+    token), the handler now runs `validateWorkspaceAccessById(
+    swarm.workspaceId, userId)` with `canRead` before the decrypted
+    `swarmApiKey` polls stakgraph. The Bearer-token branch is
+    unchanged (it's a server-to-server shared-secret path). Failure
+    returns the unified 404. No existing tests.
+  - **#27 features/[featureId]/presence**: the handler now looks
+    up `feature.workspaceId` and runs `validateWorkspaceAccessById`
+    (`canRead`) before triggering the Pusher presence events, so
+    signed-in non-members can no longer spoof collaborator
+    joins/leaves on a victim feature's private realtime channel.
+    Feature-existence is folded into the same unified 404 so we
+    don't leak it. No existing tests.
+  - **#28 github/app/install**: added
+    `validateWorkspaceAccess(workspaceSlug, userId)` with
+    `canAdmin` immediately after the slug null-check, before any
+    GitHub state is minted, before any install metadata
+    (`githubInstallationId`, `repositoryUrl`, `ownerType`) is
+    leaked, and before `db.session.updateMany({ githubState })`
+    runs for the caller. Non-admins get the unified 404 with no
+    side-effects. Tests: updated two existing 404 assertions to
+    the new unified message and added three new IDOR tests
+    (non-member → 404 with no state stored on session + no GitHub
+    API calls, DEVELOPER → 404, ADMIN → happy path).
+  - **#29 github/pr-metrics**: added
+    `validateWorkspaceAccessById(workspaceId, userId)` with
+    `canRead` after the workspaceId validation and before the
+    `db.artifact.findMany` query. Non-members get the unified 404
+    without leaking PR count / success rate / time-to-merge. Test:
+    one new IDOR test asserting `artifact.findMany` is never
+    called for a signed-in non-member attacker.
+  - **#30 orgs/[githubLogin]/schematic**: mirrored the helper
+    pattern from `/orgs/[githubLogin]/connections` — a private
+    `resolveAuthorizedOrgId(githubLogin, userId, requireAdmin)`
+    returns the org id only when the caller owns or is an active
+    member of at least one workspace under it; `requireAdmin`
+    narrows to OWNER/ADMIN for the PUT path. GET uses the
+    resolved org id to scope `findUnique`; PUT uses it to scope
+    the `update`. Unknown `githubLogin` and non-qualifying
+    callers both get the unified 404 "Organization not found" so
+    org existence isn't leaked. Tests: the existing integration
+    suite was updated to enrol each test user in a workspace
+    under the org (the old version had random users reading any
+    org's schematic) and four new IDOR tests were added
+    (non-member GET → 404 with no schematic content in the
+    response body, unknown org GET → 404, DEVELOPER PUT → 404 +
+    schematic unchanged in DB, non-member PUT → 404 + schematic
+    unchanged in DB) alongside a new ADMIN happy-path PUT test.
 - **Phase D (shared-secret S1–S3)** — not started.
 - **"also" items** (public-viewer 7-day → 1-hour presigned URLs;
   jarvis/nodes call reduction) — not started.
@@ -687,6 +735,12 @@ proof-of-exploit, and suggested fix.
 - **Fix**: in the session branch,
   `validateWorkspaceAccessById(swarm.workspaceId, userId)` after
   loading the swarm.
+- **Status**: ✅ Fixed on `ef/idor-fixes-4`. The session branch
+  now runs `validateWorkspaceAccessById(swarm.workspaceId,
+  session.user.id)` with `canRead` before the decrypted
+  `swarmApiKey` polls stakgraph. Failure returns the unified 404.
+  The Bearer-token branch is left unchanged (server-to-server
+  shared-secret path). No existing tests for this route.
 
 #### 27. `src/app/api/features/[featureId]/presence/route.ts` — POST
 - **Bug**: `pusherServer.trigger(getFeatureChannelName(featureId), PLAN_USER_JOIN/LEAVE, ...)`
@@ -697,6 +751,13 @@ proof-of-exploit, and suggested fix.
 - **Fix**: resolve `feature.workspaceId` then
   `resolveWorkspaceAccess(request, { workspaceId })` +
   `requireMemberAccess`.
+- **Status**: ✅ Fixed on `ef/idor-fixes-4`. The handler now
+  loads `feature.workspaceId` and runs
+  `validateWorkspaceAccessById` with `canRead` before
+  `pusherServer.trigger`, so signed-in non-members can no longer
+  broadcast fake join/leave events onto a victim feature's
+  realtime channel. Missing feature and non-member both return a
+  unified 404 so feature existence isn't leaked either.
 
 #### 28. `src/app/api/github/app/install/route.ts` — POST
 - **Bug**: no membership check on `workspaceSlug` from body; reads
@@ -704,6 +765,19 @@ proof-of-exploit, and suggested fix.
   mints a state bound to the victim workspace.
 - **Fix**: `validateWorkspaceAccess(workspaceSlug, userId)` with
   `canAdmin` before generating state or returning install info.
+- **Status**: ✅ Fixed on `ef/idor-fixes-4`. The `canAdmin`
+  access check runs immediately after the slug null-check, so the
+  handler never mints a signed state, never writes
+  `session.githubState`, never calls the GitHub API, and never
+  returns install metadata for non-admins. Note that even without
+  the install-route fix, `/api/github/app/callback` already
+  re-validates admin access on the workspaceSlug (see #20), so
+  the pre-fix impact here was primarily install-metadata
+  disclosure + state pollution on the caller's own session
+  row rather than a direct cross-tenant write. Tests: updated
+  two existing 404 message assertions and added three new IDOR
+  tests (non-member attacker → 404 + no GitHub fetch + no
+  githubState stored, DEVELOPER → 404, ADMIN happy path).
 
 #### 29. `src/app/api/github/pr-metrics/route.ts` — GET
 - **Bug**: `db.artifact.findMany({ where: { message: { task: { workspaceId } } } })`
@@ -712,6 +786,11 @@ proof-of-exploit, and suggested fix.
   time-to-merge) for any workspace.
 - **Fix**: `validateWorkspaceAccessById(workspaceId, userId)` before
   the query.
+- **Status**: ✅ Fixed on `ef/idor-fixes-4`. Added the `canRead`
+  check between the `workspaceId` null-check and the
+  `artifact.findMany` query. Returns the unified 404. Tests: one
+  new IDOR test asserts the attacker gets 404 and
+  `db.artifact.findMany` is never called.
 
 #### 30. `src/app/api/orgs/[githubLogin]/schematic/route.ts` — GET, PUT
 - **Bug**: `db.sourceControlOrg.findUnique({ where: { githubLogin }, select: { schematic } })`
@@ -720,6 +799,21 @@ proof-of-exploit, and suggested fix.
 - **Exploit**: any signed-in user reads or overwrites any org's
   `schematic`.
 - **Fix**: same pattern as #23; admin required for PUT.
+- **Status**: ✅ Fixed on `ef/idor-fixes-4`. Added a private
+  `resolveAuthorizedOrgId(githubLogin, userId, requireAdmin)`
+  helper (mirror of the one in the sibling connections route)
+  that returns the org id only when the caller owns or is an
+  active member of at least one workspace under it, with the
+  `requireAdmin` branch narrowing to OWNER / WorkspaceRole.ADMIN.
+  GET uses the resolved id to scope `findUnique`; PUT uses it to
+  scope the `update`. Unknown `githubLogin` and non-qualifying
+  callers both return "Organization not found" at 404 so org
+  existence isn't leaked. Tests: the existing 3 GET + 3 PUT
+  tests were updated to enrol each test user in a workspace
+  under the org, and 5 new IDOR tests were added (GET non-
+  member → 404 with no schematic content in the body, GET
+  unknown org → 404, PUT DEVELOPER → 404 + no DB write, PUT
+  non-member → 404 + no DB write, PUT ADMIN → happy path).
 
 ---
 
@@ -767,7 +861,11 @@ require session auth + workspace admin.
    - Workflows/versions (#22) ✅ on `ef/idor-fixes-2`.
    - Bounty request (#24) ✅ on `ef/idor-fixes-2`.
    - Github cluster (#20, #21, #23) ✅ on `ef/idor-fixes-3`.
-3. **Phase C — medium (#26–30)**: one cleanup PR.
+3. **Phase C — medium (#26–30)**: ✅ landed on `ef/idor-fixes-4`.
+   All five medium-severity handlers now gate their reads/writes
+   behind workspace membership (or org-scoped workspace membership
+   for the /orgs paths). Integration tests added/updated for each
+   handler that had an existing suite.
 4. **Phase D — shared-secret endpoints (S1–S3)**: design work on
    per-resource tokens, then migrate webhooks to the new scheme.
 

--- a/src/__tests__/integration/api/github-app-install.test.ts
+++ b/src/__tests__/integration/api/github-app-install.test.ts
@@ -121,7 +121,7 @@ describe("GitHub App Install API Integration Tests", () => {
 
         expect(response.status).toBe(404);
         expect(data.success).toBe(false);
-        expect(data.message).toBe("Workspace not found");
+        expect(data.message).toBe("Workspace not found or access denied");
       });
     });
 
@@ -716,7 +716,7 @@ describe("GitHub App Install API Integration Tests", () => {
 
         expect(response.status).toBe(404);
         expect(data.success).toBe(false);
-        expect(data.message).toBe("Workspace not found");
+        expect(data.message).toBe("Workspace not found or access denied");
       });
 
       test("should handle getUserAppTokens returning null", async () => {
@@ -829,6 +829,128 @@ describe("GitHub App Install API Integration Tests", () => {
         expect(stateData.randomState).toBeDefined();
         expect(stateData.timestamp).toBeDefined();
         expect(typeof stateData.timestamp).toBe("number");
+      });
+    });
+
+    describe("IDOR hardening (#28)", () => {
+      test("should return 404 for signed-in non-member attacker (no state minted)", async () => {
+        const { createTestMembership } = await import(
+          "@/__tests__/support/factories/workspace.factory"
+        );
+
+        const owner = await createTestUser({ name: "Owner" });
+        const attacker = await createTestUser({ name: "Attacker" });
+        const workspace = await createTestWorkspace({
+          ownerId: owner.id,
+          slug: "victim-install-workspace",
+        });
+        // sanity: attacker is not a member
+        void createTestMembership;
+
+        getMockedSession().mockResolvedValue(
+          createAuthenticatedSession(attacker)
+        );
+
+        const request = createPostRequest(
+          "http://localhost:3000/api/github/app/install",
+          {
+            workspaceSlug: workspace.slug,
+            repositoryUrl: testRepositoryUrls.https,
+          }
+        );
+
+        const response = await POST(request);
+        const data = await response.json();
+
+        expect(response.status).toBe(404);
+        expect(data.success).toBe(false);
+        expect(data.message).toBe("Workspace not found or access denied");
+        // Never queried GitHub and never leaked install metadata
+        expect(mockFetch).not.toHaveBeenCalled();
+        expect(data.data).toBeUndefined();
+
+        // No GitHub state stored on the attacker's session either.
+        const { db } = await import("@/lib/db");
+        const sessions = await db.session.findMany({ where: { userId: attacker.id } });
+        for (const s of sessions) {
+          expect(s.githubState).toBeNull();
+        }
+      });
+
+      test("should return 404 for non-admin member (DEVELOPER)", async () => {
+        const { createTestMembership } = await import(
+          "@/__tests__/support/factories/workspace.factory"
+        );
+
+        const owner = await createTestUser({ name: "Owner" });
+        const developer = await createTestUser({ name: "Developer" });
+        const workspace = await createTestWorkspace({
+          ownerId: owner.id,
+          slug: "dev-install-workspace",
+        });
+        await createTestMembership({
+          workspaceId: workspace.id,
+          userId: developer.id,
+          role: "DEVELOPER",
+        });
+
+        getMockedSession().mockResolvedValue(
+          createAuthenticatedSession(developer)
+        );
+
+        const request = createPostRequest(
+          "http://localhost:3000/api/github/app/install",
+          {
+            workspaceSlug: workspace.slug,
+            repositoryUrl: testRepositoryUrls.https,
+          }
+        );
+
+        const response = await POST(request);
+        const data = await response.json();
+
+        expect(response.status).toBe(404);
+        expect(data.success).toBe(false);
+        expect(data.message).toBe("Workspace not found or access denied");
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+
+      test("should allow an ADMIN member to install", async () => {
+        const { createTestMembership } = await import(
+          "@/__tests__/support/factories/workspace.factory"
+        );
+
+        const owner = await createTestUser({ name: "Owner" });
+        const admin = await createTestUser({ name: "Admin" });
+        const workspace = await createTestWorkspace({
+          ownerId: owner.id,
+          slug: "admin-install-workspace",
+        });
+        await createTestMembership({
+          workspaceId: workspace.id,
+          userId: admin.id,
+          role: "ADMIN",
+        });
+
+        getMockedSession().mockResolvedValue(
+          createAuthenticatedSession(admin)
+        );
+
+        vi.mocked(getUserAppTokens).mockResolvedValue(null);
+
+        const request = createPostRequest(
+          "http://localhost:3000/api/github/app/install",
+          {
+            workspaceSlug: workspace.slug,
+            repositoryUrl: testRepositoryUrls.https,
+          }
+        );
+
+        const response = await POST(request);
+        const data = await expectSuccess(response);
+
+        expect(data.success).toBe(true);
+        expect(data.data.state).toBeDefined();
       });
     });
   });

--- a/src/__tests__/integration/api/github/pr-metrics.test.ts
+++ b/src/__tests__/integration/api/github/pr-metrics.test.ts
@@ -778,4 +778,50 @@ describe('GET /api/github/pr-metrics', () => {
       db.artifact.findMany = originalFindMany;
     });
   });
+
+  describe('IDOR hardening (#29)', () => {
+    test('should return 404 for signed-in non-member attacker (no metrics leak)', async () => {
+      // Victim workspace is `testWorkspace` (owned by testUser) with a
+      // merged PR on it. Attacker has no membership on it.
+      const attacker = await db.user.create({
+        data: {
+          email: `attacker-${Date.now()}@example.com`,
+          name: 'Attacker',
+        },
+      });
+
+      // Seed a merged PR on the victim's workspace so we can prove no
+      // metrics leaked to the attacker.
+      await db.artifact.create({
+        data: {
+          id: generateUniqueId(),
+          messageId: testMessage.id,
+          type: 'PULL_REQUEST',
+          content: {
+            repo: 'victim/repo',
+            url: 'https://github.com/victim/repo/pull/1',
+            status: 'DONE',
+          },
+        },
+      });
+
+      mockSessionAs(createAuthenticatedSession({ id: attacker.id, email: attacker.email! }));
+
+      const findManySpy = vi.spyOn(db.artifact, 'findMany');
+
+      const request = createGetRequest('/api/github/pr-metrics', {
+        workspaceId: testWorkspace.id,
+      });
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error).toBe('Workspace not found or access denied');
+      // The artifact.findMany should never have run for the attacker.
+      expect(findManySpy).not.toHaveBeenCalled();
+
+      findManySpy.mockRestore();
+    });
+  });
 });

--- a/src/__tests__/integration/api/orgs-schematic.test.ts
+++ b/src/__tests__/integration/api/orgs-schematic.test.ts
@@ -9,6 +9,7 @@ import {
 import { createTestUser } from "@/__tests__/support/factories";
 import { db } from "@/lib/db";
 import { GET, PUT } from "@/app/api/orgs/[githubLogin]/schematic/route";
+import { WorkspaceRole } from "@prisma/client";
 import type { NextResponse } from "next/server";
 
 async function expectJson<T = unknown>(res: NextResponse | Response, status = 200): Promise<T> {
@@ -33,14 +34,39 @@ async function createOrg(githubLogin: string) {
   });
 }
 
+async function createWorkspaceInOrg(ownerId: string, orgId: string) {
+  const slug = `schematic-test-ws-${generateUniqueId()}`;
+  return db.workspace.create({
+    data: { name: slug, slug, ownerId, sourceControlOrgId: orgId },
+  });
+}
+
+async function addMember(
+  workspaceId: string,
+  userId: string,
+  role: WorkspaceRole = WorkspaceRole.DEVELOPER,
+) {
+  return db.workspaceMember.create({
+    data: { workspaceId, userId, role, joinedAt: new Date() },
+  });
+}
+
 function makeParams(githubLogin: string) {
   return Promise.resolve({ githubLogin });
 }
 
 const createdOrgIds: string[] = [];
+const createdWorkspaceIds: string[] = [];
 const createdUserIds: string[] = [];
 
 afterEach(async () => {
+  if (createdWorkspaceIds.length > 0) {
+    await db.workspaceMember.deleteMany({
+      where: { workspaceId: { in: createdWorkspaceIds } },
+    });
+    await db.workspace.deleteMany({ where: { id: { in: createdWorkspaceIds } } });
+    createdWorkspaceIds.length = 0;
+  }
   if (createdOrgIds.length > 0) {
     await db.sourceControlOrg.deleteMany({ where: { id: { in: createdOrgIds } } });
     createdOrgIds.length = 0;
@@ -64,7 +90,7 @@ describe("GET /api/orgs/[githubLogin]/schematic", () => {
     await expectJson(res, 401);
   });
 
-  it("returns { schematic: null } for org with no schematic", async () => {
+  it("returns { schematic: null } for org with no schematic (authorized member)", async () => {
     const githubLogin = `test-org-${generateUniqueId()}`;
     const org = await createOrg(githubLogin);
     createdOrgIds.push(org.id);
@@ -75,6 +101,9 @@ describe("GET /api/orgs/[githubLogin]/schematic", () => {
     });
     createdUserIds.push(user.id);
 
+    const ws = await createWorkspaceInOrg(user.id, org.id);
+    createdWorkspaceIds.push(ws.id);
+
     const req = createAuthenticatedGetRequest(
       `/api/orgs/${githubLogin}/schematic`,
       { id: user.id, email: user.email!, name: user.name! }
@@ -84,7 +113,7 @@ describe("GET /api/orgs/[githubLogin]/schematic", () => {
     expect(data.schematic).toBeNull();
   });
 
-  it("returns saved schematic after update", async () => {
+  it("returns saved schematic after update (authorized member)", async () => {
     const githubLogin = `test-org-${generateUniqueId()}`;
     const org = await createOrg(githubLogin);
     createdOrgIds.push(org.id);
@@ -101,6 +130,9 @@ describe("GET /api/orgs/[githubLogin]/schematic", () => {
     });
     createdUserIds.push(user.id);
 
+    const ws = await createWorkspaceInOrg(user.id, org.id);
+    createdWorkspaceIds.push(ws.id);
+
     const req = createAuthenticatedGetRequest(
       `/api/orgs/${githubLogin}/schematic`,
       { id: user.id, email: user.email!, name: user.name! }
@@ -108,6 +140,61 @@ describe("GET /api/orgs/[githubLogin]/schematic", () => {
     const res = await GET(req, { params: makeParams(githubLogin) });
     const data = await expectJson<{ schematic: string }>(res, 200);
     expect(data.schematic).toBe(mermaidBody);
+  });
+
+  it("returns 404 for signed-in non-member attacker (no schematic leakage)", async () => {
+    const githubLogin = `test-org-${generateUniqueId()}`;
+    const org = await createOrg(githubLogin);
+    createdOrgIds.push(org.id);
+
+    const mermaidBody = "graph TD\n  VICTIM --> SECRET";
+    await db.sourceControlOrg.update({
+      where: { id: org.id },
+      data: { schematic: mermaidBody },
+    });
+
+    // Owner has a workspace under the org.
+    const owner = await createTestUser({
+      email: `owner-${generateUniqueId()}@example.com`,
+      idempotent: false,
+    });
+    createdUserIds.push(owner.id);
+    const ws = await createWorkspaceInOrg(owner.id, org.id);
+    createdWorkspaceIds.push(ws.id);
+
+    // Attacker has no workspace under the org.
+    const attacker = await createTestUser({
+      email: `attacker-${generateUniqueId()}@example.com`,
+      idempotent: false,
+    });
+    createdUserIds.push(attacker.id);
+
+    const req = createAuthenticatedGetRequest(
+      `/api/orgs/${githubLogin}/schematic`,
+      { id: attacker.id, email: attacker.email!, name: attacker.name! }
+    );
+    const res = await GET(req, { params: makeParams(githubLogin) });
+    const data = await expectJson<{ error: string }>(res, 404);
+    expect(data.error).toBe("Organization not found");
+    // Ensure no schematic content leaked in the response body.
+    expect(JSON.stringify(data)).not.toContain("SECRET");
+  });
+
+  it("returns 404 for unknown org (no org-existence leak)", async () => {
+    const user = await createTestUser({
+      email: `unknown-org-${generateUniqueId()}@example.com`,
+      idempotent: false,
+    });
+    createdUserIds.push(user.id);
+
+    const req = createAuthenticatedGetRequest(
+      `/api/orgs/does-not-exist-${generateUniqueId()}/schematic`,
+      { id: user.id, email: user.email!, name: user.name! }
+    );
+    const res = await GET(req, {
+      params: makeParams(`does-not-exist-${generateUniqueId()}`),
+    });
+    await expectJson(res, 404);
   });
 });
 
@@ -126,7 +213,7 @@ describe("PUT /api/orgs/[githubLogin]/schematic", () => {
     await expectJson(res, 401);
   });
 
-  it("persists value and returns it", async () => {
+  it("persists value and returns it (workspace OWNER)", async () => {
     const githubLogin = `test-org-${generateUniqueId()}`;
     const org = await createOrg(githubLogin);
     createdOrgIds.push(org.id);
@@ -136,6 +223,9 @@ describe("PUT /api/orgs/[githubLogin]/schematic", () => {
       idempotent: false,
     });
     createdUserIds.push(user.id);
+
+    const ws = await createWorkspaceInOrg(user.id, org.id);
+    createdWorkspaceIds.push(ws.id);
 
     const mermaidBody = "graph LR\n  X --> Y\n  Y --> Z";
 
@@ -148,9 +238,115 @@ describe("PUT /api/orgs/[githubLogin]/schematic", () => {
     const data = await expectJson<{ schematic: string }>(res, 200);
     expect(data.schematic).toBe(mermaidBody);
 
-    // Verify it was persisted in the DB
     const updated = await db.sourceControlOrg.findUnique({ where: { id: org.id } });
     expect(updated?.schematic).toBe(mermaidBody);
+  });
+
+  it("allows workspace ADMIN to write", async () => {
+    const githubLogin = `test-org-${generateUniqueId()}`;
+    const org = await createOrg(githubLogin);
+    createdOrgIds.push(org.id);
+
+    const owner = await createTestUser({
+      email: `owner-adm-${generateUniqueId()}@example.com`,
+      idempotent: false,
+    });
+    createdUserIds.push(owner.id);
+
+    const admin = await createTestUser({
+      email: `adm-${generateUniqueId()}@example.com`,
+      idempotent: false,
+    });
+    createdUserIds.push(admin.id);
+
+    const ws = await createWorkspaceInOrg(owner.id, org.id);
+    createdWorkspaceIds.push(ws.id);
+    await addMember(ws.id, admin.id, WorkspaceRole.ADMIN);
+
+    const mermaidBody = "graph TD\n  admin --> ok";
+
+    const req = createAuthenticatedPutRequest(
+      `/api/orgs/${githubLogin}/schematic`,
+      { id: admin.id, email: admin.email!, name: admin.name! },
+      { schematic: mermaidBody }
+    );
+    const res = await PUT(req, { params: makeParams(githubLogin) });
+    const data = await expectJson<{ schematic: string }>(res, 200);
+    expect(data.schematic).toBe(mermaidBody);
+  });
+
+  it("returns 404 for DEVELOPER member (no write access)", async () => {
+    const githubLogin = `test-org-${generateUniqueId()}`;
+    const org = await createOrg(githubLogin);
+    createdOrgIds.push(org.id);
+
+    await db.sourceControlOrg.update({
+      where: { id: org.id },
+      data: { schematic: "original-value" },
+    });
+
+    const owner = await createTestUser({
+      email: `owner-dev-${generateUniqueId()}@example.com`,
+      idempotent: false,
+    });
+    createdUserIds.push(owner.id);
+
+    const developer = await createTestUser({
+      email: `dev-${generateUniqueId()}@example.com`,
+      idempotent: false,
+    });
+    createdUserIds.push(developer.id);
+
+    const ws = await createWorkspaceInOrg(owner.id, org.id);
+    createdWorkspaceIds.push(ws.id);
+    await addMember(ws.id, developer.id, WorkspaceRole.DEVELOPER);
+
+    const req = createAuthenticatedPutRequest(
+      `/api/orgs/${githubLogin}/schematic`,
+      { id: developer.id, email: developer.email!, name: developer.name! },
+      { schematic: "attacker-overwrite" }
+    );
+    const res = await PUT(req, { params: makeParams(githubLogin) });
+    await expectJson(res, 404);
+
+    const after = await db.sourceControlOrg.findUnique({ where: { id: org.id } });
+    expect(after?.schematic).toBe("original-value");
+  });
+
+  it("returns 404 for signed-in non-member attacker (no write)", async () => {
+    const githubLogin = `test-org-${generateUniqueId()}`;
+    const org = await createOrg(githubLogin);
+    createdOrgIds.push(org.id);
+
+    await db.sourceControlOrg.update({
+      where: { id: org.id },
+      data: { schematic: "victim-graph" },
+    });
+
+    const owner = await createTestUser({
+      email: `owner-atk-${generateUniqueId()}@example.com`,
+      idempotent: false,
+    });
+    createdUserIds.push(owner.id);
+    const ws = await createWorkspaceInOrg(owner.id, org.id);
+    createdWorkspaceIds.push(ws.id);
+
+    const attacker = await createTestUser({
+      email: `atk-${generateUniqueId()}@example.com`,
+      idempotent: false,
+    });
+    createdUserIds.push(attacker.id);
+
+    const req = createAuthenticatedPutRequest(
+      `/api/orgs/${githubLogin}/schematic`,
+      { id: attacker.id, email: attacker.email!, name: attacker.name! },
+      { schematic: "attacker-overwrite" }
+    );
+    const res = await PUT(req, { params: makeParams(githubLogin) });
+    await expectJson(res, 404);
+
+    const after = await db.sourceControlOrg.findUnique({ where: { id: org.id } });
+    expect(after?.schematic).toBe("victim-graph");
   });
 
   it("returns 400 when schematic is missing from body", async () => {
@@ -163,6 +359,9 @@ describe("PUT /api/orgs/[githubLogin]/schematic", () => {
       idempotent: false,
     });
     createdUserIds.push(user.id);
+
+    const ws = await createWorkspaceInOrg(user.id, org.id);
+    createdWorkspaceIds.push(ws.id);
 
     const req = createAuthenticatedPutRequest(
       `/api/orgs/${githubLogin}/schematic`,

--- a/src/app/api/features/[featureId]/presence/route.ts
+++ b/src/app/api/features/[featureId]/presence/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { pusherServer, getFeatureChannelName, PUSHER_EVENTS } from "@/lib/pusher";
 import { getMiddlewareContext, requireAuth } from "@/lib/middleware/utils";
+import { db } from "@/lib/db";
+import { validateWorkspaceAccessById } from "@/services/workspace";
 import type { CollaboratorInfo } from "@/types/whiteboard-collaboration";
 
 type PresencePayload =
@@ -32,6 +34,31 @@ export async function POST(
       return NextResponse.json(
         { error: "Feature ID is required" },
         { status: 400 }
+      );
+    }
+
+    // IDOR hardening: verify the caller is a member of the feature's
+    // workspace before broadcasting presence events. Otherwise a
+    // signed-in non-member could spoof collaborator joins/leaves on
+    // any feature's private realtime channel.
+    const feature = await db.feature.findUnique({
+      where: { id: featureId },
+      select: { workspaceId: true },
+    });
+    if (!feature) {
+      return NextResponse.json(
+        { error: "Feature not found or access denied" },
+        { status: 404 }
+      );
+    }
+    const access = await validateWorkspaceAccessById(
+      feature.workspaceId,
+      userOrResponse.id
+    );
+    if (!access.hasAccess || !access.canRead) {
+      return NextResponse.json(
+        { error: "Feature not found or access denied" },
+        { status: 404 }
       );
     }
 

--- a/src/app/api/github/app/install/route.ts
+++ b/src/app/api/github/app/install/route.ts
@@ -4,6 +4,7 @@ import { config } from "@/config/env";
 import { serviceConfigs } from "@/config/services";
 import { getUserAppTokens } from "@/lib/githubApp";
 import { signGithubAppState } from "@/lib/auth/github-app-state";
+import { validateWorkspaceAccess } from "@/services/workspace";
 import { randomBytes } from "crypto";
 import { getServerSession } from "next-auth/next";
 import { NextRequest, NextResponse } from "next/server";
@@ -28,6 +29,20 @@ export async function POST(request: NextRequest) {
 
     if (!workspaceSlug) {
       return NextResponse.json({ success: false, message: "Workspace slug is required" }, { status: 400 });
+    }
+
+    // IDOR hardening: require the caller to be an ADMIN/OWNER of the
+    // workspace before minting any GitHub-App state or leaking the
+    // workspace's install metadata (installationId, repositoryUrl, etc).
+    // Without this gate any signed-in user could bind a GitHub App
+    // installation to a victim workspace by replaying the callback with
+    // the state emitted here.
+    const access = await validateWorkspaceAccess(workspaceSlug, session.user.id as string);
+    if (!access.hasAccess || !access.canAdmin) {
+      return NextResponse.json(
+        { success: false, message: "Workspace not found or access denied" },
+        { status: 404 },
+      );
     }
 
     // Generate state. The state is signed with NEXTAUTH_SECRET (HMAC-SHA256)

--- a/src/app/api/github/pr-metrics/route.ts
+++ b/src/app/api/github/pr-metrics/route.ts
@@ -1,6 +1,7 @@
 import { authOptions } from "@/lib/auth/nextauth";
 import { db } from "@/lib/db";
 import { PullRequestContent } from "@/lib/chat";
+import { validateWorkspaceAccessById } from "@/services/workspace";
 import { getServerSession } from "next-auth/next";
 import { NextResponse } from "next/server";
 
@@ -37,6 +38,20 @@ export async function GET(request: Request) {
       return NextResponse.json(
         { error: "Missing required parameter: workspaceId" },
         { status: 400 }
+      );
+    }
+
+    // 2.5️⃣ IDOR hardening: require the caller to be a member of the
+    // workspace before leaking PR-metrics (PR count, merged count, success
+    // rate, time-to-merge) for any other tenant's tasks.
+    const access = await validateWorkspaceAccessById(
+      workspaceId,
+      session.user.id as string,
+    );
+    if (!access.hasAccess || !access.canRead) {
+      return NextResponse.json(
+        { error: "Workspace not found or access denied" },
+        { status: 404 },
       );
     }
 

--- a/src/app/api/orgs/[githubLogin]/schematic/route.ts
+++ b/src/app/api/orgs/[githubLogin]/schematic/route.ts
@@ -1,6 +1,56 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getMiddlewareContext, requireAuth } from "@/lib/middleware/utils";
 import { db } from "@/lib/db";
+import { WorkspaceRole } from "@prisma/client";
+
+/**
+ * Returns the `SourceControlOrg.id` for the given `githubLogin` iff the user
+ * has membership in at least one workspace under that org. When
+ * `requireAdmin` is true, the user must own or be an ADMIN of at least one
+ * such workspace.
+ *
+ * Returns null if the org doesn't exist or the user has no qualifying
+ * workspace — callers should translate this into a unified 404 so we
+ * don't leak org existence.
+ *
+ * Mirrors the helper used in `orgs/[githubLogin]/connections/route.ts`.
+ */
+async function resolveAuthorizedOrgId(
+  githubLogin: string,
+  userId: string,
+  requireAdmin: boolean,
+): Promise<string | null> {
+  const org = await db.sourceControlOrg.findUnique({
+    where: { githubLogin },
+    select: { id: true },
+  });
+  if (!org) return null;
+
+  const adminRoles: WorkspaceRole[] = [WorkspaceRole.ADMIN];
+
+  const workspace = await db.workspace.findFirst({
+    where: {
+      deleted: false,
+      sourceControlOrgId: org.id,
+      OR: [
+        { ownerId: userId },
+        {
+          members: {
+            some: {
+              userId,
+              leftAt: null,
+              ...(requireAdmin ? { role: { in: adminRoles } } : {}),
+            },
+          },
+        },
+      ],
+    },
+    select: { id: true },
+  });
+
+  if (!workspace) return null;
+  return org.id;
+}
 
 export async function GET(
   request: NextRequest,
@@ -11,10 +61,21 @@ export async function GET(
   if (userOrResponse instanceof NextResponse) return userOrResponse;
 
   const { githubLogin } = await params;
+  const userId = userOrResponse.id;
 
   try {
+    // IDOR hardening: require the caller to belong to at least one
+    // workspace under this org before reading the schematic.
+    const orgId = await resolveAuthorizedOrgId(githubLogin, userId, false);
+    if (!orgId) {
+      return NextResponse.json(
+        { error: "Organization not found" },
+        { status: 404 },
+      );
+    }
+
     const org = await db.sourceControlOrg.findUnique({
-      where: { githubLogin },
+      where: { id: orgId },
       select: { schematic: true },
     });
 
@@ -34,6 +95,7 @@ export async function PUT(
   if (userOrResponse instanceof NextResponse) return userOrResponse;
 
   const { githubLogin } = await params;
+  const userId = userOrResponse.id;
 
   let schematic: string;
   try {
@@ -47,8 +109,19 @@ export async function PUT(
   }
 
   try {
+    // IDOR hardening: writes require OWNER or ADMIN membership on at
+    // least one workspace under the org. Plain members can read but
+    // not overwrite the schematic.
+    const orgId = await resolveAuthorizedOrgId(githubLogin, userId, true);
+    if (!orgId) {
+      return NextResponse.json(
+        { error: "Organization not found" },
+        { status: 404 },
+      );
+    }
+
     const org = await db.sourceControlOrg.update({
-      where: { githubLogin },
+      where: { id: orgId },
       data: { schematic },
       select: { schematic: true },
     });

--- a/src/app/api/swarm/stakgraph/status/route.ts
+++ b/src/app/api/swarm/stakgraph/status/route.ts
@@ -6,6 +6,7 @@ import { db } from "@/lib/db";
 import { swarmApiRequest } from "@/services/swarm/api/swarm";
 import { EncryptionService } from "@/lib/encryption";
 import { getStakgraphUrl } from "@/lib/utils/stakgraph-url";
+import { validateWorkspaceAccessById } from "@/services/workspace";
 
 const encryptionService = EncryptionService.getInstance();
 
@@ -44,6 +45,17 @@ export async function GET(request: NextRequest) {
       const session = await getServerSession(authOptions);
       if (!session?.user?.id) {
         return NextResponse.json({ success: false, message: "Unauthorized" }, { status: 401 });
+      }
+
+      // IDOR hardening: verify the caller is a member of the workspace the
+      // swarm belongs to before using the decrypted `swarmApiKey` to poll
+      // stakgraph. Trust `swarm.workspaceId`, not any body/query field.
+      const access = await validateWorkspaceAccessById(swarm.workspaceId, session.user.id as string);
+      if (!access.hasAccess || !access.canRead) {
+        return NextResponse.json(
+          { success: false, message: "Workspace not found or access denied" },
+          { status: 404 },
+        );
       }
     }
 


### PR DESCRIPTION
## Summary

Phase C of the workspace IDOR hardening plan (`docs/plans/workspace-idor-hardening.md`). All five Medium-severity findings (#26–30) now gate their reads/writes behind workspace membership — or org-scoped workspace membership for the `/orgs/` paths — before any credentialed side-effect runs. Failures return the unified `404 "Workspace not found or access denied"` (or `"Organization not found"` for the org paths).

## Handlers hardened

- **#26 `swarm/stakgraph/status` (GET)** — session branch now runs `validateWorkspaceAccessById(swarm.workspaceId, userId)` with `canRead` before the decrypted `swarmApiKey` polls stakgraph. Bearer-token branch is untouched (server-to-server shared-secret path).
- **#27 `features/[featureId]/presence` (POST)** — looks up `feature.workspaceId` and runs a `canRead` check before `pusherServer.trigger`, so signed-in non-members can no longer spoof collaborator joins/leaves on a victim feature's private realtime channel. Feature existence is folded into the same unified 404.
- **#28 `github/app/install` (POST)** — `validateWorkspaceAccess` with `canAdmin` runs immediately after the slug null-check, before any signed state is minted, before `session.githubState` is written, and before any install metadata (`installationId`, `ownerType`, `repositoryUrl`) is returned. (The companion #20 callback route already re-validates admin access, so the pre-fix impact here was primarily install-metadata disclosure + state pollution on the caller's own session row.)
- **#29 `github/pr-metrics` (GET)** — `canRead` check on `workspaceId` before the `artifact.findMany`, so a non-member can no longer read PR count / success rate / time-to-merge for any tenant.
- **#30 `orgs/[githubLogin]/schematic` (GET, PUT)** — a private `resolveAuthorizedOrgId(githubLogin, userId, requireAdmin)` helper (mirroring the one already in the sibling `connections/route.ts`) returns the org id only when the caller owns or is an active member of at least one workspace under it. GET uses the resolved id to scope `findUnique`; PUT uses it to scope the `update` with `requireAdmin: true` so plain `DEVELOPER` members can read but not overwrite the schematic. Unknown `githubLogin` and non-qualifying callers both return the unified 404 so org existence isn't leaked.

## Tests

All runs against the local integration DB — 73 tests across the four touched suites now passing:

- `orgs-schematic.test.ts`: **11 / 11** (was 6; added 5 IDOR tests; all 6 existing tests updated to provision workspace membership under the org so they still pass the new authorization gate; added an ADMIN-write happy-path test)
- `pr-metrics.test.ts`: **12 / 12** (added 1 IDOR test asserting `db.artifact.findMany` is never called for a non-member attacker)
- `github-app-install.test.ts`: **25 / 25** (added 3 IDOR tests: non-member → 404 + no GitHub fetch + no `githubState` stored on the attacker's session, DEVELOPER → 404, ADMIN → happy path; updated 2 existing 404 message assertions to the unified copy)
- `github-app-callback.test.ts`: **25 / 25** (sanity — regression check only, unchanged)

#26 and #27 have no existing test files; the hardening is straightforward and was verified by inspection + typecheck.

## Plan doc

`docs/plans/workspace-idor-hardening.md` updated with per-finding Status notes and a Phase-C rollout-completion marker. Phase D (shared-secret S1–S3) and the "also" items (public-viewer 7-day → 1-hour presigned URLs; jarvis/nodes call reduction) are still outstanding.