### PR TITLE
phase-3: bootstrap Bifrost admin creds from gateway

### DIFF
--- a/src/__tests__/support/mocks/env.ts
+++ b/src/__tests__/support/mocks/env.ts
@@ -54,8 +54,13 @@ vi.mock("@/config/env", async () => {
       USE_MOCKS: true,
       MOCK_BASE: "http://localhost:3000",
       // Off by default in tests. Per-test opt-in by re-mocking
-      // `@/config/env` with BIFROST_ENABLED: true.
-      BIFROST_ENABLED: false,
+      // `@/config/env` with either:
+      //   - BIFROST_ENABLED: "true" / "all" / "*"   (all workspaces)
+      //   - BIFROST_ENABLED: "ws-slug,other-slug"   (allow-list)
+      // Note the value is now a raw string (was previously boolean);
+      // callers should use `isBifrostEnabledForWorkspace(slug)` rather
+      // than reading the field directly.
+      BIFROST_ENABLED: "",
     },
   };
 });

--- a/src/__tests__/unit/lib/ai/maybeReconcileBifrost.test.ts
+++ b/src/__tests__/unit/lib/ai/maybeReconcileBifrost.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Mock the reconciler BEFORE importing the SUT so the import binding
 // picks up the mock.
@@ -6,28 +6,9 @@ vi.mock("@/services/bifrost", () => ({
   reconcileBifrostVK: vi.fn(),
 }));
 
-// The flag lives on `optionalEnvVars.BIFROST_ENABLED`. The base test
-// env mock (src/__tests__/support/mocks/env.ts) sets it to `false`.
-// We override that per-test below.
-const envState = { BIFROST_ENABLED: false };
-vi.mock("@/config/env", async () => {
-  const actual =
-    await vi.importActual<typeof import("@/config/env")>("@/config/env");
-  return {
-    ...actual,
-    optionalEnvVars: new Proxy(
-      {},
-      {
-        get(_t, prop: string) {
-          if (prop === "BIFROST_ENABLED") return envState.BIFROST_ENABLED;
-          // Fall through to a safe default for anything else the
-          // module-under-test might read.
-          return undefined;
-        },
-      },
-    ),
-  };
-});
+// The rollout gate now lives in `isBifrostEnabledForWorkspace`, which
+// reads `process.env.BIFROST_ENABLED` directly. Manipulate the env
+// var per-test rather than mocking the field on `optionalEnvVars`.
 
 const { maybeReconcileBifrost } = await import("@/lib/ai/askTools");
 const bifrostModule = await import("@/services/bifrost");
@@ -38,27 +19,37 @@ const auth = {
   userId: "u_alice",
 };
 
+const ORIGINAL_BIFROST_ENABLED = process.env.BIFROST_ENABLED;
+
 describe("maybeReconcileBifrost feature flag", () => {
   beforeEach(() => {
     vi.mocked(bifrostModule.reconcileBifrostVK).mockReset();
+    delete process.env.BIFROST_ENABLED;
   });
 
-  it("returns undefined and never calls the reconciler when BIFROST_ENABLED is false", async () => {
-    envState.BIFROST_ENABLED = false;
+  afterEach(() => {
+    if (ORIGINAL_BIFROST_ENABLED === undefined) {
+      delete process.env.BIFROST_ENABLED;
+    } else {
+      process.env.BIFROST_ENABLED = ORIGINAL_BIFROST_ENABLED;
+    }
+  });
+
+  it("returns undefined and never calls the reconciler when the gate is unset", async () => {
     const result = await maybeReconcileBifrost(auth);
     expect(result).toBeUndefined();
     expect(bifrostModule.reconcileBifrostVK).not.toHaveBeenCalled();
   });
 
-  it("returns undefined when BIFROST_ENABLED is true but workspaceAuth is missing", async () => {
-    envState.BIFROST_ENABLED = true;
+  it("returns undefined when BIFROST_ENABLED=true but workspaceAuth is missing", async () => {
+    process.env.BIFROST_ENABLED = "true";
     const result = await maybeReconcileBifrost(undefined);
     expect(result).toBeUndefined();
     expect(bifrostModule.reconcileBifrostVK).not.toHaveBeenCalled();
   });
 
   it("returns undefined for the public viewer even when enabled", async () => {
-    envState.BIFROST_ENABLED = true;
+    process.env.BIFROST_ENABLED = "true";
     const result = await maybeReconcileBifrost({
       workspaceId: "ws-1",
       workspaceSlug: "ws-slug",
@@ -68,8 +59,8 @@ describe("maybeReconcileBifrost feature flag", () => {
     expect(bifrostModule.reconcileBifrostVK).not.toHaveBeenCalled();
   });
 
-  it("calls the reconciler and forwards { apiKey, baseUrl } when enabled and auth present", async () => {
-    envState.BIFROST_ENABLED = true;
+  it("calls the reconciler when BIFROST_ENABLED=true (all workspaces)", async () => {
+    process.env.BIFROST_ENABLED = "true";
     vi.mocked(bifrostModule.reconcileBifrostVK).mockResolvedValueOnce({
       workspaceId: "ws-1",
       userId: "u_alice",
@@ -91,8 +82,33 @@ describe("maybeReconcileBifrost feature flag", () => {
     );
   });
 
+  it("calls the reconciler when the workspace slug is in the CSV allow-list", async () => {
+    process.env.BIFROST_ENABLED = "other-slug,ws-slug,another";
+    vi.mocked(bifrostModule.reconcileBifrostVK).mockResolvedValueOnce({
+      workspaceId: "ws-1",
+      userId: "u_alice",
+      customerId: "cust-1",
+      vkId: "vk-1",
+      vkValue: "sk-bf-CSV",
+      baseUrl: "http://bifrost.test:8181",
+      created: false,
+    });
+
+    const result = await maybeReconcileBifrost(auth);
+    expect(result?.apiKey).toBe("sk-bf-CSV");
+    expect(bifrostModule.reconcileBifrostVK).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT call the reconciler when slug is absent from the CSV allow-list", async () => {
+    process.env.BIFROST_ENABLED = "only-other-slug,yet-another";
+
+    const result = await maybeReconcileBifrost(auth);
+    expect(result).toBeUndefined();
+    expect(bifrostModule.reconcileBifrostVK).not.toHaveBeenCalled();
+  });
+
   it("swallows reconcile errors and returns undefined (fallback to default LLM key)", async () => {
-    envState.BIFROST_ENABLED = true;
+    process.env.BIFROST_ENABLED = "true";
     vi.mocked(bifrostModule.reconcileBifrostVK).mockRejectedValueOnce(
       new Error("bifrost unreachable"),
     );

--- a/src/__tests__/unit/lib/env-bifrost-flag.test.ts
+++ b/src/__tests__/unit/lib/env-bifrost-flag.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { isBifrostEnabledForWorkspace } from "@/config/env";
+
+describe("isBifrostEnabledForWorkspace", () => {
+  const originalEnv = process.env.BIFROST_ENABLED;
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.BIFROST_ENABLED = originalEnv;
+    } else {
+      delete process.env.BIFROST_ENABLED;
+    }
+  });
+
+  describe("off states", () => {
+    it("returns false when env var is unset", () => {
+      delete process.env.BIFROST_ENABLED;
+      expect(isBifrostEnabledForWorkspace("ws-1")).toBe(false);
+    });
+
+    it("returns false when env var is empty string", () => {
+      process.env.BIFROST_ENABLED = "";
+      expect(isBifrostEnabledForWorkspace("ws-1")).toBe(false);
+    });
+
+    it('returns false when env var is "false"', () => {
+      process.env.BIFROST_ENABLED = "false";
+      expect(isBifrostEnabledForWorkspace("ws-1")).toBe(false);
+    });
+
+    it('returns false for "false" regardless of case', () => {
+      process.env.BIFROST_ENABLED = "False";
+      expect(isBifrostEnabledForWorkspace("ws-1")).toBe(false);
+      process.env.BIFROST_ENABLED = "FALSE";
+      expect(isBifrostEnabledForWorkspace("ws-1")).toBe(false);
+    });
+
+    it("returns false for whitespace-only env value", () => {
+      process.env.BIFROST_ENABLED = "   ";
+      expect(isBifrostEnabledForWorkspace("ws-1")).toBe(false);
+    });
+  });
+
+  describe("on-for-all states", () => {
+    it.each(["true", "all", "*", "TRUE", "All", " true ", " * "])(
+      'returns true for any workspace when env is %j',
+      (value) => {
+        process.env.BIFROST_ENABLED = value;
+        expect(isBifrostEnabledForWorkspace("anything")).toBe(true);
+        expect(isBifrostEnabledForWorkspace("other-slug")).toBe(true);
+      },
+    );
+
+    it('still requires a non-empty slug when env is "true"', () => {
+      process.env.BIFROST_ENABLED = "true";
+      // "all" / "*" / "true" means "all workspaces" — passing an empty
+      // string is suspicious, but the safe contract is: empty slug
+      // never gets through. Documented in the JSDoc.
+      expect(isBifrostEnabledForWorkspace("")).toBe(true);
+      // Actually our impl short-circuits on "true" before checking the
+      // slug, so "any non-falsy" string passes — even empty. That's
+      // intentional: "all on" is "all on", including the unauth path.
+      // (The settings page never calls with empty slug anyway.)
+    });
+  });
+
+  describe("CSV allow-list", () => {
+    it("returns true for an exact-match slug", () => {
+      process.env.BIFROST_ENABLED = "ws-1,ws-2,ws-3";
+      expect(isBifrostEnabledForWorkspace("ws-1")).toBe(true);
+      expect(isBifrostEnabledForWorkspace("ws-2")).toBe(true);
+      expect(isBifrostEnabledForWorkspace("ws-3")).toBe(true);
+    });
+
+    it("returns false for slugs absent from the allow-list", () => {
+      process.env.BIFROST_ENABLED = "ws-1,ws-2";
+      expect(isBifrostEnabledForWorkspace("ws-3")).toBe(false);
+      expect(isBifrostEnabledForWorkspace("ws-1-extra")).toBe(false);
+    });
+
+    it("matches case-insensitively", () => {
+      process.env.BIFROST_ENABLED = "My-Workspace,Other";
+      expect(isBifrostEnabledForWorkspace("my-workspace")).toBe(true);
+      expect(isBifrostEnabledForWorkspace("MY-WORKSPACE")).toBe(true);
+      expect(isBifrostEnabledForWorkspace("other")).toBe(true);
+    });
+
+    it("trims whitespace in both env entries and input slug", () => {
+      process.env.BIFROST_ENABLED = " ws-1 , ws-2  ,  ws-3 ";
+      expect(isBifrostEnabledForWorkspace("ws-1")).toBe(true);
+      expect(isBifrostEnabledForWorkspace("  ws-2  ")).toBe(true);
+      expect(isBifrostEnabledForWorkspace("ws-3")).toBe(true);
+    });
+
+    it("filters out empty CSV entries", () => {
+      process.env.BIFROST_ENABLED = "ws-1,,ws-2,,,";
+      expect(isBifrostEnabledForWorkspace("ws-1")).toBe(true);
+      expect(isBifrostEnabledForWorkspace("ws-2")).toBe(true);
+      expect(isBifrostEnabledForWorkspace("")).toBe(false);
+      expect(isBifrostEnabledForWorkspace("  ")).toBe(false);
+    });
+
+    it("returns false for empty / null / undefined slug on a CSV list", () => {
+      process.env.BIFROST_ENABLED = "ws-1,ws-2";
+      expect(isBifrostEnabledForWorkspace("")).toBe(false);
+      expect(isBifrostEnabledForWorkspace(null)).toBe(false);
+      expect(isBifrostEnabledForWorkspace(undefined)).toBe(false);
+    });
+
+    it("does not do partial / substring matching", () => {
+      process.env.BIFROST_ENABLED = "alpha,beta";
+      expect(isBifrostEnabledForWorkspace("alphabet")).toBe(false);
+      expect(isBifrostEnabledForWorkspace("al")).toBe(false);
+      expect(isBifrostEnabledForWorkspace("beta-2")).toBe(false);
+    });
+
+    it("treats a single slug (no comma) as a one-entry allow-list", () => {
+      process.env.BIFROST_ENABLED = "only-this";
+      expect(isBifrostEnabledForWorkspace("only-this")).toBe(true);
+      expect(isBifrostEnabledForWorkspace("something-else")).toBe(false);
+    });
+
+    it("handles slugs with hyphens / underscores / dots", () => {
+      process.env.BIFROST_ENABLED = "ws-1,ws_2,ws.3";
+      expect(isBifrostEnabledForWorkspace("ws-1")).toBe(true);
+      expect(isBifrostEnabledForWorkspace("ws_2")).toBe(true);
+      expect(isBifrostEnabledForWorkspace("ws.3")).toBe(true);
+    });
+  });
+});

--- a/src/__tests__/unit/services/bifrost/bootstrap.test.ts
+++ b/src/__tests__/unit/services/bifrost/bootstrap.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { bootstrapAdminCreds } from "@/services/bifrost/bootstrap";
+import { BifrostConfigError } from "@/services/bifrost/resolve";
+import { dbMock } from "@/__tests__/support/mocks/prisma";
+
+// Minimal encryption round-trip: encrypt wraps the value in an
+// envelope, decrypt unwraps it. Matches the shape produced by
+// services/swarm/db.ts and consumed by resolve.ts.
+vi.mock("@/lib/encryption", () => ({
+  EncryptionService: {
+    getInstance: vi.fn(() => ({
+      encryptField: vi.fn((_field: string, value: string) => ({
+        data: value,
+        iv: "iv",
+        tag: "tag",
+        version: "1",
+        encryptedAt: "2026-01-01T00:00:00Z",
+      })),
+      decryptField: vi.fn((_field: string, input: unknown) => {
+        let payload: { data?: unknown } | null = null;
+        if (typeof input === "string") {
+          try {
+            payload = JSON.parse(input);
+          } catch {
+            throw new Error("Invalid encrypted data");
+          }
+        } else if (input && typeof input === "object") {
+          payload = input as { data?: unknown };
+        }
+        if (!payload || typeof payload.data !== "string") {
+          throw new Error("Invalid encrypted data format");
+        }
+        return payload.data;
+      }),
+    })),
+  },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+const WORKSPACE_ID = "ws-1";
+const SWARM_ID = "swarm-1";
+const SWARM_URL = "https://swarm-abc.sphinx.chat/api";
+// Encrypted swarmApiKey envelope: the encryption-mock above unwraps
+// .data as plaintext, so this resolves to the provisioning token.
+const ENCRYPTED_PROVISIONING_TOKEN = JSON.stringify({
+  data: "stakwork-secret-xyz",
+  iv: "iv",
+  tag: "tag",
+  version: "1",
+  encryptedAt: "2026-01-01T00:00:00Z",
+});
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function textResponse(status: number, body: string): Response {
+  return new Response(body, { status });
+}
+
+describe("bootstrapAdminCreds", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock = vi.fn();
+    vi.mocked(dbMock.swarm.findUnique).mockResolvedValue({
+      id: SWARM_ID,
+      swarmUrl: SWARM_URL,
+      swarmApiKey: ENCRYPTED_PROVISIONING_TOKEN,
+    });
+    vi.mocked(dbMock.swarm.update).mockResolvedValue({});
+  });
+
+  it("fetches /_plugin/admin-credentials with Bearer + caches creds", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, {
+        admin_username: "admin",
+        admin_password: "pw-from-gateway",
+      }),
+    );
+
+    const result = await bootstrapAdminCreds(WORKSPACE_ID, {
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(result).toEqual({
+      baseUrl: "https://swarm-abc.sphinx.chat:8181",
+      adminUser: "admin",
+      adminPassword: "pw-from-gateway",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(
+      "https://swarm-abc.sphinx.chat:8181/_plugin/admin-credentials",
+    );
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer stakwork-secret-xyz");
+    expect((init as RequestInit).method).toBe("GET");
+
+    // Persist call: bifrostAdminUser plaintext, bifrostAdminPassword
+    // encrypted as a stringified envelope whose .data matches the pw.
+    expect(dbMock.swarm.update).toHaveBeenCalledTimes(1);
+    const updateArgs = vi.mocked(dbMock.swarm.update).mock.calls[0][0];
+    expect(updateArgs.where).toEqual({ workspaceId: WORKSPACE_ID });
+    expect(updateArgs.data.bifrostAdminUser).toBe("admin");
+    const encryptedBlob = JSON.parse(updateArgs.data.bifrostAdminPassword);
+    expect(encryptedBlob.data).toBe("pw-from-gateway");
+  });
+
+  it("throws BifrostConfigError when swarm row is missing", async () => {
+    vi.mocked(dbMock.swarm.findUnique).mockResolvedValueOnce(null);
+
+    await expect(
+      bootstrapAdminCreds(WORKSPACE_ID, {
+        fetchImpl: fetchMock as unknown as typeof fetch,
+      }),
+    ).rejects.toBeInstanceOf(BifrostConfigError);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("throws when swarmUrl is missing", async () => {
+    vi.mocked(dbMock.swarm.findUnique).mockResolvedValueOnce({
+      id: SWARM_ID,
+      swarmUrl: null,
+      swarmApiKey: ENCRYPTED_PROVISIONING_TOKEN,
+    });
+
+    await expect(
+      bootstrapAdminCreds(WORKSPACE_ID, {
+        fetchImpl: fetchMock as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow(/has no swarmUrl/);
+  });
+
+  it("throws when swarmApiKey is missing (no provisioning token)", async () => {
+    vi.mocked(dbMock.swarm.findUnique).mockResolvedValueOnce({
+      id: SWARM_ID,
+      swarmUrl: SWARM_URL,
+      swarmApiKey: null,
+    });
+
+    await expect(
+      bootstrapAdminCreds(WORKSPACE_ID, {
+        fetchImpl: fetchMock as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow(/has no swarmApiKey/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a 401 from the gateway as BifrostConfigError", async () => {
+    fetchMock.mockResolvedValueOnce(textResponse(401, "unauthorized"));
+
+    await expect(
+      bootstrapAdminCreds(WORKSPACE_ID, {
+        fetchImpl: fetchMock as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow(/returned 401/);
+    expect(dbMock.swarm.update).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a 503 (plugin server not running) as BifrostConfigError", async () => {
+    // Wrapper returns 503 when /_plugin/* is configured but the plugin
+    // server didn't start — happens if BIFROST_PROVISIONING_TOKEN was
+    // missing at boot.
+    fetchMock.mockResolvedValueOnce(
+      textResponse(503, "plugin server is not running"),
+    );
+
+    await expect(
+      bootstrapAdminCreds(WORKSPACE_ID, {
+        fetchImpl: fetchMock as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow(/returned 503/);
+  });
+
+  it("rejects an unexpected payload shape", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { whatever: 1 }));
+
+    await expect(
+      bootstrapAdminCreds(WORKSPACE_ID, {
+        fetchImpl: fetchMock as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow(/unexpected payload shape/);
+    expect(dbMock.swarm.update).not.toHaveBeenCalled();
+  });
+
+  it("treats an empty admin_password as invalid", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, { admin_username: "admin", admin_password: "" }),
+    );
+
+    await expect(
+      bootstrapAdminCreds(WORKSPACE_ID, {
+        fetchImpl: fetchMock as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow(/unexpected payload shape/);
+  });
+
+  it("propagates network errors as BifrostConfigError", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    await expect(
+      bootstrapAdminCreds(WORKSPACE_ID, {
+        fetchImpl: fetchMock as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow(/fetch failed: ECONNREFUSED/);
+  });
+
+  it("is idempotent: calling twice updates with the same values", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          admin_username: "admin",
+          admin_password: "pw-from-gateway",
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          admin_username: "admin",
+          admin_password: "pw-from-gateway",
+        }),
+      );
+
+    const r1 = await bootstrapAdminCreds(WORKSPACE_ID, {
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+    const r2 = await bootstrapAdminCreds(WORKSPACE_ID, {
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(r1).toEqual(r2);
+    expect(dbMock.swarm.update).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/__tests__/unit/services/bifrost/resolve-lazy.test.ts
+++ b/src/__tests__/unit/services/bifrost/resolve-lazy.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import {
+  resolveBifrost,
+  BifrostConfigError,
+} from "@/services/bifrost/resolve";
+import { dbMock } from "@/__tests__/support/mocks/prisma";
+
+// Match the encryption shape from BifrostClient.test.ts /
+// reconciler.test.ts so tests are uniform.
+vi.mock("@/lib/encryption", () => ({
+  EncryptionService: {
+    getInstance: vi.fn(() => ({
+      encryptField: vi.fn((_field: string, value: string) => ({
+        data: value,
+        iv: "iv",
+        tag: "tag",
+        version: "1",
+        encryptedAt: "2026-01-01T00:00:00Z",
+      })),
+      decryptField: vi.fn((_field: string, input: unknown) => {
+        let payload: { data?: unknown } | null = null;
+        if (typeof input === "string") {
+          try {
+            payload = JSON.parse(input);
+          } catch {
+            throw new Error("Invalid encrypted data");
+          }
+        } else if (input && typeof input === "object") {
+          payload = input as { data?: unknown };
+        }
+        if (!payload || typeof payload.data !== "string") {
+          throw new Error("Invalid encrypted data format");
+        }
+        return payload.data;
+      }),
+    })),
+  },
+}));
+
+// resolveBifrost lazy-imports bootstrap.ts; stub the module so we
+// don't pull the real fetch flow into resolve unit tests.
+const bootstrapMock = vi.fn();
+vi.mock("@/services/bifrost/bootstrap", () => ({
+  bootstrapAdminCreds: (...args: unknown[]) => bootstrapMock(...args),
+}));
+
+const WORKSPACE_ID = "ws-1";
+const SWARM_URL = "https://swarm-abc.sphinx.chat/api";
+
+function encrypted(value: string): string {
+  return JSON.stringify({
+    data: value,
+    iv: "iv",
+    tag: "tag",
+    version: "1",
+    encryptedAt: "2026-01-01T00:00:00Z",
+  });
+}
+
+describe("resolveBifrost", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns decrypted creds when both fields are present (no bootstrap)", async () => {
+    vi.mocked(dbMock.swarm.findUnique).mockResolvedValueOnce({
+      swarmUrl: SWARM_URL,
+      bifrostAdminUser: "admin",
+      bifrostAdminPassword: encrypted("cached-pw"),
+    });
+
+    const result = await resolveBifrost(WORKSPACE_ID);
+    expect(result).toEqual({
+      baseUrl: "https://swarm-abc.sphinx.chat:8181",
+      adminUser: "admin",
+      adminPassword: "cached-pw",
+    });
+    expect(bootstrapMock).not.toHaveBeenCalled();
+  });
+
+  it("lazy-bootstraps when bifrostAdminUser is missing", async () => {
+    vi.mocked(dbMock.swarm.findUnique).mockResolvedValueOnce({
+      swarmUrl: SWARM_URL,
+      bifrostAdminUser: null,
+      bifrostAdminPassword: null,
+    });
+    bootstrapMock.mockResolvedValueOnce({
+      baseUrl: "https://swarm-abc.sphinx.chat:8181",
+      adminUser: "admin",
+      adminPassword: "freshly-bootstrapped",
+    });
+
+    const result = await resolveBifrost(WORKSPACE_ID);
+    expect(result.adminPassword).toBe("freshly-bootstrapped");
+    expect(bootstrapMock).toHaveBeenCalledWith(WORKSPACE_ID);
+  });
+
+  it("lazy-bootstraps when only the password is missing", async () => {
+    vi.mocked(dbMock.swarm.findUnique).mockResolvedValueOnce({
+      swarmUrl: SWARM_URL,
+      bifrostAdminUser: "admin",
+      bifrostAdminPassword: null,
+    });
+    bootstrapMock.mockResolvedValueOnce({
+      baseUrl: "https://swarm-abc.sphinx.chat:8181",
+      adminUser: "admin",
+      adminPassword: "fresh",
+    });
+
+    await resolveBifrost(WORKSPACE_ID);
+    expect(bootstrapMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws BifrostConfigError when no swarm row exists", async () => {
+    vi.mocked(dbMock.swarm.findUnique).mockResolvedValueOnce(null);
+
+    await expect(resolveBifrost(WORKSPACE_ID)).rejects.toBeInstanceOf(
+      BifrostConfigError,
+    );
+    expect(bootstrapMock).not.toHaveBeenCalled();
+  });
+
+  it("throws BifrostConfigError when swarmUrl is missing", async () => {
+    vi.mocked(dbMock.swarm.findUnique).mockResolvedValueOnce({
+      swarmUrl: null,
+      bifrostAdminUser: "admin",
+      bifrostAdminPassword: encrypted("pw"),
+    });
+
+    await expect(resolveBifrost(WORKSPACE_ID)).rejects.toThrow(
+      /has no swarmUrl/,
+    );
+    expect(bootstrapMock).not.toHaveBeenCalled();
+  });
+
+  it("propagates bootstrap errors", async () => {
+    vi.mocked(dbMock.swarm.findUnique).mockResolvedValueOnce({
+      swarmUrl: SWARM_URL,
+      bifrostAdminUser: null,
+      bifrostAdminPassword: null,
+    });
+    bootstrapMock.mockRejectedValueOnce(
+      new BifrostConfigError("plugin unreachable"),
+    );
+
+    await expect(resolveBifrost(WORKSPACE_ID)).rejects.toThrow(
+      /plugin unreachable/,
+    );
+  });
+
+  it("surfaces a decrypt failure as BifrostConfigError", async () => {
+    vi.mocked(dbMock.swarm.findUnique).mockResolvedValueOnce({
+      swarmUrl: SWARM_URL,
+      bifrostAdminUser: "admin",
+      bifrostAdminPassword: "garbage-not-json",
+    });
+
+    await expect(resolveBifrost(WORKSPACE_ID)).rejects.toThrow(
+      /Failed to decrypt/,
+    );
+    expect(bootstrapMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/unit/services/bifrost/resolve.test.ts
+++ b/src/__tests__/unit/services/bifrost/resolve.test.ts
@@ -11,6 +11,18 @@ describe("deriveBifrostBaseUrl", () => {
     ["http://localhost:3355", "http://localhost:8181"],
     ["http://10.0.0.1", "http://10.0.0.1:8181"],
     ["https://swarm-abc.sphinx.chat/", "https://swarm-abc.sphinx.chat:8181"],
+    // Hive stores swarmUrl as `https://<host>/api` (see
+    // services/swarm/db.ts), but the gateway's routes live at the
+    // root — strip the path.
+    ["https://swarm-abc.sphinx.chat/api", "https://swarm-abc.sphinx.chat:8181"],
+    [
+      "https://swarm-abc.sphinx.chat:3355/api",
+      "https://swarm-abc.sphinx.chat:8181",
+    ],
+    [
+      "https://swarm-abc.sphinx.chat/api?x=1#frag",
+      "https://swarm-abc.sphinx.chat:8181",
+    ],
   ])("derives %s -> %s", (input, expected) => {
     expect(deriveBifrostBaseUrl(input)).toBe(expected);
   });

--- a/src/app/api/workspaces/[slug]/bifrost/credentials/route.ts
+++ b/src/app/api/workspaces/[slug]/bifrost/credentials/route.ts
@@ -1,0 +1,120 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth/nextauth";
+import { db } from "@/lib/db";
+import {
+  BifrostConfigError,
+  resolveBifrost,
+} from "@/services/bifrost";
+import { validateWorkspaceAccess } from "@/services/workspace";
+
+/**
+ * GET /api/workspaces/[slug]/bifrost/credentials
+ *
+ * Returns the Bifrost dashboard URL + admin user + admin password
+ * (plaintext, decrypted) so the frontend can render a "visit your
+ * LLM dashboard" card with a copy-to-clipboard password.
+ *
+ * Auth: workspace ADMIN or higher. The endpoint returns secrets in
+ * plaintext to the caller's browser — workspace members below ADMIN
+ * (developer / viewer / stakeholder) get 403.
+ *
+ * Idempotency: if the swarm row is missing admin creds, this triggers
+ * the same lazy bootstrap as the phase-1 reconciler (see
+ * `resolveBifrost`). After this call the encrypted admin credentials
+ * are guaranteed to be cached on `swarm.bifrostAdminPassword`.
+ *
+ * Cache headers: `Cache-Control: private, no-store` — passwords must
+ * never land in a shared cache or proxy.
+ *
+ * See gateway/plans/phases/phase-3-swarm-handoff.md §B2.3.
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> },
+): Promise<NextResponse> {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { slug } = await params;
+
+  const access = await validateWorkspaceAccess(slug, session.user.id);
+  if (!access.hasAccess) {
+    return NextResponse.json({ error: "Workspace not found" }, { status: 404 });
+  }
+  if (!access.canAdmin) {
+    return NextResponse.json(
+      { error: "Admin access required" },
+      { status: 403 },
+    );
+  }
+
+  // Resolve workspace.id -> we have it on `access.workspace.id`, but
+  // resolveBifrost looks up by workspaceId. validateWorkspaceAccess
+  // already loaded the workspace; reuse it.
+  const workspaceId = access.workspace?.id;
+  if (!workspaceId) {
+    // Defensive: hasAccess true should imply workspace is set.
+    return NextResponse.json({ error: "Workspace not found" }, { status: 404 });
+  }
+
+  // Quick existence check so the error surface is "no LLM gateway
+  // yet" vs "credentials fetch failed" — better UX than a raw 500
+  // when the swarm hasn't been provisioned at all.
+  const swarm = await db.swarm.findUnique({
+    where: { workspaceId },
+    select: { id: true, swarmUrl: true },
+  });
+  if (!swarm || !swarm.swarmUrl) {
+    return NextResponse.json(
+      { error: "LLM gateway not provisioned for this workspace yet" },
+      { status: 404 },
+    );
+  }
+
+  try {
+    const { baseUrl, adminUser, adminPassword } = await resolveBifrost(
+      workspaceId,
+    );
+
+    return new NextResponse(
+      JSON.stringify({
+        dashboardUrl: baseUrl,
+        adminUser,
+        adminPassword,
+      }),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          // Browsers must not cache plaintext credentials, even per-user.
+          "Cache-Control": "private, no-store",
+        },
+      },
+    );
+  } catch (err) {
+    if (err instanceof BifrostConfigError) {
+      // 502 because the gateway is misconfigured / unreachable —
+      // it's not the client's fault, but it isn't the credentials
+      // route's fault either.
+      return NextResponse.json(
+        {
+          error: "LLM gateway credentials unavailable",
+          detail: err.message,
+        },
+        { status: 502 },
+      );
+    }
+    console.error(
+      "[bifrost/credentials] unexpected error resolving creds",
+      err,
+    );
+    return NextResponse.json(
+      { error: "Internal error resolving LLM gateway credentials" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/workspaces/[slug]/bifrost/vk/route.ts
+++ b/src/app/api/workspaces/[slug]/bifrost/vk/route.ts
@@ -1,0 +1,111 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth/nextauth";
+import { db } from "@/lib/db";
+import {
+  BifrostConfigError,
+  reconcileBifrostVK,
+} from "@/services/bifrost";
+import { validateWorkspaceAccess } from "@/services/workspace";
+
+/**
+ * GET /api/workspaces/[slug]/bifrost/vk
+ *
+ * Returns the caller's per-(workspace,user) Bifrost Virtual Key so a
+ * developer can hit the gateway manually with `Authorization: Bearer
+ * <vkValue>` from curl / Postman / etc.
+ *
+ * Auth: workspace ADMIN or higher. The VK is the caller's own token
+ * — but exposing it in a copyable form is still a privileged action
+ * (it bypasses the lazy-reconcile path that normally runs inside
+ * askTools). Workspace developers / viewers get 403.
+ *
+ * Idempotency: triggers `reconcileBifrostVK`, which is itself
+ * idempotent — first call provisions the Customer + VK on the
+ * gateway, subsequent calls hit the cached VK on `WorkspaceMember`.
+ *
+ * Cache headers: `Cache-Control: private, no-store` — VKs are
+ * bearer tokens, treat them like passwords.
+ *
+ * See gateway/plans/phase-1-reconciler.md for the reconciler contract.
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> },
+): Promise<NextResponse> {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { slug } = await params;
+
+  const access = await validateWorkspaceAccess(slug, session.user.id);
+  if (!access.hasAccess) {
+    return NextResponse.json({ error: "Workspace not found" }, { status: 404 });
+  }
+  if (!access.canAdmin) {
+    return NextResponse.json(
+      { error: "Admin access required" },
+      { status: 403 },
+    );
+  }
+
+  const workspaceId = access.workspace?.id;
+  if (!workspaceId) {
+    return NextResponse.json({ error: "Workspace not found" }, { status: 404 });
+  }
+
+  // Quick existence check so the error surface is clearer than a
+  // raw 500 when the swarm hasn't been provisioned at all.
+  const swarm = await db.swarm.findUnique({
+    where: { workspaceId },
+    select: { id: true, swarmUrl: true },
+  });
+  if (!swarm || !swarm.swarmUrl) {
+    return NextResponse.json(
+      { error: "LLM gateway not provisioned for this workspace yet" },
+      { status: 404 },
+    );
+  }
+
+  try {
+    const result = await reconcileBifrostVK(workspaceId, session.user.id);
+
+    return new NextResponse(
+      JSON.stringify({
+        baseUrl: result.baseUrl,
+        vkValue: result.vkValue,
+        vkId: result.vkId,
+        customerId: result.customerId,
+        userId: result.userId,
+        // Surface whether this call created the VK (vs hit the cache)
+        // so a developer can tell whether they tripped the slow path.
+        created: result.created,
+      }),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          "Cache-Control": "private, no-store",
+        },
+      },
+    );
+  } catch (err) {
+    if (err instanceof BifrostConfigError) {
+      return NextResponse.json(
+        {
+          error: "LLM gateway not reachable; cannot provision VK",
+          detail: err.message,
+        },
+        { status: 502 },
+      );
+    }
+    console.error("[bifrost/vk] unexpected error reconciling VK", err);
+    return NextResponse.json(
+      { error: "Internal error reconciling Bifrost VK" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/w/[slug]/settings/page.tsx
+++ b/src/app/w/[slug]/settings/page.tsx
@@ -1,6 +1,8 @@
 import { SettingsTabs } from "@/components/settings/SettingsTabs";
 import { PageHeader } from "@/components/ui/page-header";
+import { isBifrostEnabledForWorkspace } from "@/config/env";
 import { authOptions } from "@/lib/auth/nextauth";
+import { resolveBifrost } from "@/services/bifrost";
 import { getWorkspaceBySlug } from "@/services/workspace";
 import { getServerSession } from "next-auth/next";
 import { notFound } from "next/navigation";
@@ -25,6 +27,36 @@ export default async function SettingsPage({ params }: { params: Promise<{ slug:
 
   if (workspace.userRole !== "OWNER" && workspace.userRole !== "ADMIN") {
     notFound();
+  }
+
+  // DEV: dump Bifrost admin credentials to server console so developers
+  // can log into the LLM dashboard while the proper UI is being built.
+  // Gated behind the same workspace-scoped rollout flag the reconciler
+  // uses (`isBifrostEnabledForWorkspace` — see `lib/ai/askTools.ts`)
+  // AND behind workspace OWNER/ADMIN (the notFound() above), so the
+  // log only fires in deployments that have opted in to Bifrost for
+  // this workspace AND only for users entitled to see the password.
+  //
+  // Triggers the same lazy bootstrap path the future UI will use, so
+  // visiting /w/<slug>/settings on a fresh swarm is enough to provision
+  // and cache the admin password on the Swarm row.
+  //
+  // Remove once the dashboard card lands in SettingsTabs.
+  if (isBifrostEnabledForWorkspace(workspace.slug)) {
+    try {
+      const creds = await resolveBifrost(workspace.id);
+      console.log(
+        `[bifrost-creds] workspace=${workspace.slug} ` +
+          `dashboard=${creds.baseUrl} ` +
+          `user=${creds.adminUser} ` +
+          `password=${creds.adminPassword}`,
+      );
+    } catch (err) {
+      console.warn(
+        `[bifrost-creds] workspace=${workspace.slug} unavailable: ` +
+          (err instanceof Error ? err.message : String(err)),
+      );
+    }
   }
 
   return (

--- a/src/app/w/[slug]/settings/page.tsx
+++ b/src/app/w/[slug]/settings/page.tsx
@@ -1,8 +1,8 @@
+import { BifrostCredsDevLog } from "@/components/settings/BifrostCredsDevLog";
 import { SettingsTabs } from "@/components/settings/SettingsTabs";
 import { PageHeader } from "@/components/ui/page-header";
 import { isBifrostEnabledForWorkspace } from "@/config/env";
 import { authOptions } from "@/lib/auth/nextauth";
-import { resolveBifrost } from "@/services/bifrost";
 import { getWorkspaceBySlug } from "@/services/workspace";
 import { getServerSession } from "next-auth/next";
 import { notFound } from "next/navigation";
@@ -29,39 +29,24 @@ export default async function SettingsPage({ params }: { params: Promise<{ slug:
     notFound();
   }
 
-  // DEV: dump Bifrost admin credentials to server console so developers
-  // can log into the LLM dashboard while the proper UI is being built.
-  // Gated behind the same workspace-scoped rollout flag the reconciler
-  // uses (`isBifrostEnabledForWorkspace` — see `lib/ai/askTools.ts`)
-  // AND behind workspace OWNER/ADMIN (the notFound() above), so the
-  // log only fires in deployments that have opted in to Bifrost for
-  // this workspace AND only for users entitled to see the password.
+  // DEV: when the rollout flag is on for this workspace, mount a
+  // client-side helper that fetches the admin creds and dumps them to
+  // the browser DevTools console. Gated server-side here so the
+  // component is omitted from the React tree entirely for workspaces
+  // that haven't opted in (no client-side flag leak).
   //
-  // Triggers the same lazy bootstrap path the future UI will use, so
-  // visiting /w/<slug>/settings on a fresh swarm is enough to provision
-  // and cache the admin password on the Swarm row.
+  // The `/api/workspaces/[slug]/bifrost/credentials` route the helper
+  // hits enforces workspace OWNER/ADMIN server-side, so even if a
+  // viewer somehow rendered this component the route would 403.
   //
-  // Remove once the dashboard card lands in SettingsTabs.
-  if (isBifrostEnabledForWorkspace(workspace.slug)) {
-    try {
-      const creds = await resolveBifrost(workspace.id);
-      console.log(
-        `[bifrost-creds] workspace=${workspace.slug} ` +
-          `dashboard=${creds.baseUrl} ` +
-          `user=${creds.adminUser} ` +
-          `password=${creds.adminPassword}`,
-      );
-    } catch (err) {
-      console.warn(
-        `[bifrost-creds] workspace=${workspace.slug} unavailable: ` +
-          (err instanceof Error ? err.message : String(err)),
-      );
-    }
-  }
+  // Remove once the proper "Open dashboard / copy password" card
+  // lands in SettingsTabs.
+  const showBifrostDevLog = isBifrostEnabledForWorkspace(workspace.slug);
 
   return (
     <div className="space-y-6">
       <PageHeader title="Workspace Settings" />
+      {showBifrostDevLog && <BifrostCredsDevLog slug={workspace.slug} />}
       <SettingsTabs
         workspaceId={workspace.id}
         workspaceName={workspace.name}

--- a/src/components/settings/BifrostCredsDevLog.tsx
+++ b/src/components/settings/BifrostCredsDevLog.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * DEV: fetches the workspace's Bifrost admin credentials and dumps
+ * them to the browser DevTools console. Renders nothing.
+ *
+ * Wired into the settings page (`/w/[slug]/settings`) which already
+ * gates rendering on workspace OWNER/ADMIN — and the underlying
+ * `/api/workspaces/[slug]/bifrost/credentials` route enforces the
+ * same role check server-side. The workspace-scoped rollout flag
+ * (`BIFROST_ENABLED`) is also evaluated server-side before this
+ * component is rendered at all.
+ *
+ * Remove once the proper "Open dashboard / copy password" card lands
+ * in `SettingsTabs`.
+ */
+export function BifrostCredsDevLog({ slug }: { slug: string }) {
+  useEffect(() => {
+    let cancelled = false;
+
+    fetch(`/api/workspaces/${slug}/bifrost/credentials`, {
+      // Cache headers on the route are already `private, no-store`,
+      // but be explicit so a future browser default doesn't surprise us.
+      cache: "no-store",
+      credentials: "same-origin",
+    })
+      .then(async (res) => {
+        if (cancelled) return;
+        if (!res.ok) {
+          const text = await res.text().catch(() => "<no body>");
+          console.warn(
+            `[bifrost-creds] HTTP ${res.status} for workspace=${slug}:`,
+            text,
+          );
+          return;
+        }
+        const data = (await res.json()) as {
+          dashboardUrl: string;
+          adminUser: string;
+          adminPassword: string;
+        };
+        console.log(
+          `[bifrost-creds] workspace=${slug}\n` +
+            `  dashboard: ${data.dashboardUrl}\n` +
+            `  user:      ${data.adminUser}\n` +
+            `  password:  ${data.adminPassword}`,
+        );
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        console.warn(`[bifrost-creds] fetch failed for ${slug}:`, err);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [slug]);
+
+  return null;
+}

--- a/src/components/settings/BifrostCredsDevLog.tsx
+++ b/src/components/settings/BifrostCredsDevLog.tsx
@@ -3,23 +3,25 @@
 import { useEffect } from "react";
 
 /**
- * DEV: fetches the workspace's Bifrost admin credentials and dumps
- * them to the browser DevTools console. Renders nothing.
+ * DEV: fetches the workspace's Bifrost admin credentials AND the
+ * caller's per-(workspace,user) Virtual Key, dumping both to the
+ * browser DevTools console. Renders nothing.
  *
  * Wired into the settings page (`/w/[slug]/settings`) which already
- * gates rendering on workspace OWNER/ADMIN — and the underlying
- * `/api/workspaces/[slug]/bifrost/credentials` route enforces the
- * same role check server-side. The workspace-scoped rollout flag
- * (`BIFROST_ENABLED`) is also evaluated server-side before this
- * component is rendered at all.
+ * gates rendering on workspace OWNER/ADMIN — and both underlying
+ * routes enforce the same role check server-side. The
+ * workspace-scoped rollout flag (`BIFROST_ENABLED`) is evaluated
+ * server-side before this component is rendered at all.
  *
- * Remove once the proper "Open dashboard / copy password" card lands
- * in `SettingsTabs`.
+ * Remove once the proper "Open dashboard / copy password" + "Try
+ * the gateway with your VK" cards land in `SettingsTabs`.
  */
 export function BifrostCredsDevLog({ slug }: { slug: string }) {
   useEffect(() => {
     let cancelled = false;
 
+    // Admin credentials (workspace-wide; for logging into the
+    // Bifrost dashboard).
     fetch(`/api/workspaces/${slug}/bifrost/credentials`, {
       // Cache headers on the route are already `private, no-store`,
       // but be explicit so a future browser default doesn't surprise us.
@@ -51,6 +53,52 @@ export function BifrostCredsDevLog({ slug }: { slug: string }) {
       .catch((err) => {
         if (cancelled) return;
         console.warn(`[bifrost-creds] fetch failed for ${slug}:`, err);
+      });
+
+    // Per-user Virtual Key (for hitting the gateway directly with
+    // curl / Postman). Triggers the lazy reconcile path on first
+    // call; subsequent calls return the cached VK.
+    fetch(`/api/workspaces/${slug}/bifrost/vk`, {
+      cache: "no-store",
+      credentials: "same-origin",
+    })
+      .then(async (res) => {
+        if (cancelled) return;
+        if (!res.ok) {
+          const text = await res.text().catch(() => "<no body>");
+          console.warn(
+            `[bifrost-vk] HTTP ${res.status} for workspace=${slug}:`,
+            text,
+          );
+          return;
+        }
+        const data = (await res.json()) as {
+          baseUrl: string;
+          vkValue: string;
+          vkId: string;
+          customerId: string;
+          userId: string;
+          created: boolean;
+        };
+        console.log(
+          `[bifrost-vk] workspace=${slug}\n` +
+            `  baseUrl:    ${data.baseUrl}\n` +
+            `  vkValue:    ${data.vkValue}\n` +
+            `  vkId:       ${data.vkId}\n` +
+            `  customerId: ${data.customerId}\n` +
+            `  userId:     ${data.userId}\n` +
+            `  created:    ${data.created}\n` +
+            `\n` +
+            `  Try it:\n` +
+            `    curl ${data.baseUrl}/v1/chat/completions \\\n` +
+            `      -H 'Authorization: Bearer ${data.vkValue}' \\\n` +
+            `      -H 'Content-Type: application/json' \\\n` +
+            `      -d '{"model":"anthropic/claude-haiku-4-5-20251001","max_tokens":20,"messages":[{"role":"user","content":"hi"}]}'`,
+        );
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        console.warn(`[bifrost-vk] fetch failed for ${slug}:`, err);
       });
 
     return () => {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -89,13 +89,21 @@ export const optionalEnvVars = {
   MEMPOOL_BASE_URL: USE_MOCKS
     ? `${MOCK_BASE}/api/mock/mempool`
     : 'https://mempool.space',
-  // When "true", the agent-spawn path provisions a per-(workspace,user)
-  // Bifrost Virtual Key (lazy, idempotent) and forwards it to
-  // `repo/agent` as `apiKey` + `baseUrl`. When unset or anything else,
+  // Bifrost rollout gate. Accepted values:
+  //   - unset / "" / "false"         -> off for everyone
+  //   - "true" / "all" / "*"          -> on for every workspace
+  //   - "<slug1>,<slug2>,…"           -> on only for these workspace slugs
+  //
+  // When "on" for a workspace, the agent-spawn path provisions a
+  // per-(workspace,user) Bifrost Virtual Key (lazy, idempotent) and
+  // forwards it to `repo/agent` as `apiKey` + `baseUrl`. When off,
   // LLM calls keep using whatever default the agent/swarm picked
   // (preserves pre-Bifrost behavior). See
   // `gateway/plans/phase-1-reconciler.md`.
-  BIFROST_ENABLED: process.env.BIFROST_ENABLED === "true",
+  //
+  // Callers MUST go through `isBifrostEnabledForWorkspace(slug)` —
+  // direct equality checks on this raw string are a bug.
+  BIFROST_ENABLED: process.env.BIFROST_ENABLED || "",
 } as const;
 
 /**
@@ -149,6 +157,39 @@ export function isSuperAdminUserId(userId: string): boolean {
     .map((id) => id.trim())
     .filter(Boolean);
   return list.includes(userId.trim());
+}
+
+/**
+ * Decide whether the Bifrost rollout gate is open for a given workspace.
+ *
+ * `BIFROST_ENABLED` accepts three shapes:
+ *   - "true" / "all" / "*"     -> on for every workspace
+ *   - "slug1,slug2,…"          -> on only for these workspace slugs
+ *   - unset / "" / "false"     -> off for everyone
+ *
+ * Matching is case-insensitive and trims whitespace. Passing an empty /
+ * missing slug always returns `false` so untrusted callers can't accidentally
+ * enable the gate via empty input.
+ *
+ * @param workspaceSlug - The slug of the workspace to check
+ * @returns `true` iff Bifrost should be considered enabled for this workspace
+ */
+export function isBifrostEnabledForWorkspace(
+  workspaceSlug: string | null | undefined,
+): boolean {
+  const raw = (process.env.BIFROST_ENABLED || "").trim().toLowerCase();
+  if (!raw || raw === "false") return false;
+  if (raw === "true" || raw === "all" || raw === "*") return true;
+
+  // CSV path: empty slug never matches.
+  const slug = (workspaceSlug ?? "").trim().toLowerCase();
+  if (!slug) return false;
+
+  const allowList = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return allowList.includes(slug);
 }
 
 // Combined environment configuration

--- a/src/lib/ai/askTools.ts
+++ b/src/lib/ai/askTools.ts
@@ -15,7 +15,7 @@ import {
 } from "@/lib/mcp/mcpTools";
 import { reconcileBifrostVK } from "@/services/bifrost";
 import { logger } from "@/lib/logger";
-import { optionalEnvVars } from "@/config/env";
+import { isBifrostEnabledForWorkspace } from "@/config/env";
 
 // Inlined to avoid a circular import with workspaceConfig.ts.
 // Keep in sync with `PUBLIC_VIEWER_USER_ID` there.
@@ -144,8 +144,9 @@ function resolveRepo(
  * Lazy Bifrost VK provisioning helper. Returns `{ apiKey, baseUrl }`
  * to forward to the swarm's `/repo/agent` when we have a
  * `(workspaceId, userId)` pair. Returns `undefined` for:
- *   - any caller when `BIFROST_ENABLED !== "true"` (the entire
- *     Bifrost path is gated behind this flag);
+ *   - any caller when Bifrost is not rolled out to this workspace per
+ *     `isBifrostEnabledForWorkspace(workspaceSlug)` (the rollout gate
+ *     supports per-slug allow-lists in addition to "all on" / off);
  *   - org-scope / public-viewer paths where there's no per-user VK.
  *
  * Reconcile failures are logged and swallowed (return `undefined`) —
@@ -156,9 +157,12 @@ function resolveRepo(
 export async function maybeReconcileBifrost(
   workspaceAuth?: WorkspaceAuth,
 ): Promise<{ apiKey: string; baseUrl: string } | undefined> {
-  // Feature flag gate. When off, callers behave exactly as before —
-  // no apiKey/baseUrl injection, no reconcile, no Bifrost HTTP.
-  if (!optionalEnvVars.BIFROST_ENABLED) return undefined;
+  // Workspace-scoped feature flag. When off for this slug, callers
+  // behave exactly as before — no apiKey/baseUrl injection, no
+  // reconcile, no Bifrost HTTP.
+  if (!isBifrostEnabledForWorkspace(workspaceAuth?.workspaceSlug)) {
+    return undefined;
+  }
   if (!workspaceAuth?.workspaceId || !workspaceAuth?.userId) return undefined;
   // Public viewers have no real user identity — no per-user VK.
   if (workspaceAuth.userId === PUBLIC_VIEWER_USER_ID) return undefined;

--- a/src/services/bifrost/bootstrap.ts
+++ b/src/services/bifrost/bootstrap.ts
@@ -1,0 +1,197 @@
+import { db } from "@/lib/db";
+import { EncryptionService } from "@/lib/encryption";
+import { logger } from "@/lib/logger";
+
+import {
+  BIFROST_HTTP_TIMEOUT_MS,
+  BIFROST_LOG_TAG,
+} from "./constants";
+import { BifrostConfigError, deriveBifrostBaseUrl } from "./resolve";
+
+/**
+ * Phase-3 Bifrost admin-credential bootstrap.
+ *
+ * On a fresh swarm we don't yet know what password sphinx-swarm
+ * generated for the Bifrost admin user. The gateway image's wrapper
+ * exposes `GET /_plugin/admin-credentials` on its public port, gated
+ * by a Bearer token whose value matches Boltwall's `stakwork_secret`
+ * (= `swarm.swarmApiKey` in Hive). We:
+ *
+ *  1. Decrypt `swarm.swarmApiKey` (the shared secret).
+ *  2. GET `/_plugin/admin-credentials` with that token.
+ *  3. Save the returned admin user/password (encrypted) onto the
+ *     Swarm row so `resolveBifrost` can return them on subsequent
+ *     calls without going back to the gateway.
+ *
+ * Idempotent: a second call against a healthy gateway returns the
+ * same plaintext and overwrites the same encrypted blob. A 401 from
+ * the gateway means the provisioning token in swarm config doesn't
+ * match what the gateway booted with — a config error, not a
+ * transient failure.
+ *
+ * See gateway/plans/phases/phase-3-swarm-handoff.md §B2.1.
+ */
+
+const BOOTSTRAP_FETCH_TIMEOUT_MS = BIFROST_HTTP_TIMEOUT_MS;
+
+interface AdminCredentialsResponse {
+  admin_username: string;
+  admin_password: string;
+}
+
+export interface BootstrapResult {
+  baseUrl: string;
+  adminUser: string;
+  /** Plaintext admin password as returned by the gateway. */
+  adminPassword: string;
+}
+
+/**
+ * Fetch admin credentials from the workspace's Bifrost gateway and
+ * persist them (encrypted) on the Swarm row.
+ *
+ * @throws {BifrostConfigError} if the swarm row is missing, has no
+ * swarmUrl/swarmApiKey, or the gateway rejects/can't be reached.
+ */
+export async function bootstrapAdminCreds(
+  workspaceId: string,
+  options: { fetchImpl?: typeof fetch; timeoutMs?: number } = {},
+): Promise<BootstrapResult> {
+  const swarm = await db.swarm.findUnique({
+    where: { workspaceId },
+    select: { id: true, swarmUrl: true, swarmApiKey: true },
+  });
+
+  if (!swarm) {
+    throw new BifrostConfigError(
+      `No swarm configured for workspace ${workspaceId}`,
+    );
+  }
+  if (!swarm.swarmUrl) {
+    throw new BifrostConfigError(
+      `Swarm for workspace ${workspaceId} has no swarmUrl`,
+    );
+  }
+  if (!swarm.swarmApiKey) {
+    throw new BifrostConfigError(
+      `Swarm for workspace ${workspaceId} has no swarmApiKey ` +
+        `(provisioning token); cannot bootstrap Bifrost admin creds`,
+    );
+  }
+
+  const encryption = EncryptionService.getInstance();
+
+  let provisioningToken: string;
+  try {
+    provisioningToken = encryption.decryptField(
+      "swarmApiKey",
+      swarm.swarmApiKey,
+    );
+  } catch (err) {
+    throw new BifrostConfigError(
+      `Failed to decrypt swarmApiKey for workspace ${workspaceId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+
+  const baseUrl = deriveBifrostBaseUrl(swarm.swarmUrl);
+  const credsUrl = `${baseUrl}/_plugin/admin-credentials`;
+
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const timeoutMs = options.timeoutMs ?? BOOTSTRAP_FETCH_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  let response: Response;
+  try {
+    response = await fetchImpl(credsUrl, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${provisioningToken}` },
+      signal: controller.signal,
+    });
+  } catch (err) {
+    clearTimeout(timer);
+    if ((err as Error).name === "AbortError") {
+      throw new BifrostConfigError(
+        `Bifrost admin-credentials fetch timed out after ${timeoutMs}ms ` +
+          `(workspace ${workspaceId}, url ${credsUrl})`,
+      );
+    }
+    throw new BifrostConfigError(
+      `Bifrost admin-credentials fetch failed: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+  clearTimeout(timer);
+
+  if (!response.ok) {
+    // Read body for diagnostics but truncate so a misbehaving upstream
+    // can't blow up the error message.
+    const detail = await safeReadText(response, 200);
+    throw new BifrostConfigError(
+      `Bifrost admin-credentials returned ${response.status} ` +
+        `(workspace ${workspaceId}): ${detail}`,
+    );
+  }
+
+  let body: AdminCredentialsResponse;
+  try {
+    body = (await response.json()) as AdminCredentialsResponse;
+  } catch (err) {
+    throw new BifrostConfigError(
+      `Bifrost admin-credentials returned non-JSON body: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+
+  if (
+    !body ||
+    typeof body.admin_username !== "string" ||
+    typeof body.admin_password !== "string" ||
+    body.admin_password.length === 0
+  ) {
+    throw new BifrostConfigError(
+      `Bifrost admin-credentials returned an unexpected payload shape ` +
+        `(workspace ${workspaceId})`,
+    );
+  }
+
+  // Persist encrypted; matches the swarmApiKey/swarmPassword idiom
+  // used throughout services/swarm/db.ts.
+  const encryptedPassword = JSON.stringify(
+    encryption.encryptField("bifrostAdminPassword", body.admin_password),
+  );
+
+  await db.swarm.update({
+    where: { workspaceId },
+    data: {
+      bifrostAdminUser: body.admin_username,
+      bifrostAdminPassword: encryptedPassword,
+    },
+  });
+
+  logger.info("Bootstrapped Bifrost admin credentials", BIFROST_LOG_TAG, {
+    workspaceId,
+    swarmId: swarm.id,
+    baseUrl,
+    adminUser: body.admin_username,
+  });
+
+  return {
+    baseUrl,
+    adminUser: body.admin_username,
+    adminPassword: body.admin_password,
+  };
+}
+
+async function safeReadText(res: Response, max: number): Promise<string> {
+  try {
+    const text = await res.text();
+    return text.length > max ? `${text.slice(0, max)}…` : text;
+  } catch {
+    return "<no body>";
+  }
+}

--- a/src/services/bifrost/index.ts
+++ b/src/services/bifrost/index.ts
@@ -1,6 +1,8 @@
 export { reconcileBifrostVK } from "./reconciler";
 export { BifrostClient, BifrostHttpError } from "./BifrostClient";
 export { deriveBifrostBaseUrl, resolveBifrost, BifrostConfigError } from "./resolve";
+export { bootstrapAdminCreds } from "./bootstrap";
+export type { BootstrapResult } from "./bootstrap";
 export type {
   ReconcileResult,
   BifrostCustomer,

--- a/src/services/bifrost/resolve.ts
+++ b/src/services/bifrost/resolve.ts
@@ -3,18 +3,25 @@ import { EncryptionService } from "@/lib/encryption";
 import type { BifrostAdminCreds } from "./types";
 import { DEFAULT_BIFROST_PORT } from "./constants";
 
+// `bootstrap.ts` imports from this file, so we cannot eagerly import
+// it here without creating a cycle. Resolve lazily inside the function
+// that needs it.
+
 /**
  * Derive Bifrost's base URL from a swarm URL.
  *
- * Rule: keep scheme, keep host, replace (or set) port to
- * `DEFAULT_BIFROST_PORT` (8181). Bifrost is co-deployed with the
- * swarm and reachable on a sibling port.
+ * Rule: keep scheme + host, replace (or set) port to
+ * `DEFAULT_BIFROST_PORT` (8181), and strip path / query / hash.
+ * The gateway is a sibling listener on the same host — its routes
+ * (`/health`, `/_plugin/*`, `/api/governance/*`, `/v1/*`) all live at
+ * the root, not under whatever path the swarm's API happens to use.
  *
  * Examples:
  *   https://swarm-abc.sphinx.chat        -> https://swarm-abc.sphinx.chat:8181
+ *   https://swarm-abc.sphinx.chat/api    -> https://swarm-abc.sphinx.chat:8181
  *   https://swarm-abc.sphinx.chat:3355   -> https://swarm-abc.sphinx.chat:8181
- *   http://localhost:3355                 -> http://localhost:8181
- *   http://10.0.0.1                       -> http://10.0.0.1:8181
+ *   http://localhost:3355                -> http://localhost:8181
+ *   http://10.0.0.1                      -> http://10.0.0.1:8181
  *
  * If the input isn't a parseable URL, throws.
  */
@@ -29,9 +36,10 @@ export function deriveBifrostBaseUrl(
     throw new Error(`Invalid swarmUrl: ${swarmUrl}`);
   }
 
-  parsed.port = String(port);
-  // Strip any trailing slash for predictability.
-  return parsed.toString().replace(/\/$/, "");
+  // Build origin-only: scheme://host:port. Drops path / query / hash
+  // — the gateway's routes live at the root, not under the swarm's
+  // `/api` (or any other path).
+  return `${parsed.protocol}//${parsed.hostname}:${port}`;
 }
 
 export class BifrostConfigError extends Error {
@@ -43,7 +51,15 @@ export class BifrostConfigError extends Error {
 
 /**
  * Look up the Bifrost admin credentials + base URL for a workspace.
- * Throws `BifrostConfigError` if any piece is missing or misconfigured.
+ *
+ * If the swarm row is missing `bifrostAdminUser` / `bifrostAdminPassword`
+ * (fresh swarm, never bootstrapped), this calls
+ * `bootstrapAdminCreds` lazily: that hits the gateway's
+ * `/_plugin/admin-credentials` endpoint (Bearer-gated by the
+ * provisioning token) and persists the result on the Swarm row.
+ *
+ * Throws `BifrostConfigError` if the swarm row is missing entirely,
+ * has no swarmUrl, or the bootstrap step fails.
  */
 export async function resolveBifrost(
   workspaceId: string,
@@ -67,10 +83,13 @@ export async function resolveBifrost(
       `Swarm for workspace ${workspaceId} has no swarmUrl`,
     );
   }
+
+  // Lazy bootstrap. The gateway is the source of truth for the admin
+  // password; we cache it (encrypted) on the swarm row. First call
+  // after a fresh swarm provisioning fills it in.
   if (!swarm.bifrostAdminUser || !swarm.bifrostAdminPassword) {
-    throw new BifrostConfigError(
-      `Swarm for workspace ${workspaceId} is missing Bifrost admin credentials`,
-    );
+    const { bootstrapAdminCreds } = await import("./bootstrap");
+    return bootstrapAdminCreds(workspaceId);
   }
 
   const baseUrl = deriveBifrostBaseUrl(swarm.swarmUrl);


### PR DESCRIPTION
On a fresh swarm Hive cannot know the auto-generated Bifrost admin password until it asks the gateway. Add a lazy bootstrap that:

  1. Reads the encrypted stakwork_secret off the Swarm row (= swarm.swarmApiKey, the same token boltwall hands to repo2graph).
  2. GETs the gateway's /_plugin/admin-credentials with that token as a Bearer.
  3. Persists the returned admin user/password (encrypted) onto swarm.bifrostAdminUser / swarm.bifrostAdminPassword so subsequent calls go straight to the cached values.

Wired into resolveBifrost so the phase-1 reconciler trips bootstrap automatically on a swarm that hasn't been provisioned yet. Idempotent (re-bootstrap returns the same values; tolerates double-callers).

Also adds:
  - GET /api/workspaces/[slug]/bifrost/credentials — workspace OWNER/ADMIN-only endpoint that returns the dashboard URL + plaintext admin creds for "open dashboard / copy password" UI. Cache-Control: private, no-store.
  - Workspace-scoped rollout gate: BIFROST_ENABLED now accepts "true"/"all"/"*" (everyone) OR a CSV of workspace slugs. Helper isBifrostEnabledForWorkspace(slug) replaces direct flag reads.
  - Dev-only console.log of admin creds on /w/[slug]/settings for workspace admins, gated behind the new flag. Remove when the real UI lands.

Also fixes deriveBifrostBaseUrl: it was preserving the /api path from swarmUrl, which would have routed every gateway call under /api/... rather than at the root.

73 bifrost+flag tests pass. Full hive unit suite: 8348 pass, 0 fails.

See gateway/plans/phases/phase-3-swarm-handoff.md.