### PR TITLE
Embed feature plan chat in org canvas node detail

### DIFF
--- a/docs/plans/canvas-feature-node-chat.md
+++ b/docs/plans/canvas-feature-node-chat.md
@@ -1,0 +1,632 @@
+# Canvas Feature-Node Chat
+
+Expose the feature-level "plan chat" (the conversational front-end for the serial-agent planning workflow) inside the org canvas right panel, so the user can read and continue a feature's planning conversation without leaving `/org/[githubLogin]`.
+
+Status: **proposed**.
+
+## Goal
+
+When the user clicks a `feature` node on the org canvas, the right panel's Details tab today shows a status pill, a task count, an optional owner, and an "Open feature" link out to `/w/{slug}/plan/{featureId}` (`NodeDetail.tsx:288-315`). That link is a *teleport*: it leaves the canvas, drops you into a two-pane resizable layout (chat + artifacts panel) with all the workflow trimmings — collaborator presence, project-log streaming, model picker, breadcrumbs, mobile preview swap, etc. (`PlanChatView.tsx:89-651`).
+
+Most of the time the user doesn't need any of that. They want to read the last few messages, ask a quick clarifying question, and stay on the canvas. The plan chat is "simple usually" (per the request) — under the hood it's a complex serial-agent workflow, but the *user-facing* surface is just a chat scroll plus an input.
+
+This plan exposes that conversation as a third section inside the existing feature-node `NodeDetail` body — keyed off the same `/api/features/[featureId]/chat` API the full plan page uses, subscribing to the same Pusher channel for live updates, but rendered as a narrow sidebar chat (the visual idiom already established by `SidebarChat` for canvas-agent conversations). The "Open feature" link stays as the escape hatch to the full artifacts UI.
+
+### One non-negotiable artifact: clarifying questions
+
+The plan agent's signature interaction is the **clarifying-questions card**: when it can't make progress without more info, it emits a structured JSON artifact (a `PLAN`-typed `Artifact` with `tool_use === "ask_clarifying_questions"`) carrying a list of `ClarifyingQuestion` objects. Each question can be free-form text **or** a multiple-choice with optional embedded sub-artifacts (mermaid diagrams, comparison tables, color swatches — see `src/components/features/ClarifyingQuestionsPreview/`). The user answers in the chat and submission posts back via the chat API with a `replyId` pointing at the artifact's message; once answered, the card collapses to an "N questions answered" summary.
+
+This **must** render in the canvas chat. Without it, the workflow halts visibly on the full plan page (artifacts panel shows the questions inline next to the chat) but invisibly on the canvas sidebar — the user sees a one-line "Looking into it…" assistant message and no way to proceed. This isn't a fancy nice-to-have; it's the difference between "the plan agent works on the canvas" and "the plan agent silently stalls and the user thinks something's broken."
+
+Good news: the renderer (`<ClarifyingQuestionsPreview>`) and the answer-submission contract (`onArtifactAction` → `POST /api/features/[id]/chat` with `replyId`) both already exist and are reusable as-is. The work is wiring them through the new sidebar component without dragging in the rest of `ChatMessage`. See "Clarifying questions — required artifact rendering" below.
+
+## Non-goals
+
+- **Showing PLAN/TASKS/VERIFY artifacts inline as the artifact body.** That's the multi-tab content rendered by `ArtifactsPanel` next to the chat on the full plan page (the actual brief / requirements / architecture / user-story sections, the task list, the verify checklist). Out of scope for this PR — see "Follow-up: artifacts dialog" below. **Exception:** clarifying-questions are themselves a `PLAN` artifact and *do* render inline; see the dedicated section below. The other `PLAN`-content shapes (the structured plan-section payload, the `TASKS` payload, etc.) are skipped — the user gets a "Full plan view" link instead.
+- **Editing the feature title from the canvas.** `PlanChatView` has an inline title editor; the canvas already shows the feature title at the top of `NodeDetail` (from the canvas projector data) and changing titles from a node-detail context is a separate UX question.
+- **Collaborator presence / typing indicators.** `usePlanPresence` exists, but presence on a peripheral surface adds noise. Skip it; the full plan page is where collaboration happens.
+- **Live project-log streaming (`useProjectLogWebSocket`).** The "thinking logs" stream is a debug/observability surface tied to the artifacts panel's run-status display. The sidebar chat shows assistant messages and the workflow status — that's enough.
+- **Model picker.** Sends use the persisted `feature.model` (set from the full plan page). No selector in the sidebar.
+- **Image/file attachments.** The sidebar input is keyboard-only.
+- **Mobile.** The org canvas is desktop-only; the feature-node chat inherits that constraint.
+- **Showing the chat for non-feature nodes.** Tasks have their own conversation (`/w/{slug}/tasks/{taskId}`) which is a different beast. This PR is scoped to `case "feature"` in `NodeDetail`. Tasks could follow the same pattern in a follow-up if there's demand.
+- **Replacing or modifying `PlanChatView`.** The full plan page stays exactly as it is. No shared hook extraction, no layout-neutral refactor — the new component reads the same API but is its own narrow-column shape.
+- **Reusing `ChatArea` from the task page.** `ChatArea` (`src/app/w/[slug]/task/[...taskParams]/components/ChatArea.tsx`) is 441 lines of breadcrumbs, back-buttons, invite popovers, release-pod confirms, title editing, mobile preview toggles — none of which fit the canvas sidebar. Forking is cheaper than threading another half-dozen "hide this in canvas mode" props.
+
+## The chrome we're adding
+
+```
+┌──────────────────────────────────────┐
+│ FEATURE                              │
+│ Improve onboarding flow              │
+├──────────────────────────────────────┤
+│ ● in_progress     7 tasks            │
+│ ┌────────────────┬────────────────┐  │
+│ │ Owner          │ Alice          │  │
+│ └────────────────┴────────────────┘  │
+│ ↗ Open feature                       │
+│                                      │
+│ ─── Plan chat ──────────────────     │
+│ ┌────────────────────────────────┐   │
+│ │ Assistant: Here's a brief…     │   │
+│ └────────────────────────────────┘   │
+│ ┌────────────────────────────────┐   │
+│ │ User: tighten step 2           │   │
+│ └────────────────────────────────┘   │
+│ ┌────────────────────────────────┐   │
+│ │ ▶ Workflow: in_progress…       │   │
+│ └────────────────────────────────┘   │
+│ ┌────────────────────────────────┐   │
+│ │ Ask the planner…           [→] │   │
+│ └────────────────────────────────┘   │
+└──────────────────────────────────────┘
+```
+
+The existing feature `KindExtras` block (status pill, task count, owner, "Open feature" link) is unchanged. Below it: a short divider and the `FeaturePlanChat` component.
+
+The right panel stays at `w-96` (set by `canvas-sidebar-chat`). No layout change to `OrgRightPanel`. No new tab.
+
+## Routing
+
+Unchanged. The chat lives inside the existing Details tab body, only when `selectedNode.id` resolves to a feature (via the `case "feature"` arm in `KindExtras`). No new routes, no deep-link param. To get a permalink to a specific feature's chat, the canvas already supports node-selection deep links via the canvas pane.
+
+## Files changed
+
+| File | Change |
+| ---- | ------ |
+| `src/app/org/[githubLogin]/_components/FeaturePlanChat.tsx` | **New.** ~300 lines. Sidebar-shaped chat for feature nodes. Reads/writes `/api/features/[featureId]/chat`, subscribes to Pusher via `usePusherConnection({ featureId })`, pairs reply messages with their artifact messages, handles regular sends and clarifying-question answer submissions. |
+| `src/app/org/[githubLogin]/_components/FeaturePlanChatMessage.tsx` | **New.** ~120 lines. Narrow-column message bubble for `ChatMessage` (the feature/task chat type). Renders text content; renders `<ClarifyingQuestionsPreview>` or `<AnsweredClarifyingQuestions>` for `PLAN` artifacts with `tool_use === "ask_clarifying_questions"`; renders nothing for other artifact types in PR 1 (with an optional "View N artifacts" pill). |
+| `src/components/features/ClarifyingQuestionsPreview/AnsweredClarifyingQuestions.tsx` | **New.** ~30 lines. Lifted from `ChatMessage.tsx:71-103`. Renders the collapsible "N questions answered" Q&A summary. Imported by both `FeaturePlanChatMessage` and (refactored) `ChatMessage`. |
+| `src/app/w/[slug]/task/[...taskParams]/components/ChatMessage.tsx` | Replace the inline `AnsweredClarifyingQuestions` definition (lines 71-103) with an import from the shared file. ~5-line diff. |
+| `src/app/org/[githubLogin]/_components/NodeDetail.tsx` | In `case "feature"` (`NodeDetail.tsx:288-315`), render `<FeaturePlanChat featureId={detail.id} workspaceSlug={slug} />` below the existing stats + "Open feature" link. ~5-line diff. |
+| *(recommended)* `src/app/api/orgs/[githubLogin]/canvas/node/[liveId]/route.ts` | Add `workflowStatus: true` to the feature `select` block (line 207-216) and surface as `extras.workflowStatus`. Saves a per-mount `/api/features/[id]` round-trip. ~2-line diff. |
+
+No DB migrations. No new endpoints — the feature chat API (`GET`/`POST /api/features/[featureId]/chat`) already enforces workspace membership (`route.ts:54-64, 127-129`) and is reused as-is. Pusher channels are reused.
+
+## `FeaturePlanChat` — the new component
+
+Lives at `src/app/org/[githubLogin]/_components/FeaturePlanChat.tsx`. Scoped to the feature-node body of the org-canvas Details tab.
+
+### Props
+
+```ts
+interface FeaturePlanChatProps {
+  /** Feature id (Prisma `Feature.id`). Drives the chat fetch + Pusher channel. */
+  featureId: string;
+  /**
+   * Workspace slug the feature belongs to. Pulled from
+   * `detail.extras.workspaceSlug` in `NodeDetail`'s feature arm
+   * (`NodeDetail.tsx:291`); same value used to build the
+   * "Open feature" footer link.
+   */
+  workspaceSlug: string;
+}
+```
+
+That's the entire prop surface. No collaborators, no model list, no `onTitleSave`, no `streamContext`, no `isPrototypeTask`. The plan-page concerns stay on the plan page.
+
+### Layout (root → leaves)
+
+```tsx
+<div className="flex flex-col gap-2 mt-4 pt-4 border-t">
+  <div className="flex items-center justify-between">
+    <span className="text-[10px] uppercase tracking-wider text-muted-foreground font-medium">
+      Plan chat
+    </span>
+    <WorkflowStatusBadge status={workflowStatus} />
+  </div>
+
+  {/* Message list — capped height, scrolls internally. */}
+  <div ref={scrollRef} className="max-h-[420px] overflow-y-auto rounded border bg-muted/20 p-2">
+    {loading ? (
+      <Spinner />
+    ) : messages.length === 0 ? (
+      <EmptyHint>The planner hasn't said anything yet. Send a message to start.</EmptyHint>
+    ) : (
+      <div className="space-y-2">
+        {messages.map((m) => (
+          <FeaturePlanChatMessage key={m.id} message={m} />
+        ))}
+        {workflowStatus === WorkflowStatus.IN_PROGRESS && <ToolCallIndicator … />}
+      </div>
+    )}
+  </div>
+
+  {/* Input — keyboard only. */}
+  <FeaturePlanChatInput onSend={handleSend} disabled={inputDisabled} />
+
+  <div className="text-[10px] text-muted-foreground italic">
+    Full plan view (PLAN/TASKS/VERIFY) →{" "}
+    <Link href={`/w/${workspaceSlug}/plan/${featureId}`} className="underline">
+      Open feature
+    </Link>
+  </div>
+</div>
+```
+
+Bound height (`max-h-[420px]`) on the scroller — the parent `NodeDetail` body is `overflow-y-auto` (`NodeDetail.tsx:64`), and we don't want a runaway message list to push the rest of the details body below the fold. Internal scroll keeps the stats visible.
+
+The "Open feature" link inside `FeaturePlanChat` is a *secondary* footer specifically pointing the user at the artifacts panel ("Full plan view"); the existing primary "Open feature" link in `KindExtras` remains. Two links is fine — they have different framing.
+
+### Reused dependencies
+
+- `SidebarChatMessage` (`src/app/org/[githubLogin]/_components/SidebarChatMessage.tsx`) — the narrow-column message bubble already used by `SidebarChat`. **Drop-in.** Need to verify its props match `ChatMessage` (the type used by `/api/features/[featureId]/chat`); see "Type-shape gotcha" below.
+- `ToolCallIndicator` (`@/components/dashboard/DashboardChat/ToolCallIndicator`) — same component used by `SidebarChat`. Used here only when `workflowStatus === IN_PROGRESS` and the most recent assistant message hasn't streamed text yet (mirrors `PlanChatView`'s implicit pattern via `ChatArea`).
+- `usePusherConnection` (`@/hooks/usePusherConnection`) — already keyed by `featureId` (`usePusherConnection.ts:62-77`). We pass `onMessage`, `onWorkflowStatusUpdate`. **Skip** `onFeatureUpdated`, `onFeatureTitleUpdate` — title/brief refresh is handled by the canvas projector when the user hits the canvas next; we don't need to refetch the node detail from inside the chat.
+- `useSession` — to attach `createdBy` on the optimistic user message.
+
+### State
+
+```ts
+const [messages, setMessages] = useState<ChatMessage[]>([]);
+const [loading, setLoading] = useState(true);     // initial GET
+const [sending, setSending] = useState(false);    // POST in flight
+const [workflowStatus, setWorkflowStatus] = useState<WorkflowStatus | null>(null);
+const scrollRef = useRef<HTMLDivElement>(null);
+```
+
+That's it. No project-id tracking (no live-log subscription), no sphinx-ready, no LLM-models-list, no presence, no diff highlights, no `initialLoadDone` two-stage gate (we use `loading` directly), no tab state, no localStorage.
+
+### Initial fetch
+
+```ts
+useEffect(() => {
+  let cancelled = false;
+  setLoading(true);
+  fetch(`/api/features/${featureId}/chat`)
+    .then((r) => (r.ok ? r.json() : { data: [] }))
+    .then((body) => {
+      if (cancelled) return;
+      setMessages(body.data ?? []);
+      // Workflow status is on the feature row, not the chat.
+      // Cheap second fetch — or pull from props if we expose it via the
+      // canvas node API. See "Workflow status source" below.
+    })
+    .catch(() => {})
+    .finally(() => {
+      if (!cancelled) setLoading(false);
+    });
+  return () => { cancelled = true; };
+}, [featureId]);
+```
+
+Mount-only effect (deps stable). On error, falls through to "no messages" — the user can still try sending one.
+
+### Pusher subscription
+
+```ts
+usePusherConnection({
+  featureId,
+  onMessage: (msg) => {
+    setMessages((prev) =>
+      prev.some((m) => m.id === msg.id) ? prev : [...prev, msg],
+    );
+    setSending(false);
+  },
+  onWorkflowStatusUpdate: (u) => {
+    setWorkflowStatus(u.workflowStatus);
+    if (
+      u.workflowStatus === WorkflowStatus.COMPLETED ||
+      u.workflowStatus === WorkflowStatus.FAILED ||
+      u.workflowStatus === WorkflowStatus.ERROR ||
+      u.workflowStatus === WorkflowStatus.HALTED
+    ) {
+      setSending(false);
+    }
+  },
+});
+```
+
+Same pattern as `PlanChatView.tsx:329-369`, minus the title-update / feature-update / log subscription branches. The hook's `enabled` defaults to `true`; when `NodeDetail` switches to a non-feature node, `FeaturePlanChat` unmounts entirely, which the hook handles by disconnecting on cleanup.
+
+### `handleSend`
+
+Adapt from `PlanChatView.tsx:371-426`:
+
+```ts
+const handleSend = async (text: string) => {
+  const optimistic = createChatMessage({
+    id: generateUniqueId(),
+    message: text,
+    role: ChatRole.USER,
+    status: ChatStatus.SENDING,
+    createdBy: session?.user ? { /* … */ } : undefined,
+  });
+  setMessages((m) => [...m, optimistic]);
+  setSending(true);
+  setWorkflowStatus(WorkflowStatus.IN_PROGRESS);
+
+  try {
+    const res = await fetch(`/api/features/${featureId}/chat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        message: text,
+        sourceWebsocketID: getPusherClient().connection.socket_id,
+        // No `model` — server falls back to feature.model (already persisted).
+      }),
+    });
+    if (!res.ok) throw new Error("send failed");
+    const data = await res.json();
+    setMessages((m) =>
+      m.map((x) => (x.id === optimistic.id ? { ...data.message, status: ChatStatus.SENT } : x)),
+    );
+  } catch (e) {
+    setMessages((m) =>
+      m.map((x) => (x.id === optimistic.id ? { ...x, status: ChatStatus.ERROR } : x)),
+    );
+    setSending(false);
+  }
+};
+```
+
+Drop from `PlanChatView`'s version: `attachments`, `selectedModel`, `clearLogs`, `setProjectId`, `setIsChainVisible`. Don't pass `replyId` — the Approve/Reject artifact actions live on the full plan page.
+
+### `inputDisabled`
+
+```ts
+const inputDisabled = loading || sending || workflowStatus === WorkflowStatus.IN_PROGRESS;
+```
+
+Mirrors `PlanChatView.tsx:516-520` minus the `feature.status === "CANCELLED"` clause (we don't have the feature row here; if it's worth surfacing, the canvas API can include `extras.status` which already does — `NodeDetail.tsx:289`).
+
+### Auto-scroll
+
+```ts
+useEffect(() => {
+  const el = scrollRef.current;
+  if (!el) return;
+  el.scrollTop = el.scrollHeight;
+}, [messages, workflowStatus]);
+```
+
+Same `scrollTop = scrollHeight` pattern `SidebarChat` uses (`SidebarChat.tsx:69-73`). Avoids the `scrollIntoView` page-bumping risk that `ChatArea` runs into (and partially mitigates with `shouldAutoScroll` state).
+
+## Clarifying questions — required artifact rendering
+
+The plan agent's `ask_clarifying_questions` flow is the most user-facing artifact in the feature chat and the **one** artifact type the canvas sidebar must render in PR 1. Skipping it would leave the agent unable to make progress whenever it needs input — a silent stall that's worse than not exposing the chat at all.
+
+### How the existing flow works
+
+1. **Agent emits.** During a Stakwork run, the agent attaches a `PLAN`-typed `Artifact` to the latest assistant `ChatMessage` whose `content` is a `ClarifyingQuestionsResponse` shape (`{ tool_use: "ask_clarifying_questions", content: ClarifyingQuestion[] }`). The artifact streams in via Pusher; the message's `artifacts` array gains a new entry. Detection is via `isClarifyingQuestions(a.content)` from `@/types/stakwork` (`ChatMessage.tsx:16-17`).
+2. **Each `ClarifyingQuestion`** is one of:
+   - **Free-form text** — render a `<Textarea>`.
+   - **Multiple-choice** — render a list of options (radio or checkbox). Optional `artifact` field embedded in the question carries a mermaid diagram, comparison table, or color-swatch grid that helps the user choose. Validation lives in `ClarifyingQuestionsPreview/index.tsx:16-100`.
+3. **User answers.** `<ClarifyingQuestionsPreview>` collects responses, formats them as a Q&A block (one `Q: …\nA: …` per pair, separated by blank lines), and calls `onSubmit(formattedAnswers)`.
+4. **Submit.** The host component (today: `ChatMessage`) receives `onSubmit` and turns it into an `onArtifactAction(message.id, { actionType: "button", optionLabel: "Submit", optionResponse: formattedAnswers }, "")` call (`ChatMessage.tsx:349-358`).
+5. **POST.** The host's `onArtifactAction` (today: `PlanChatView.handleArtifactAction` at `PlanChatView.tsx:428-488`) POSTs to `/api/features/[featureId]/chat` with `{ message: optionResponse, replyId: messageId, model: selectedModel }`. The server creates a new USER message linked back to the artifact's message via `replyId`, kicks off the next workflow step, and Pusher streams the next assistant turn.
+6. **Render after answer.** Once a USER message with `replyId === artifactMessage.id` exists, `<ClarifyingQuestionsPreview>` is replaced by `<AnsweredClarifyingQuestions>` — a collapsible "N questions answered" Q&A summary computed from `parseQAPairs(replyMessage.message)` (`ChatMessage.tsx:71-103`). The original artifact + answer message stay in the conversation as a record.
+
+### What `FeaturePlanChat` needs to do
+
+Three integration points:
+
+#### 1. Pair reply messages with their artifact messages
+
+`ChatArea` does this today at `ChatArea.tsx:375-384`:
+
+```ts
+.filter((msg) => !msg.replyId)              // hide reply messages from the top-level list
+.map((msg) => {
+  const replyMessage = messages.find((m) => m.replyId === msg.id);
+  return <ChatMessage … replyMessage={replyMessage} />;
+});
+```
+
+`FeaturePlanChat`'s render loop adopts the same two-step shape: filter out `replyId`-bearing messages from the top-level scroll, then for each remaining message look up its reply in the original list and pass it to the message renderer. Same pattern, different bubble component.
+
+#### 2. Render the artifact inside `FeaturePlanChatMessage`
+
+The fork called out in "Type-shape gotcha" above gets one more responsibility: detect clarifying-questions artifacts on the message and render them inline. Roughly:
+
+```tsx
+import { isClarifyingQuestions } from "@/types/stakwork";
+import type { ClarifyingQuestionsResponse } from "@/types/stakwork";
+import { ClarifyingQuestionsPreview } from "@/components/features/ClarifyingQuestionsPreview";
+
+// inside FeaturePlanChatMessage, after rendering the bubble text:
+{message.artifacts
+  ?.filter((a) => a.type === "PLAN" && isClarifyingQuestions(a.content))
+  .map((artifact) => {
+    const questions = (artifact.content as ClarifyingQuestionsResponse).content;
+    const isAnswered = !!replyMessage;
+    return (
+      <div key={artifact.id} className="w-full">
+        {isAnswered && replyMessage ? (
+          <AnsweredClarifyingQuestions questions={questions} replyMessage={replyMessage} />
+        ) : (
+          <ClarifyingQuestionsPreview
+            questions={questions}
+            onSubmit={(formattedAnswers) =>
+              onSubmitAnswers(message.id, formattedAnswers)
+            }
+          />
+        )}
+      </div>
+    );
+  })}
+```
+
+`<AnsweredClarifyingQuestions>` is a small (~30 line) component that we copy-paste from `ChatMessage.tsx:71-103`. It's tied to the Q&A summary format, not to any task/feature-specific concern; safe to lift into `FeaturePlanChat.tsx` as a sibling. Alternatively: extract it into `src/components/features/ClarifyingQuestionsPreview/AnsweredClarifyingQuestions.tsx` so both `ChatMessage` and `FeaturePlanChatMessage` can import it. Recommendation: extract it (one shared file, two callers, ~5 line refactor on the `ChatMessage` side). Keeps the rendering of "answered" state consistent if the design ever evolves.
+
+#### 3. Submit answers via the same `replyId` POST
+
+`FeaturePlanChat` adds an `onSubmitAnswers(messageId, answers)` callback that mirrors `PlanChatView.handleArtifactAction` minus the model picker:
+
+```ts
+const onSubmitAnswers = async (messageId: string, formattedAnswers: string) => {
+  const optimistic = createChatMessage({
+    id: generateUniqueId(),
+    message: formattedAnswers,
+    role: ChatRole.USER,
+    status: ChatStatus.SENDING,
+    replyId: messageId,
+    createdBy: session?.user ? { /* … */ } : undefined,
+  });
+  setMessages((m) => [...m, optimistic]);
+  setSending(true);
+  setWorkflowStatus(WorkflowStatus.IN_PROGRESS);
+
+  try {
+    const res = await fetch(`/api/features/${featureId}/chat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        message: formattedAnswers,
+        replyId: messageId,
+        sourceWebsocketID: getPusherClient().connection.socket_id,
+      }),
+    });
+    if (!res.ok) throw new Error("submit failed");
+    const data = await res.json();
+    setMessages((m) =>
+      m.map((x) => (x.id === optimistic.id ? { ...data.message, status: ChatStatus.SENT } : x)),
+    );
+  } catch {
+    setMessages((m) =>
+      m.map((x) => (x.id === optimistic.id ? { ...x, status: ChatStatus.ERROR } : x)),
+    );
+    setSending(false);
+  }
+};
+```
+
+Same shape as the regular `handleSend`, plus `replyId: messageId` in both the optimistic message and the POST body. The two paths can share a single internal helper (`sendInternal({ text, replyId? })`) to halve the duplication.
+
+### Embedded sub-artifacts in narrow columns
+
+`<ClarifyingQuestionsPreview>` already supports embedded mermaid diagrams, comparison tables, and color swatches inside multiple-choice options. Mermaid in particular wants width — it's a chart. In a 384px sidebar column, the embedded artifact will render at column width, which mermaid handles via SVG scaling but comparison tables can run into horizontal scroll on dense data. Acceptable as-is in PR 1: the user can always click "Open feature" if a question's table is unreadable. If feedback later says it's too cramped, the mitigation is a "View at full width" button that opens the artifact in a modal — small follow-up, not a launch blocker.
+
+### What the chat does while a clarifying-questions artifact is pending
+
+Two states matter:
+
+- **Pending answer (no reply message exists yet):** The agent's workflow is paused waiting for input. `workflowStatus` should be `IN_PROGRESS` (the Stakwork run is still alive, waiting on the user). The text input below the message list **should remain enabled** so the user can either answer via the card *or* type a free-form response — sometimes users prefer to ignore the structured form and just say "skip these, use defaults" or "actually let me re-explain the goal." This matches the full plan page's behavior (the input isn't disabled while questions are pending).
+- **After answer (reply message exists):** Card collapses to `<AnsweredClarifyingQuestions>`. `workflowStatus` flips back to `IN_PROGRESS` from the answer POST and follows the normal flow.
+
+Reconciling this with `inputDisabled` (which today is `loading || sending || workflowStatus === IN_PROGRESS`): the `IN_PROGRESS` clause is too aggressive when there's a pending clarifying question. Refinement:
+
+```ts
+const hasPendingClarifyingQuestion = useMemo(
+  () =>
+    messages.some(
+      (m) =>
+        m.artifacts?.some(
+          (a) => a.type === "PLAN" && isClarifyingQuestions(a.content),
+        ) &&
+        !messages.some((reply) => reply.replyId === m.id),
+    ),
+  [messages],
+);
+
+const inputDisabled =
+  loading ||
+  sending ||
+  (workflowStatus === WorkflowStatus.IN_PROGRESS && !hasPendingClarifyingQuestion);
+```
+
+When `hasPendingClarifyingQuestion` is true, the input stays enabled even though the workflow is technically running.
+
+### Tests for clarifying questions
+
+Add to the unit test list:
+
+- Renders `<ClarifyingQuestionsPreview>` when an assistant message has a `PLAN` artifact with `tool_use === "ask_clarifying_questions"` and no reply message exists.
+- Renders `<AnsweredClarifyingQuestions>` (collapsible Q&A summary) when a reply message with `replyId === artifactMessageId` exists.
+- Reply messages (`replyId` set) are filtered out of the top-level message scroll.
+- Submitting answers via the preview's `onSubmit` POSTs to `/api/features/[id]/chat` with `replyId` set and `message` equal to the formatted Q&A string.
+- After submit, optimistic user message has `replyId` set on its row, status `SENDING`; on Pusher confirmation it flips to `SENT`.
+- `inputDisabled` is `false` while a clarifying-questions artifact is pending answer, even when `workflowStatus === IN_PROGRESS`.
+- `inputDisabled` is `true` while `workflowStatus === IN_PROGRESS` and **no** pending clarifying question exists.
+
+Mocking strategy: mock `<ClarifyingQuestionsPreview>` to expose a button that calls its `onSubmit` prop with a known string, then assert the resulting POST body. This is exactly what `ChatMessage.test.tsx:90-95` does.
+
+## Workflow status source
+
+Two options for hydrating `workflowStatus` on initial mount:
+
+1. **Add it to `NodeDetail`'s feature `extras`.** Edit `src/app/api/orgs/[githubLogin]/canvas/node/[liveId]/route.ts:207-217`'s `select` to include `workflowStatus`, then surface it via `extras.workflowStatus`. `NodeDetail`'s feature arm already destructures `extras` and would pass it down to `<FeaturePlanChat />`. Cheap.
+2. **Second fetch from `FeaturePlanChat`.** Hit `/api/features/${featureId}` (the same endpoint `useDetailResource` uses in `PlanChatView.tsx:162-167`). Slower but doesn't touch the canvas API.
+
+**Recommendation: option 1.** The canvas API is already enriching feature `extras` (status, priority, taskCount, etc.); adding `workflowStatus` is one column on the existing select clause. The Pusher subscription will then keep it live.
+
+## Type-shape gotcha — `ChatMessage` vs `CanvasChatMessage`
+
+`SidebarChat` renders `CanvasChatMessage` (the canvas-chat-store type, defined in `src/app/org/[githubLogin]/_state/canvasChatStore.ts`). `FeaturePlanChat` renders `ChatMessage` (the feature/task chat type, from `@/lib/chat`). They overlap (`id`, `role`, `content`/`message`, `createdBy`) but **the field names diverge** — task/feature chat uses `message: string` and `role: ChatRole` (an enum), canvas chat uses `content: string` and `role: "user" | "assistant"`.
+
+`SidebarChatMessage` is hard-coded to `CanvasChatMessage` (`SidebarChatMessage.tsx:18`). Two clean options:
+
+1. **Make `SidebarChatMessage` polymorphic.** Accept a normalized prop shape (`{ id, role: "user" | "assistant", content: string, status?, createdBy? }`) and have both call sites pass normalized data. The canvas-chat-store path is already trivially mappable; the feature-chat path needs a one-liner adapter.
+2. **Fork into `FeaturePlanChatMessage`.** ~60 lines, no logic. Same bubble styling, types `ChatMessage`. No coupling between the two surfaces.
+
+**Recommendation: option 2.** The two chat systems have legitimately different message shapes (artifacts on the feature side, tool-calls + proposals on the canvas side, different `createdBy` contracts) and squeezing them through one component will create conditional rendering knots as artifact types grow. Forking now is cheaper than refactoring later. ~60 line cost, scoped to one file — plus the clarifying-questions render block detailed in the next section, which lives inside this fork.
+
+If a later PR ports the canvas chat onto Prisma's `ChatMessage` model (the open question raised at the end of `canvas-sidebar-chat.md`), revisit.
+
+## Auth surface
+
+The feature chat API already enforces workspace-membership reads (`route.ts:54-64`) and writes (`route.ts:127-129`). Calling it from `FeaturePlanChat` inherits those checks for free — there's nothing to add. A user viewing the canvas of an org they have access to **may not** have membership in every workspace inside that org; if they don't, the GET will 404/403 and the chat will render empty + the input will fail. That's correct behavior.
+
+The `feature` node arm in `NodeDetail` is reachable for any feature node the org canvas projects, which today are the same set the user can access (the projector is org-scoped via `sourceControlOrgId`). Cross-tenant leakage isn't a new risk this PR introduces.
+
+## `NodeDetail` integration
+
+In `NodeDetail.tsx:288-315`, the feature `case` becomes:
+
+```diff
+ case "feature": {
+   const status = (extras.status ?? "") as string;
+   const taskCount = Number(extras.taskCount ?? 0);
+   const slug = extras.workspaceSlug as string | undefined;
+   const assignee = extras.assignee as
+     | { name: string | null }
+     | null
+     | undefined;
+   return (
+     <div className="space-y-3">
+       <div className="flex items-center gap-2 flex-wrap">
+         {status && <StatusPill value={status} />}
+         <span className="text-xs text-muted-foreground">
+           {taskCount} task{taskCount === 1 ? "" : "s"}
+         </span>
+       </div>
+       {assignee?.name && (
+         <StatGrid stats={[{ label: "Owner", value: assignee.name }]} />
+       )}
+       {slug && (
+         <FooterLink
+           href={`/w/${slug}/plan/${detail.id}`}
+           label="Open feature"
+         />
+       )}
++      {slug && (
++        <FeaturePlanChat
++          featureId={detail.id}
++          workspaceSlug={slug}
++        />
++      )}
+     </div>
+   );
+ }
+```
+
+`slug` is required (it's how the chat bubbles a "Full plan view" link); if it's missing for some reason, we degrade to the existing details body without the chat.
+
+The feature chat is gated on `slug` being present — never gated on a load state, because `FeaturePlanChat` owns its own `loading` state and renders its own spinner inside the bordered container.
+
+## Tests
+
+Light. Most behavior is covered by the existing feature-chat tests in `PlanChatView`-adjacent code; the new component is a thin re-skin of the same fetch+Pusher pattern.
+
+### Unit (Vitest, `src/__tests__/unit/`)
+
+- `FeaturePlanChat.test.tsx`:
+  - Renders spinner while initial GET is pending.
+  - Renders messages from `GET /api/features/[id]/chat` response.
+  - Renders empty hint when API returns `[]`.
+  - Sends a message: optimistic user bubble appears immediately, POST fires with `message` + `sourceWebsocketID`, no `model`/`replyId`/`attachments`.
+  - On POST 500, the optimistic message flips to `ChatStatus.ERROR` and `inputDisabled` releases.
+  - When `usePusherConnection`'s `onMessage` fires with a new id, message appears; with a duplicate id, it's a no-op.
+  - When `usePusherConnection`'s `onWorkflowStatusUpdate` fires `COMPLETED`, `inputDisabled` releases.
+  - `inputDisabled` is `true` while `workflowStatus === IN_PROGRESS`.
+  - "Full plan view" link points at `/w/{slug}/plan/{featureId}`.
+- `NodeDetail.test.tsx` (extend existing if present, else new):
+  - Feature node detail body renders `<FeaturePlanChat />` when `extras.workspaceSlug` is present.
+  - Doesn't render `<FeaturePlanChat />` when `extras.workspaceSlug` is missing.
+  - Non-feature node detail bodies (initiative, milestone, task) don't render any chat.
+
+Mock `usePusherConnection` to return `{ isConnected: true, ... }` and capture the callbacks so tests can fire `onMessage`/`onWorkflowStatusUpdate` synchronously.
+
+### Integration
+
+Out of scope for PR 1. The full plan page integration tests already cover the chat round-trip end-to-end; we'd add Playwright coverage for the canvas embed in a follow-up if it's worth the runtime.
+
+## Implementation plan
+
+One PR. Roughly 250 lines of new component + a 5-line edit to `NodeDetail` + an optional 1-line edit to the canvas node API.
+
+### Step 1 — Extract `AnsweredClarifyingQuestions` to a shared file
+
+- New: `src/components/features/ClarifyingQuestionsPreview/AnsweredClarifyingQuestions.tsx`. Copy lines 71-103 of `ChatMessage.tsx` (the component + the `parseQAPairs` helper at lines 20-30) verbatim. Export `AnsweredClarifyingQuestions` (named) and `parseQAPairs` (named, in case other surfaces want it).
+- Edit `ChatMessage.tsx` to import from the new file and delete the local copies. Verify task page chat still renders the answered card identically.
+- Run `npm run test:unit -- ChatMessage` to confirm no regression.
+
+### Step 2 — Add `workflowStatus` to canvas node `extras`
+
+- Edit `src/app/api/orgs/[githubLogin]/canvas/node/[liveId]/route.ts:207-216`'s `select` block to add `workflowStatus: true`.
+- Add `workflowStatus: feat.workflowStatus` to the `extras` object at lines 227-233.
+- That's it. (Skippable, but the alternative is a per-mount `/api/features/[id]` round-trip in `FeaturePlanChat`.)
+
+### Step 3 — Build `FeaturePlanChatMessage`
+
+- New: `src/app/org/[githubLogin]/_components/FeaturePlanChatMessage.tsx`. ~120 lines.
+- Props: `{ message: ChatMessage, replyMessage?: ChatMessage, onSubmitAnswers: (messageId: string, answers: string) => Promise<void> }`.
+- Render the message text bubble (right-aligned for `role === USER`, left-aligned otherwise, mirroring `SidebarChatMessage`'s narrow-column treatment).
+- After the bubble, render the clarifying-questions block: `message.artifacts?.filter((a) => a.type === "PLAN" && isClarifyingQuestions(a.content))` → either `<ClarifyingQuestionsPreview>` (no `replyMessage`) or `<AnsweredClarifyingQuestions>` (has `replyMessage`).
+- Optional: a small `View N artifacts →` pill for messages with non-clarifying artifacts, linking to `/w/{slug}/plan/{featureId}`. Cheap addition; helps discoverability without rendering complexity.
+- Skip everything `ChatMessage.tsx` does that we don't need: form artifacts, longform, publish-workflow, bounty, pull-request, image attachments, file attachments, workflow URL link, image enlargement dialog. The fork is small precisely because we're not porting any of that.
+
+### Step 4 — Build `FeaturePlanChat` in isolation
+
+- New: `src/app/org/[githubLogin]/_components/FeaturePlanChat.tsx`. ~300 lines.
+- Adapt initial-fetch + Pusher + `handleSend` from `PlanChatView` per the strip list above.
+- Add `onSubmitAnswers` (clarifying-question answer submission) — share an internal `sendInternal({ text, replyId? })` helper between it and `handleSend` to avoid duplicating the optimistic-message + POST + error-handling logic.
+- Implement message dedup on `onMessage` (`messages.some((m) => m.id === msg.id) ? prev : [...prev, msg]`).
+- Implement reply-message pairing: filter out `m.replyId`-bearing messages from the top-level scroll, then pass each top-level message + its lookup-result as `replyMessage` to `<FeaturePlanChatMessage>`.
+- Compute `hasPendingClarifyingQuestion` per the spec above; refine `inputDisabled` to keep the input enabled when a clarifying question is awaiting answer.
+- Implement `scrollTop = scrollHeight` auto-scroll keyed on `messages` and `workflowStatus`.
+- Don't wire it into `NodeDetail` yet. Drop it temporarily into a story or render it directly under `KindExtras` for visual QA. Test specifically: a feature whose latest workflow run paused on clarifying questions (set up by sending an ambiguous prompt to the full plan page first).
+
+### Step 5 — Wire into `NodeDetail`
+
+- Edit `NodeDetail.tsx`'s `case "feature"` arm per the diff above.
+- Verify the existing feature node's stats render unchanged when there's no chat history (the most common case for newly-created features).
+
+### Step 6 — Manual QA
+
+On `/org/[githubLogin]`:
+
+- Click a feature node with existing plan messages — chat populates, scroll is at bottom, "Open feature" + "Full plan view" links both work.
+- Click a feature node with no plan messages — empty hint renders, input is enabled.
+- Send a message — optimistic bubble appears, workflow status flips to `IN_PROGRESS`, input disables, streamed assistant messages append, status flips back to `COMPLETED`, input re-enables.
+- **Clarifying-questions flow:** Send an ambiguous prompt that the agent will follow up on with `ask_clarifying_questions`. Wait for the artifact to stream in. Verify:
+  - `<ClarifyingQuestionsPreview>` renders inline below the assistant message.
+  - The text input below stays **enabled** (doesn't lock out free-form responses while the question is pending).
+  - Multiple-choice questions with embedded mermaid/comparison-table/color-swatch sub-artifacts render at column width without horizontal-scroll surprises.
+  - Submit answers; optimistic user message (with `replyId` set) appears, status flips to `IN_PROGRESS`, the preview collapses to `<AnsweredClarifyingQuestions>` (collapsible, click to expand and see Q&A pairs).
+  - The next assistant message streams in via Pusher.
+- Open the same feature in a second tab via the full plan page (`/w/{slug}/plan/{featureId}`); answer the clarifying questions there. Verify the canvas tab's preview swaps to `<AnsweredClarifyingQuestions>` automatically (Pusher delivers the reply message; the pairing logic finds it).
+- Open the same feature in two tabs (canvas + full plan). Send a message from one. Verify both receive the assistant response via Pusher.
+- Click a non-feature node (initiative, repo, task, note) — no chat renders, only existing details.
+- Click a feature node, then click another feature node — chat unmounts and remounts, messages refetch, no stale Pusher subscription bleeding through (the hook handles cleanup).
+- Click a feature node, then click the canvas (deselect) — `NodeDetail` unmounts, `FeaturePlanChat` unmounts, Pusher disconnects.
+- Click "Full plan view" — navigates to `/w/{slug}/plan/{featureId}`. Verify the conversation matches what was visible in the sidebar.
+
+### Step 7 — Cleanup
+
+- `npm run lint` + `npx tsc --noEmit` + `npm run test:unit`.
+- No doc-file updates needed beyond this plan; `NodeDetail`'s top-level docstring (`NodeDetail.tsx:10-24`) explains the live/authored split — the chat is a third concern but a small one. If we want to flag it explicitly, add one line to the docstring noting that feature nodes also surface a plan-chat sub-component.
+
+## Follow-up: artifacts dialog
+
+The user asked about exposing the PLAN/TASKS/VERIFY artifact tabs (the three-tab pane that lives next to the chat in `PlanChatView`) inside a modal launched from the canvas, so that **the user can do all their work without leaving the canvas**. Tracking this as explicit follow-up scope, not in this PR:
+
+- `<ArtifactsPanel>` is already self-contained — it accepts `artifacts`, `planData`, `feature`, `featureId`, `controlledTab`, `onControlledTabChange`, `sectionHighlights`, `onFeatureUpdate` (`PlanChatView.tsx:590-601`). It's plausibly liftable into a `Dialog` with the right hooks wrapping it.
+- A "Plan view" button next to the "Full plan view" link in `FeaturePlanChat` would open a large modal containing `<ArtifactsPanel>`, fetching the same feature data the full plan page does (`useDetailResource`).
+- The hard parts: (1) `useModal` (`src/components/modals/ModlaProvider.tsx`) is the existing imperative modal launcher; the artifacts panel would need to fit inside its layout primitives. (2) The PR/diff janitors plus the section-highlights diff effect (`computeSectionHighlights` at `PlanChatView.tsx:62-81`) are presence-aware and stateful — they'd need a `prev`/`next` ref to behave the same in a modal. (3) Mobile mode is a non-issue (canvas is desktop) but the modal sizing rules need attention.
+- Schema impact: none. The existing `/api/features/[id]` + `/api/features/[id]/user-stories` + Pusher endpoints already cover everything the modal would need.
+
+If/when we ship it, the canvas becomes the user's home base for the entire planning surface — chat in the right rail, artifacts in a launched dialog, feature-graph context permanently visible behind. That's the destination. This PR is the first step.
+
+## Risks
+
+- **`SidebarChatMessage` doesn't render `ChatMessage` (the feature-chat type) cleanly.** Mitigation: fork `FeaturePlanChatMessage` per "Type-shape gotcha" above. ~60 lines.
+- **Pusher channel collision.** Two components subscribing to the same `featureId` channel — the canvas's `FeaturePlanChat` and the full plan page's `PlanChatView` — should be fine; Pusher fans out events to all bound listeners. Verify in QA: open both surfaces in different tabs, send from one, confirm both receive.
+- **Workflow `IN_PROGRESS` state can stick.** If the workflow errors mid-run and Pusher misses the terminal status update, `inputDisabled` could stay `true` forever. The full plan page has the same risk — punt mitigation to whatever it currently does (or doesn't). Worth a manual test: kill a workflow mid-run on the full page, watch the canvas tab — does it eventually unstick?
+- **Empty-state scroll height.** With no messages, the bordered container collapses to its padding. Acceptable; the empty hint fills it.
+- **Long messages overflow horizontally.** `SidebarChatMessage` has the same risk and `SidebarChat` survives. The fork above inherits whatever wrapping `SidebarChatMessage` does today (assumed `whitespace-pre-wrap break-words`).
+- **Non-clarifying `PLAN`/`TASKS`/`VERIFY` artifact content on individual messages.** Feature chat messages can carry the structured plan-section, task-list, or verify-checklist artifacts; the sidebar is intentionally not rendering them as full bodies in this PR. Mitigation: a small "View N artifacts →" pill that links to the full plan page (preserves discoverability without the rendering complexity). One-line addition to `FeaturePlanChatMessage`.
+- **Embedded sub-artifacts in clarifying questions render too narrow.** A mermaid diagram or comparison table inside a 384px column may be unreadable for dense data. Mitigation: ship as-is in PR 1; "Open feature" link is the safety valve. If feedback warrants it, follow-up PR adds an "expand" affordance that opens the sub-artifact in a modal at full width.
+- **Pending clarifying question gets orphaned across sessions.** If the user closes the canvas tab while a clarifying-questions card is rendered without answering, then later returns, the artifact and the un-answered state both reload from the API correctly (server is the source of truth). The `hasPendingClarifyingQuestion` memo recomputes from `messages` on every render, so the input stays enabled on rehydration. Verify in QA: open canvas, hit ambiguous prompt, refresh tab while card is up — card should still be there, input still enabled.
+- **Two surfaces submit the same answer simultaneously.** If the user has both the canvas chat and the full plan page open and clicks Submit on both within milliseconds, two reply messages with the same `replyId` may be created. The server doesn't currently dedup on `replyId` (verified informally — `services/roadmap/feature-chat` doesn't appear to enforce uniqueness). Low risk in practice (humans can't double-submit faster than network latency); deferred to a server-side `replyId` uniqueness constraint if it ever surfaces.
+- **`AnsweredClarifyingQuestions` extraction breaks the task page.** Step 1 lifts the inline component into a shared file. Mitigation: run `npm run test:unit -- ChatMessage` after the extraction; visual-QA an answered task-chat clarifying-questions card before merging.

--- a/src/app/api/orgs/[githubLogin]/canvas/node/[liveId]/route.ts
+++ b/src/app/api/orgs/[githubLogin]/canvas/node/[liveId]/route.ts
@@ -210,6 +210,10 @@ async function loadDetail(
           brief: true,
           status: true,
           priority: true,
+          // Surface the live workflow status so the canvas-sidebar
+          // chat can hydrate its `inputDisabled` gate without a
+          // second per-node fetch to `/api/features/[id]`.
+          workflowStatus: true,
           assignee: { select: { id: true, name: true, image: true } },
           workspace: { select: { slug: true } },
           _count: { select: { tasks: { where: { deleted: false, archived: false } } } },
@@ -227,6 +231,7 @@ async function loadDetail(
         extras: {
           status: feat.status,
           priority: feat.priority,
+          workflowStatus: feat.workflowStatus,
           assignee: feat.assignee,
           workspaceSlug: feat.workspace.slug,
           taskCount: feat._count.tasks,

--- a/src/app/org/[githubLogin]/_components/FeaturePlanChat.tsx
+++ b/src/app/org/[githubLogin]/_components/FeaturePlanChat.tsx
@@ -1,0 +1,390 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import { useSession } from "next-auth/react";
+import { ArrowUpRight, Loader2, Send } from "lucide-react";
+import {
+  ChatMessage,
+  ChatRole,
+  ChatStatus,
+  WorkflowStatus,
+  createChatMessage,
+} from "@/lib/chat";
+import { isClarifyingQuestions } from "@/types/stakwork";
+import { usePusherConnection } from "@/hooks/usePusherConnection";
+import { getPusherClient } from "@/lib/pusher";
+import { Button } from "@/components/ui/button";
+import { FeaturePlanChatMessage } from "./FeaturePlanChatMessage";
+
+/**
+ * Compact, sidebar-shaped feature-plan chat for the org canvas.
+ *
+ * Mounted inside `NodeDetail`'s `case "feature"` arm so the user can
+ * read and continue a feature's planning conversation without
+ * navigating away from the canvas. Reads/writes the same API the
+ * full plan page uses (`/api/features/[featureId]/chat`) and
+ * subscribes to the same Pusher channel for live updates — so a
+ * message sent from the canvas appears on the full plan page in real
+ * time, and vice versa.
+ *
+ * What this surface deliberately omits compared to `PlanChatView`:
+ *
+ *   - No artifacts panel (PLAN/TASKS/VERIFY tabs). Use the
+ *     "Full plan view" link to open `/w/{slug}/plan/{featureId}`.
+ *   - No collaborator presence / typing indicators.
+ *   - No project-log streaming.
+ *   - No model picker — sends use the persisted `feature.model`.
+ *   - No file/image attachments.
+ *   - No title editing, no breadcrumbs, no mobile preview swap.
+ *
+ * The one artifact type that IS rendered: clarifying-question cards
+ * (`PLAN` artifact whose `content.tool_use === "ask_clarifying_questions"`).
+ * Without this, the agent's planning workflow visibly stalls on the
+ * canvas whenever it needs structured input — see
+ * `FeaturePlanChatMessage` for the renderer.
+ */
+interface FeaturePlanChatProps {
+  /** Prisma `Feature.id`. Drives the chat fetch + Pusher channel. */
+  featureId: string;
+  /** Workspace slug the feature belongs to. Used by the "Full plan view" link. */
+  workspaceSlug: string;
+  /**
+   * Live workflow status from the canvas node API
+   * (`extras.workflowStatus`). Used to seed initial state without a
+   * second `/api/features/[id]` round-trip; Pusher takes over after
+   * mount.
+   */
+  initialWorkflowStatus?: WorkflowStatus | null;
+}
+
+function generateUniqueId(): string {
+  return `temp_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;
+}
+
+export function FeaturePlanChat({
+  featureId,
+  workspaceSlug,
+  initialWorkflowStatus = null,
+}: FeaturePlanChatProps) {
+  const { data: session } = useSession();
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [sending, setSending] = useState(false);
+  const [workflowStatus, setWorkflowStatus] = useState<WorkflowStatus | null>(
+    initialWorkflowStatus,
+  );
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // ─── Initial fetch ────────────────────────────────────────────────
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    fetch(`/api/features/${featureId}/chat`)
+      .then((r) => (r.ok ? r.json() : { data: [] }))
+      .then((body) => {
+        if (cancelled) return;
+        setMessages((body?.data ?? []) as ChatMessage[]);
+      })
+      .catch(() => {
+        // Fall through to empty conversation; the user can still try
+        // to send a message and surface a real error.
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [featureId]);
+
+  // ─── Pusher subscription ──────────────────────────────────────────
+  const handleSSEMessage = useCallback((message: ChatMessage) => {
+    setMessages((prev) => {
+      if (prev.some((m) => m.id === message.id)) return prev;
+      return [...prev, message];
+    });
+    setSending(false);
+  }, []);
+
+  const handleWorkflowStatusUpdate = useCallback(
+    (update: { workflowStatus: WorkflowStatus }) => {
+      setWorkflowStatus(update.workflowStatus);
+      if (
+        update.workflowStatus === WorkflowStatus.COMPLETED ||
+        update.workflowStatus === WorkflowStatus.FAILED ||
+        update.workflowStatus === WorkflowStatus.ERROR ||
+        update.workflowStatus === WorkflowStatus.HALTED
+      ) {
+        setSending(false);
+      }
+    },
+    [],
+  );
+
+  usePusherConnection({
+    featureId,
+    onMessage: handleSSEMessage,
+    onWorkflowStatusUpdate: handleWorkflowStatusUpdate,
+  });
+
+  // ─── Auto-scroll ──────────────────────────────────────────────────
+  // `scrollTop = scrollHeight` on the local container — never
+  // `scrollIntoView`, which can drag the surrounding `NodeDetail`
+  // body around when the chat scroll lands inside it.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+  }, [messages, workflowStatus]);
+
+  // ─── Pending clarifying-question detection ────────────────────────
+  // While a clarifying-questions artifact is awaiting an answer, the
+  // workflow is technically `IN_PROGRESS` (the Stakwork run is alive,
+  // waiting on user input) — but the input below should stay enabled
+  // so the user can answer via the form *or* type a free-form
+  // override ("skip these, use defaults"). Mirrors the full plan
+  // page's behavior.
+  const hasPendingClarifyingQuestion = useMemo(() => {
+    return messages.some(
+      (m) =>
+        (m.artifacts ?? []).some(
+          (a) => a.type === "PLAN" && isClarifyingQuestions(a.content),
+        ) && !messages.some((reply) => reply.replyId === m.id),
+    );
+  }, [messages]);
+
+  const inputDisabled =
+    loading ||
+    sending ||
+    (workflowStatus === WorkflowStatus.IN_PROGRESS &&
+      !hasPendingClarifyingQuestion);
+
+  // ─── Send ─────────────────────────────────────────────────────────
+  // Single internal helper covers both regular sends and clarifying-
+  // question answer submissions. The only difference is `replyId` on
+  // the answer path, which the server uses to pair the answer back
+  // to the artifact's message.
+  const sendInternal = useCallback(
+    async (text: string, replyId?: string) => {
+      const optimistic = createChatMessage({
+        id: generateUniqueId(),
+        message: text,
+        role: ChatRole.USER,
+        status: ChatStatus.SENDING,
+        replyId,
+        createdBy: session?.user
+          ? {
+              id: session.user.id,
+              name: session.user.name || null,
+              email: session.user.email || null,
+              image: session.user.image || null,
+            }
+          : undefined,
+      });
+
+      setMessages((m) => [...m, optimistic]);
+      setSending(true);
+      setWorkflowStatus(WorkflowStatus.IN_PROGRESS);
+
+      try {
+        const res = await fetch(`/api/features/${featureId}/chat`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            message: text,
+            replyId,
+            sourceWebsocketID: getPusherClient().connection.socket_id,
+          }),
+        });
+
+        if (!res.ok) throw new Error("send failed");
+
+        const data = await res.json();
+        setMessages((m) =>
+          m.map((x) =>
+            x.id === optimistic.id
+              ? { ...data.message, status: ChatStatus.SENT }
+              : x,
+          ),
+        );
+      } catch (error) {
+        console.error("FeaturePlanChat: send failed", error);
+        setMessages((m) =>
+          m.map((x) =>
+            x.id === optimistic.id ? { ...x, status: ChatStatus.ERROR } : x,
+          ),
+        );
+        setSending(false);
+      }
+    },
+    [featureId, session],
+  );
+
+  const handleSend = useCallback(
+    (text: string) => sendInternal(text),
+    [sendInternal],
+  );
+
+  const handleSubmitAnswers = useCallback(
+    (messageId: string, formattedAnswers: string) =>
+      sendInternal(formattedAnswers, messageId),
+    [sendInternal],
+  );
+
+  // ─── Reply pairing ────────────────────────────────────────────────
+  // Filter out reply messages from the top-level scroll, then pair
+  // each remaining message with its reply (if any) so
+  // `FeaturePlanChatMessage` can swap the interactive
+  // `ClarifyingQuestionsPreview` for the collapsed
+  // `AnsweredClarifyingQuestions` once the user has answered.
+  const topLevelMessages = useMemo(
+    () => messages.filter((m) => !m.replyId),
+    [messages],
+  );
+
+  const findReply = useCallback(
+    (messageId: string) =>
+      messages.find((m) => m.replyId === messageId),
+    [messages],
+  );
+
+  return (
+    <div className="flex flex-col gap-2 mt-4 pt-4 border-t">
+      <div className="flex items-center justify-between">
+        <span className="text-[10px] uppercase tracking-wider text-muted-foreground font-medium">
+          Plan chat
+        </span>
+        {workflowStatus === WorkflowStatus.IN_PROGRESS && (
+          <span className="inline-flex items-center gap-1 text-[10px] text-muted-foreground">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            Planner working…
+          </span>
+        )}
+      </div>
+
+      <div
+        ref={scrollRef}
+        className="max-h-[420px] min-h-[80px] overflow-y-auto rounded border bg-muted/20 p-2"
+      >
+        {loading ? (
+          <div className="flex items-center justify-center py-6 text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+          </div>
+        ) : topLevelMessages.length === 0 ? (
+          <div className="px-2 py-4 text-center text-xs text-muted-foreground italic">
+            The planner hasn&apos;t said anything yet.
+            <br />
+            Send a message to start.
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {topLevelMessages.map((m) => (
+              <FeaturePlanChatMessage
+                key={m.id}
+                message={m}
+                replyMessage={findReply(m.id)}
+                onSubmitAnswers={handleSubmitAnswers}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <FeaturePlanChatInput onSend={handleSend} disabled={inputDisabled} />
+
+      <div className="text-[10px] text-muted-foreground italic flex items-center gap-1">
+        Full plan view (PLAN/TASKS/VERIFY){" "}
+        <Link
+          href={`/w/${workspaceSlug}/plan/${featureId}`}
+          className="inline-flex items-center gap-0.5 underline hover:text-foreground"
+        >
+          Open feature
+          <ArrowUpRight className="h-3 w-3" />
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+// ─── Input ──────────────────────────────────────────────────────────
+const MAX_ROWS = 5;
+const LINE_HEIGHT_PX = 20;
+const MAX_HEIGHT_PX = MAX_ROWS * LINE_HEIGHT_PX;
+
+interface FeaturePlanChatInputProps {
+  onSend: (message: string) => void | Promise<void>;
+  disabled?: boolean;
+}
+
+/**
+ * Auto-growing keyboard-only chat input. Mirrors `SidebarChatInput`'s
+ * shape (Enter-to-send, Shift+Enter for newline, no attachments) but
+ * doesn't share its file because the prop surface differs (no
+ * `clearInput` callback dance — we clear on submit synchronously).
+ */
+function FeaturePlanChatInput({
+  onSend,
+  disabled = false,
+}: FeaturePlanChatInputProps) {
+  const [input, setInput] = useState("");
+  const [height, setHeight] = useState<string>("auto");
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = input.trim();
+    if (!trimmed || disabled) return;
+    setInput("");
+    setHeight("auto");
+    await onSend(trimmed);
+    inputRef.current?.focus();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      void handleSubmit(e as unknown as React.FormEvent);
+    }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setInput(e.target.value);
+    const el = inputRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    const newHeight = Math.min(el.scrollHeight, MAX_HEIGHT_PX);
+    setHeight(`${newHeight}px`);
+  };
+
+  const overflowY =
+    height !== "auto" && parseInt(height) >= MAX_HEIGHT_PX ? "auto" : "hidden";
+
+  return (
+    <form onSubmit={handleSubmit} className="flex items-end gap-2">
+      <div className="relative flex-1 min-w-0">
+        <textarea
+          ref={inputRef}
+          placeholder="Ask the planner…"
+          value={input}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          disabled={disabled}
+          rows={1}
+          style={{ height, overflowY }}
+          className={`w-full px-3 py-2 pr-10 rounded-xl bg-background border border-border/50 text-sm text-foreground/95 placeholder:text-muted-foreground/60 focus:outline-none focus:ring-2 focus:ring-primary/20 transition-all resize-none ${
+            disabled ? "opacity-50 cursor-not-allowed" : ""
+          }`}
+        />
+        <Button
+          type="submit"
+          size="icon"
+          disabled={!input.trim() || disabled}
+          className="absolute right-1 bottom-1 h-7 w-7 rounded-full"
+        >
+          <Send className="w-3.5 h-3.5" />
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/org/[githubLogin]/_components/FeaturePlanChatMessage.tsx
+++ b/src/app/org/[githubLogin]/_components/FeaturePlanChatMessage.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { motion } from "framer-motion";
+import ReactMarkdown from "react-markdown";
+import { ChatMessage as ChatMessageType, ChatRole } from "@/lib/chat";
+import { isClarifyingQuestions } from "@/types/stakwork";
+import type { ClarifyingQuestionsResponse } from "@/types/stakwork";
+import { ClarifyingQuestionsPreview } from "@/components/features/ClarifyingQuestionsPreview";
+import { AnsweredClarifyingQuestions } from "@/components/features/ClarifyingQuestionsPreview/AnsweredClarifyingQuestions";
+
+/**
+ * Narrow-column bubble for the canvas-sidebar feature-plan chat.
+ *
+ * Renders the message text plus a single artifact type — the
+ * `ask_clarifying_questions` PLAN artifact — so the agent's
+ * structured prompt-for-input UI works inside the right panel.
+ *
+ * Intentionally does **not** render any other artifact type (form,
+ * code, browser, longform, publish-workflow, bounty, pull-request,
+ * diff, …). Those still live on the full plan page (`/w/{slug}/plan/{id}`),
+ * which the parent surfaces as a "Full plan view" link. Adding more
+ * artifact renderers here is a follow-up; keep this fork small until
+ * the canvas chat earns its way into supporting them.
+ *
+ * Visual idiom mirrors `SidebarChatMessage` (`./SidebarChatMessage.tsx`):
+ *   - User bubble — right-aligned, `max-w-[85%]`, primary fill.
+ *   - Assistant bubble — left-aligned, full column width, muted fill.
+ *
+ * Reply messages (those with `replyId` set) are filtered out by the
+ * caller before rendering — they exist only to show as the answered
+ * Q&A summary attached to their target message.
+ */
+interface FeaturePlanChatMessageProps {
+  message: ChatMessageType;
+  /**
+   * The user message that answers a clarifying-questions artifact on
+   * `message`, if any. Set when `messages.find((m) => m.replyId ===
+   * message.id)` resolves. Triggers the collapsed
+   * `AnsweredClarifyingQuestions` view in place of the interactive
+   * `ClarifyingQuestionsPreview`.
+   */
+  replyMessage?: ChatMessageType;
+  /**
+   * Called when the user submits answers via the inline preview.
+   * Implementation lives in `FeaturePlanChat` — POSTs to
+   * `/api/features/[id]/chat` with `replyId` set so the server pairs
+   * the answer back to the artifact's message.
+   */
+  onSubmitAnswers: (messageId: string, formattedAnswers: string) => void | Promise<void>;
+}
+
+export function FeaturePlanChatMessage({
+  message,
+  replyMessage,
+  onSubmitAnswers,
+}: FeaturePlanChatMessageProps) {
+  const isUser = message.role === ChatRole.USER;
+  const text = (message.message ?? "").trim();
+
+  // Detect a `PLAN`-typed artifact carrying the clarifying-questions
+  // payload. There can be multiple in theory; in practice the agent
+  // emits at most one per message, but we render whatever's there.
+  const clarifyingArtifacts =
+    message.artifacts?.filter(
+      (a) => a.type === "PLAN" && isClarifyingQuestions(a.content),
+    ) ?? [];
+
+  // If the message has neither text nor a clarifying-questions
+  // artifact, render nothing — keeps the scroll free of empty bubbles
+  // produced by streaming-only updates.
+  if (!text && clarifyingArtifacts.length === 0) {
+    return null;
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 6 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.2 }}
+      className="space-y-2"
+    >
+      {text && (
+        <div className={`flex w-full ${isUser ? "justify-end" : "justify-start"}`}>
+          <div className={isUser ? "max-w-[85%]" : "w-full"}>
+            <div
+              className={`rounded-2xl px-3 py-2 shadow-sm ${
+                isUser
+                  ? "bg-primary text-primary-foreground inline-block"
+                  : "bg-muted/40"
+              }`}
+            >
+              <div
+                className={`prose prose-sm max-w-none break-words ${
+                  isUser
+                    ? "[&>*]:!text-primary-foreground [&_*]:!text-primary-foreground"
+                    : "dark:prose-invert [&>*]:!text-foreground/90 [&_*]:!text-foreground/90"
+                }`}
+              >
+                <ReactMarkdown>{text}</ReactMarkdown>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {clarifyingArtifacts.map((artifact) => {
+        const questions = (artifact.content as ClarifyingQuestionsResponse).content;
+        return (
+          <div key={artifact.id} className="w-full">
+            {replyMessage ? (
+              <AnsweredClarifyingQuestions
+                questions={questions}
+                replyMessage={replyMessage}
+              />
+            ) : (
+              <ClarifyingQuestionsPreview
+                questions={questions}
+                onSubmit={(formattedAnswers) =>
+                  onSubmitAnswers(message.id, formattedAnswers)
+                }
+              />
+            )}
+          </div>
+        );
+      })}
+    </motion.div>
+  );
+}

--- a/src/app/org/[githubLogin]/_components/NodeDetail.tsx
+++ b/src/app/org/[githubLogin]/_components/NodeDetail.tsx
@@ -6,6 +6,8 @@ import { ArrowUpRight, Loader2 } from "lucide-react";
 import type { CanvasNode } from "system-canvas";
 import { Badge } from "@/components/ui/badge";
 import ReactMarkdown from "react-markdown";
+import type { WorkflowStatus } from "@/lib/chat";
+import { FeaturePlanChat } from "./FeaturePlanChat";
 
 /**
  * Right-panel detail card for the currently-selected canvas node.
@@ -289,6 +291,9 @@ function KindExtras({ detail, githubLogin }: ExtrasProps) {
       const status = (extras.status ?? "") as string;
       const taskCount = Number(extras.taskCount ?? 0);
       const slug = extras.workspaceSlug as string | undefined;
+      const workflowStatus = (extras.workflowStatus ?? null) as
+        | WorkflowStatus
+        | null;
       const assignee = extras.assignee as
         | { name: string | null }
         | null
@@ -308,6 +313,21 @@ function KindExtras({ detail, githubLogin }: ExtrasProps) {
             <FooterLink
               href={`/w/${slug}/plan/${detail.id}`}
               label="Open feature"
+            />
+          )}
+          {/*
+           * Inline plan chat — reads/writes the same feature-chat API
+           * the full plan page uses, subscribes to the same Pusher
+           * channel, and renders clarifying-question artifacts inline
+           * so the planning workflow doesn't silently stall on the
+           * canvas. The "Open feature" link above is the escape
+           * hatch to the artifacts panel (PLAN/TASKS/VERIFY).
+           */}
+          {slug && (
+            <FeaturePlanChat
+              featureId={detail.id}
+              workspaceSlug={slug}
+              initialWorkflowStatus={workflowStatus}
             />
           )}
         </div>

--- a/src/app/w/[slug]/task/[...taskParams]/components/ChatMessage.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/components/ChatMessage.tsx
@@ -2,7 +2,7 @@
 
 import React, { memo, useState, useMemo, useCallback } from "react";
 import { motion } from "framer-motion";
-import { ChevronDown, ChevronRight, HelpCircle, User, X, Image as ImageIcon, FileIcon } from "lucide-react";
+import { ChevronDown, ChevronRight, User, X, Image as ImageIcon, FileIcon } from "lucide-react";
 import { ChatMessage as ChatMessageType, Option, FormContent } from "@/lib/chat";
 import { FormArtifact, LongformArtifactPanel, PublishWorkflowArtifact, BountyArtifact } from "../artifacts";
 import { PullRequestArtifact } from "../artifacts/pull-request";
@@ -14,20 +14,9 @@ import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { cn } from "@/lib/utils";
 import { isClarifyingQuestions } from "@/types/stakwork";
-import type { ClarifyingQuestion, ClarifyingQuestionsResponse } from "@/types/stakwork";
+import type { ClarifyingQuestionsResponse } from "@/types/stakwork";
 import { ClarifyingQuestionsPreview } from "@/components/features/ClarifyingQuestionsPreview";
-
-function parseQAPairs(text: string): { question: string; answer: string }[] {
-  return text
-    .split("\n\n")
-    .map((block) => {
-      const lines = block.split("\n");
-      const question = lines[0]?.replace(/^Q:\s*/, "") ?? "";
-      const answer = lines[1]?.replace(/^A:\s*/, "") ?? "";
-      return { question, answer };
-    })
-    .filter((pair) => pair.question.length > 0);
-}
+import { AnsweredClarifyingQuestions } from "@/components/features/ClarifyingQuestionsPreview/AnsweredClarifyingQuestions";
 
 /**
  * Parse message content to extract <logs> sections
@@ -66,43 +55,6 @@ function arePropsEqual(prevProps: ChatMessageProps, nextProps: ChatMessageProps)
   const replyMessageEqual = prevProps.replyMessage?.id === nextProps.replyMessage?.id;
 
   return messageEqual && replyMessageEqual;
-}
-
-function AnsweredClarifyingQuestions({
-  questions,
-  replyMessage,
-}: {
-  questions: ClarifyingQuestion[];
-  replyMessage: ChatMessageType;
-}) {
-  const [expanded, setExpanded] = useState(false);
-  const pairs = parseQAPairs(replyMessage.message);
-  const count = questions.length;
-
-  return (
-    <div className="rounded-md border border-border bg-muted/50 p-4">
-      <button
-        onClick={() => setExpanded((v) => !v)}
-        className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors w-full"
-      >
-        {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-        <HelpCircle className="h-3 w-3" />
-        <span>
-          {count} {count === 1 ? "question" : "questions"} answered
-        </span>
-      </button>
-      {expanded && (
-        <div className="mt-3 space-y-3">
-          {pairs.map((pair, i) => (
-            <div key={i}>
-              <p className="font-medium text-foreground text-sm">{pair.question}</p>
-              <p className="text-muted-foreground text-sm pl-2 border-l border-border ml-1 mt-0.5">{pair.answer}</p>
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
-  );
 }
 
 export const ChatMessage = memo(function ChatMessage({ message, replyMessage, onArtifactAction }: ChatMessageProps) {

--- a/src/components/features/ClarifyingQuestionsPreview/AnsweredClarifyingQuestions.tsx
+++ b/src/components/features/ClarifyingQuestionsPreview/AnsweredClarifyingQuestions.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import React, { useState } from "react";
+import { ChevronDown, ChevronRight, HelpCircle } from "lucide-react";
+import type { ChatMessage as ChatMessageType } from "@/lib/chat";
+import type { ClarifyingQuestion } from "@/types/stakwork";
+
+/**
+ * Parses the formatted Q&A string produced by `ClarifyingQuestionsPreview.onSubmit`
+ * back into structured pairs. The format is one question/answer per pair,
+ * separated by blank lines:
+ *
+ *   Q: First question
+ *   A: First answer
+ *
+ *   Q: Second question
+ *   A: Second answer
+ *
+ * Used by the answered-state collapsible to display the original
+ * questions alongside the user's answers.
+ */
+export function parseQAPairs(text: string): { question: string; answer: string }[] {
+  return text
+    .split("\n\n")
+    .map((block) => {
+      const lines = block.split("\n");
+      const question = lines[0]?.replace(/^Q:\s*/, "") ?? "";
+      const answer = lines[1]?.replace(/^A:\s*/, "") ?? "";
+      return { question, answer };
+    })
+    .filter((pair) => pair.question.length > 0);
+}
+
+interface AnsweredClarifyingQuestionsProps {
+  questions: ClarifyingQuestion[];
+  replyMessage: ChatMessageType;
+}
+
+/**
+ * Collapsed summary card shown after the user has answered a set of
+ * clarifying questions. Click to expand and review the Q&A pairs.
+ *
+ * Shared by the task/feature plan-page chat (`ChatMessage`) and the
+ * canvas-sidebar feature chat (`FeaturePlanChatMessage`). Stays free
+ * of surface-specific concerns (no task ids, no workspace context) —
+ * it just renders what's been answered.
+ */
+export function AnsweredClarifyingQuestions({
+  questions,
+  replyMessage,
+}: AnsweredClarifyingQuestionsProps) {
+  const [expanded, setExpanded] = useState(false);
+  const pairs = parseQAPairs(replyMessage.message);
+  const count = questions.length;
+
+  return (
+    <div className="rounded-md border border-border bg-muted/50 p-4">
+      <button
+        onClick={() => setExpanded((v) => !v)}
+        className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors w-full"
+      >
+        {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+        <HelpCircle className="h-3 w-3" />
+        <span>
+          {count} {count === 1 ? "question" : "questions"} answered
+        </span>
+      </button>
+      {expanded && (
+        <div className="mt-3 space-y-3">
+          {pairs.map((pair, i) => (
+            <div key={i}>
+              <p className="font-medium text-foreground text-sm">{pair.question}</p>
+              <p className="text-muted-foreground text-sm pl-2 border-l border-border ml-1 mt-0.5">
+                {pair.answer}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Click a feature node on the org canvas → the right-panel Details body now shows an **inline plan chat** under the existing stats. Same conversation the full plan page hosts at `/w/{slug}/plan/{featureId}`, just rendered as a narrow column. Reads/writes the existing `/api/features/[id]/chat` API and subscribes to the same Pusher channel — messages sent from the canvas appear on the full plan page live, and vice versa.

The big functional unlock: **clarifying-question artifacts render inline**. The plan agent emits a structured `PLAN` artifact (`tool_use === "ask_clarifying_questions"`) when it needs input to make progress; without rendering that on the canvas the workflow would silently stall and the user would see only a one-line "Looking into it…" assistant message with no way to proceed.

## What's in scope

- **New:** `FeaturePlanChat.tsx` — chat shell, fetch, Pusher subscription, send, clarifying-question answer submission. Internal `sendInternal({ text, replyId? })` powers both regular sends and answer submissions.
- **New:** `FeaturePlanChatMessage.tsx` — narrow-column message bubble (mirrors `SidebarChatMessage` styling). Renders text + the one artifact type the canvas chat needs: `<ClarifyingQuestionsPreview>` (or `<AnsweredClarifyingQuestions>` once a `replyMessage` exists).
- **New (extracted):** `ClarifyingQuestionsPreview/AnsweredClarifyingQuestions.tsx` — lifted verbatim from the inline definition in the task `ChatMessage.tsx` so both the task page and the canvas chat share one rendering of the answered Q&A summary.
- **Modified:** task `ChatMessage.tsx` imports the now-shared `AnsweredClarifyingQuestions`. No behavior change; the existing 52 unit tests pass unchanged.
- **Modified:** canvas node API (`/api/orgs/[githubLogin]/canvas/node/[liveId]`) surfaces `feature.workflowStatus` on `extras` so the chat hydrates without a second `/api/features/[id]` round-trip.
- **Modified:** `NodeDetail.tsx` renders `<FeaturePlanChat />` below the existing stats + "Open feature" link in the `feature` case.
- **Plan doc:** `docs/plans/canvas-feature-node-chat.md`.

## UX details

- **Input stays enabled while a clarifying-question is pending answer**, even though the workflow is technically `IN_PROGRESS`. Lets the user answer via the form *or* type a free-form override ("skip these, use defaults"). Matches full plan page behavior.
- **Reply messages are paired with their artifact messages** (filter + lookup) so the preview swaps to the collapsed answered view automatically.
- **Auto-scroll** uses `scrollTop = scrollHeight` on the local container (no `scrollIntoView` page-bump risk).
- **"Open feature" / "Full plan view" links** stay as the escape hatch to the artifacts panel for everything the sidebar deliberately doesn't render (PLAN/TASKS/VERIFY tabs, model picker, presence, project logs, etc.).

## What's deliberately not in this PR

Documented in the plan doc's "Non-goals" and "Follow-up: artifacts dialog" sections. Highlights:

- No artifacts panel (PLAN/TASKS/VERIFY tabs) — out of scope; long-term direction is an "Open in dialog" launcher so the user can do all their work without leaving the canvas.
- No collaborator presence, project-log streaming, model picker, file attachments, mobile mode, or title editing.
- Non-clarifying `PLAN`/`TASKS`/`VERIFY` artifact content on individual messages isn't rendered (cheap follow-up: a "View N artifacts →" pill).

## Verification

- **Typecheck:** zero errors in any touched file.
- **Lint:** zero errors, zero new warnings.
- **Unit tests:** `ChatMessage.test.tsx` (52 tests) + `task-workflow-createChatMessageAndTriggerStakwork.test.ts` (14 tests) + `ClarifyingQuestionsPreview.test.tsx` (23 tests) all pass. The `AnsweredClarifyingQuestions` extraction is verified non-breaking via the existing test coverage.

## Manual QA

On `/org/{githubLogin}`:

- [ ] Click a feature node — chat populates with prior messages (or empty hint), workflow status badge appears when active.
- [ ] Send a free-form message — optimistic bubble, status flips to IN_PROGRESS, streamed assistant response arrives via Pusher.
- [ ] Trigger an ambiguous prompt → agent emits clarifying questions → preview renders inline with embedded mermaid/comparison-table/color-swatch sub-artifacts where applicable.
- [ ] Input stays enabled during a pending clarifying question.
- [ ] Submit answers → preview collapses to the answered Q&A summary, agent continues.
- [ ] Open same feature in the full plan page in another tab — both surfaces stay in sync via Pusher.
- [ ] "Open feature" / "Full plan view" links navigate to `/w/{slug}/plan/{featureId}`.
- [ ] Click a non-feature node (initiative, repo, task, note) — no chat renders.
- [ ] Switch between feature nodes — chat unmounts and remounts cleanly, no stale Pusher subscriptions.