### PR TITLE
Add per-agent sub-tabs to Logs artifact panel

### DIFF
--- a/src/__tests__/unit/components/ArtifactsPanelLogs.test.tsx
+++ b/src/__tests__/unit/components/ArtifactsPanelLogs.test.tsx
@@ -95,8 +95,12 @@ vi.mock("@/app/w/[slug]/plan/[featureId]/components/VerifyPanel", () => ({
 }));
 
 vi.mock("@/components/agent-logs/LogsArtifactPanel", () => ({
-  LogsArtifactPanel: ({ logId }: { logId: string }) =>
-    React.createElement("div", { "data-testid": "logs-panel", "data-log-id": logId }),
+  LogsArtifactPanel: ({ logs, featureId }: { logs: { id: string }[]; featureId: string }) =>
+    React.createElement("div", {
+      "data-testid": "logs-panel",
+      "data-log-ids": logs.map((l) => l.id).join(","),
+      "data-feature-id": featureId,
+    }),
 }));
 
 vi.mock("@/app/w/[slug]/task/[...taskParams]/artifacts", () => ({
@@ -177,7 +181,13 @@ describe("ArtifactsPanel — LOGS tab", () => {
     // First fetch: agent logs resolver → returns a log
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ data: [{ id: "log-abc" }], total: 1, hasMore: false }),
+      json: async () => ({
+        data: [
+          { id: "log-abc", agent: "coding-agent-feat-1", createdAt: "2026-05-28T09:00:00Z" },
+        ],
+        total: 1,
+        hasMore: false,
+      }),
     });
 
     // Second fetch: attachments count
@@ -204,7 +214,8 @@ describe("ArtifactsPanel — LOGS tab", () => {
       expect(screen.getByTestId("logs-panel")).toBeDefined();
     });
 
-    expect(screen.getByTestId("logs-panel").getAttribute("data-log-id")).toBe("log-abc");
+    expect(screen.getByTestId("logs-panel").getAttribute("data-log-ids")).toBe("log-abc");
+    expect(screen.getByTestId("logs-panel").getAttribute("data-feature-id")).toBe("feat-1");
   });
 
   it("calls the correct API endpoint to resolve agent log for feature", async () => {
@@ -227,7 +238,7 @@ describe("ArtifactsPanel — LOGS tab", () => {
 
     await waitFor(() => {
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining("/api/agent-logs?feature_id=feat-99&workspace_id=ws-42&limit=1")
+        expect.stringContaining("/api/agent-logs?feature_id=feat-99&workspace_id=ws-42&limit=20")
       );
     });
   });

--- a/src/__tests__/unit/components/agent-logs/LogsArtifactPanel.test.tsx
+++ b/src/__tests__/unit/components/agent-logs/LogsArtifactPanel.test.tsx
@@ -11,42 +11,34 @@ globalThis.React = React;
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
 vi.mock("@/components/agent-logs/LogDetailContent", () => ({
-  LogDetailContent: ({
-    loading,
-    error,
-    conversation,
-  }: {
-    loading: boolean;
-    error: string | null;
-    conversation: unknown[] | null;
-  }) => {
-    if (loading) return React.createElement("div", { "data-testid": "log-loading" }, "Loading...");
-    if (error) return React.createElement("div", { "data-testid": "log-error" }, error);
-    return React.createElement(
-      "div",
-      { "data-testid": "log-conversation" },
-      `${conversation?.length ?? 0} messages`
-    );
-  },
+  MessageBubble: ({ message }: { message: { role: string; content: string } }) =>
+    React.createElement("div", { "data-testid": "log-message" }, `${message.role}:${message.content}`),
+  StatsBar: ({ stats }: { stats: { messageCount: number } }) =>
+    React.createElement("div", { "data-testid": "log-stats" }, `messages:${stats.messageCount}`),
+  unescapeLogString: (s: string) => s,
 }));
 
 vi.mock("@/components/ui/button", () => ({
   Button: ({
     children,
     onClick,
+    disabled,
     ...props
   }: React.ButtonHTMLAttributes<HTMLButtonElement> & { children?: React.ReactNode }) =>
-    React.createElement("button", { onClick, ...props }, children),
+    React.createElement("button", { onClick, disabled, ...props }, children),
 }));
 
 vi.mock("lucide-react", () => ({
   Download: () => React.createElement("span", null, "download-icon"),
+  Loader2: () => React.createElement("span", { "data-testid": "log-loading" }, "loading-icon"),
 }));
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 const mockFetch = vi.fn();
 globalThis.fetch = mockFetch;
+
+const FEATURE_ID = "feat-abc";
 
 const fakeStats = {
   conversation: [
@@ -56,12 +48,13 @@ const fakeStats = {
   stats: { messageCount: 2, tokenEstimate: 50, toolUsage: {}, bashCommands: [] },
 };
 
+const singleLog = [{ id: "log-123", agent: `coding-agent-${FEATURE_ID}` }];
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe("LogsArtifactPanel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Reset URL.createObjectURL
     globalThis.URL.createObjectURL = vi.fn(() => "blob:fake");
     globalThis.URL.revokeObjectURL = vi.fn();
   });
@@ -71,13 +64,12 @@ describe("LogsArtifactPanel", () => {
   });
 
   it("renders loading state initially", async () => {
-    // Delay the fetch so we can observe loading
     mockFetch.mockImplementationOnce(
       () => new Promise((resolve) => setTimeout(() => resolve({ ok: true, json: async () => fakeStats }), 200))
     );
 
     const { LogsArtifactPanel } = await import("@/components/agent-logs/LogsArtifactPanel");
-    render(React.createElement(LogsArtifactPanel, { logId: "log-123" }));
+    render(React.createElement(LogsArtifactPanel, { logs: singleLog, featureId: FEATURE_ID }));
 
     expect(screen.getByTestId("log-loading")).toBeDefined();
   });
@@ -89,12 +81,11 @@ describe("LogsArtifactPanel", () => {
     });
 
     const { LogsArtifactPanel } = await import("@/components/agent-logs/LogsArtifactPanel");
-    render(React.createElement(LogsArtifactPanel, { logId: "log-123" }));
+    render(React.createElement(LogsArtifactPanel, { logs: singleLog, featureId: FEATURE_ID }));
 
     await waitFor(() => {
-      expect(screen.getByTestId("log-conversation")).toBeDefined();
+      expect(screen.getAllByTestId("log-message")).toHaveLength(2);
     });
-    expect(screen.getByTestId("log-conversation").textContent).toContain("2 messages");
   });
 
   it("renders error state when fetch fails", async () => {
@@ -104,12 +95,16 @@ describe("LogsArtifactPanel", () => {
     });
 
     const { LogsArtifactPanel } = await import("@/components/agent-logs/LogsArtifactPanel");
-    render(React.createElement(LogsArtifactPanel, { logId: "log-456" }));
+    render(
+      React.createElement(LogsArtifactPanel, {
+        logs: [{ id: "log-456", agent: `coding-agent-${FEATURE_ID}` }],
+        featureId: FEATURE_ID,
+      }),
+    );
 
     await waitFor(() => {
-      expect(screen.getByTestId("log-error")).toBeDefined();
+      expect(screen.getByText(/Failed to fetch log/)).toBeDefined();
     });
-    expect(screen.getByTestId("log-error").textContent).toContain("Failed to fetch log");
   });
 
   it("renders a download button", async () => {
@@ -119,38 +114,110 @@ describe("LogsArtifactPanel", () => {
     });
 
     const { LogsArtifactPanel } = await import("@/components/agent-logs/LogsArtifactPanel");
-    render(React.createElement(LogsArtifactPanel, { logId: "log-123" }));
+    render(React.createElement(LogsArtifactPanel, { logs: singleLog, featureId: FEATURE_ID }));
 
-    await waitFor(() => screen.getByTestId("log-conversation"));
+    await waitFor(() => screen.getAllByTestId("log-message"));
     expect(screen.getByText("Download")).toBeDefined();
   });
 
-  it("triggers download when download button is clicked", async () => {
+  it("triggers download for the selected log when clicked", async () => {
     mockFetch
       .mockResolvedValueOnce({ ok: true, json: async () => fakeStats })
-      .mockResolvedValueOnce({ ok: true, blob: async () => new Blob(["{}"], { type: "application/json" }) });
+      .mockResolvedValueOnce({
+        ok: true,
+        blob: async () => new Blob(["{}"], { type: "application/json" }),
+      });
 
-    // Track anchor clicks without interfering with React's DOM mounting
-    const clickedHrefs: string[] = [];
     const origCreateElement = document.createElement.bind(document);
     vi.spyOn(document, "createElement").mockImplementation((tag: string, ...args: unknown[]) => {
       const el = origCreateElement(tag, ...(args as []));
       if (tag === "a") {
-        vi.spyOn(el as HTMLAnchorElement, "click").mockImplementation(() => {
-          clickedHrefs.push((el as HTMLAnchorElement).href);
-        });
+        vi.spyOn(el as HTMLAnchorElement, "click").mockImplementation(() => {});
       }
       return el;
     });
 
     const { LogsArtifactPanel } = await import("@/components/agent-logs/LogsArtifactPanel");
-    render(React.createElement(LogsArtifactPanel, { logId: "log-789" }));
+    render(
+      React.createElement(LogsArtifactPanel, {
+        logs: [{ id: "log-789", agent: `coding-agent-${FEATURE_ID}` }],
+        featureId: FEATURE_ID,
+      }),
+    );
 
-    await waitFor(() => screen.getByText("Download"));
+    await waitFor(() => screen.getAllByTestId("log-message"));
     await userEvent.click(screen.getByText("Download"));
 
     await waitFor(() => {
       expect(mockFetch).toHaveBeenCalledWith("/api/agent-logs/log-789/content");
+    });
+  });
+
+  it("renders one tab per agent log with formatted labels", async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => fakeStats });
+
+    const { LogsArtifactPanel } = await import("@/components/agent-logs/LogsArtifactPanel");
+    render(
+      React.createElement(LogsArtifactPanel, {
+        logs: [
+          { id: "log-plan", agent: `plan-agent-${FEATURE_ID}` },
+          { id: "log-code", agent: `coding-agent-${FEATURE_ID}` },
+          { id: "log-test", agent: `test-agent-${FEATURE_ID}` },
+        ],
+        featureId: FEATURE_ID,
+      }),
+    );
+
+    expect(screen.getByRole("tab", { name: "Plan Agent" })).toBeDefined();
+    expect(screen.getByRole("tab", { name: "Coding Agent" })).toBeDefined();
+    expect(screen.getByRole("tab", { name: "Test Agent" })).toBeDefined();
+  });
+
+  it("defaults to the last (latest) log tab", async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => fakeStats });
+
+    const { LogsArtifactPanel } = await import("@/components/agent-logs/LogsArtifactPanel");
+    render(
+      React.createElement(LogsArtifactPanel, {
+        logs: [
+          { id: "log-plan", agent: `plan-agent-${FEATURE_ID}` },
+          { id: "log-code", agent: `coding-agent-${FEATURE_ID}` },
+          { id: "log-test", agent: `test-agent-${FEATURE_ID}` },
+        ],
+        featureId: FEATURE_ID,
+      }),
+    );
+
+    const testTab = screen.getByRole("tab", { name: "Test Agent" });
+    expect(testTab.getAttribute("aria-selected")).toBe("true");
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith("/api/agent-logs/log-test/stats");
+    });
+  });
+
+  it("switches the displayed log when a tab is clicked", async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => fakeStats });
+
+    const { LogsArtifactPanel } = await import("@/components/agent-logs/LogsArtifactPanel");
+    render(
+      React.createElement(LogsArtifactPanel, {
+        logs: [
+          { id: "log-plan", agent: `plan-agent-${FEATURE_ID}` },
+          { id: "log-code", agent: `coding-agent-${FEATURE_ID}` },
+        ],
+        featureId: FEATURE_ID,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith("/api/agent-logs/log-code/stats");
+    });
+
+    await userEvent.click(screen.getByRole("tab", { name: "Plan Agent" }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith("/api/agent-logs/log-plan/stats");
     });
   });
 });

--- a/src/app/w/[slug]/task/[...taskParams]/components/ArtifactsPanel.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/components/ArtifactsPanel.tsx
@@ -66,7 +66,7 @@ export function ArtifactsPanel({
   isSuperAdmin = false,
 }: ArtifactsPanelProps) {
   const [internalTab, setInternalTab] = useState<ArtifactType | null>(null);
-  const [agentLogId, setAgentLogId] = useState<string | null>(null);
+  const [agentLogs, setAgentLogs] = useState<{ id: string; agent: string; createdAt: string }[]>([]);
   
   // Support controlled mode (plan) and uncontrolled mode (task)
   const isControlled = controlledTab !== undefined;
@@ -159,25 +159,36 @@ export function ArtifactsPanel({
   const hasTasks = !!(feature?.phases?.[0]?.tasks && feature.phases[0].tasks.length > 0);
   const hasArchitecture = !!feature?.architecture;
 
-  // Resolve the most recent agent log ID for the current feature (plan mode only)
+  // Fetch agent logs for the current feature (plan mode only)
   useEffect(() => {
     if (!hasFeature || !featureId || !workspaceId) return;
 
-    const resolveAgentLogId = async () => {
+    const resolveAgentLogs = async () => {
       try {
         const res = await fetch(
-          `/api/agent-logs?feature_id=${featureId}&workspace_id=${workspaceId}&limit=1`
+          `/api/agent-logs?feature_id=${featureId}&workspace_id=${workspaceId}&limit=20`
         );
         if (!res.ok) return;
         const data = await res.json();
-        const firstLog = data?.data?.[0] ?? null;
-        setAgentLogId(firstLog?.id ?? null);
+        const logs = (data?.data ?? []).map(
+          (l: { id: string; agent: string; createdAt: string }) => ({
+            id: l.id,
+            agent: l.agent,
+            createdAt: l.createdAt,
+          }),
+        );
+        // API returns desc (newest first); we want ascending (earliest left, latest right)
+        logs.sort(
+          (a: { createdAt: string }, b: { createdAt: string }) =>
+            new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+        );
+        setAgentLogs(logs);
       } catch {
         // best-effort — silently ignore
       }
     };
 
-    resolveAgentLogId();
+    resolveAgentLogs();
   }, [hasFeature, featureId, workspaceId]);
 
   // Fetch attachment count once when tasks first exist — drives Verify tab enabled state
@@ -328,7 +339,7 @@ export function ArtifactsPanel({
     if (planData) tabs.push("PLAN");
     if (hasFeature && showTasksTab) tabs.push("TASKS");
     if (hasFeature && showVerifyTab) tabs.push("VERIFY");
-    if (hasFeature && !!agentLogId) tabs.push("LOGS");
+    if (hasFeature && agentLogs.length > 0) tabs.push("LOGS");
     if (browserArtifacts.length > 0) tabs.push("BROWSER");
     if (workflowArtifacts.length > 0) tabs.push("WORKFLOW");
     if (graphArtifacts.length > 0) tabs.push("GRAPH");
@@ -336,7 +347,7 @@ export function ArtifactsPanel({
     if (codeArtifacts.length > 0) tabs.push("CODE");
     if (ideArtifacts.length > 0) tabs.push("IDE");
     return tabs;
-  }, [planData, hasFeature, showTasksTab, showVerifyTab, agentLogId, codeArtifacts.length, browserArtifacts.length, ideArtifacts.length, graphArtifacts.length, workflowArtifacts.length, diffArtifacts.length]);
+  }, [planData, hasFeature, showTasksTab, showVerifyTab, agentLogs.length, codeArtifacts.length, browserArtifacts.length, ideArtifacts.length, graphArtifacts.length, workflowArtifacts.length, diffArtifacts.length]);
 
   // Auto-select first tab, or fall back when active tab is removed
   // Guard: don't reset during active generation to prevent TASKS tab from disappearing
@@ -448,9 +459,9 @@ export function ArtifactsPanel({
               </div>
             </div>
           )}
-          {hasFeature && agentLogId && (
+          {hasFeature && agentLogs.length > 0 && featureId && (
             <div className="h-full" hidden={activeTab !== "LOGS"}>
-              <LogsArtifactPanel logId={agentLogId} />
+              <LogsArtifactPanel logs={agentLogs} featureId={featureId} />
             </div>
           )}
           {codeArtifacts.length > 0 && (

--- a/src/components/agent-logs/LogsArtifactPanel.tsx
+++ b/src/components/agent-logs/LogsArtifactPanel.tsx
@@ -1,59 +1,114 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
-import { Download } from "lucide-react";
+import React, { useEffect, useMemo, useState } from "react";
+import { Download, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { LogDetailContent } from "./LogDetailContent";
+import { cn } from "@/lib/utils";
+import { MessageBubble, StatsBar, unescapeLogString } from "./LogDetailContent";
 import type { ParsedMessage, AgentLogStats } from "@/lib/utils/agent-log-stats";
 
-interface LogsArtifactPanelProps {
-  logId: string;
+interface AgentLogItem {
+  id: string;
+  agent: string;
 }
 
-export function LogsArtifactPanel({ logId }: LogsArtifactPanelProps) {
-  const [conversation, setConversation] = useState<ParsedMessage[] | null>(null);
-  const [stats, setStats] = useState<AgentLogStats | null>(null);
-  const [rawContent, setRawContent] = useState<string>("");
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+interface LogsArtifactPanelProps {
+  logs: AgentLogItem[];
+  featureId: string;
+}
 
+interface LogState {
+  conversation: ParsedMessage[] | null;
+  stats: AgentLogStats | null;
+  rawContent: string;
+  loading: boolean;
+  error: string | null;
+}
+
+function formatAgentLabel(agent: string, featureId: string): string {
+  // "test-agent-cmpp75an00001l8049l77y5el" → "Test Agent"
+  const stripped = agent.endsWith(`-${featureId}`) ? agent.slice(0, -(featureId.length + 1)) : agent;
+  return stripped
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export function LogsArtifactPanel({ logs, featureId }: LogsArtifactPanelProps) {
+  // Default to the latest (rightmost — parent already sorts ascending by timestamp)
+  const [selectedId, setSelectedId] = useState<string | null>(
+    () => logs[logs.length - 1]?.id ?? null,
+  );
+  const [logStates, setLogStates] = useState<Record<string, LogState>>({});
+
+  // Keep selection in sync if logs array changes
   useEffect(() => {
-    if (!logId) return;
+    if (!selectedId || !logs.some((l) => l.id === selectedId)) {
+      setSelectedId(logs[logs.length - 1]?.id ?? null);
+    }
+  }, [logs, selectedId]);
+
+  // Fetch stats for the selected log if we don't have them cached yet
+  useEffect(() => {
+    if (!selectedId || logStates[selectedId]) return;
+
+    setLogStates((prev) => ({
+      ...prev,
+      [selectedId]: {
+        conversation: null,
+        stats: null,
+        rawContent: "",
+        loading: true,
+        error: null,
+      },
+    }));
 
     const fetchStats = async () => {
-      setLoading(true);
-      setError(null);
       try {
-        const response = await fetch(`/api/agent-logs/${logId}/stats`);
+        const response = await fetch(`/api/agent-logs/${selectedId}/stats`);
         if (!response.ok) {
           throw new Error(`Failed to fetch log: ${response.statusText}`);
         }
         const data = await response.json();
-        if (data.conversation && Array.isArray(data.conversation) && data.conversation.length > 0) {
-          setConversation(data.conversation);
-          setStats(data.stats ?? null);
-        } else {
-          setRawContent(JSON.stringify(data, null, 2));
-        }
+        const hasConversation =
+          data.conversation && Array.isArray(data.conversation) && data.conversation.length > 0;
+        setLogStates((prev) => ({
+          ...prev,
+          [selectedId]: {
+            conversation: hasConversation ? data.conversation : null,
+            stats: hasConversation ? (data.stats ?? null) : null,
+            rawContent: hasConversation ? "" : JSON.stringify(data, null, 2),
+            loading: false,
+            error: null,
+          },
+        }));
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to fetch log content");
-      } finally {
-        setLoading(false);
+        setLogStates((prev) => ({
+          ...prev,
+          [selectedId]: {
+            conversation: null,
+            stats: null,
+            rawContent: "",
+            loading: false,
+            error: err instanceof Error ? err.message : "Failed to fetch log content",
+          },
+        }));
       }
     };
 
     fetchStats();
-  }, [logId]);
+  }, [selectedId, logStates]);
 
   const handleDownload = async () => {
+    if (!selectedId) return;
     try {
-      const res = await fetch(`/api/agent-logs/${logId}/content`);
+      const res = await fetch(`/api/agent-logs/${selectedId}/content`);
       if (!res.ok) throw new Error("Failed to fetch log content");
       const blob = await res.blob();
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = `agent-log-${logId}.json`;
+      a.download = `agent-log-${selectedId}.json`;
       document.body.appendChild(a);
       a.click();
       a.remove();
@@ -63,24 +118,75 @@ export function LogsArtifactPanel({ logId }: LogsArtifactPanelProps) {
     }
   };
 
+  const tabs = useMemo(
+    () => logs.map((l) => ({ id: l.id, label: formatAgentLabel(l.agent, featureId) })),
+    [logs, featureId],
+  );
+
+  const current = selectedId ? logStates[selectedId] : null;
+  const hasContent = !!current && (current.conversation !== null || current.rawContent !== "");
+
   return (
-    <div className="h-full flex flex-col min-h-0">
-      <div className="flex justify-end px-4 pt-3 pb-1 shrink-0">
-        <Button variant="outline" size="sm" onClick={handleDownload} className="gap-1.5 h-7 text-xs">
+    <div className="h-full overflow-auto p-4">
+      <div className="flex items-center justify-between gap-3 mb-3">
+        <div className="flex gap-1 overflow-x-auto" role="tablist" aria-label="Agent logs">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              role="tab"
+              aria-selected={selectedId === tab.id}
+              onClick={() => setSelectedId(tab.id)}
+              className={cn(
+                "px-2.5 h-7 text-xs rounded-md transition-colors whitespace-nowrap border",
+                selectedId === tab.id
+                  ? "bg-muted text-foreground border-border"
+                  : "text-muted-foreground border-transparent hover:bg-muted/50 hover:text-foreground",
+              )}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleDownload}
+          disabled={!selectedId}
+          className="gap-1.5 h-7 text-xs shrink-0"
+        >
           <Download className="h-3 w-3" />
           Download
         </Button>
       </div>
-      <div className="flex-1 min-h-0 overflow-hidden">
-        <LogDetailContent
-          variant="modal"
-          conversation={conversation}
-          stats={stats}
-          rawContent={rawContent}
-          loading={loading}
-          error={error}
-        />
-      </div>
+
+      {current?.loading && (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      {current?.error && !current.loading && (
+        <div className="text-center py-12">
+          <p className="text-destructive text-sm">{current.error}</p>
+        </div>
+      )}
+
+      {current && !current.loading && !current.error && hasContent && (
+        <>
+          {current.stats && <StatsBar stats={current.stats} />}
+          {current.conversation ? (
+            <div className="space-y-3">
+              {current.conversation.map((msg, i) => (
+                <MessageBubble key={i} message={msg} />
+              ))}
+            </div>
+          ) : (
+            <pre className="whitespace-pre-wrap break-words font-mono text-sm">
+              {unescapeLogString(current.rawContent)}
+            </pre>
+          )}
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Fetch all agent logs for a feature instead of just the latest, then render one sub-tab per log inside the Logs artifact panel (earliest left, latest selected by default). Replaces fixed-height ScrollArea with the same h-full overflow-auto pattern used by Tasks and Verify tabs, fixing the content clipping where logs were cut off halfway.