### PR TITLE
Fix note and decision card text overflow with word-wrap and clipping

### DIFF
--- a/src/__tests__/unit/app/canvas-theme-note-body.test.tsx
+++ b/src/__tests__/unit/app/canvas-theme-note-body.test.tsx
@@ -1,0 +1,262 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+
+// system-canvas re-exports must be mocked before the module under test is
+// imported so the dynamic `require` inside canvas-theme.ts resolves to mocks.
+vi.mock("system-canvas", () => ({
+  darkTheme: {
+    node: {
+      fill: "#000",
+      stroke: "#333",
+      cornerRadius: 8,
+      labelColor: "#fff",
+      sublabelColor: "#aaa",
+      fontFamily: "monospace",
+      labelFont: "sans-serif",
+      fontSize: 13,
+      sublabelFontSize: 11,
+      strokeWidth: 1,
+    },
+    group: {
+      fill: "#111",
+      stroke: "#444",
+      strokeDasharray: "4 4",
+      labelColor: "#aaa",
+      labelFontSize: 11,
+      cornerRadius: 8,
+      strokeWidth: 1,
+    },
+    grid: { color: "#222" },
+    lanes: {
+      bandFillEven: "#111",
+      bandFillOdd: "#000",
+      dividerColor: "#333",
+      dividerWidth: 1,
+      headerBackground: "#000",
+      headerTextColor: "#aaa",
+      headerFontFamily: "sans-serif",
+      headerFontSize: 11,
+      headerSize: 26,
+    },
+  },
+  resolveTheme: (_config: unknown, _base: unknown) => _config,
+}));
+
+// geometry constants
+vi.mock("@/lib/canvas/geometry", () => ({
+  CARD_H: 120,
+  CARD_W: 320,
+  INITIATIVE_H: 140,
+  INITIATIVE_W: 320,
+  MILESTONE_H: 86,
+  MILESTONE_W: 220,
+  SMALL_W: 220,
+}));
+
+// canvas-categories registry – only needs to satisfy the keys check
+vi.mock(
+  "/workspaces/hive/src/app/org/[githubLogin]/connections/canvas-categories",
+  () => ({
+    CATEGORY_REGISTRY: [
+      { id: "workspace" },
+      { id: "repository" },
+      { id: "initiative" },
+      { id: "milestone" },
+      { id: "note" },
+      { id: "decision" },
+    ],
+  }),
+);
+
+import { renderNoteBody, wrapWords } from "@/app/org/[githubLogin]/connections/canvas-theme";
+import type { SlotContext } from "system-canvas";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCtx(
+  text: string,
+  region: { x: number; y: number; width: number; height: number },
+  nodeId = "node-1",
+): SlotContext {
+  return {
+    node: {
+      id: nodeId,
+      text,
+      customData: {},
+    } as SlotContext["node"],
+    theme: {
+      node: {
+        fontSize: 13,
+        fontFamily: "monospace",
+      },
+    } as SlotContext["theme"],
+    region,
+    getSubCanvas: () => undefined,
+    rollup: () => ({ count: 0, total: 0 }),
+  } as unknown as SlotContext;
+}
+
+// ---------------------------------------------------------------------------
+// wrapWords – pure word-wrap utility
+// ---------------------------------------------------------------------------
+
+describe("wrapWords", () => {
+  it("returns a single line when text fits in maxWidth", () => {
+    // 5 chars × 13 × 0.62 ≈ 40px < 200px
+    const lines = wrapWords("hello", 200, 13);
+    expect(lines).toEqual(["hello"]);
+  });
+
+  it("wraps a long sentence across multiple lines", () => {
+    // Each word is ~5 chars; at fontSize 13, width ≈ 5×13×0.62≈40px per word.
+    // maxWidth = 100 → roughly 2–3 words per line.
+    const text = "one two three four five six seven eight";
+    const lines = wrapWords(text, 100, 13);
+    expect(lines.length).toBeGreaterThan(1);
+    // Every line must fit within maxWidth (individual words may exceed it, but
+    // that is acceptable — the wrapper never splits words).
+    for (const line of lines) {
+      const wordCount = line.split(" ").length;
+      expect(wordCount).toBeGreaterThanOrEqual(1);
+    }
+    // Reassembling all lines must recover the original text.
+    expect(lines.join(" ")).toBe(text);
+  });
+
+  it("wraps a single unbroken long word as its own line (no word-split)", () => {
+    const word = "averylongwordthatexceedsmaxwidth";
+    const lines = wrapWords(word, 50, 13);
+    // Cannot split a single word — must appear on one line.
+    expect(lines).toEqual([word]);
+  });
+
+  it("handles empty string gracefully", () => {
+    const lines = wrapWords("", 200, 13);
+    // An empty string splits into one empty word but the loop pushes nothing
+    // (the candidate is "" which never exceeds maxWidth, but `current` stays
+    // empty so the trailing push produces [""]).
+    // In practice renderNoteBody guards with `if (!raw) return null` before
+    // calling wrapWords, so the empty case never reaches the renderer.
+    expect(lines.length).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderNoteBody – React element structure
+// ---------------------------------------------------------------------------
+
+describe("renderNoteBody", () => {
+  it("returns null for empty node.text", () => {
+    const ctx = makeCtx("", { x: 0, y: 30, width: 188, height: 56 });
+    expect(renderNoteBody(ctx)).toBeNull();
+  });
+
+  it("renders a single text element for a short string", () => {
+    const ctx = makeCtx("Short note", { x: 4, y: 30, width: 188, height: 56 });
+    const el = renderNoteBody(ctx) as React.ReactElement;
+    expect(el).not.toBeNull();
+    expect(el.type).toBe("g");
+
+    // The outer <g> has two children: <defs> and the clipped inner <g>.
+    const [defs, innerG] = el.props.children as React.ReactElement[];
+
+    // defs should hold the clipPath
+    expect(defs.type).toBe("defs");
+    const clipPath = defs.props.children as React.ReactElement;
+    expect(clipPath.type).toBe("clipPath");
+    expect(clipPath.props.id).toBe("note-clip-node-1");
+
+    // clipPath rect must match the region exactly
+    const clipRect = clipPath.props.children as React.ReactElement;
+    expect(clipRect.props).toMatchObject({
+      x: 4,
+      y: 30,
+      width: 188,
+      height: 56,
+    });
+
+    // Inner group holds the text lines — React may return a single element
+    // (not an array) when there is only one child.
+    expect(innerG.type).toBe("g");
+    const rawLines = innerG.props.children;
+    const textLines: React.ReactElement[] = Array.isArray(rawLines)
+      ? rawLines
+      : [rawLines];
+    // Short text should be a single line
+    expect(textLines).toHaveLength(1);
+    expect(textLines[0].type).toBe("text");
+    expect(textLines[0].props.children).toBe("Short note");
+  });
+
+  it("wraps long text into multiple <text> lines", () => {
+    // A long string that will definitely need to wrap within 188px
+    const longText =
+      "This is a really long note that should definitely wrap across multiple lines";
+    const ctx = makeCtx(longText, {
+      x: 4,
+      y: 30,
+      width: 188,
+      height: 56,
+    });
+    const el = renderNoteBody(ctx) as React.ReactElement;
+    const [, innerG] = el.props.children as React.ReactElement[];
+    const lines = innerG.props.children as React.ReactElement[];
+    expect(lines.length).toBeGreaterThan(1);
+    // Reassemble to verify no text is dropped
+    const allText = lines.map((l: React.ReactElement) => l.props.children as string).join(" ");
+    expect(allText).toBe(longText);
+  });
+
+  it("renders each newline paragraph independently", () => {
+    const multiLine = "First paragraph\nSecond paragraph";
+    const ctx = makeCtx(multiLine, {
+      x: 4,
+      y: 30,
+      width: 188,
+      height: 80,
+    });
+    const el = renderNoteBody(ctx) as React.ReactElement;
+    const [, innerG] = el.props.children as React.ReactElement[];
+    const lines = innerG.props.children as React.ReactElement[];
+    // Each paragraph should produce at least one line; total ≥ 2
+    expect(lines.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("clipPath rect dimensions match the provided region (overflow clipping)", () => {
+    // Simulate overflowing text by giving a narrow/short region
+    const ctx = makeCtx(
+      "Word1 Word2 Word3 Word4 Word5 Word6 Word7 Word8 Word9 Word10",
+      { x: 10, y: 40, width: 80, height: 30 },
+      "overflow-node",
+    );
+    const el = renderNoteBody(ctx) as React.ReactElement;
+    const [defs] = el.props.children as React.ReactElement[];
+    const clipPath = defs.props.children as React.ReactElement;
+    const clipRect = clipPath.props.children as React.ReactElement;
+    expect(clipRect.props).toMatchObject({
+      x: 10,
+      y: 40,
+      width: 80,
+      height: 30,
+    });
+    expect(clipPath.props.id).toBe("note-clip-overflow-node");
+  });
+
+  it("falls back to SMALL_W - 16 when region.width is 0", () => {
+    // When width is 0, wrapWords should still be called with SMALL_W - 16 = 204
+    const ctx = makeCtx("hello world", { x: 0, y: 30, width: 0, height: 56 });
+    // Should not throw and should produce output
+    const el = renderNoteBody(ctx) as React.ReactElement;
+    expect(el).not.toBeNull();
+  });
+
+  it("uses the node id to create a unique clipPath id per node", () => {
+    const ctx = makeCtx("note text", { x: 0, y: 30, width: 188, height: 56 }, "unique-abc");
+    const el = renderNoteBody(ctx) as React.ReactElement;
+    const [defs] = el.props.children as React.ReactElement[];
+    const clipPath = defs.props.children as React.ReactElement;
+    expect(clipPath.props.id).toBe("note-clip-unique-abc");
+  });
+});

--- a/src/app/org/[githubLogin]/connections/canvas-theme.ts
+++ b/src/app/org/[githubLogin]/connections/canvas-theme.ts
@@ -399,6 +399,103 @@ const milestoneCategory: CategoryDefinition = {
 // Note / decision accent cards (authored)
 // ---------------------------------------------------------------------------
 
+/**
+ * Word-wrap a single paragraph string into lines that fit within `maxWidth`
+ * pixels, using `estimateTextWidth` for glyph-width approximation.
+ *
+ * Exported for unit testing.
+ */
+export function wrapWords(text: string, maxWidth: number, fontSize: number): string[] {
+  const words = text.split(" ");
+  const lines: string[] = [];
+  let current = "";
+  for (const word of words) {
+    const candidate = current ? `${current} ${word}` : word;
+    if (estimateTextWidth(candidate, fontSize) > maxWidth && current) {
+      lines.push(current);
+      current = word;
+    } else {
+      current = candidate;
+    }
+  }
+  if (current) lines.push(current);
+  return lines;
+}
+
+/**
+ * Render the note/decision card body text with word-wrap and clip.
+ *
+ * - Reads `node.text`, splits on `\n` for explicit paragraphs.
+ * - Word-wraps each paragraph to fit within `region.width`
+ *   (falls back to `SMALL_W - 16` when region width is unavailable).
+ * - Renders each line as an SVG `<text>` element.
+ * - Clips the whole group to the region rect so no text bleeds past
+ *   the card boundary, horizontally or vertically.
+ *
+ * Exported for unit testing.
+ */
+export function renderNoteBody(ctx: SlotContext): React.ReactNode {
+  const { region, node, theme } = ctx;
+  const raw = node.text ?? "";
+  if (!raw) return null;
+
+  const fs = theme.node.fontSize;
+  const lineHeight = fs + 3;
+  const font = theme.node.fontFamily;
+  const maxWidth = (region.width > 0 ? region.width : SMALL_W) - 16;
+  const clipId = `note-clip-${node.id}`;
+
+  // Expand each newline-separated paragraph through word-wrap.
+  const paragraphs = raw.split("\n");
+  const allLines: string[] = [];
+  for (const para of paragraphs) {
+    const wrapped = wrapWords(para || " ", maxWidth, fs);
+    allLines.push(...wrapped);
+  }
+
+  const baseY = region.y + fs;
+
+  return createElement(
+    "g",
+    { pointerEvents: "none" },
+    // Define the clip rect keyed to this node so multiple cards
+    // each have an independent clip region.
+    createElement(
+      "defs",
+      null,
+      createElement(
+        "clipPath",
+        { id: clipId },
+        createElement("rect", {
+          x: region.x,
+          y: region.y,
+          width: region.width,
+          height: region.height,
+        }),
+      ),
+    ),
+    createElement(
+      "g",
+      { clipPath: `url(#${clipId})`, pointerEvents: "none" },
+      ...allLines.map((line, i) =>
+        createElement(
+          "text",
+          {
+            key: i,
+            x: region.x,
+            y: baseY + i * lineHeight,
+            fill: TEXT,
+            fontSize: fs,
+            fontFamily: font,
+            pointerEvents: "none",
+          },
+          line,
+        ),
+      ),
+    ),
+  );
+}
+
 function accentNote(color: string, kicker: string): CategoryDefinition {
   return {
     ...baseCard,
@@ -409,6 +506,10 @@ function accentNote(color: string, kicker: string): CategoryDefinition {
     fill: hexAlpha(color, 0.05),
     slots: {
       header: { kind: "text", value: kicker, color },
+      body: {
+        kind: "custom",
+        render: (ctx: SlotContext) => renderNoteBody(ctx),
+      },
     },
   } as CategoryDefinition;
 }


### PR DESCRIPTION
Generated with Hive: Fix note and decision card text overflow with word-wrap and clipping