### PR TITLE
fix VM Open IDE / Open Browser URLs

### DIFF
--- a/src/__tests__/unit/VMGrid.test.tsx
+++ b/src/__tests__/unit/VMGrid.test.tsx
@@ -161,62 +161,105 @@ describe("VMGrid — dropdown actions", () => {
 });
 
 describe("VMGrid — Open Browser action", () => {
-  it("renders 'Open Browser' in dropdown when frontendUrl is set", async () => {
+  it("renders 'Open Browser' in dropdown when workspaceSlug is provided", async () => {
     const user = userEvent.setup();
     render(
       <VMGrid
-        vms={[
-          makeVM({
-            password: "secret",
-            url: "https://ide.example.com",
-            frontendUrl: "https://pod-3000.example.com",
-          }),
-        ]}
-      />
+        vms={[makeVM({ password: "secret", url: "https://ide.example.com" })]}
+        workspaceSlug="my-workspace"
+      />,
     );
 
     await user.click(screen.getByRole("button"));
     expect(screen.getByText("Open Browser")).toBeInTheDocument();
   });
 
-  it("does not render 'Open Browser' when frontendUrl is absent", async () => {
+  it("does not render 'Open Browser' when workspaceSlug is absent", async () => {
     const user = userEvent.setup();
     render(
       <VMGrid
-        vms={[
-          makeVM({
-            password: "secret",
-            url: "https://ide.example.com",
-          }),
-        ]}
-      />
+        vms={[makeVM({ password: "secret", url: "https://ide.example.com" })]}
+      />,
     );
 
     await user.click(screen.getByRole("button"));
     expect(screen.queryByText("Open Browser")).not.toBeInTheDocument();
   });
 
-  it("calls window.open with frontendUrl when 'Open Browser' is clicked", async () => {
+  it("fetches frontend-url and opens the resolved URL on click", async () => {
     const user = userEvent.setup();
+    const fakeWindow = { location: { href: "" }, close: vi.fn() };
+    vi.mocked(window.open).mockReturnValue(fakeWindow as unknown as Window);
+
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          success: true,
+          data: { frontendUrl: "https://vm-1-3000.workspaces.sphinx.chat" },
+        }),
+        { status: 200 },
+      ),
+    );
+
     render(
       <VMGrid
         vms={[
           makeVM({
+            id: "vm-1",
             password: "secret",
             url: "https://ide.example.com",
-            frontendUrl: "https://pod-3000.example.com",
           }),
         ]}
-      />
+        workspaceSlug="my-workspace"
+      />,
     );
 
     await user.click(screen.getByRole("button"));
     await user.click(screen.getByText("Open Browser"));
 
+    // Synchronously opens about:blank to dodge popup blockers, then fetches.
     expect(window.open).toHaveBeenCalledWith(
-      "https://pod-3000.example.com",
+      "about:blank",
       "_blank",
-      "noopener,noreferrer"
+      "noopener,noreferrer",
     );
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/w/my-workspace/pool/vm-1/frontend-url",
+    );
+
+    // After the fetch resolves, the blank tab is navigated to the resolved URL.
+    await vi.waitFor(() => {
+      expect(fakeWindow.location.href).toBe(
+        "https://vm-1-3000.workspaces.sphinx.chat",
+      );
+    });
+
+    fetchSpy.mockRestore();
+  });
+
+  it("closes the placeholder tab if the API returns no URL", async () => {
+    const user = userEvent.setup();
+    const fakeWindow = { location: { href: "" }, close: vi.fn() };
+    vi.mocked(window.open).mockReturnValue(fakeWindow as unknown as Window);
+
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ success: false }), { status: 500 }),
+    );
+
+    render(
+      <VMGrid
+        vms={[makeVM({ id: "vm-1", password: "secret", url: "https://ide.example.com" })]}
+        workspaceSlug="my-workspace"
+      />,
+    );
+
+    await user.click(screen.getByRole("button"));
+    await user.click(screen.getByText("Open Browser"));
+
+    await vi.waitFor(() => {
+      expect(fakeWindow.close).toHaveBeenCalled();
+    });
+
+    fetchSpy.mockRestore();
   });
 });

--- a/src/__tests__/unit/api/w/slug/pool/frontend-url.test.ts
+++ b/src/__tests__/unit/api/w/slug/pool/frontend-url.test.ts
@@ -1,0 +1,168 @@
+import { NextRequest, NextResponse } from "next/server";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/middleware/utils", () => ({
+  getMiddlewareContext: vi.fn(),
+  requireAuth: vi.fn(),
+}));
+
+vi.mock("@/services/workspace", () => ({
+  getWorkspaceBySlug: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    pod: { findFirst: vi.fn() },
+  },
+}));
+
+// Use the real POD_BASE_DOMAIN/buildPodUrl/POD_PORTS so URL assertions are
+// meaningful.
+
+// ── Imports (after mocks) ──────────────────────────────────────────────────
+
+import { GET } from "@/app/api/w/[slug]/pool/[podId]/frontend-url/route";
+import { getMiddlewareContext, requireAuth } from "@/lib/middleware/utils";
+import { getWorkspaceBySlug } from "@/services/workspace";
+import { db } from "@/lib/db";
+
+// ── Test data ─────────────────────────────────────────────────────────────
+
+const MOCK_USER = { id: "user-1", email: "u@test.com", name: "Test" };
+const MOCK_WORKSPACE = { id: "ws-001", slug: "my-workspace" };
+
+function makeRequest(slug = "my-workspace", podId = "pod-abc"): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/w/${slug}/pool/${podId}/frontend-url`,
+    { method: "GET" },
+  );
+}
+
+function makeParams(slug = "my-workspace", podId = "pod-abc") {
+  return { params: Promise.resolve({ slug, podId }) };
+}
+
+function authenticated() {
+  vi.mocked(getMiddlewareContext).mockReturnValue({
+    authStatus: "authenticated",
+    user: MOCK_USER,
+  } as never);
+  vi.mocked(requireAuth).mockReturnValue(MOCK_USER as never);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  authenticated();
+  vi.mocked(getWorkspaceBySlug).mockResolvedValue(MOCK_WORKSPACE as never);
+  vi.mocked(db.pod.findFirst).mockResolvedValue({
+    podId: "pod-abc",
+    password: "s3cr3t",
+  } as never);
+});
+
+describe("GET /api/w/[slug]/pool/[podId]/frontend-url", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(requireAuth).mockReturnValue(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 }) as never,
+    );
+    const res = await GET(makeRequest(), makeParams());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when workspace is not found", async () => {
+    vi.mocked(getWorkspaceBySlug).mockResolvedValue(null as never);
+    const res = await GET(makeRequest(), makeParams());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when pod doesn't belong to workspace", async () => {
+    vi.mocked(db.pod.findFirst).mockResolvedValue(null as never);
+    const res = await GET(makeRequest(), makeParams());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns the discovered frontend URL when jlist reports the frontend port", async () => {
+    const fetchSpy = vi.fn(async () =>
+      new Response(
+        JSON.stringify([
+          { pid: 1, name: "goose", status: "online", port: "15551" },
+          { pid: 2, name: "frontend", status: "online", port: "8080" },
+        ]),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const res = await GET(makeRequest(), makeParams());
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.data.frontendUrl).toBe(
+      "https://pod-abc-8080.workspaces.sphinx.chat",
+    );
+    // jlist call hits the control port with Bearer auth.
+    const call = fetchSpy.mock.calls[0] as [string, RequestInit | undefined];
+    const [url, init] = call;
+    expect(url).toBe("https://pod-abc-15552.workspaces.sphinx.chat/jlist");
+    expect(init?.headers).toMatchObject({
+      Authorization: "Bearer s3cr3t",
+    });
+  });
+
+  it("falls back to port 3000 when jlist has no frontend process", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify([
+            { pid: 1, name: "goose", status: "online", port: "15551" },
+          ]),
+          { status: 200 },
+        ),
+      ),
+    );
+
+    const res = await GET(makeRequest(), makeParams());
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.data.frontendUrl).toBe(
+      "https://pod-abc-3000.workspaces.sphinx.chat",
+    );
+  });
+
+  it("falls back to port 3000 when jlist request fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("network error");
+      }),
+    );
+
+    const res = await GET(makeRequest(), makeParams());
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.data.frontendUrl).toBe(
+      "https://pod-abc-3000.workspaces.sphinx.chat",
+    );
+  });
+
+  it("falls back to port 3000 when jlist returns non-OK", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("nope", { status: 500 })),
+    );
+
+    const res = await GET(makeRequest(), makeParams());
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.data.frontendUrl).toBe(
+      "https://pod-abc-3000.workspaces.sphinx.chat",
+    );
+  });
+});

--- a/src/__tests__/unit/lib/pods/capacity-queries.test.ts
+++ b/src/__tests__/unit/lib/pods/capacity-queries.test.ts
@@ -13,7 +13,7 @@ vi.mock("@/lib/db", () => ({
 }));
 
 vi.mock("@/lib/pods/queries", () => ({
-  buildPodUrl: vi.fn((podId: string, port: number | string) => `https://${podId}-${port}.workspaces.sphinx.chat`),
+  POD_BASE_DOMAIN: "workspaces.sphinx.chat",
 }));
 
 import { db } from "@/lib/db";
@@ -24,7 +24,7 @@ const mockTaskFindMany = vi.mocked(db.task.findMany);
 
 const SWARM_ID = "swarm-test-123";
 
-function makePod(portMappings: unknown = null) {
+function makePod() {
   return {
     podId: "pod-abc",
     status: "RUNNING" as PodStatus,
@@ -32,7 +32,6 @@ function makePod(portMappings: unknown = null) {
     usageStatusMarkedBy: null,
     password: "secret",
     createdAt: new Date(),
-    portMappings,
   };
 }
 
@@ -41,54 +40,25 @@ beforeEach(() => {
   mockTaskFindMany.mockResolvedValue([]);
 });
 
-describe("getBasicVMDataFromPods — url construction", () => {
-  it("uses first non-control port when portMappings has [3000, 15552]", async () => {
-    mockPodFindMany.mockResolvedValue([makePod([3000, 15552])] as never);
+describe("getBasicVMDataFromPods — IDE url construction", () => {
+  it("returns the bare pod hostname (no port suffix) as the IDE url", async () => {
+    mockPodFindMany.mockResolvedValue([makePod()] as never);
     const [vm] = await getBasicVMDataFromPods(SWARM_ID);
-    expect(vm.url).toBe("https://pod-abc-3000.workspaces.sphinx.chat");
+    expect(vm.url).toBe("https://pod-abc.workspaces.sphinx.chat");
   });
 
-  it("falls back to port 3000 when portMappings is null", async () => {
-    mockPodFindMany.mockResolvedValue([makePod(null)] as never);
+  it("does not include any port in the url", async () => {
+    mockPodFindMany.mockResolvedValue([makePod()] as never);
     const [vm] = await getBasicVMDataFromPods(SWARM_ID);
-    expect(vm.url).toBe("https://pod-abc-3000.workspaces.sphinx.chat");
+    // No `-NNNN.` segment between the subdomain and the base domain.
+    expect(vm.url).not.toMatch(/-\d+\./);
   });
 
-  it("falls back to port 3000 when portMappings is []", async () => {
-    mockPodFindMany.mockResolvedValue([makePod([])] as never);
+  it("does not synthesize a frontendUrl (resolved on-demand instead)", async () => {
+    mockPodFindMany.mockResolvedValue([makePod()] as never);
     const [vm] = await getBasicVMDataFromPods(SWARM_ID);
-    expect(vm.url).toBe("https://pod-abc-3000.workspaces.sphinx.chat");
-  });
-
-  it("falls back to port 3000 when portMappings is [15552] (only control port)", async () => {
-    mockPodFindMany.mockResolvedValue([makePod([15552])] as never);
-    const [vm] = await getBasicVMDataFromPods(SWARM_ID);
-    expect(vm.url).toBe("https://pod-abc-3000.workspaces.sphinx.chat");
-  });
-
-  it("does not use control port 15552 as the url port", async () => {
-    mockPodFindMany.mockResolvedValue([makePod([3000, 15552])] as never);
-    const [vm] = await getBasicVMDataFromPods(SWARM_ID);
-    expect(vm.url).not.toContain("-15552.");
-  });
-});
-
-describe("getBasicVMDataFromPods — frontendUrl", () => {
-  it("frontendUrl equals url (same resolved port)", async () => {
-    mockPodFindMany.mockResolvedValue([makePod([3000, 15552])] as never);
-    const [vm] = await getBasicVMDataFromPods(SWARM_ID);
-    expect(vm.frontendUrl).toBe(vm.url);
-  });
-
-  it("frontendUrl is set when portMappings is null (fallback)", async () => {
-    mockPodFindMany.mockResolvedValue([makePod(null)] as never);
-    const [vm] = await getBasicVMDataFromPods(SWARM_ID);
-    expect(vm.frontendUrl).toBe("https://pod-abc-3000.workspaces.sphinx.chat");
-  });
-
-  it("frontendUrl is set when portMappings is empty (fallback)", async () => {
-    mockPodFindMany.mockResolvedValue([makePod([])] as never);
-    const [vm] = await getBasicVMDataFromPods(SWARM_ID);
-    expect(vm.frontendUrl).toBe("https://pod-abc-3000.workspaces.sphinx.chat");
+    // The capacity query no longer ships a frontendUrl; that lookup happens
+    // on-click via /api/w/[slug]/pool/[podId]/frontend-url.
+    expect((vm as { frontendUrl?: string }).frontendUrl).toBeUndefined();
   });
 });

--- a/src/app/api/w/[slug]/pool/[podId]/frontend-url/route.ts
+++ b/src/app/api/w/[slug]/pool/[podId]/frontend-url/route.ts
@@ -1,0 +1,146 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getMiddlewareContext, requireAuth } from "@/lib/middleware/utils";
+import { getWorkspaceBySlug } from "@/services/workspace";
+import { db } from "@/lib/db";
+import { POD_BASE_DOMAIN, buildPodUrl } from "@/lib/pods/queries";
+import { POD_PORTS, PROCESS_NAMES } from "@/lib/pods/constants";
+import { JlistResponseSchema, type JlistProcess } from "@/types/pod-repair";
+
+export const runtime = "nodejs";
+
+/**
+ * Resolve the "Open Browser" frontend URL for a given pod.
+ *
+ * Strategy (in order):
+ *   1. Hit the pod's `/jlist` (control port) and look for the `frontend` process.
+ *      Use its declared port to build the URL.
+ *   2. Fall back to port 3000 (POD_PORTS.FRONTEND_FALLBACK) if jlist is
+ *      unreachable, returns no frontend process, or the process has no port.
+ *
+ * The IDE URL (no port) is intentionally NOT returned here — that's the bare
+ * `vm.url` already on `VMData`.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string; podId: string }> },
+) {
+  try {
+    const context = getMiddlewareContext(request);
+    const userOrResponse = requireAuth(context);
+    if (userOrResponse instanceof NextResponse) return userOrResponse;
+
+    const { slug, podId } = await params;
+
+    if (!slug || !podId) {
+      return NextResponse.json(
+        { error: "Workspace slug and podId are required" },
+        { status: 400 },
+      );
+    }
+
+    const workspace = await getWorkspaceBySlug(slug, userOrResponse.id);
+    if (!workspace) {
+      return NextResponse.json(
+        { error: "Workspace not found or access denied" },
+        { status: 404 },
+      );
+    }
+
+    // Verify the pod belongs to this workspace's swarm
+    const pod = await db.pod.findFirst({
+      where: {
+        podId,
+        deletedAt: null,
+        swarm: { workspaceId: workspace.id },
+      },
+      select: { podId: true, password: true },
+    });
+
+    if (!pod) {
+      return NextResponse.json(
+        { error: "Pod not found in this workspace" },
+        { status: 404 },
+      );
+    }
+
+    const fallbackUrl = buildPodUrl(pod.podId, POD_PORTS.FRONTEND_FALLBACK);
+
+    // Best-effort jlist lookup. On any failure we return the fallback URL so
+    // the user always gets *something* to click.
+    const frontendUrl = await resolveFrontendUrl(pod.podId, pod.password).catch(
+      (err) => {
+        console.warn(
+          `[frontend-url] jlist lookup failed for ${pod.podId}, using fallback:`,
+          err,
+        );
+        return fallbackUrl;
+      },
+    );
+
+    return NextResponse.json({ success: true, data: { frontendUrl } });
+  } catch (error) {
+    console.error("[frontend-url] unexpected error:", error);
+    return NextResponse.json(
+      {
+        success: false,
+        message: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+async function resolveFrontendUrl(
+  podId: string,
+  password: string | null,
+): Promise<string> {
+  const fallbackUrl = buildPodUrl(podId, POD_PORTS.FRONTEND_FALLBACK);
+
+  const jlist = await fetchJlist(podId, password);
+  if (!jlist) return fallbackUrl;
+
+  const frontendProcess = jlist.find(
+    (proc) => proc.name === PROCESS_NAMES.FRONTEND,
+  );
+  if (!frontendProcess?.port) return fallbackUrl;
+
+  return buildPodUrl(podId, frontendProcess.port);
+}
+
+async function fetchJlist(
+  podId: string,
+  password: string | null,
+): Promise<JlistProcess[] | null> {
+  const jlistUrl = `https://${podId}-${POD_PORTS.CONTROL}.${POD_BASE_DOMAIN}/jlist`;
+
+  try {
+    const response = await fetch(jlistUrl, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        ...(password ? { Authorization: `Bearer ${password}` } : {}),
+      },
+      signal: AbortSignal.timeout(5000),
+    });
+
+    if (!response.ok) {
+      console.warn(
+        `[frontend-url] jlist ${response.status} for ${podId}`,
+      );
+      return null;
+    }
+
+    const data = await response.json();
+    const parsed = JlistResponseSchema.safeParse(data);
+    if (!parsed.success) {
+      console.warn(
+        `[frontend-url] invalid jlist payload for ${podId}: ${parsed.error.message}`,
+      );
+      return null;
+    }
+    return parsed.data as JlistProcess[];
+  } catch (error) {
+    console.warn(`[frontend-url] jlist fetch error for ${podId}:`, error);
+    return null;
+  }
+}

--- a/src/components/capacity/VMGrid.tsx
+++ b/src/components/capacity/VMGrid.tsx
@@ -79,14 +79,43 @@ function VMCard({
     }
   };
 
+  const [isOpeningBrowser, setIsOpeningBrowser] = useState(false);
+
   const handleOpenIDE = () => {
     if (!vm.url) return;
     window.open(vm.url, "_blank", "noopener,noreferrer");
   };
 
-  const handleOpenBrowser = () => {
-    if (!vm.frontendUrl) return;
-    window.open(vm.frontendUrl, "_blank", "noopener,noreferrer");
+  const handleOpenBrowser = async () => {
+    if (!workspaceSlug || !vm.id || isOpeningBrowser) return;
+
+    // Open a blank tab synchronously so the popup blocker treats it as
+    // user-initiated. We'll set its location once the URL is resolved.
+    const newWindow = window.open("about:blank", "_blank", "noopener,noreferrer");
+    setIsOpeningBrowser(true);
+
+    try {
+      const res = await fetch(
+        `/api/w/${encodeURIComponent(workspaceSlug)}/pool/${encodeURIComponent(vm.id)}/frontend-url`,
+      );
+      const json = await res.json().catch(() => null);
+      const url = json?.data?.frontendUrl as string | undefined;
+
+      if (url && newWindow) {
+        newWindow.location.href = url;
+      } else if (url) {
+        // Popup blocked — try a fresh window.open as a fallback.
+        window.open(url, "_blank", "noopener,noreferrer");
+      } else {
+        newWindow?.close();
+        console.error("Failed to resolve frontend URL", json);
+      }
+    } catch (err) {
+      newWindow?.close();
+      console.error("Failed to resolve frontend URL", err);
+    } finally {
+      setIsOpeningBrowser(false);
+    }
   };
 
   return (
@@ -118,10 +147,21 @@ function VMCard({
                     <ExternalLink className="h-4 w-4 mr-2" />
                     Open IDE
                   </DropdownMenuItem>
-                  {vm.frontendUrl && (
-                    <DropdownMenuItem onClick={handleOpenBrowser}>
-                      <Globe className="h-4 w-4 mr-2" />
-                      Open Browser
+                  {workspaceSlug && (
+                    <DropdownMenuItem
+                      onClick={handleOpenBrowser}
+                      disabled={isOpeningBrowser}
+                      onSelect={(e) => {
+                        // Keep the menu logic simple; default close-on-select is fine.
+                        if (isOpeningBrowser) e.preventDefault();
+                      }}
+                    >
+                      {isOpeningBrowser ? (
+                        <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                      ) : (
+                        <Globe className="h-4 w-4 mr-2" />
+                      )}
+                      {isOpeningBrowser ? "Opening..." : "Open Browser"}
                     </DropdownMenuItem>
                   )}
                   {isAdmin && onDeletePod && (

--- a/src/lib/pods/capacity-queries.ts
+++ b/src/lib/pods/capacity-queries.ts
@@ -1,7 +1,6 @@
 import { db } from "@/lib/db";
 import { VMData } from "@/types/pool-manager";
-import { buildPodUrl } from "./queries";
-import { POD_PORTS } from "./constants";
+import { POD_BASE_DOMAIN } from "./queries";
 
 /**
  * Fast database-only query for basic VM data
@@ -23,7 +22,6 @@ export async function getBasicVMDataFromPods(
       usageStatusMarkedBy: true,
       password: true,
       createdAt: true,
-      portMappings: true,
     },
     orderBy: {
       createdAt: "desc",
@@ -52,15 +50,11 @@ export async function getBasicVMDataFromPods(
   }
 
   return pods.map((pod) => {
-    const portMappings = pod.portMappings as number[] | null;
-    const controlPort = parseInt(POD_PORTS.CONTROL, 10);
-    const fallbackPort = parseInt(POD_PORTS.FRONTEND_FALLBACK, 10);
-    const frontendPort =
-      Array.isArray(portMappings) && portMappings.length > 0
-        ? (portMappings.find((p) => p !== controlPort) ?? fallbackPort)
-        : fallbackPort;
-    const url = buildPodUrl(pod.podId, frontendPort);
-    const frontendUrl = url;
+    // IDE URL is the bare pod hostname (proxied to code-server). No port suffix.
+    // The "Open Browser" frontend URL is resolved on-demand via /jlist (see
+    // /api/w/[slug]/pool/[podId]/frontend-url) since the frontend port is
+    // pod-specific and may not be 3000.
+    const url = `https://${pod.podId}.${POD_BASE_DOMAIN}`;
     const subdomain = pod.podId;
 
     // Map database status to pool-manager state format
@@ -102,7 +96,6 @@ export async function getBasicVMDataFromPods(
       marked_at: pod.usageStatusMarkedBy ? pod.createdAt.toISOString() : null,
       password: pod.password || undefined,
       url,
-      frontendUrl,
       repository: undefined, // Not available in basic query
       assignedTask: assignedTask
         ? {

--- a/src/services/pool-manager/PoolManagerService.ts
+++ b/src/services/pool-manager/PoolManagerService.ts
@@ -15,6 +15,19 @@ import { EncryptionService } from "@/lib/encryption";
 
 const encryptionService: EncryptionService = EncryptionService.getInstance();
 
+/**
+ * Strip the `-{port}` suffix from a pod URL so it points at the bare hostname
+ * (which is proxied to code-server / the IDE).
+ *
+ * Example: `https://abc123-8444.workspaces.sphinx.chat` → `https://abc123.workspaces.sphinx.chat`
+ *
+ * Returns the input unchanged if it doesn't match the expected pattern.
+ */
+function stripPodUrlPort(url: string | null | undefined): string | undefined {
+  if (!url || typeof url !== "string") return undefined;
+  return url.replace(/^(https?:\/\/[^.\-/]+)-\d+(\.[^/]+)/, "$1$2");
+}
+
 interface IPoolManagerService {
   createUser: (user: CreateUserRequest) => Promise<PoolUserResponse>;
   deleteUser: (user: DeleteUserRequest) => Promise<void>;
@@ -165,7 +178,9 @@ export class PoolManagerService extends BaseServiceClass implements IPoolManager
           user_info: vm.user_info || null,
           resource_usage: vm.resource_usage,
           marked_at: vm.marked_at || null,
-          url: vm.url,
+          // Strip the upstream port suffix so the IDE URL is the bare hostname.
+          // The frontend (browser) URL is resolved on-demand via /jlist.
+          url: stripPodUrlPort(vm.url),
           created: vm.created,
           repoName: vm.repoName,
           primaryRepo: vm.primaryRepo,

--- a/src/types/pool-manager.ts
+++ b/src/types/pool-manager.ts
@@ -195,7 +195,6 @@ export interface VMData {
       image: string | null;
     };
   } | null;
-  frontendUrl?: string;
 }
 
 export interface PoolWorkspacesResponse {


### PR DESCRIPTION
Open IDE now opens the bare pod hostname (no port) which is proxied to code-server. Open Browser resolves the frontend URL on-click via a new endpoint that hits the pod's /jlist and falls back to port 3000.