### PR TITLE
Generated with Hive: Add ignoreRepoInfo param to bypass repo info injection in repo_agent

### DIFF
--- a/src/lib/ai/askTools.ts
+++ b/src/lib/ai/askTools.ts
@@ -53,6 +53,7 @@ export async function repoAgent(
     model?: string;
     skills?: Record<string, boolean>;
     subAgents?: SubAgent[];
+    ignoreRepoInfo?: boolean;
   },
   /**
    * Optional Bifrost routing. When provided, the swarm-side `repo/agent`


### PR DESCRIPTION
Generated with Hive: Add ignoreRepoInfo param to bypass repo info injection in repo_agent