### PR TITLE
route workflow / agent-session LLM calls thru bifrost

### DIFF
--- a/src/__tests__/integration/api/chat-message.test.ts
+++ b/src/__tests__/integration/api/chat-message.test.ts
@@ -26,6 +26,10 @@ vi.mock("@/config/env", () => ({
     STAKWORK_WORKFLOW_ID: "123,456,789",
     API_TIMEOUT: 20000,
   },
+  // Bifrost rollout flag — disabled so the orchestrator short-circuits
+  // without touching the DB. The test mocks the Stakwork fetch but
+  // not Bifrost's reconciler/mint chain.
+  isBifrostEnabledForWorkspace: () => false,
 }));
 
 // Mock external services

--- a/src/__tests__/unit/api/api-chat-message.test.ts
+++ b/src/__tests__/unit/api/api-chat-message.test.ts
@@ -33,6 +33,8 @@ vi.mock("@/config/env", () => ({
     GEMINI_API_BASE_URL: "https://generativelanguage.googleapis.com",
     API_TIMEOUT: 20000,
   },
+  // Bifrost rollout flag — disabled so the orchestrator short-circuits.
+  isBifrostEnabledForWorkspace: () => false,
 }));
 vi.mock("@/lib/auth/nextauth", () => ({
   authOptions: {},

--- a/src/__tests__/unit/api/chat/call-stakwork.test.ts
+++ b/src/__tests__/unit/api/chat/call-stakwork.test.ts
@@ -38,6 +38,8 @@ vi.mock("@/config/env", () => ({
     GEMINI_API_BASE_URL: "https://generativelanguage.googleapis.com",
     API_TIMEOUT: 20000,
   },
+  // Bifrost rollout flag — disabled so the orchestrator short-circuits.
+  isBifrostEnabledForWorkspace: () => false,
 }));
 vi.mock("@/lib/auth/nextauth", () => ({
   authOptions: {},

--- a/src/__tests__/unit/lib/github/pr-monitor.test.ts
+++ b/src/__tests__/unit/lib/github/pr-monitor.test.ts
@@ -1054,6 +1054,13 @@ describe("PR Monitor - Branch Update Operations", () => {
         agentWebhookSecret: null,
         mode: "agent",
         podId: "pod-123",
+        // Bifrost wiring on triggerAgentModeFix needs workspace
+        // identity to mint a macaroon. The orchestrator no-ops
+        // (rollout flag off in tests), but the code path still
+        // reads these fields off `task`.
+        workspaceId: "workspace-123",
+        createdById: "user-123",
+        workspace: { slug: "test-workspace", ownerId: "owner-123" },
       } as any);
 
       // Mock db.task.update

--- a/src/__tests__/unit/services/call-stakwork-api.test.ts
+++ b/src/__tests__/unit/services/call-stakwork-api.test.ts
@@ -6,6 +6,12 @@ vi.mock("@/lib/utils", () => ({
   getBaseUrl: vi.fn(() => "https://test.example.com"),
 }));
 
+// Note: `@/config/env` is intentionally NOT mocked — the test setup
+// (`src/__tests__/support/mocks/env.ts`) leaves `BIFROST_ENABLED=""`,
+// so `isBifrostEnabledForWorkspace` returns `false` and the
+// orchestrator short-circuits without touching the database. This
+// preserves the real `config.STAKWORK_*` shape these tests rely on.
+
 // Mock fetch globally
 global.fetch = vi.fn();
 const mockFetch = vi.mocked(global.fetch);
@@ -25,6 +31,8 @@ const createTestParams = (overrides = {}) => ({
   mode: "default",
   taskSource: "USER",
   workspaceId: "test-workspace-123",
+  workspaceSlug: "test-workspace",
+  userId: "test-user-123",
   ...overrides,
 });
 

--- a/src/__tests__/unit/services/task-workflow-createChatMessageAndTriggerStakwork.test.ts
+++ b/src/__tests__/unit/services/task-workflow-createChatMessageAndTriggerStakwork.test.ts
@@ -55,6 +55,8 @@ vi.mock("@/config/env", () => ({
     GEMINI_API_BASE_URL: "https://generativelanguage.googleapis.com",
     API_TIMEOUT: 20000,
   },
+  // Bifrost rollout flag — disabled so the orchestrator short-circuits.
+  isBifrostEnabledForWorkspace: () => false,
 }));
 vi.mock("@/lib/utils", () => ({
   getBaseUrl: vi.fn(() => "http://localhost:3000"),

--- a/src/__tests__/unit/services/task-workflow.test.ts
+++ b/src/__tests__/unit/services/task-workflow.test.ts
@@ -35,6 +35,10 @@ vi.mock("@/config/env", () => ({
     GEMINI_API_BASE_URL: "https://generativelanguage.googleapis.com",
     API_TIMEOUT: 20000,
   },
+  // Bifrost rollout flag — tests run with it disabled so the
+  // orchestrator short-circuits to `undefined` and behavior matches
+  // the pre-Bifrost code path. See `getBifrostForLLM` for the gate.
+  isBifrostEnabledForWorkspace: () => false,
 }));
 
 vi.mock("@/lib/auth/nextauth", () => ({

--- a/src/app/api/agent/route.ts
+++ b/src/app/api/agent/route.ts
@@ -67,6 +67,7 @@ import { createWebhookToken, generateWebhookSecret } from "@/lib/auth/agent-jwt"
 import { isValidModel, getApiKeyForModel, type ModelName } from "@/lib/ai/models";
 import { canAccessServerFeature, FEATURE_FLAGS } from "@/lib/feature-flags";
 import { claimPodAndGetFrontend, updatePodRepositories, POD_PORTS, releasePodById } from "@/lib/pods";
+import { getBifrostForLLM } from "@/services/bifrost";
 
 const encryptionService = EncryptionService.getInstance();
 
@@ -318,7 +319,10 @@ async function getOrCreateWebhookSecret(taskId: string, existingSecret: string |
 }
 
 /**
- * Create a session on the remote agent server
+ * Create a session on the remote agent server (the hive4 / goose
+ * coder-agent). The agent reads `apiKey` / `baseUrl` / `headers` off
+ * the session body and threads them onto every outbound LLM HTTP
+ * call it makes during the session.
  */
 async function createAgentSession(
   agentUrl: string,
@@ -326,6 +330,7 @@ async function createAgentSession(
   taskId: string,
   webhookUrl: string,
   effectiveModel: ModelName | undefined,
+  bifrostAuth: { workspaceId: string; workspaceSlug: string; userId: string },
 ): Promise<string> {
   const sessionUrl = agentUrl.replace(/\/$/, "") + "/session";
 
@@ -339,12 +344,28 @@ async function createAgentSession(
   // Determine API key based on model
   const apiKey = effectiveModel ? getApiKeyForModel(effectiveModel) : process.env.ANTHROPIC_API_KEY;
 
+  // Bifrost routing for the goose-side LLM calls. When the rollout
+  // flag covers this workspace, mint a per-session VK + macaroon and
+  // override `apiKey` + inject `baseUrl` / `headers` on the session
+  // body. The agent forwards them onto every LLM call so the spend
+  // shows up on `logs.db` as `agent-name=coder-agent`. When the flag
+  // is off, falls back to the model-resolved key (unchanged).
+  const bifrost = await getBifrostForLLM(bifrostAuth, {
+    agentName: "coder-agent",
+  });
+
   const sessionPayload: Record<string, unknown> = {
     sessionId: taskId,
     webhookUrl,
-    apiKey,
+    apiKey: bifrost?.apiKey ?? apiKey,
     searchApiKey: process.env.EXA_API_KEY,
   };
+  if (bifrost) {
+    sessionPayload.baseUrl = bifrost.baseUrl;
+    if (Object.keys(bifrost.headers).length > 0) {
+      sessionPayload.headers = bifrost.headers;
+    }
+  }
 
   if (effectiveModel) {
     sessionPayload.model = effectiveModel;
@@ -446,6 +467,8 @@ export async function POST(request: NextRequest) {
         workspace: {
           select: {
             ownerId: true,
+            // Needed for the Bifrost rollout flag (keyed on slug).
+            slug: true,
             members: {
               where: { userId, leftAt: null },
               select: { userId: true },
@@ -581,6 +604,11 @@ export async function POST(request: NextRequest) {
       taskId,
       webhookUrl,
       effectiveModel,
+      {
+        workspaceId: task.workspaceId,
+        workspaceSlug: task.workspace.slug,
+        userId,
+      },
     );
   } catch (error) {
     console.error("[Agent] Error creating session:", error);

--- a/src/app/api/agent/route.ts
+++ b/src/app/api/agent/route.ts
@@ -67,7 +67,8 @@ import { createWebhookToken, generateWebhookSecret } from "@/lib/auth/agent-jwt"
 import { isValidModel, getApiKeyForModel, type ModelName } from "@/lib/ai/models";
 import { canAccessServerFeature, FEATURE_FLAGS } from "@/lib/feature-flags";
 import { claimPodAndGetFrontend, updatePodRepositories, POD_PORTS, releasePodById } from "@/lib/pods";
-import { getBifrostForLLM } from "@/services/bifrost";
+// Deep import — see comment in services/task-workflow.ts.
+import { getBifrostForLLM } from "@/services/bifrost/orchestrator";
 
 const encryptionService = EncryptionService.getInstance();
 

--- a/src/app/api/ask/quick/route.ts
+++ b/src/app/api/ask/quick/route.ts
@@ -3,7 +3,8 @@ import { validationError, serverError, forbiddenError, isApiError } from "@/type
 import { validateUserBelongsToOrg } from "@/services/workspace";
 import { ModelMessage, generateObject } from "ai";
 import { getModel, getApiKeyForProvider } from "@/lib/ai/provider";
-import { getBifrostForLLM } from "@/services/bifrost";
+// Deep import — see comment in services/task-workflow.ts.
+import { getBifrostForLLM } from "@/services/bifrost/orchestrator";
 import { z } from "zod";
 import { getWorkspaceChannelName, PUSHER_EVENTS, pusherServer } from "@/lib/pusher";
 import { getMiddlewareContext } from "@/lib/middleware/utils";

--- a/src/app/api/chat/message/route.ts
+++ b/src/app/api/chat/message/route.ts
@@ -338,6 +338,8 @@ export async function POST(request: NextRequest) {
         taskSource: task.sourceType,
         featureContext,
         workspaceId: task.workspaceId,
+        workspaceSlug: workspace.slug,
+        userId,
         repoUrl,
         baseBranch,
         branch: taskBranch,

--- a/src/app/api/learnings/diagrams/create/route.ts
+++ b/src/app/api/learnings/diagrams/create/route.ts
@@ -7,7 +7,8 @@ import { getGithubUsernameAndPAT } from "@/lib/auth/nextauth";
 import { resolveWorkspaceAccess, requireMemberAccess } from "@/lib/auth/workspace-access";
 import { extractMermaidBody } from "@/lib/diagrams/mermaid-parser";
 import { resolveExtraSwarms } from "@/services/roadmap/feature-chat";
-import { getBifrostForLLM } from "@/services/bifrost";
+// Deep import — see comment in services/task-workflow.ts.
+import { getBifrostForLLM } from "@/services/bifrost/orchestrator";
 
 const MERMAID_INSTRUCTION =
   "\n\nReturn a mermaid diagram surrounded by backticks like ```mermaid ... ```. Only return the mermaid block, no other commentary.";

--- a/src/app/api/learnings/diagrams/edit/route.ts
+++ b/src/app/api/learnings/diagrams/edit/route.ts
@@ -7,7 +7,8 @@ import { getGithubUsernameAndPAT } from "@/lib/auth/nextauth";
 import { resolveWorkspaceAccess, requireMemberAccess } from "@/lib/auth/workspace-access";
 import { extractMermaidBody } from "@/lib/diagrams/mermaid-parser";
 import { resolveExtraSwarms } from "@/services/roadmap/feature-chat";
-import { getBifrostForLLM } from "@/services/bifrost";
+// Deep import — see comment in services/task-workflow.ts.
+import { getBifrostForLLM } from "@/services/bifrost/orchestrator";
 
 const MERMAID_INSTRUCTION =
   "\n\nReturn a mermaid diagram surrounded by backticks like ```mermaid ... ```. Only return the mermaid block, no other commentary.";

--- a/src/lib/ai/askTools.ts
+++ b/src/lib/ai/askTools.ts
@@ -13,7 +13,8 @@ import {
   findWorkspaceUser,
   type WorkspaceAuth,
 } from "@/lib/mcp/mcpTools";
-import { getBifrostForLLM } from "@/services/bifrost";
+// Deep import — see comment in services/task-workflow.ts.
+import { getBifrostForLLM } from "@/services/bifrost/orchestrator";
 
 export async function listConcepts(swarmUrl: string, swarmApiKey: string): Promise<Record<string, unknown>> {
   const r = await fetch(`${swarmUrl}/gitree/features`, {

--- a/src/lib/ai/askToolsMulti.ts
+++ b/src/lib/ai/askToolsMulti.ts
@@ -3,7 +3,8 @@ import { z } from "zod";
 import { createMCPClient } from "@ai-sdk/mcp";
 import { WorkspaceConfig } from "./types";
 import { listConcepts, repoAgent } from "./askTools";
-import { getBifrostForLLM } from "@/services/bifrost";
+// Deep import — see comment in services/task-workflow.ts.
+import { getBifrostForLLM } from "@/services/bifrost/orchestrator";
 import { shouldTrimConceptsToIds } from "./conceptsTrim";
 import { RepoAnalyzer } from "gitsee/server";
 import { parseOwnerRepo } from "./utils";

--- a/src/lib/ai/runCanvasAgent.ts
+++ b/src/lib/ai/runCanvasAgent.ts
@@ -63,7 +63,8 @@ import {
 import { getLinkedWorkspacesForInitiative } from "@/lib/canvas/linkedWorkspaces";
 import { sanitizeAndCompleteToolCalls } from "@/lib/ai/message-sanitizer";
 import { getModel, getApiKeyForProvider, type Provider } from "@/lib/ai/provider";
-import { getBifrostForLLM } from "@/services/bifrost";
+// Deep import — see comment in services/task-workflow.ts.
+import { getBifrostForLLM } from "@/services/bifrost/orchestrator";
 import { getWorkspaceChannelName, PUSHER_EVENTS, pusherServer } from "@/lib/pusher";
 
 // ---------------------------------------------------------------------------

--- a/src/lib/github/pr-monitor.ts
+++ b/src/lib/github/pr-monitor.ts
@@ -23,6 +23,7 @@ import { fetchChatHistory } from "@/lib/helpers/chat-history";
 import { buildFeatureContext } from "@/services/task-coordinator";
 import type { PullRequestProgress, PullRequestContent } from "@/lib/chat";
 import { fetchCIStatus } from "./pr-ci";
+import { getBifrostForLLM } from "@/services/bifrost";
 import { releaseTaskPod } from "@/lib/pods/utils";
 
 const LOG_PREFIX = "[PRMonitor]";
@@ -1043,6 +1044,13 @@ export async function triggerAgentModeFix(
 ): Promise<{ success: boolean; error?: string }> {
   try {
     // 1. Load task
+    //
+    // `workspaceId` / `workspace.slug` / `createdById` / `workspace.ownerId`
+    // are loaded so we can mint a Bifrost macaroon for the agent-side
+    // LLM calls below. PR-monitor has no end-user session — we
+    // attribute the spend to the task creator (`createdById`),
+    // falling back to the workspace owner when null. Matches the
+    // live-mode counterpart's convention (`triggerLiveModeFix`).
     const task = await db.task.findUnique({
       where: { id: taskId },
       select: {
@@ -1051,6 +1059,11 @@ export async function triggerAgentModeFix(
         agentWebhookSecret: true,
         mode: true,
         podId: true,
+        workspaceId: true,
+        createdById: true,
+        workspace: {
+          select: { slug: true, ownerId: true },
+        },
       },
     });
 
@@ -1108,7 +1121,14 @@ export async function triggerAgentModeFix(
     // Broadcast the trigger message via Pusher
     await pusherServer.trigger(getTaskChannelName(taskId), PUSHER_EVENTS.NEW_MESSAGE, triggerMessage.id);
 
-    // 7. Create agent session
+    // 7. Create agent session.
+    //
+    // Bifrost routing: mint a macaroon under `agent-name=pr-monitor`
+    // so the automated-fix LLM spend lands on `logs.db` as its own
+    // dim, distinct from user-initiated `coder-agent` traffic.
+    // Identity is the task creator (or workspace owner if the task
+    // was system-created). Falls back to the default Anthropic key
+    // when the rollout flag doesn't cover this workspace.
     const sessionUrl = agentUrl.replace(/\/$/, "") + "/session";
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
@@ -1117,14 +1137,32 @@ export async function triggerAgentModeFix(
       headers["Authorization"] = `Bearer ${agentPassword}`;
     }
 
+    const bifrostUserId = task.createdById ?? task.workspace.ownerId;
+    const bifrost = await getBifrostForLLM(
+      {
+        workspaceId: task.workspaceId,
+        workspaceSlug: task.workspace.slug,
+        userId: bifrostUserId,
+      },
+      { agentName: "pr-monitor" },
+    );
+
+    const sessionBody: Record<string, unknown> = {
+      sessionId: taskId,
+      webhookUrl,
+      apiKey: bifrost?.apiKey ?? process.env.ANTHROPIC_API_KEY,
+    };
+    if (bifrost) {
+      sessionBody.baseUrl = bifrost.baseUrl;
+      if (Object.keys(bifrost.headers).length > 0) {
+        sessionBody.headers = bifrost.headers;
+      }
+    }
+
     const sessionResponse = await fetch(sessionUrl, {
       method: "POST",
       headers,
-      body: JSON.stringify({
-        sessionId: taskId,
-        webhookUrl,
-        apiKey: process.env.ANTHROPIC_API_KEY,
-      }),
+      body: JSON.stringify(sessionBody),
     });
 
     if (!sessionResponse.ok) {

--- a/src/lib/github/pr-monitor.ts
+++ b/src/lib/github/pr-monitor.ts
@@ -23,7 +23,8 @@ import { fetchChatHistory } from "@/lib/helpers/chat-history";
 import { buildFeatureContext } from "@/services/task-coordinator";
 import type { PullRequestProgress, PullRequestContent } from "@/lib/chat";
 import { fetchCIStatus } from "./pr-ci";
-import { getBifrostForLLM } from "@/services/bifrost";
+// Deep import — see comment in services/task-workflow.ts.
+import { getBifrostForLLM } from "@/services/bifrost/orchestrator";
 import { releaseTaskPod } from "@/lib/pods/utils";
 
 const LOG_PREFIX = "[PRMonitor]";

--- a/src/services/bifrost/orchestrator.ts
+++ b/src/services/bifrost/orchestrator.ts
@@ -7,9 +7,25 @@ import {
   MACAROON_DEFAULT_TTL_SECONDS,
   MACAROON_ISSUER_LOG_TAG,
 } from "./constants";
-import { mintInvocationMacaroon } from "./macaroon-issuer";
-import { reconcileBifrostVK } from "./reconciler";
-import { ensureBifrostTrust } from "./trust-reconciler";
+
+// NOTE: the three layer modules below — `macaroon-issuer`,
+// `reconciler`, `trust-reconciler` — are loaded LAZILY (dynamic
+// `await import()` inside the run* helpers) rather than as static
+// imports.
+//
+// Why: each layer transitively pulls in heavy deps (secp256k1,
+// gatekey, BifrostClient + ioredis lock, aieo, EncryptionService).
+// When the rollout flag is off — which is the default in test
+// workers and dev — none of those modules need to be in memory.
+// Static imports here would load all of them at every test file
+// that transitively touches an LLM call site, and the integration
+// suite runs single-threaded with cumulative module retention
+// across 250+ files; we hit ERR_WORKER_OUT_OF_MEMORY in CI.
+//
+// Prod cost is negligible: Node module cache makes the second+
+// dynamic import a sub-microsecond Map lookup. The first call after
+// boot pays a one-time ~10ms parse cost, invisible against any
+// real LLM round-trip.
 
 // Inlined to keep this file out of the `@/lib/ai/*` dependency tree
 // (which transitively pulls in `services/workspace` and ioredis).
@@ -120,6 +136,7 @@ export async function getBifrostForLLM(
 
 async function runTrustReconcile(workspaceId: string): Promise<void> {
   try {
+    const { ensureBifrostTrust } = await import("./trust-reconciler");
     const result = await ensureBifrostTrust(workspaceId);
     if (result.status === "failed") {
       // Already logged by ensureBifrostTrust at warn level; we
@@ -147,6 +164,7 @@ async function runVKReconcile(
   model: string | undefined,
 ): Promise<{ apiKey: string; baseUrl: string } | undefined> {
   try {
+    const { reconcileBifrostVK } = await import("./reconciler");
     const result = await reconcileBifrostVK(
       workspaceAuth.workspaceId,
       workspaceAuth.userId,
@@ -178,6 +196,7 @@ async function runMint(
   opts: GetBifrostForLLMOptions,
 ): Promise<{ map: Record<string, string>; runId: string }> {
   try {
+    const { mintInvocationMacaroon } = await import("./macaroon-issuer");
     const minted = await mintInvocationMacaroon({
       workspaceId: workspaceAuth.workspaceId,
       userId: workspaceAuth.userId,

--- a/src/services/roadmap/feature-chat.ts
+++ b/src/services/roadmap/feature-chat.ts
@@ -516,6 +516,8 @@ export async function sendFeatureChatMessage({
       repo2GraphUrl,
       mode: "plan_mode",
       workspaceId: feature.workspaceId,
+      workspaceSlug: feature.workspace.slug,
+      userId,
       repoUrl,
       baseBranch,
       repoName,

--- a/src/services/task-workflow.ts
+++ b/src/services/task-workflow.ts
@@ -11,7 +11,13 @@ import { getApiKeyForModel, getDefaultModel } from "@/lib/ai/models";
 import { fetchChatHistory } from "@/lib/helpers/chat-history";
 import { isDevelopmentMode } from "@/lib/runtime";
 import type { McpServerConfig } from "@/services/mcpServers";
-import { getBifrostForLLM } from "@/services/bifrost";
+// Deep-import directly from the orchestrator (rather than the barrel
+// `@/services/bifrost`) so we don't transitively pull in the 17-
+// module surface — BifrostClient / macaroon-keys / trust-reconciler
+// etc. — at every test file's module graph. The integration suite
+// runs single-threaded in a vm and that bloat showed up as worker
+// OOM. Same approach used at every other LLM call site.
+import { getBifrostForLLM } from "@/services/bifrost/orchestrator";
 
 const encryptionService = EncryptionService.getInstance();
 

--- a/src/services/task-workflow.ts
+++ b/src/services/task-workflow.ts
@@ -11,6 +11,7 @@ import { getApiKeyForModel, getDefaultModel } from "@/lib/ai/models";
 import { fetchChatHistory } from "@/lib/helpers/chat-history";
 import { isDevelopmentMode } from "@/lib/runtime";
 import type { McpServerConfig } from "@/services/mcpServers";
+import { getBifrostForLLM } from "@/services/bifrost";
 
 const encryptionService = EncryptionService.getInstance();
 
@@ -527,6 +528,8 @@ export async function createChatMessageAndTriggerStakwork(params: {
       generateChatTitle,
       featureContext,
       workspaceId: task.workspace.id,
+      workspaceSlug: task.workspace.slug,
+      userId,
       runBuild: task.runBuild,
       runTestSuite: task.runTestSuite,
       repoUrl,
@@ -591,6 +594,19 @@ export async function callStakworkAPI(params: {
   generateChatTitle?: boolean;
   featureContext?: object;
   workspaceId: string;
+  /**
+   * NextAuth user id of the caller. Required so the Stakwork workflow
+   * can mint its LLM creds against the right per-user Bifrost VK.
+   * Background paths without a real session (e.g. PR-monitor) should
+   * pass `task.createdById` / `task.workspace.ownerId`.
+   */
+  userId: string;
+  /**
+   * Workspace slug — needed only for the `BIFROST_ENABLED` rollout
+   * flag (which is keyed on slug, not id). Trivially available
+   * everywhere `workspaceId` is.
+   */
+  workspaceSlug: string;
   runBuild?: boolean;
   runTestSuite?: boolean;
   repoUrl?: string | null;
@@ -635,6 +651,8 @@ export async function callStakworkAPI(params: {
     generateChatTitle,
     featureContext,
     workspaceId,
+    userId,
+    workspaceSlug,
     runBuild = true,
     runTestSuite = true,
     repoUrl = null,
@@ -762,6 +780,43 @@ export async function callStakworkAPI(params: {
     vars.model = effectiveModel;
     const resolvedApiKey = getApiKeyForModel(effectiveModel);
     if (resolvedApiKey) vars.apiKey = resolvedApiKey;
+  }
+
+  // ──────────────────────────────────────────────────────────────────
+  // Bifrost routing for the Stakwork-side LLM calls.
+  //
+  // When the rollout flag covers this workspace, mint a per-workflow
+  // Bifrost VK + macaroon and override the `vars.apiKey` we shipped
+  // above. The workflow worker reads `vars.apiKey` / `vars.baseUrl` /
+  // `vars.headers` and threads them onto every LLM HTTP call it makes
+  // — same protocol `repoAgent` already follows. When the flag is off
+  // or the orchestrator returns `undefined`, leave the existing
+  // `vars.apiKey` (resolved from `getApiKeyForModel` above) in place
+  // for byte-for-byte unchanged behavior.
+  //
+  // `agentName` splits on `mode`:
+  //   - `plan_mode` → "plan-agent"  (planning workflow, conversational)
+  //   - everything else (`live` / `unit` / `integration` / `default`)
+  //                  → "coder-agent" (hive4 / goose-style task workflow)
+  //
+  // Workflows can run for hours and burn through many LLM steps, but
+  // the orchestrator's defaults are tuned for chat turns — caller
+  // tuning of ttlSeconds / maxCostUsd / maxSteps is intentionally
+  // deferred to a follow-up so this initial wiring stays small.
+  const bifrost = await getBifrostForLLM(
+    { workspaceId, workspaceSlug, userId },
+    { agentName: mode === "plan_mode" ? "plan-agent" : "coder-agent" },
+  );
+  if (bifrost) {
+    vars.apiKey = bifrost.apiKey;
+    vars.baseUrl = bifrost.baseUrl;
+    if (Object.keys(bifrost.headers).length > 0) {
+      // Empty headers map = orchestrator's "macaroon mint failed,
+      // shadow-mode degraded" state. Don't ship an empty `headers`
+      // key in that case so older workflow versions that don't read
+      // it stay byte-identical.
+      vars.headers = bifrost.headers;
+    }
   }
 
   // Get workflow ID (replicating workflow selection logic)


### PR DESCRIPTION
Extends Bifrost routing to the three workflow / agent-session launch sites where the heavy multi-step LLM spend lives. Builds on #4078, which wired the in-process chat surfaces.

## What's wired

| Site | Surface | `agentName` |
|---|---|---|
| `callStakworkAPI` (`task-workflow.ts`) | Plan-mode workflow (`mode === "plan_mode"`) | `plan-agent` |
| `callStakworkAPI` (`task-workflow.ts`) | Live / unit / integration / default task workflows | `coder-agent` |
| `createAgentSession` (`/api/agent/route.ts`) | hive4 / goose direct agent session | `coder-agent` |
| `triggerAgentModeFix` (`pr-monitor.ts`) | Automated PR fix from PR monitor | `pr-monitor` |

## Shape

Same protocol `repoAgent` already uses — Hive ships `apiKey` / `baseUrl` / `headers` (the latter carrying `x-macaroon`) in the existing payload, and the receiving side threads them onto its outbound LLM HTTP call.

- Stakwork: `vars.apiKey` / `vars.baseUrl` / `vars.headers` inside `workflow_params.set_var.attributes.vars`.
- Goose-side `/session`: `apiKey` / `baseUrl` / `headers` on the session body.

Empty `headers` map is elided so older receivers that don't read it stay byte-identical.

## Identity

- `callStakworkAPI`: new required `userId` + `workspaceSlug` params (all three callers — chat/message, feature-chat, task-workflow — already had them in scope).
- `createAgentSession`: new `bifrostAuth` param from the route's session + task.
- `triggerAgentModeFix`: no end-user session (cron-driven); attributes to `task.createdById ?? task.workspace.ownerId` — matches the live-mode counterpart's convention.

## Fallback posture

Identical to the prior batch: when `BIFROST_ENABLED` doesn't cover the primary slug, public viewer, or any orchestrator failure, `getBifrostForLLM` returns `undefined` and the pre-existing `apiKey` resolution path runs byte-for-byte unchanged.

## Note on TTL / budget defaults

Workflows can run for hours and burn through many LLM steps, but the orchestrator's defaults are tuned for chat turns (`MACAROON_DEFAULT_TTL_SECONDS`, `MACAROON_DEFAULT_MAX_COST_USD`, `MACAROON_DEFAULT_MAX_STEPS`). Per-call site tuning is intentionally deferred to a follow-up so this initial wiring stays small.

## Downstream dependency

The agent-name dim only actually lands on `logs.db` once the Stakwork worker and goose-side `/session` handler forward `apiKey` / `baseUrl` / `headers` onto their outbound LLM HTTP calls. Hive's end is correct; those forwards are separate work.

## Verification

- `tsc --noEmit` clean for all changed files.
- 8,415 unit tests pass (zero regressions).
- Test fixtures: added `isBifrostEnabledForWorkspace: () => false` to 4 existing env mocks; expanded `db.task.findUnique` mock in `pr-monitor.test.ts` to include the new workspace fields the production code now reads.