### PR TITLE
phase-11 macaroon shape + realm_id sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
         "ecpair": "^3.0.0",
         "elkjs": "^0.11.0",
         "framer-motion": "^12.23.24",
-        "gatekey": "^0.1.0",
+        "gatekey": "^0.1.1",
         "gitsee": "^1.0.13",
         "globrex": "^0.1.2",
         "gsap": "^3.13.0",
@@ -20702,9 +20702,9 @@
       "optional": true
     },
     "node_modules/gatekey": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/gatekey/-/gatekey-0.1.0.tgz",
-      "integrity": "sha512-1sUDFAILqYJOnIGzgpIOhjzKzT/I3tY/y4RBwZowbBk5qZo3fJa2F3/neMb4LLwij6r3sZ9TJT6wzWJ3MpPOFw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/gatekey/-/gatekey-0.1.1.tgz",
+      "integrity": "sha512-vpJw5sLToc3yfHm4U9Dg8+KPcpvUdWThaCvknNE5c+0jZgV2ZGd0aP64YXygC43I8lxFmCLViyvFQb244Ingbg==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "ecpair": "^3.0.0",
     "elkjs": "^0.11.0",
     "framer-motion": "^12.23.24",
-    "gatekey": "^0.1.0",
+    "gatekey": "^0.1.1",
     "gitsee": "^1.0.13",
     "globrex": "^0.1.2",
     "gsap": "^3.13.0",

--- a/src/__tests__/unit/services/bifrost/macaroon-issuer.test.ts
+++ b/src/__tests__/unit/services/bifrost/macaroon-issuer.test.ts
@@ -144,7 +144,6 @@ describe("mintInvocationMacaroon", () => {
     expect(minted.orgId).toBe(`gh_${GITHUB_LOGIN}`);
     expect(minted.userId).toBe(USER_ID);
     expect(minted.agentName).toBe("ask-repo-agent");
-    expect(minted.realm).toBe(WORKSPACE_SLUG);
     expect(minted.runId).toMatch(/^[0-9a-f-]{36}$/i); // UUID
     expect(new Date(minted.expiresAt).getTime()).toBeGreaterThan(Date.now());
 
@@ -153,15 +152,23 @@ describe("mintInvocationMacaroon", () => {
     // canonicalization, wrong signature scheme, wrong key binding,
     // wrong narrowing between layers — all the cross-language
     // contract issues fixtures catch on the gatekey side.
+    //
+    // Phase-11 claims surface: `agent_name` is the leaf of
+    // `effective_caveats.agents` (here, the single-element invocation
+    // list); `realm` is gone — the swarm carries its own self-identity
+    // on the trust registry, not on the macaroon.
     const claims = verify(minted.token, policy, new Date());
     expect(claims.org_id).toBe(`gh_${GITHUB_LOGIN}`);
     expect(claims.user_id).toBe(USER_ID);
     expect(claims.agent_name).toBe("ask-repo-agent");
-    expect(claims.realm).toBe(WORKSPACE_SLUG);
     expect(claims.run_id).toBe(minted.runId);
     expect(claims.effective_caveats.max_cost_usd).toBe(5);
     expect(claims.effective_caveats.max_steps).toBe(100);
     expect(claims.effective_caveats.agents).toEqual(["ask-repo-agent"]);
+    // Issuer mints simple-deployment macaroons: no `budget` block,
+    // no `realm_budgets`. Permitted-realms passes through as null.
+    expect(claims.effective_caveats.budget).toBeNull();
+    expect(claims.permitted_realms).toBeNull();
   });
 
   it("respects a caller-supplied runId", async () => {
@@ -206,17 +213,19 @@ describe("mintInvocationMacaroon", () => {
       agentName: "parse-test",
     });
 
+    // Phase-11 wire shape: `agents` is top-level on the UA (no more
+    // `permissions` wrapper), and the invocation no longer carries a
+    // singular `realm` field. The issuer omits the optional `budget`
+    // block entirely — simple-deployment mode.
     const parsed = decodeMacaroon(minted.token);
     expect(parsed.v).toBe(1);
     expect(parsed.org_id).toBe(`gh_${GITHUB_LOGIN}`);
     expect(parsed.user_authorization.user_id).toBe(USER_ID);
     expect(parsed.user_authorization.user_pubkey.alg).toBe("ed25519");
-    expect(parsed.user_authorization.permissions).toEqual({
-      realms: [WORKSPACE_SLUG],
-      agents: ["parse-test"],
-    });
-    expect(parsed.invocation.realm).toBe(WORKSPACE_SLUG);
+    expect(parsed.user_authorization.agents).toEqual(["parse-test"]);
+    expect(parsed.user_authorization.budget).toBeUndefined();
     expect(parsed.invocation.agents).toEqual(["parse-test"]);
+    expect(parsed.invocation.budget).toBeUndefined();
     expect(parsed.invocation.user_sig.alg).toBe("ed25519");
     expect(parsed.attenuations).toEqual([]);
   });

--- a/src/__tests__/unit/services/bifrost/trust-reconciler.test.ts
+++ b/src/__tests__/unit/services/bifrost/trust-reconciler.test.ts
@@ -53,6 +53,7 @@ vi.mock("@/services/bifrost/resolve", async () => {
 });
 
 const WORKSPACE_ID = "ws-1";
+const WORKSPACE_SLUG = "acme-ws";
 const SCORG_ID = "scorg-1";
 const ORG_PUBKEY = "02" + "ab".repeat(32);
 const ENCRYPTED_TOKEN = JSON.stringify({ data: "provisioning-secret-plain" });
@@ -61,6 +62,7 @@ type PluginClientStub = {
   getTrustStatus: ReturnType<typeof vi.fn>;
   getTrustOrg: ReturnType<typeof vi.fn>;
   upsertTrust: ReturnType<typeof vi.fn>;
+  setRealmId: ReturnType<typeof vi.fn>;
 };
 
 function makePluginClient(
@@ -70,6 +72,10 @@ function makePluginClient(
     getTrustStatus: vi.fn(),
     getTrustOrg: vi.fn(),
     upsertTrust: vi.fn(),
+    // Phase-11 realm_id sync. Default to a successful no-op return so
+    // tests that don't care about realm_id don't need to wire one
+    // up. Tests that DO care override to assert calls / arguments.
+    setRealmId: vi.fn().mockResolvedValue({ ok: true, realm_id: "" }),
     ...overrides,
   } as unknown as BifrostPluginClient;
 }
@@ -566,5 +572,226 @@ describe("ensureBifrostTrust", () => {
     expect(result.status).toBe("failed");
     expect(dbMock.swarm.findUnique).not.toHaveBeenCalled();
     expect(client.getTrustStatus).not.toHaveBeenCalled();
+  });
+
+  // ─── phase 11: realm_id sync ──────────────────────────────────────
+  //
+  // The reconciler publishes `Workspace.slug` as the swarm's
+  // `realm_id` whenever it walks the cache-miss path (i.e. it already
+  // has the plugin's status response in hand). On the cache-hit hot
+  // path it skips the round-trip entirely. We test both branches plus
+  // the "already in sync" no-op and a write-on-divergence case.
+
+  it("publishes the workspace slug as realm_id when the plugin has none", async () => {
+    vi.mocked(dbMock.workspace.findUnique).mockResolvedValueOnce({
+      id: WORKSPACE_ID,
+      slug: WORKSPACE_SLUG,
+      sourceControlOrgId: SCORG_ID,
+    } as never);
+    vi.mocked(dbMock.swarm.findUnique)
+      .mockResolvedValueOnce({
+        id: "swarm-1",
+        swarmUrl: "http://swarm.test",
+        swarmApiKey: ENCRYPTED_TOKEN,
+        bifrostTrustedOrgId: null,
+        bifrostTrustedPubkey: null,
+        bifrostTrustSyncedAt: null,
+      } as never)
+      .mockResolvedValueOnce({
+        bifrostTrustedOrgId: null,
+        bifrostTrustedPubkey: null,
+      } as never);
+    vi.mocked(dbMock.swarm.update).mockResolvedValueOnce({} as never);
+
+    const client = makePluginClient({
+      getTrustStatus: vi.fn().mockResolvedValue({
+        claimed: false,
+        org_count: 0,
+        orgs: [],
+        seed_source: "",
+        last_modified: "",
+        // `realm_id` absent → simple-deployment mode on the plugin
+        // side. Hive should publish the workspace slug.
+      }),
+      upsertTrust: vi
+        .fn()
+        .mockResolvedValue({ ok: true, org_id: "gh_stakwork" }),
+    });
+
+    const result = await ensureBifrostTrust(WORKSPACE_ID, {
+      pluginClientFactory: () => client,
+      ensureKeysFn: defaultEnsureKeys(),
+    });
+
+    expect(result.status).toBe("upserted");
+    expect(client.setRealmId).toHaveBeenCalledTimes(1);
+    expect(client.setRealmId).toHaveBeenCalledWith(WORKSPACE_SLUG);
+  });
+
+  it("does not call setRealmId when the plugin's realm_id already matches", async () => {
+    // Idempotency: a warm reconcile that happens to also trip the
+    // cache miss (e.g. pubkey rotation) shouldn't churn the plugin's
+    // realm_id when it's already correct.
+    vi.mocked(dbMock.workspace.findUnique).mockResolvedValueOnce({
+      id: WORKSPACE_ID,
+      slug: WORKSPACE_SLUG,
+      sourceControlOrgId: SCORG_ID,
+    } as never);
+    vi.mocked(dbMock.swarm.findUnique)
+      .mockResolvedValueOnce({
+        id: "swarm-1",
+        swarmUrl: "http://swarm.test",
+        swarmApiKey: ENCRYPTED_TOKEN,
+        bifrostTrustedOrgId: null,
+        bifrostTrustedPubkey: null,
+        bifrostTrustSyncedAt: null,
+      } as never)
+      .mockResolvedValueOnce({
+        bifrostTrustedOrgId: null,
+        bifrostTrustedPubkey: null,
+      } as never);
+    vi.mocked(dbMock.swarm.update).mockResolvedValueOnce({} as never);
+
+    const client = makePluginClient({
+      getTrustStatus: vi.fn().mockResolvedValue({
+        claimed: false,
+        org_count: 0,
+        orgs: [],
+        seed_source: "",
+        last_modified: "",
+        realm_id: WORKSPACE_SLUG, // already in sync
+      }),
+      upsertTrust: vi
+        .fn()
+        .mockResolvedValue({ ok: true, org_id: "gh_stakwork" }),
+    });
+
+    const result = await ensureBifrostTrust(WORKSPACE_ID, {
+      pluginClientFactory: () => client,
+      ensureKeysFn: defaultEnsureKeys(),
+    });
+
+    expect(result.status).toBe("upserted");
+    expect(client.setRealmId).not.toHaveBeenCalled();
+  });
+
+  it("PUTs setRealmId when the plugin's realm_id diverges from the workspace slug", async () => {
+    // E.g. the workspace was renamed (rare) or the plugin was
+    // bootstrapped with a stale value via the env seed.
+    vi.mocked(dbMock.workspace.findUnique).mockResolvedValueOnce({
+      id: WORKSPACE_ID,
+      slug: WORKSPACE_SLUG,
+      sourceControlOrgId: SCORG_ID,
+    } as never);
+    vi.mocked(dbMock.swarm.findUnique)
+      .mockResolvedValueOnce({
+        id: "swarm-1",
+        swarmUrl: "http://swarm.test",
+        swarmApiKey: ENCRYPTED_TOKEN,
+        bifrostTrustedOrgId: null,
+        bifrostTrustedPubkey: null,
+        bifrostTrustSyncedAt: null,
+      } as never)
+      .mockResolvedValueOnce({
+        bifrostTrustedOrgId: null,
+        bifrostTrustedPubkey: null,
+      } as never);
+    vi.mocked(dbMock.swarm.update).mockResolvedValueOnce({} as never);
+
+    const client = makePluginClient({
+      getTrustStatus: vi.fn().mockResolvedValue({
+        claimed: false,
+        org_count: 0,
+        orgs: [],
+        seed_source: "",
+        last_modified: "",
+        realm_id: "stale-old-slug",
+      }),
+      upsertTrust: vi
+        .fn()
+        .mockResolvedValue({ ok: true, org_id: "gh_stakwork" }),
+    });
+
+    const result = await ensureBifrostTrust(WORKSPACE_ID, {
+      pluginClientFactory: () => client,
+      ensureKeysFn: defaultEnsureKeys(),
+    });
+
+    expect(result.status).toBe("upserted");
+    expect(client.setRealmId).toHaveBeenCalledTimes(1);
+    expect(client.setRealmId).toHaveBeenCalledWith(WORKSPACE_SLUG);
+  });
+
+  it("does not touch the plugin's realm_id on the cache-hit hot path", async () => {
+    // Steady state: (orgId, pubkey) cache matches, we never even
+    // call getTrustStatus, so realm_id can't possibly drift via
+    // this reconcile. A drifted realm_id requires bursting the
+    // org/pubkey cache to reconcile — see the module doc.
+    vi.mocked(dbMock.workspace.findUnique).mockResolvedValueOnce({
+      id: WORKSPACE_ID,
+      slug: WORKSPACE_SLUG,
+      sourceControlOrgId: SCORG_ID,
+    } as never);
+    vi.mocked(dbMock.swarm.findUnique).mockResolvedValueOnce({
+      id: "swarm-1",
+      swarmUrl: "http://swarm.test",
+      swarmApiKey: ENCRYPTED_TOKEN,
+      bifrostTrustedOrgId: "gh_stakwork",
+      bifrostTrustedPubkey: ORG_PUBKEY,
+      bifrostTrustSyncedAt: new Date("2026-01-01"),
+    } as never);
+
+    const client = makePluginClient();
+    const result = await ensureBifrostTrust(WORKSPACE_ID, {
+      pluginClientFactory: () => client,
+      ensureKeysFn: defaultEnsureKeys(),
+    });
+
+    expect(result.status).toBe("cached");
+    expect(client.getTrustStatus).not.toHaveBeenCalled();
+    expect(client.setRealmId).not.toHaveBeenCalled();
+  });
+
+  it("returns 'failed' when setRealmId rejects (does not stamp cache)", async () => {
+    vi.mocked(dbMock.workspace.findUnique).mockResolvedValueOnce({
+      id: WORKSPACE_ID,
+      slug: WORKSPACE_SLUG,
+      sourceControlOrgId: SCORG_ID,
+    } as never);
+    vi.mocked(dbMock.swarm.findUnique)
+      .mockResolvedValueOnce({
+        id: "swarm-1",
+        swarmUrl: "http://swarm.test",
+        swarmApiKey: ENCRYPTED_TOKEN,
+        bifrostTrustedOrgId: null,
+        bifrostTrustedPubkey: null,
+        bifrostTrustSyncedAt: null,
+      } as never)
+      .mockResolvedValueOnce({
+        bifrostTrustedOrgId: null,
+        bifrostTrustedPubkey: null,
+      } as never);
+
+    const client = makePluginClient({
+      getTrustStatus: vi.fn().mockResolvedValue({
+        claimed: false,
+        org_count: 0,
+        orgs: [],
+        seed_source: "",
+        last_modified: "",
+      }),
+      setRealmId: vi
+        .fn()
+        .mockRejectedValue(new BifrostHttpError(500, undefined, "boom")),
+    });
+
+    const result = await ensureBifrostTrust(WORKSPACE_ID, {
+      pluginClientFactory: () => client,
+      ensureKeysFn: defaultEnsureKeys(),
+    });
+
+    expect(result.status).toBe("failed");
+    expect(client.upsertTrust).not.toHaveBeenCalled();
+    expect(dbMock.swarm.update).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/workspaces/[slug]/bifrost/vk/route.ts
+++ b/src/app/api/workspaces/[slug]/bifrost/vk/route.ts
@@ -154,7 +154,6 @@ export async function GET(
               macaroonUserId: macaroon.macaroonUserId,
               agentName: macaroon.agentName,
               runId: macaroon.runId,
-              realm: macaroon.realm,
               expiresAt: macaroon.expiresAt,
               maxCostUsd: DEV_MACAROON_MAX_COST_USD,
             }

--- a/src/components/settings/BifrostCredsDevLog.tsx
+++ b/src/components/settings/BifrostCredsDevLog.tsx
@@ -85,7 +85,6 @@ export function BifrostCredsDevLog({ slug }: { slug: string }) {
             macaroonUserId: string;
             agentName: string;
             runId: string;
-            realm: string;
             expiresAt: string;
             maxCostUsd: number;
           } | null;
@@ -110,7 +109,6 @@ export function BifrostCredsDevLog({ slug }: { slug: string }) {
               `  macaroonUserId: ${m.macaroonUserId}\n` +
               `  agentName:      ${m.agentName}\n` +
               `  runId:          ${m.runId}\n` +
-              `  realm:          ${m.realm}\n` +
               `  expiresAt:      ${m.expiresAt}\n` +
               `  maxCostUsd:     $${m.maxCostUsd}`,
           );

--- a/src/services/bifrost/BifrostPluginClient.ts
+++ b/src/services/bifrost/BifrostPluginClient.ts
@@ -3,6 +3,8 @@ import { BifrostHttpError } from "./BifrostClient";
 import type {
   TrustOrgRow,
   TrustOrgUpsert,
+  TrustRealmIDRequest,
+  TrustRealmIDResponse,
   TrustStatusResponse,
   TrustUpsertResponse,
 } from "./types";
@@ -92,8 +94,23 @@ export class BifrostPluginClient {
     );
   }
 
+  /**
+   * PUT /_plugin/trust/realm_id — set (or clear, with `""`) the
+   * swarm's own self-identity. Added in phase 11 so multi-swarm
+   * deployments can pin a per-swarm realm-id without redeploying
+   * the plugin. Idempotent: re-sending the same value is a no-op.
+   */
+  async setRealmId(realmId: string): Promise<TrustRealmIDResponse> {
+    const body: TrustRealmIDRequest = { realm_id: realmId };
+    return this.request<TrustRealmIDResponse>(
+      "PUT",
+      "/_plugin/trust/realm_id",
+      body,
+    );
+  }
+
   private async request<T>(
-    method: "GET" | "POST",
+    method: "GET" | "POST" | "PUT",
     path: string,
     body?: unknown,
   ): Promise<T> {

--- a/src/services/bifrost/macaroon-issuer.ts
+++ b/src/services/bifrost/macaroon-issuer.ts
@@ -25,7 +25,7 @@ import { ensureMacaroonUserKeys } from "./macaroon-user-keys";
 import { buildBifrostName } from "./reconciler";
 
 /**
- * Phase-4 macaroon issuer.
+ * Phase-4/11 macaroon issuer.
  *
  * Custodial / phase-1 happy path:
  *
@@ -34,17 +34,24 @@ import { buildBifrostName } from "./reconciler";
  * org_sig         ←  signUserAuthorizationSingle(ua, orgPrivkey)
  * user_pubkey     ←  User.macaroonUserPubkey         (ed25519)
  * user_sig        ←  signInvocation(inv, userPrivkey)
- * realm           ←  Workspace.slug                  (human-readable; see note)
  * agents          ←  [agentName]                     (the dim that ends up on logs.db)
  * run_id          ←  caller-supplied or fresh UUID
  * ```
  *
  * The minted macaroon goes into the `x-macaroon` HTTP header on
  * Bifrost-bound LLM calls. The gateway plugin verifies it, stamps
- * `agent-name` / `run-id` / `user-id` / `realm-id` onto Bifrost's
- * dimensions map, and Bifrost's logging plugin records cost-per-
- * dimension into `logs.db` — that's the minimal-slice payoff:
- * cost-per-agent observability with no Redis accumulators yet.
+ * `agent-name` / `run-id` / `user-id` onto Bifrost's dimensions
+ * map, and Bifrost's logging plugin records cost-per-dimension
+ * into `logs.db` — that's the minimal-slice payoff: cost-per-agent
+ * observability with no Redis accumulators yet.
+ *
+ * Phase-11 wire shape: `permissions` is gone (agents lifted to
+ * top-level on UA), `invocation.realm` is gone, and no `budget`
+ * block is emitted by this issuer — the swarm enforces only
+ * `max_cost_usd` / `max_steps` per call. The swarm's self-identity
+ * (`realm_id`) lives on the trust registry, set by the trust
+ * reconciler from `Workspace.slug`; the issuer doesn't touch it.
+ * See `gateway/plans/phases/phase-11-symmetric-recursive-authorization.md`.
  *
  * Failure posture: the issuer throws. Call sites wrap in a
  * `try`/`catch` and proceed without the header on failure (shadow
@@ -54,20 +61,12 @@ import { buildBifrostName } from "./reconciler";
 
 export interface MintInvocationOptions {
   /**
-   * `Workspace.id` — the immutable lookup key. We resolve this to
-   * `Workspace.slug` internally and use the slug as the macaroon
-   * `realm`, on the (current) premise that realms are observability
-   * dims rather than load-bearing authorization checks: a readable
-   * slug in `logs.db` is worth more to operators than cuid stability.
-   *
-   * The pure verifier doesn't interpret the realm string; it only
-   * checks `invocation.realm ∈ user_authorization.permissions.realms`,
-   * and since we mint both layers in the same call they always line
-   * up. If/when phase 2+ starts pre-signing UAs at onboarding and
-   * re-using them across mints, revisit this — a workspace rename
-   * would then invalidate the pre-signed UA. At that point switch
-   * realm back to `Workspace.id` and surface the slug as a separate
-   * non-authoritative dim.
+   * `Workspace.id` — the immutable lookup key. Used to resolve the
+   * owning `SourceControlOrg` so we know which org keypair to sign
+   * with. Phase 11 dropped the `realm` field from the macaroon
+   * wire shape, so the workspace's slug no longer travels on the
+   * macaroon itself; the swarm's self-identity is registered on
+   * the trust registry separately (see `trust-reconciler.ts`).
    */
   workspaceId: string;
 
@@ -129,12 +128,6 @@ export interface MintedMacaroon {
   agentName: string;
   /** Either the caller-supplied or auto-generated run id. */
   runId: string;
-  /**
-   * Workspace realm — set to `Workspace.slug`. See the note on
-   * {@link MintInvocationOptions.workspaceId} for the rationale and
-   * the conditions under which this should switch back to the id.
-   */
-  realm: string;
   /** UTC RFC3339 timestamp for the macaroon's `exp`. Caller logs this. */
   expiresAt: string;
 }
@@ -185,7 +178,7 @@ export async function mintInvocationMacaroon(
   const [ws, userRow] = await Promise.all([
     db.workspace.findUnique({
       where: { id: workspaceId },
-      select: { id: true, slug: true, sourceControlOrgId: true },
+      select: { id: true, sourceControlOrgId: true },
     }),
     db.user.findUnique({
       where: { id: userId },
@@ -202,15 +195,6 @@ export async function mintInvocationMacaroon(
       `Workspace ${workspaceId} has no sourceControlOrgId; cannot mint macaroon`,
     );
   }
-  // `Workspace.slug` is `@unique` and `NOT NULL` in the schema, so the
-  // empty-string check is defensive against a hypothetical future
-  // soft-rename / undo flow rather than a real production case.
-  if (!ws.slug) {
-    throw new MacaroonIssuerError(
-      `Workspace ${workspaceId} has no slug; cannot mint macaroon`,
-    );
-  }
-  const realm = ws.slug;
 
   // `{login}-{userId}` when we have a login, otherwise bare `userId`.
   // The trailing cuid is what makes the claim immutable and unique
@@ -260,16 +244,13 @@ export async function mintInvocationMacaroon(
     // vs. `macaroonUserId` for the split.
     user_id: macaroonUserId,
     user_pubkey: userEd25519Pubkey,
-    permissions: {
-      // Phase 1 — narrow exactly to what this invocation needs.
-      // No reason to grant broader permissions on a custodial UA
-      // we control end-to-end. Phase 2+ will mint broader UAs at
-      // onboarding (Yubikey-signed user keys can't be re-asked on
-      // every call) and attenuate via the invocation; until then
-      // single-mint is the simpler shape.
-      realms: [realm],
-      agents: [agentName],
-    },
+    // Phase 11: `agents` is top-level on the UA (no more `permissions`
+    // wrapper). Narrow exactly to what this invocation needs — no
+    // reason to grant broader permissions on a custodial UA we
+    // control end-to-end. No `budget` block: this issuer mints
+    // simple-deployment macaroons (single-swarm, per-call caps via
+    // `invocation.max_cost_usd`, no UA-cumulative or per-realm caps).
+    agents: [agentName],
     iat,
     exp,
     nonce: randomNonceHex(),
@@ -277,8 +258,10 @@ export async function mintInvocationMacaroon(
   const ua = signUserAuthorizationSingle(uaUnsigned, orgPrivkey);
 
   // 4. Build + sign the `invocation` layer (user → run).
+  // Phase 11 dropped the singular `realm` field. The swarm enforces
+  // its own self-identity via the trust registry (see
+  // `trust-reconciler.ts`); the macaroon no longer carries one.
   const invUnsigned: InvocationUnsigned = {
-    realm,
     agents: [agentName],
     run_id: runId,
     max_cost_usd: maxCostUsd,
@@ -300,7 +283,6 @@ export async function mintInvocationMacaroon(
 
   logger.debug?.("Minted macaroon", MACAROON_ISSUER_LOG_TAG, {
     workspaceId,
-    realm,
     userId,
     macaroonUserId,
     agentName,
@@ -318,7 +300,6 @@ export async function mintInvocationMacaroon(
     macaroonUserId,
     agentName,
     runId,
-    realm,
     expiresAt: exp,
   };
 }

--- a/src/services/bifrost/trust-reconciler.ts
+++ b/src/services/bifrost/trust-reconciler.ts
@@ -20,7 +20,7 @@ import {
 import { deriveBifrostBaseUrl } from "./resolve";
 
 /**
- * Phase-5 Hive trust reconciler.
+ * Phase-5 Hive trust reconciler (with phase-11 realm_id sync).
  *
  * For a `workspaceId`:
  *   1. Resolve its `SourceControlOrg` (may be null → no-op).
@@ -33,8 +33,11 @@ import { deriveBifrostBaseUrl } from "./resolve";
  *   4. Mismatch → acquire a per-workspace Redis lock, hit the
  *      plugin's `GET /_plugin/trust/status` (defensive — saves a
  *      POST if already in sync), then `POST /_plugin/trust` if the
- *      org isn't registered with this pubkey. Stamp the Swarm row
- *      with the new (orgId, pubkey, syncedAt).
+ *      org isn't registered with this pubkey. Phase 11: while we
+ *      have the status response in hand, also reconcile the
+ *      swarm's `realm_id` against the workspace slug — one extra
+ *      `PUT /_plugin/trust/realm_id` if they diverge. Stamp the
+ *      Swarm row with the new (orgId, pubkey, syncedAt).
  *
  * Lazy-only: triggered from `getBifrostForLLM` (the master
  * reconciler in `services/bifrost/orchestrator.ts`) before
@@ -45,8 +48,20 @@ import { deriveBifrostBaseUrl } from "./resolve";
  * VKs and LLM calls succeed even if the trust registry is briefly
  * stale.
  *
+ * The realm_id sync rides along on the cache-miss path only:
+ * single-swarm deployments that never trip an org-pubkey change
+ * also never trigger a realm_id round-trip. If an operator
+ * manually clears the plugin's realm_id, the next time the
+ * (orgId, pubkey) cache is invalidated (key rotation, new
+ * workspace) the reconciler will re-publish it. For the rare
+ * "force realm_id resync without rotating keys" case, an
+ * operator can clear `Swarm.bifrostTrustedPubkey` to bust the
+ * cache.
+ *
  * See `gateway/plans/phases/phase-5-trust-registry.md` §"Hive's
- * reconciler addition".
+ * reconciler addition" and
+ * `gateway/plans/phases/phase-11-symmetric-recursive-authorization.md`
+ * §"Where the swarm's realm_id lives".
  */
 
 export type TrustReconcileStatus =
@@ -107,9 +122,13 @@ export async function ensureBifrostTrust(
   workspaceId: string,
   options: TrustReconcileOptions = {},
 ): Promise<TrustReconcileResult> {
+  // Phase 11 reads `slug` too: the swarm's `realm_id` is published
+  // to the plugin as the workspace slug (human-readable identifier,
+  // grep-friendly in logs). See `syncLocked` for the realm_id sync
+  // logic.
   const ws = await db.workspace.findUnique({
     where: { id: workspaceId },
-    select: { id: true, sourceControlOrgId: true },
+    select: { id: true, slug: true, sourceControlOrgId: true },
   });
   if (!ws) {
     return { workspaceId, status: "skipped-no-org" };
@@ -189,7 +208,15 @@ export async function ensureBifrostTrust(
   try {
     return await withLock(
       lockKey,
-      () => syncLocked(workspaceId, swarm.swarmUrl!, swarm.swarmApiKey!, keys, options),
+      () =>
+        syncLocked(
+          workspaceId,
+          swarm.swarmUrl!,
+          swarm.swarmApiKey!,
+          keys,
+          ws.slug,
+          options,
+        ),
       {
         ttlMs: BIFROST_TRUST_LOCK_TTL_MS,
         acquireTimeoutMs: BIFROST_TRUST_LOCK_ACQUIRE_TIMEOUT_MS,
@@ -208,6 +235,7 @@ async function syncLocked(
   swarmUrl: string,
   encryptedToken: string,
   keys: MacaroonOrgKeys,
+  desiredRealmId: string,
   options: TrustReconcileOptions,
 ): Promise<TrustReconcileResult> {
   // Re-check the cache inside the lock — a racing caller may have
@@ -260,6 +288,31 @@ async function syncLocked(
     status = await client.getTrustStatus();
   } catch (err) {
     throw wrapHttpError(err, "GET /_plugin/trust/status");
+  }
+
+  // Phase 11: reconcile the swarm's `realm_id` against the workspace
+  // slug while we have the status in hand. The plugin's status
+  // response omits the field when unset, so `??""` normalises the
+  // single-swarm case. We only PUT on actual divergence to keep this
+  // a no-op on warm reconciles. Empty `desiredRealmId` (defensive —
+  // `Workspace.slug` is NOT NULL) leaves the plugin's value alone
+  // rather than clearing it, since clearing is an explicit operator
+  // intent we shouldn't infer from missing data.
+  if (desiredRealmId && (status.realm_id ?? "") !== desiredRealmId) {
+    try {
+      await client.setRealmId(desiredRealmId);
+      logger.info(
+        "Bifrost trust realm_id updated",
+        BIFROST_TRUST_LOG_TAG,
+        {
+          workspaceId,
+          previousRealmId: status.realm_id ?? "",
+          newRealmId: desiredRealmId,
+        },
+      );
+    } catch (err) {
+      throw wrapHttpError(err, "PUT /_plugin/trust/realm_id");
+    }
   }
 
   // If the org is already in the list, do a precise GET to compare

--- a/src/services/bifrost/types.ts
+++ b/src/services/bifrost/types.ts
@@ -164,6 +164,28 @@ export interface TrustStatusResponse {
   orgs: string[];
   seed_source: "env" | "api" | "" | null;
   last_modified: string;
+  /**
+   * Phase-11: the swarm's own self-identity. Single-swarm
+   * deployments leave this unset and the plugin's status omits the
+   * field (`omitempty` on the Go side). Multi-swarm deployments
+   * set it via `PUT /_plugin/trust/realm_id`; the trust reconciler
+   * keeps it in sync with the workspace's slug.
+   */
+  realm_id?: string;
+}
+
+/**
+ * PUT /_plugin/trust/realm_id request body. Sending an empty string
+ * clears the swarm's self-identity (back to single-swarm mode).
+ */
+export interface TrustRealmIDRequest {
+  realm_id: string;
+}
+
+/** PUT /_plugin/trust/realm_id response body. */
+export interface TrustRealmIDResponse {
+  ok: boolean;
+  realm_id: string;
 }
 
 /**


### PR DESCRIPTION
Adopts the phase-11 symmetric-recursive macaroon wire shape and adds plugin-side `realm_id` reconciliation.

Companion to the gateway-side change documented in [`gateway/plans/phases/phase-11-symmetric-recursive-authorization.md`](https://github.com/stakwork/stakgraph/blob/main/gateway/plans/phases/phase-11-symmetric-recursive-authorization.md) (stakgraph repo) and the published `gatekey@0.1.1`.

## Wire-shape changes

`gatekey` bumped `^0.1.0` → `^0.1.1`. The macaroon issuer (`services/bifrost/macaroon-issuer.ts`) is updated for the new shape:

- **`UserAuthorization`:** `agents` lifted to top-level. The `permissions` wrapper (and its `realms` field) is gone.
- **`Invocation`:** singular `realm` field removed.
- **No `budget` block** emitted by the issuer — simple-deployment mode. Per-call enforcement still works via `invocation.max_cost_usd` / `max_steps`.
- **`MintedMacaroon.realm`** removed, along with the two display consumers (`/api/workspaces/[slug]/bifrost/vk` route + `BifrostCredsDevLog`).

## Trust registry — phase-11 `realm_id`

The swarm's own identity (`realm_id`) now lives on the trust registry. Hive publishes it as `Workspace.slug`:

- **`TrustStatusResponse`** gains optional `realm_id`.
- **`BifrostPluginClient.setRealmId(realmId)`** wraps `PUT /_plugin/trust/realm_id`.
- **`trust-reconciler`** reads `Workspace.slug` and reconciles the plugin's `realm_id` on the **cache-miss path only** — zero extra cost on the steady-state hot path. To force a resync without rotating org keys, clear `Swarm.bifrostTrustedPubkey` for the workspace.

## Test coverage

| File | Δ |
| --- | --- |
| `macaroon-issuer.test.ts` | 10 tests, assertions migrated to new shape (no `realm`, no `permissions` wrapper; `budget`/`permitted_realms` null) |
| `trust-reconciler.test.ts` | 14 existing + **5 new** = 19 tests: publish-on-missing, idempotency, drift, cache-hit no-op, `setRealmId` rejection |

Full bifrost suite (10 files, 121 tests) passes locally.

## Out of scope

- No DB schema migration. A `Swarm.bifrostTrustedRealmId` cache column would shave one HTTP round-trip in the rare workspace-rename case, but the cost is not worth the extra wiring — realms reconcile along with org/pubkey on cache miss.
- No attenuation / cross-swarm spawn changes. The hive issuer does not mint attenuated macaroons today.

## Cutover

Per the phase-11 doc, this is a breaking wire-format change. Coordinate the deploy with the gateway side:

1. Disable macaroon enforcement on the active workspace (`enforce_macaroons=false` in the plugin config).
2. Deploy plugin + hive together (gateway repo PR + this PR).
3. Re-enable enforcement.

Shadow-mode behavior is preserved: a mint failure is logged and the LLM call proceeds without an `x-macaroon` header.