### PR TITLE
fix(plan): render suggestion chips independent of workflow status

### DIFF
--- a/src/app/api/features/[featureId]/suggestions/route.ts
+++ b/src/app/api/features/[featureId]/suggestions/route.ts
@@ -24,15 +24,15 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ featureId: string }> },
 ) {
+  const { featureId } = await params;
   try {
-    const { featureId } = await params;
-
     const feature = await db.feature.findUnique({
       where: { id: featureId },
       select: { workspaceId: true },
     });
 
     if (!feature) {
+      console.warn("[suggestions] feature not found", { featureId });
       return NextResponse.json({ suggestions: [] }, { status: 200 });
     }
 
@@ -40,12 +40,16 @@ export async function POST(
       workspaceId: feature.workspaceId,
     });
     const ok = requireReadAccess(access);
-    if (ok instanceof NextResponse) return NextResponse.json({ suggestions: [] }, { status: 200 });
+    if (ok instanceof NextResponse) {
+      console.warn("[suggestions] workspace access denied", { featureId, workspaceId: feature.workspaceId });
+      return NextResponse.json({ suggestions: [] }, { status: 200 });
+    }
 
     const body = await request.json();
     const messages: Array<{ role: string; message: string }> = body.messages ?? [];
 
     if (messages.length === 0) {
+      console.warn("[suggestions] no messages in request body", { featureId });
       return NextResponse.json({ suggestions: [] });
     }
 
@@ -64,9 +68,13 @@ export async function POST(
       prompt: `Conversation:\n${conversationText}\n\nGenerate 2–3 short affirmative reply chips for the user.`,
     });
 
+    console.info("[suggestions] generated", { featureId, count: result.object.suggestions.length, suggestions: result.object.suggestions });
     return NextResponse.json({ suggestions: result.object.suggestions });
-  } catch {
-    // Fail silently — never surface errors to the client
+  } catch (error) {
+    console.error("[suggestions] failed", {
+      featureId,
+      error: error instanceof Error ? { name: error.name, message: error.message } : error,
+    });
     return NextResponse.json({ suggestions: [] });
   }
 }

--- a/src/app/w/[slug]/task/[...taskParams]/components/ChatArea.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/components/ChatArea.tsx
@@ -399,7 +399,7 @@ export function ChatArea({
       <TypingIndicator typingUsers={typingUsers ?? []} />
 
       {/* Quick-reply suggestion chips (plan mode only) */}
-      {isPlanChat && !inputDisabled && !!suggestions?.length && !!onSuggestionSelect && (
+      {isPlanChat && !isLoading && !!suggestions?.length && !!onSuggestionSelect && (
         <SuggestionChips suggestions={suggestions} onSelect={onSuggestionSelect} />
       )}
 

--- a/src/components/plan/SuggestionChips.tsx
+++ b/src/components/plan/SuggestionChips.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { AnimatePresence, motion } from "framer-motion";
+import { cn } from "@/lib/utils";
 
 interface SuggestionChipsProps {
   suggestions: string[];
@@ -17,12 +18,17 @@ export function SuggestionChips({ suggestions, onSelect }: SuggestionChipsProps)
         {suggestions.map((suggestion, index) => (
           <motion.button
             key={suggestion}
-            initial={{ opacity: 0, y: 6 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: 4 }}
-            transition={{ duration: 0.15, delay: index * 0.05 }}
+            initial={{ opacity: 0, scale: 0.96 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.96 }}
+            transition={{ duration: 0.15, delay: index * 0.04 }}
             onClick={() => onSelect(suggestion)}
-            className="rounded-full border border-blue-400/40 bg-blue-500/10 px-3 py-1.5 text-xs text-blue-600 dark:text-blue-400 font-medium hover:bg-blue-500/20 transition-all cursor-pointer"
+            className={cn(
+              "rounded-full bg-accent px-3.5 py-1.5 text-sm font-medium text-accent-foreground cursor-pointer",
+              "transition-all duration-150",
+              "hover:bg-accent/80 hover:scale-[1.03]",
+              "active:scale-100",
+            )}
           >
             {suggestion}
           </motion.button>


### PR DESCRIPTION
The chip render gate required `!inputDisabled`, which includes `workflowStatus !== IN_PROGRESS`. Pusher delivers the assistant message and the workflow_status_update event separately, so chips were suppressed whenever the status event was delayed or dropped — even though suggestions had been fetched successfully.

Gate on `isLoading` instead. Suggestions are only populated after an assistant message arrives, so a real IN_PROGRESS state still naturally shows no chips.

Also adds diagnostic logging to the suggestions route to surface silent failures (Haiku schema mismatches, auth denials), and updates the chip styling to the soft-filled-accent variant.