### PR TITLE
Generated with Hive: Restore input and output pricing fields to llm-models API response and update integration test

### DIFF
--- a/src/__tests__/integration/api/llm-models.test.ts
+++ b/src/__tests__/integration/api/llm-models.test.ts
@@ -252,9 +252,10 @@ describe("GET /api/llm-models - Integration Tests", () => {
         expect(model).toHaveProperty("provider");
         expect(model).toHaveProperty("providerLabel");
         expect(model).toHaveProperty("isPublic");
-        // Pricing fields should NOT be in the response (select only returns id/name/provider/providerLabel)
-        expect(model).not.toHaveProperty("inputPricePer1M");
-        expect(model).not.toHaveProperty("outputPricePer1M");
+        expect(model).toHaveProperty("inputPricePer1M");
+        expect(typeof model.inputPricePer1M).toBe("number");
+        expect(model).toHaveProperty("outputPricePer1M");
+        expect(typeof model.outputPricePer1M).toBe("number");
         expect(model).not.toHaveProperty("createdAt");
       }
     });

--- a/src/app/api/llm-models/route.ts
+++ b/src/app/api/llm-models/route.ts
@@ -27,6 +27,8 @@ export async function GET(request: NextRequest) {
       isPlanDefault: true,
       isTaskDefault: true,
       isPublic: true,
+      inputPricePer1M: true,
+      outputPricePer1M: true,
       cacheReadPer1MToken: true,
       cacheWritePer1MToken: true,
     },


### PR DESCRIPTION
Restore input and output pricing fields to llm-models API response and update integration test