### PR TITLE
open browser tab after URL resolves, drop placeholder tab

### DIFF
--- a/src/__tests__/unit/VMGrid.test.tsx
+++ b/src/__tests__/unit/VMGrid.test.tsx
@@ -188,8 +188,6 @@ describe("VMGrid — Open Browser action", () => {
 
   it("fetches frontend-url and opens the resolved URL on click", async () => {
     const user = userEvent.setup();
-    const fakeWindow = { location: { href: "" }, close: vi.fn() };
-    vi.mocked(window.open).mockReturnValue(fakeWindow as unknown as Window);
 
     const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
       new Response(
@@ -217,30 +215,23 @@ describe("VMGrid — Open Browser action", () => {
     await user.click(screen.getByRole("button"));
     await user.click(screen.getByText("Open Browser"));
 
-    // Synchronously opens about:blank to dodge popup blockers, then fetches.
-    expect(window.open).toHaveBeenCalledWith(
-      "about:blank",
-      "_blank",
-      "noopener,noreferrer",
-    );
     expect(fetchSpy).toHaveBeenCalledWith(
       "/api/w/my-workspace/pool/vm-1/frontend-url",
     );
 
-    // After the fetch resolves, the blank tab is navigated to the resolved URL.
     await vi.waitFor(() => {
-      expect(fakeWindow.location.href).toBe(
+      expect(window.open).toHaveBeenCalledWith(
         "https://vm-1-3000.workspaces.sphinx.chat",
+        "_blank",
+        "noopener,noreferrer",
       );
     });
 
     fetchSpy.mockRestore();
   });
 
-  it("closes the placeholder tab if the API returns no URL", async () => {
+  it("does not open a tab if the API returns no URL", async () => {
     const user = userEvent.setup();
-    const fakeWindow = { location: { href: "" }, close: vi.fn() };
-    vi.mocked(window.open).mockReturnValue(fakeWindow as unknown as Window);
 
     const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ success: false }), { status: 500 }),
@@ -257,8 +248,9 @@ describe("VMGrid — Open Browser action", () => {
     await user.click(screen.getByText("Open Browser"));
 
     await vi.waitFor(() => {
-      expect(fakeWindow.close).toHaveBeenCalled();
+      expect(fetchSpy).toHaveBeenCalled();
     });
+    expect(window.open).not.toHaveBeenCalled();
 
     fetchSpy.mockRestore();
   });

--- a/src/components/capacity/VMGrid.tsx
+++ b/src/components/capacity/VMGrid.tsx
@@ -89,11 +89,7 @@ function VMCard({
   const handleOpenBrowser = async () => {
     if (!workspaceSlug || !vm.id || isOpeningBrowser) return;
 
-    // Open a blank tab synchronously so the popup blocker treats it as
-    // user-initiated. We'll set its location once the URL is resolved.
-    const newWindow = window.open("about:blank", "_blank", "noopener,noreferrer");
     setIsOpeningBrowser(true);
-
     try {
       const res = await fetch(
         `/api/w/${encodeURIComponent(workspaceSlug)}/pool/${encodeURIComponent(vm.id)}/frontend-url`,
@@ -101,17 +97,16 @@ function VMCard({
       const json = await res.json().catch(() => null);
       const url = json?.data?.frontendUrl as string | undefined;
 
-      if (url && newWindow) {
-        newWindow.location.href = url;
-      } else if (url) {
-        // Popup blocked — try a fresh window.open as a fallback.
-        window.open(url, "_blank", "noopener,noreferrer");
-      } else {
-        newWindow?.close();
+      if (!url) {
         console.error("Failed to resolve frontend URL", json);
+        return;
       }
+
+      // The fetch is same-origin and fast, so we're still within the
+      // browser's user-activation window from the menu click — popup
+      // blockers treat this as user-initiated.
+      window.open(url, "_blank", "noopener,noreferrer");
     } catch (err) {
-      newWindow?.close();
       console.error("Failed to resolve frontend URL", err);
     } finally {
       setIsOpeningBrowser(false);


### PR DESCRIPTION
Same-origin fetch is fast enough to stay within the user-activation window, so we can call window.open() directly with the resolved URL instead of pre-opening about:blank and navigating it.