### PR TITLE
Add canvas presence store, collaboration API endpoint, useCanvasCollaboration hook, and wire into OrgCanvasBackground

### DIFF
--- a/src/__tests__/unit/hooks/useCanvasCollaboration.test.ts
+++ b/src/__tests__/unit/hooks/useCanvasCollaboration.test.ts
@@ -1,0 +1,367 @@
+import { renderHook, act } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { useCanvasCollaboration } from "@/hooks/useCanvasCollaboration";
+import type { MutableRefObject } from "react";
+import { usePusherChannel } from "@/hooks/usePusherChannel";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockChannel = {
+  bind: vi.fn(),
+  unbind: vi.fn(),
+  unbind_all: vi.fn(),
+};
+
+vi.mock("@/hooks/usePusherChannel", () => ({
+  usePusherChannel: vi.fn(() => mockChannel),
+}));
+
+vi.mock("@/lib/pusher", () => ({
+  PUSHER_EVENTS: {
+    CANVAS_USER_JOIN: "canvas-user-join",
+    CANVAS_USER_LEAVE: "canvas-user-leave",
+    CANVAS_CURSOR_UPDATE: "canvas-cursor-update",
+    CANVAS_SELECTION_UPDATE: "canvas-selection-update",
+  },
+}));
+
+// Route helper — re-export the real function shape so the hook can import it
+vi.mock(
+  "@/app/api/orgs/[githubLogin]/canvas/collaboration/route",
+  () => ({
+    getCanvasPresenceChannelName: (githubLogin: string, canvasRef: string) => {
+      const safeRef = (canvasRef || "root").replace(/[^a-zA-Z0-9_\-=@]/g, "-");
+      return `canvas-presence-${githubLogin}-${safeRef}`;
+    },
+  }),
+);
+
+global.fetch = vi.fn();
+const mockSendBeacon = vi.fn(() => true);
+Object.defineProperty(navigator, "sendBeacon", {
+  value: mockSendBeacon,
+  writable: true,
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Return the callback registered for a given Pusher event name. */
+function getEventCallback(eventName: string): ((data: unknown) => void) | undefined {
+  const call = mockChannel.bind.mock.calls.find((c) => c[0] === eventName);
+  return call?.[1];
+}
+
+function makeRefs() {
+  const viewportRef: MutableRefObject<{ x: number; y: number; zoom: number }> = {
+    current: { x: 0, y: 0, zoom: 1 },
+  };
+  const containerRef: MutableRefObject<HTMLDivElement | null> = { current: null };
+  return { viewportRef, containerRef };
+}
+
+const BASE_OPTS = {
+  githubLogin: "acme-org",
+  canvasRef: "",
+  userId: "user-abc",
+  userName: "Alice",
+  enabled: true,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useCanvasCollaboration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true }),
+    } as Response);
+  });
+
+  // -------------------------------------------------------------------------
+  // Lifecycle
+  // -------------------------------------------------------------------------
+  describe("lifecycle", () => {
+    it("POSTs a join event on mount", () => {
+      const { viewportRef, containerRef } = makeRefs();
+      renderHook(() =>
+        useCanvasCollaboration({ ...BASE_OPTS, viewportRef, containerRef }),
+      );
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/orgs/acme-org/canvas/collaboration",
+        expect.objectContaining({
+          method: "POST",
+          body: expect.stringContaining('"type":"join"'),
+        }),
+      );
+
+      const call = vi.mocked(global.fetch).mock.calls[0];
+      const body = JSON.parse(call[1]?.body as string);
+      expect(body.type).toBe("join");
+      expect(body.canvasRef).toBe("");
+      expect(body.user.id).toBe("user-abc");
+      expect(body.user.name).toBe("Alice");
+    });
+
+    it("POSTs a leave event on unmount", () => {
+      const { viewportRef, containerRef } = makeRefs();
+      const { unmount } = renderHook(() =>
+        useCanvasCollaboration({ ...BASE_OPTS, viewportRef, containerRef }),
+      );
+
+      unmount();
+
+      const leaveCalls = vi.mocked(global.fetch).mock.calls.filter((c) => {
+        try {
+          return JSON.parse(c[1]?.body as string)?.type === "leave";
+        } catch {
+          return false;
+        }
+      });
+      expect(leaveCalls.length).toBeGreaterThan(0);
+    });
+
+    it("re-subscribes when canvasRef changes", async () => {
+      const { usePusherChannel } = await import("@/hooks/usePusherChannel");
+      const { viewportRef, containerRef } = makeRefs();
+
+      const { rerender } = renderHook(
+        ({ canvasRef }: { canvasRef: string }) =>
+          useCanvasCollaboration({ ...BASE_OPTS, viewportRef, containerRef, canvasRef }),
+        { initialProps: { canvasRef: "" } },
+      );
+
+      rerender({ canvasRef: "initiative:xyz" });
+
+      // Channel name should change — usePusherChannel called with new name
+      expect(usePusherChannel).toHaveBeenCalledWith(
+        "canvas-presence-acme-org-initiative-xyz",
+      );
+    });
+
+    it("binds all four Pusher event handlers", () => {
+      const { viewportRef, containerRef } = makeRefs();
+      renderHook(() =>
+        useCanvasCollaboration({ ...BASE_OPTS, viewportRef, containerRef }),
+      );
+
+      expect(mockChannel.bind).toHaveBeenCalledWith("canvas-user-join", expect.any(Function));
+      expect(mockChannel.bind).toHaveBeenCalledWith("canvas-user-leave", expect.any(Function));
+      expect(mockChannel.bind).toHaveBeenCalledWith("canvas-cursor-update", expect.any(Function));
+      expect(mockChannel.bind).toHaveBeenCalledWith("canvas-selection-update", expect.any(Function));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Event handling
+  // -------------------------------------------------------------------------
+  describe("event handling", () => {
+    it("CANVAS_USER_JOIN adds a collaborator", async () => {
+      const { viewportRef, containerRef } = makeRefs();
+      const { result } = renderHook(() =>
+        useCanvasCollaboration({ ...BASE_OPTS, viewportRef, containerRef }),
+      );
+
+      const onJoin = getEventCallback("canvas-user-join");
+      act(() => {
+        onJoin?.({ user: { id: "user-bob", name: "Bob", color: "#00ff00" } });
+      });
+
+      expect(result.current.collaborators).toHaveLength(1);
+      expect(result.current.collaborators[0].id).toBe("user-bob");
+      expect(result.current.collaborators[0].name).toBe("Bob");
+    });
+
+    it("CANVAS_USER_LEAVE removes the collaborator", async () => {
+      const { viewportRef, containerRef } = makeRefs();
+      const { result } = renderHook(() =>
+        useCanvasCollaboration({ ...BASE_OPTS, viewportRef, containerRef }),
+      );
+
+      const onJoin = getEventCallback("canvas-user-join");
+      const onLeave = getEventCallback("canvas-user-leave");
+
+      act(() => {
+        onJoin?.({ user: { id: "user-bob", name: "Bob", color: "#00ff00" } });
+      });
+      expect(result.current.collaborators).toHaveLength(1);
+
+      act(() => {
+        onLeave?.({ userId: "user-bob" });
+      });
+      expect(result.current.collaborators).toHaveLength(0);
+    });
+
+    it("CANVAS_CURSOR_UPDATE updates cursor position", async () => {
+      const { viewportRef, containerRef } = makeRefs();
+      const { result } = renderHook(() =>
+        useCanvasCollaboration({ ...BASE_OPTS, viewportRef, containerRef }),
+      );
+
+      // Add a collaborator first
+      const onJoin = getEventCallback("canvas-user-join");
+      act(() => {
+        onJoin?.({ user: { id: "user-bob", name: "Bob", color: "#00ff00" } });
+      });
+
+      const onCursor = getEventCallback("canvas-cursor-update");
+      act(() => {
+        onCursor?.({ senderId: "user-bob", cursor: { x: 100, y: 200 }, color: "#00ff00" });
+      });
+
+      const collab = result.current.collaborators.find((c) => c.id === "user-bob");
+      expect(collab?.cursor).toEqual({ x: 100, y: 200 });
+    });
+
+    it("CANVAS_SELECTION_UPDATE updates selectedNodeId", async () => {
+      const { viewportRef, containerRef } = makeRefs();
+      const { result } = renderHook(() =>
+        useCanvasCollaboration({ ...BASE_OPTS, viewportRef, containerRef }),
+      );
+
+      const onJoin = getEventCallback("canvas-user-join");
+      act(() => {
+        onJoin?.({ user: { id: "user-bob", name: "Bob", color: "#00ff00" } });
+      });
+
+      const onSelection = getEventCallback("canvas-selection-update");
+      act(() => {
+        onSelection?.({ senderId: "user-bob", selectedNodeId: "node-xyz" });
+      });
+
+      const collab = result.current.collaborators.find((c) => c.id === "user-bob");
+      expect(collab?.selectedNodeId).toBe("node-xyz");
+    });
+
+    it("ignores join events from own userId", async () => {
+      const { viewportRef, containerRef } = makeRefs();
+      const { result } = renderHook(() =>
+        useCanvasCollaboration({ ...BASE_OPTS, viewportRef, containerRef }),
+      );
+
+      const onJoin = getEventCallback("canvas-user-join");
+      act(() => {
+        // user-abc is the current user (BASE_OPTS.userId)
+        onJoin?.({ user: { id: "user-abc", name: "Alice", color: "#ff0000" } });
+      });
+
+      expect(result.current.collaborators).toHaveLength(0);
+    });
+
+    it("ignores cursor events from own userId", async () => {
+      const { viewportRef, containerRef } = makeRefs();
+      const { result } = renderHook(() =>
+        useCanvasCollaboration({ ...BASE_OPTS, viewportRef, containerRef }),
+      );
+
+      const onCursor = getEventCallback("canvas-cursor-update");
+      act(() => {
+        onCursor?.({ senderId: "user-abc", cursor: { x: 100, y: 200 }, color: "#ff0000" });
+      });
+
+      expect(result.current.collaborators).toHaveLength(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Self-filtering
+  // -------------------------------------------------------------------------
+  describe("self-filtering", () => {
+    it("never includes own userId in returned collaborators", async () => {
+      const { viewportRef, containerRef } = makeRefs();
+      const { result } = renderHook(() =>
+        useCanvasCollaboration({ ...BASE_OPTS, viewportRef, containerRef }),
+      );
+
+      const onJoin = getEventCallback("canvas-user-join");
+      act(() => {
+        onJoin?.({ user: { id: "user-abc", name: "Alice", color: "#ff0000" } });
+        onJoin?.({ user: { id: "user-bob", name: "Bob", color: "#00ff00" } });
+      });
+
+      expect(result.current.collaborators.map((c) => c.id)).not.toContain("user-abc");
+      expect(result.current.collaborators.map((c) => c.id)).toContain("user-bob");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // TTL pruning
+  // -------------------------------------------------------------------------
+  describe("client-side TTL pruning", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("prunes collaborators with lastSeenAt > 60s on the next interval tick", () => {
+      const { viewportRef, containerRef } = makeRefs();
+      const { result } = renderHook(() =>
+        useCanvasCollaboration({ ...BASE_OPTS, viewportRef, containerRef }),
+      );
+
+      const onJoin = getEventCallback("canvas-user-join");
+      act(() => {
+        onJoin?.({ user: { id: "user-bob", name: "Bob", color: "#00ff00" } });
+      });
+      expect(result.current.collaborators).toHaveLength(1);
+
+      // Advance past TTL (60s) + one prune interval (15s)
+      act(() => {
+        vi.advanceTimersByTime(61_000 + 15_000);
+      });
+
+      expect(result.current.collaborators).toHaveLength(0);
+    });
+
+    it("does not prune fresh collaborators", () => {
+      const { viewportRef, containerRef } = makeRefs();
+      const { result } = renderHook(() =>
+        useCanvasCollaboration({ ...BASE_OPTS, viewportRef, containerRef }),
+      );
+
+      const onJoin = getEventCallback("canvas-user-join");
+      act(() => {
+        onJoin?.({ user: { id: "user-bob", name: "Bob", color: "#00ff00" } });
+      });
+
+      // Not quite TTL yet
+      act(() => {
+        vi.advanceTimersByTime(30_000);
+      });
+
+      expect(result.current.collaborators).toHaveLength(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Disabled mode
+  // -------------------------------------------------------------------------
+  describe("disabled mode", () => {
+    it("does not POST join or subscribe when enabled=false", () => {
+      const { viewportRef, containerRef } = makeRefs();
+
+      renderHook(() =>
+        useCanvasCollaboration({
+          ...BASE_OPTS,
+          viewportRef,
+          containerRef,
+          enabled: false,
+        }),
+      );
+
+      // When disabled, usePusherChannel should receive null (no subscription)
+      expect(usePusherChannel).toHaveBeenCalledWith(null);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/__tests__/unit/hooks/useCanvasCollaboration.test.ts
+++ b/src/__tests__/unit/hooks/useCanvasCollaboration.test.ts
@@ -27,16 +27,13 @@ vi.mock("@/lib/pusher", () => ({
   },
 }));
 
-// Route helper — re-export the real function shape so the hook can import it
-vi.mock(
-  "@/app/api/orgs/[githubLogin]/canvas/collaboration/route",
-  () => ({
-    getCanvasPresenceChannelName: (githubLogin: string, canvasRef: string) => {
-      const safeRef = (canvasRef || "root").replace(/[^a-zA-Z0-9_\-=@]/g, "-");
-      return `canvas-presence-${githubLogin}-${safeRef}`;
-    },
-  }),
-);
+// Mock the presence-channel helper the hook actually imports from
+vi.mock("@/lib/canvas/presence-channel", () => ({
+  getCanvasPresenceChannelName: (githubLogin: string, canvasRef: string) => {
+    const safeRef = (canvasRef || "root").replace(/[^a-zA-Z0-9_\-=@]/g, "-");
+    return `canvas-presence-${githubLogin}-${safeRef}`;
+  },
+}));
 
 global.fetch = vi.fn();
 const mockSendBeacon = vi.fn(() => true);

--- a/src/__tests__/unit/lib/canvas/presence-store.test.ts
+++ b/src/__tests__/unit/lib/canvas/presence-store.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import {
+  recordHeartbeat,
+  recordLeave,
+  getActivePresence,
+  __clearCanvasPresenceForTests,
+} from "@/lib/canvas/presence-store";
+
+describe("canvas presence-store", () => {
+  const roomKey = "acme-org:root";
+  const userId = "user-abc";
+  const userId2 = "user-def";
+
+  beforeEach(() => {
+    __clearCanvasPresenceForTests();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("recordHeartbeat", () => {
+    it("creates a new entry", () => {
+      recordHeartbeat(roomKey, { userId, name: "Alice", color: "#ff0000" });
+      const entries = getActivePresence(roomKey);
+      expect(entries).toHaveLength(1);
+      expect(entries[0].userId).toBe(userId);
+      expect(entries[0].name).toBe("Alice");
+      expect(entries[0].color).toBe("#ff0000");
+    });
+
+    it("refreshes lastSeenAt on repeat calls", () => {
+      recordHeartbeat(roomKey, { userId, name: "Alice" });
+      const first = getActivePresence(roomKey)[0].lastSeenAt;
+
+      vi.advanceTimersByTime(5_000);
+      recordHeartbeat(roomKey, { userId, name: "Alice" });
+      const second = getActivePresence(roomKey)[0].lastSeenAt;
+
+      expect(second).toBeGreaterThan(first);
+    });
+
+    it("preserves joinedAt across heartbeats", () => {
+      recordHeartbeat(roomKey, { userId, name: "Alice", joinedAt: 1000 });
+      vi.advanceTimersByTime(1_000);
+      recordHeartbeat(roomKey, { userId, name: "Alice" });
+      const entry = getActivePresence(roomKey)[0];
+      expect(entry.joinedAt).toBe(1000);
+    });
+
+    it("preserves name from first heartbeat when subsequent omits it", () => {
+      recordHeartbeat(roomKey, { userId, name: "Alice" });
+      recordHeartbeat(roomKey, { userId, name: null });
+      const entry = getActivePresence(roomKey)[0];
+      expect(entry.name).toBe("Alice");
+    });
+  });
+
+  describe("recordLeave", () => {
+    it("removes the entry immediately", () => {
+      recordHeartbeat(roomKey, { userId, name: "Alice" });
+      recordLeave(roomKey, userId);
+      expect(getActivePresence(roomKey)).toHaveLength(0);
+    });
+
+    it("is a no-op when user is not in the room", () => {
+      recordHeartbeat(roomKey, { userId, name: "Alice" });
+      expect(() => recordLeave(roomKey, "unknown-user")).not.toThrow();
+      expect(getActivePresence(roomKey)).toHaveLength(1);
+    });
+
+    it("cleans up empty room from the map", () => {
+      recordHeartbeat(roomKey, { userId, name: "Alice" });
+      recordLeave(roomKey, userId);
+      // After leave, calling again should still not throw
+      expect(() => recordLeave(roomKey, userId)).not.toThrow();
+    });
+  });
+
+  describe("getActivePresence", () => {
+    it("excludes the caller's own userId", () => {
+      recordHeartbeat(roomKey, { userId, name: "Alice" });
+      recordHeartbeat(roomKey, { userId: userId2, name: "Bob" });
+      const entries = getActivePresence(roomKey, userId);
+      expect(entries.map((e) => e.userId)).not.toContain(userId);
+      expect(entries.map((e) => e.userId)).toContain(userId2);
+    });
+
+    it("prunes stale entries (> 60s old)", () => {
+      recordHeartbeat(roomKey, { userId, name: "Alice" });
+      vi.advanceTimersByTime(61_000);
+      const entries = getActivePresence(roomKey);
+      expect(entries).toHaveLength(0);
+    });
+
+    it("returns fresh entries not yet expired", () => {
+      recordHeartbeat(roomKey, { userId, name: "Alice" });
+      vi.advanceTimersByTime(30_000);
+      expect(getActivePresence(roomKey)).toHaveLength(1);
+    });
+
+    it("returns empty array for unknown room", () => {
+      expect(getActivePresence("nonexistent:room")).toEqual([]);
+    });
+
+    it("handles multiple rooms independently", () => {
+      const room2 = "acme-org:initiative-xyz";
+      recordHeartbeat(roomKey, { userId, name: "Alice" });
+      recordHeartbeat(room2, { userId: userId2, name: "Bob" });
+
+      expect(getActivePresence(roomKey)).toHaveLength(1);
+      expect(getActivePresence(roomKey)[0].userId).toBe(userId);
+
+      expect(getActivePresence(room2)).toHaveLength(1);
+      expect(getActivePresence(room2)[0].userId).toBe(userId2);
+    });
+  });
+});

--- a/src/__tests__/unit/lib/pusher.test.ts
+++ b/src/__tests__/unit/lib/pusher.test.ts
@@ -295,6 +295,10 @@ describe("pusher.ts", () => {
         FEATURE_UPDATED: "feature-updated",
         CONNECTION_UPDATED: "connection-updated",
         CANVAS_UPDATED: "canvas-updated",
+        CANVAS_CURSOR_UPDATE: "canvas-cursor-update",
+        CANVAS_USER_JOIN: "canvas-user-join",
+        CANVAS_USER_LEAVE: "canvas-user-leave",
+        CANVAS_SELECTION_UPDATE: "canvas-selection-update",
         RESEARCH_UPDATED: "research-updated",
         AGENT_LOG_UPDATED: "agent-log-updated",
       });

--- a/src/app/api/orgs/[githubLogin]/canvas/collaboration/route.ts
+++ b/src/app/api/orgs/[githubLogin]/canvas/collaboration/route.ts
@@ -1,0 +1,115 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getMiddlewareContext, requireAuth } from "@/lib/middleware/utils";
+import { validateUserBelongsToOrg } from "@/services/workspace";
+import { pusherServer, PUSHER_EVENTS } from "@/lib/pusher";
+import {
+  recordHeartbeat,
+  recordLeave,
+} from "@/lib/canvas/presence-store";
+import { logger } from "@/lib/logger";
+import { getCanvasPresenceChannelName } from "@/lib/canvas/presence-channel";
+
+type RequestPayload =
+  | { type: "join"; canvasRef: string; user: { id: string; name: string; color: string } }
+  | { type: "leave"; canvasRef: string }
+  | { type: "cursor"; canvasRef: string; senderId: string; cursor: { x: number; y: number }; color: string }
+  | { type: "selection"; canvasRef: string; senderId: string; selectedNodeId: string | null };
+
+/**
+ * POST /api/orgs/[githubLogin]/canvas/collaboration
+ *
+ * Handles ephemeral canvas presence events (join, leave, cursor, selection).
+ * Events are broadcast via Pusher but never persisted to the database.
+ *
+ * Authorization: requires authenticated user AND org membership.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ githubLogin: string }> },
+) {
+  try {
+    const context = getMiddlewareContext(request);
+    const userOrResponse = requireAuth(context);
+    if (userOrResponse instanceof NextResponse) return userOrResponse;
+
+    const { githubLogin } = await params;
+
+    const isMember = await validateUserBelongsToOrg(githubLogin, userOrResponse.id);
+    if (!isMember) {
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
+    }
+
+    const body = (await request.json()) as RequestPayload;
+    const { canvasRef } = body;
+    const roomKey = `${githubLogin}:${canvasRef || "root"}`;
+    const channelName = getCanvasPresenceChannelName(githubLogin, canvasRef);
+
+    switch (body.type) {
+      case "join": {
+        const { user } = body;
+        recordHeartbeat(roomKey, {
+          userId: userOrResponse.id,
+          name: userOrResponse.name ?? user.name ?? null,
+          color: user.color,
+        });
+        await pusherServer.trigger(channelName, PUSHER_EVENTS.CANVAS_USER_JOIN, {
+          user: {
+            id: userOrResponse.id,
+            name: userOrResponse.name || user.name,
+            color: user.color,
+          },
+        });
+        logger.info(
+          `[canvas/presence] ${userOrResponse.name ?? userOrResponse.id} joined canvas ${githubLogin}:${canvasRef || "root"}`,
+        );
+        break;
+      }
+
+      case "leave": {
+        recordLeave(roomKey, userOrResponse.id);
+        await pusherServer.trigger(channelName, PUSHER_EVENTS.CANVAS_USER_LEAVE, {
+          userId: userOrResponse.id,
+        });
+        logger.info(
+          `[canvas/presence] ${userOrResponse.id} left canvas ${githubLogin}:${canvasRef || "root"}`,
+        );
+        break;
+      }
+
+      case "cursor": {
+        recordHeartbeat(roomKey, {
+          userId: userOrResponse.id,
+          name: userOrResponse.name ?? null,
+          color: body.color,
+        });
+        await pusherServer.trigger(channelName, PUSHER_EVENTS.CANVAS_CURSOR_UPDATE, {
+          senderId: userOrResponse.id,
+          cursor: body.cursor,
+          color: body.color,
+        });
+        // High-frequency — no logging
+        break;
+      }
+
+      case "selection": {
+        await pusherServer.trigger(channelName, PUSHER_EVENTS.CANVAS_SELECTION_UPDATE, {
+          senderId: userOrResponse.id,
+          selectedNodeId: body.selectedNodeId,
+        });
+        // No logging
+        break;
+      }
+
+      default:
+        return NextResponse.json({ error: "Invalid event type" }, { status: 400 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    logger.error("Error handling canvas collaboration event", "canvas/collaboration", { error });
+    return NextResponse.json(
+      { error: "Failed to handle collaboration event" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/org/[githubLogin]/connections/OrgCanvasBackground.tsx
+++ b/src/app/org/[githubLogin]/connections/OrgCanvasBackground.tsx
@@ -52,6 +52,8 @@ import { categoryAllowedOnScope } from "./canvas-categories";
 import { useCanvasChatStore } from "../_state/canvasChatStore";
 import { useSendCanvasChatMessage } from "../_state/useSendCanvasChatMessage";
 import useCanvasClipboard from "./useCanvasClipboard";
+import { useSession } from "next-auth/react";
+import { useCanvasCollaboration } from "@/hooks/useCanvasCollaboration";
 
 /**
  * Live-id detection mirrors `src/lib/canvas/scope.ts`'s `isLiveId`.
@@ -345,6 +347,7 @@ export function OrgCanvasBackground({
   onCanvasBreadcrumbChange,
   onLinkedConnectionIdsChange,
 }: OrgCanvasBackgroundProps) {
+  const { data: session } = useSession();
   const [root, setRoot] = useState<CanvasData | null>(null);
   const [subCanvases, setSubCanvases] = useState<Record<string, CanvasData>>({});
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -471,11 +474,13 @@ export function OrgCanvasBackground({
     (selection: CanvasSelection) => {
       if (!selection) {
         selectedNodeForClipboardRef.current = null;
+        setSelectedNodeIdForPresence(null);
         onSelectionChange?.(null);
         return;
       }
       if (selection.kind === "node") {
         selectedNodeForClipboardRef.current = selection.node;
+        setSelectedNodeIdForPresence(selection.node.id);
         onSelectionChange?.({
           kind: "node",
           node: selection.node,
@@ -484,6 +489,7 @@ export function OrgCanvasBackground({
         return;
       }
       selectedNodeForClipboardRef.current = null;
+      setSelectedNodeIdForPresence(null);
       // Edge — resolve human labels off the canvas the edge lives on.
       // The refs lag state by one commit, but the edge's endpoints
       // are already in the rendered canvas (it wouldn't have been
@@ -565,6 +571,9 @@ export function OrgCanvasBackground({
 
   // Selected node ref for clipboard — updated inside handleSelectionChange.
   const selectedNodeForClipboardRef = useRef<CanvasNode | null>(null);
+
+  // Selected node id for presence broadcasting.
+  const [selectedNodeIdForPresence, setSelectedNodeIdForPresence] = useState<string | null>(null);
 
   // -------------------------------------------------------------------
   // Single source of truth for canvas scope: the library's breadcrumb
@@ -2040,6 +2049,18 @@ export function OrgCanvasBackground({
     canvasContainerRef,
   });
 
+  // Real-time canvas presence — cursors, selection halos, conflict flash
+  const { collaborators } = useCanvasCollaboration({
+    githubLogin,
+    canvasRef: currentRef,
+    userId: session?.user?.id ?? "",
+    userName: session?.user?.name ?? "",
+    viewportRef: currentViewportRef,
+    containerRef: canvasContainerRef,
+    selectedNodeId: selectedNodeIdForPresence,
+    enabled: !!(session?.user?.id),
+  });
+
   /**
    * Detect a user-drawn edge whose endpoints are a feature card and a
    * milestone card on the initiative canvas. Either direction is
@@ -2858,6 +2879,9 @@ export function OrgCanvasBackground({
           onViewportChange={(vp) => {
             currentViewportRef.current = vp;
           }}
+          // @ts-expect-error collaborators prop will be available once system-canvas-react
+          // is updated with the CollaboratorsOverlay changes from Phase 1.
+          collaborators={collaborators}
         />
         {/*
          * Restore pill — top-right of the canvas area. Shown on any

--- a/src/hooks/useCanvasCollaboration.ts
+++ b/src/hooks/useCanvasCollaboration.ts
@@ -1,0 +1,335 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { usePusherChannel } from "@/hooks/usePusherChannel";
+import { PUSHER_EVENTS } from "@/lib/pusher";
+import { getCanvasPresenceChannelName } from "@/lib/canvas/presence-channel";
+
+export interface CanvasCollaboratorInfo {
+  id: string;
+  name: string;
+  color: string;
+  cursor: { x: number; y: number } | null;
+  selectedNodeId?: string | null;
+}
+
+interface CollaboratorState extends CanvasCollaboratorInfo {
+  lastSeenAt: number;
+}
+
+interface UseCanvasCollaborationOptions {
+  githubLogin: string;
+  /** Current canvas ref — empty string for root. */
+  canvasRef: string;
+  userId: string;
+  userName: string;
+  /**
+   * A ref to the current viewport state so cursor events can be
+   * converted from screen to canvas space.
+   */
+  viewportRef: React.RefObject<{ x: number; y: number; zoom: number }>;
+  /** The container DOM element to attach pointermove to. */
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  /** Currently selected node id, or null. */
+  selectedNodeId?: string | null;
+  /** Default true. */
+  enabled?: boolean;
+}
+
+interface UseCanvasCollaborationResult {
+  collaborators: CanvasCollaboratorInfo[];
+}
+
+/** TTL for stale client-side entries (60s, matching server TTL). */
+const CLIENT_TTL_MS = 60_000;
+/** Prune interval (15s). */
+const PRUNE_INTERVAL_MS = 15_000;
+/** Cursor throttle (50ms ≈ 20fps). */
+const CURSOR_THROTTLE_MS = 50;
+
+/**
+ * Generates a deterministic color from a userId using the canvas team palette.
+ * Mirrors `teamAvatarColor` in canvas-theme.ts to avoid a server-component import.
+ */
+function teamAvatarColor(userId: string): string {
+  const palette = [
+    "#5EEAD4", // teal-300
+    "#38BDF8", // sky-300
+    "#A78BFA", // violet-400
+    "#FB923C", // orange-400
+    "#34D399", // emerald-400
+    "#F472B6", // pink-400
+    "#FACC15", // yellow-400
+    "#60A5FA", // blue-400
+    "#F87171", // red-400
+    "#C084FC", // purple-400
+    "#2DD4BF", // teal-400
+    "#4ADE80", // green-400
+  ];
+  let hash = 0;
+  for (let i = 0; i < userId.length; i++) {
+    hash = (hash * 31 + userId.charCodeAt(i)) | 0;
+  }
+  return palette[Math.abs(hash) % palette.length];
+}
+
+function postCollabEvent(githubLogin: string, body: Record<string, unknown>) {
+  fetch(`/api/orgs/${githubLogin}/canvas/collaboration`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }).catch(() => {
+    // Fire-and-forget; failures are non-critical for presence
+  });
+}
+
+/**
+ * Hook that manages real-time presence for org canvas collaborators.
+ *
+ * - Joins on mount, leaves on unmount (with sendBeacon fallback for tab close)
+ * - Subscribes to presence Pusher channel
+ * - Broadcasts cursor position (throttled) and selection changes
+ * - Prunes stale entries client-side every 15s
+ * - Filters own userId from returned array
+ */
+export function useCanvasCollaboration({
+  githubLogin,
+  canvasRef,
+  userId,
+  userName,
+  viewportRef,
+  containerRef,
+  selectedNodeId,
+  enabled = true,
+}: UseCanvasCollaborationOptions): UseCanvasCollaborationResult {
+  const [collaboratorMap, setCollaboratorMap] = useState<
+    Map<string, CollaboratorState>
+  >(new Map());
+
+  const channelName =
+    enabled && userId
+      ? getCanvasPresenceChannelName(githubLogin, canvasRef)
+      : null;
+
+  const channel = usePusherChannel(channelName);
+
+  // Stable refs to avoid stale closures
+  const userIdRef = useRef(userId);
+  userIdRef.current = userId;
+  const userNameRef = useRef(userName);
+  userNameRef.current = userName;
+  const githubLoginRef = useRef(githubLogin);
+  githubLoginRef.current = githubLogin;
+  const canvasRefRef = useRef(canvasRef);
+  canvasRefRef.current = canvasRef;
+
+  // Upsert a collaborator in state
+  const upsertCollaborator = useCallback(
+    (id: string, patch: Partial<CollaboratorState>) => {
+      setCollaboratorMap((prev) => {
+        const next = new Map(prev);
+        const existing = next.get(id) ?? {
+          id,
+          name: "",
+          color: teamAvatarColor(id),
+          cursor: null,
+          selectedNodeId: null,
+          lastSeenAt: Date.now(),
+        };
+        next.set(id, { ...existing, ...patch, lastSeenAt: Date.now() });
+        return next;
+      });
+    },
+    [],
+  );
+
+  // Remove a collaborator
+  const removeCollaborator = useCallback((id: string) => {
+    setCollaboratorMap((prev) => {
+      if (!prev.has(id)) return prev;
+      const next = new Map(prev);
+      next.delete(id);
+      return next;
+    });
+  }, []);
+
+  // Bind Pusher events
+  useEffect(() => {
+    if (!channel) return;
+
+    const onJoin = (data: {
+      user: { id: string; name: string; color: string };
+    }) => {
+      if (data.user.id === userIdRef.current) return;
+      upsertCollaborator(data.user.id, {
+        name: data.user.name,
+        color: data.user.color,
+        cursor: null,
+      });
+    };
+
+    const onLeave = (data: { userId: string }) => {
+      removeCollaborator(data.userId);
+    };
+
+    const onCursor = (data: {
+      senderId: string;
+      cursor: { x: number; y: number };
+      color: string;
+    }) => {
+      if (data.senderId === userIdRef.current) return;
+      upsertCollaborator(data.senderId, {
+        cursor: data.cursor,
+        color: data.color,
+      });
+    };
+
+    const onSelection = (data: {
+      senderId: string;
+      selectedNodeId: string | null;
+    }) => {
+      if (data.senderId === userIdRef.current) return;
+      upsertCollaborator(data.senderId, {
+        selectedNodeId: data.selectedNodeId,
+      });
+    };
+
+    channel.bind(PUSHER_EVENTS.CANVAS_USER_JOIN, onJoin);
+    channel.bind(PUSHER_EVENTS.CANVAS_USER_LEAVE, onLeave);
+    channel.bind(PUSHER_EVENTS.CANVAS_CURSOR_UPDATE, onCursor);
+    channel.bind(PUSHER_EVENTS.CANVAS_SELECTION_UPDATE, onSelection);
+
+    return () => {
+      channel.unbind(PUSHER_EVENTS.CANVAS_USER_JOIN, onJoin);
+      channel.unbind(PUSHER_EVENTS.CANVAS_USER_LEAVE, onLeave);
+      channel.unbind(PUSHER_EVENTS.CANVAS_CURSOR_UPDATE, onCursor);
+      channel.unbind(PUSHER_EVENTS.CANVAS_SELECTION_UPDATE, onSelection);
+    };
+  }, [channel, upsertCollaborator, removeCollaborator]);
+
+  // Join on mount, leave on unmount
+  useEffect(() => {
+    if (!enabled || !userId) return;
+
+    const login = githubLoginRef.current;
+    const ref = canvasRefRef.current;
+    const color = teamAvatarColor(userId);
+    const name = userNameRef.current;
+
+    postCollabEvent(login, {
+      type: "join",
+      canvasRef: ref,
+      user: { id: userId, name, color },
+    });
+
+    const leavePayload = JSON.stringify({
+      type: "leave",
+      canvasRef: ref,
+    });
+    const leaveUrl = `/api/orgs/${login}/canvas/collaboration`;
+
+    const sendLeave = () => {
+      navigator.sendBeacon(
+        leaveUrl,
+        new Blob([leavePayload], { type: "application/json" }),
+      );
+    };
+
+    window.addEventListener("beforeunload", sendLeave);
+
+    return () => {
+      window.removeEventListener("beforeunload", sendLeave);
+      postCollabEvent(login, { type: "leave", canvasRef: ref });
+      // Clear collaborators for this canvas on cleanup
+      setCollaboratorMap(new Map());
+    };
+  }, [githubLogin, canvasRef, userId, enabled]);
+
+  // Broadcast cursor via pointermove (throttled ~20fps)
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || !enabled || !userId) return;
+
+    let lastFired = 0;
+
+    const onMove = (e: PointerEvent) => {
+      const now = Date.now();
+      if (now - lastFired < CURSOR_THROTTLE_MS) return;
+      lastFired = now;
+
+      const vp = viewportRef.current;
+      if (!vp) return;
+
+      const rect = el.getBoundingClientRect();
+      const screenX = e.clientX - rect.left;
+      const screenY = e.clientY - rect.top;
+
+      // Convert screen → canvas space: canvas = (screen - offset) / zoom
+      const canvasX = (screenX - vp.x) / vp.zoom;
+      const canvasY = (screenY - vp.y) / vp.zoom;
+
+      postCollabEvent(githubLoginRef.current, {
+        type: "cursor",
+        canvasRef: canvasRefRef.current,
+        senderId: userId,
+        cursor: { x: canvasX, y: canvasY },
+        color: teamAvatarColor(userId),
+      });
+    };
+
+    el.addEventListener("pointermove", onMove);
+    return () => el.removeEventListener("pointermove", onMove);
+  }, [containerRef, viewportRef, userId, enabled]);
+
+  // Broadcast selection changes
+  const prevSelectedNodeId = useRef<string | null | undefined>(undefined);
+  useEffect(() => {
+    if (!enabled || !userId) return;
+    // Skip the initial undefined → null transition (first render with no selection)
+    if (
+      prevSelectedNodeId.current === undefined &&
+      (selectedNodeId === null || selectedNodeId === undefined)
+    ) {
+      prevSelectedNodeId.current = selectedNodeId ?? null;
+      return;
+    }
+    if (prevSelectedNodeId.current === (selectedNodeId ?? null)) return;
+    prevSelectedNodeId.current = selectedNodeId ?? null;
+
+    postCollabEvent(githubLoginRef.current, {
+      type: "selection",
+      canvasRef: canvasRefRef.current,
+      senderId: userId,
+      selectedNodeId: selectedNodeId ?? null,
+    });
+  }, [selectedNodeId, userId, enabled]);
+
+  // Client-side TTL pruning every 15s
+  useEffect(() => {
+    if (!enabled) return;
+    const interval = setInterval(() => {
+      const cutoff = Date.now() - CLIENT_TTL_MS;
+      setCollaboratorMap((prev) => {
+        let changed = false;
+        const next = new Map(prev);
+        for (const [id, entry] of prev) {
+          if (entry.lastSeenAt < cutoff) {
+            next.delete(id);
+            changed = true;
+          }
+        }
+        return changed ? next : prev;
+      });
+    }, PRUNE_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [enabled]);
+
+  // Derive collaborators array (self-filtered)
+  const collaborators: CanvasCollaboratorInfo[] = Array.from(
+    collaboratorMap.values(),
+  )
+    .filter((c) => c.id !== userId)
+    .map(({ lastSeenAt: _last, ...rest }) => rest);
+
+  return { collaborators };
+}

--- a/src/lib/canvas/presence-channel.ts
+++ b/src/lib/canvas/presence-channel.ts
@@ -1,0 +1,12 @@
+/**
+ * Derive a Pusher-safe channel name for a canvas presence room.
+ * Colons and other non-alphanumeric characters (except `_`, `-`, `=`, `@`)
+ * are replaced with hyphens to satisfy Pusher's channel name restrictions.
+ */
+export function getCanvasPresenceChannelName(
+  githubLogin: string,
+  canvasRef: string,
+): string {
+  const safeRef = (canvasRef || "root").replace(/[^a-zA-Z0-9_\-=@]/g, "-");
+  return `canvas-presence-${githubLogin}-${safeRef}`;
+}

--- a/src/lib/canvas/presence-store.ts
+++ b/src/lib/canvas/presence-store.ts
@@ -1,0 +1,94 @@
+/**
+ * In-memory presence store for canvas collaborators.
+ *
+ * IMPORTANT: this store is per-Node-process. In a multi-instance deployment
+ * (e.g. Vercel autoscale, multiple containers behind a load balancer) each
+ * instance will only see the subset of presence events that landed on it.
+ * Worst case we degrade to the prior behaviour rather than break.
+ *
+ * Entries are kept fresh by `recordHeartbeat` (called from join/cursor events)
+ * and pruned with a TTL of 60 seconds. Explicit `recordLeave` removes entries
+ * immediately when the user closes the tab.
+ *
+ * Room key format: `${githubLogin}:${canvasRef || 'root'}`
+ */
+
+export interface CanvasPresenceEntry {
+  userId: string;
+  name: string | null;
+  color?: string;
+  joinedAt: number;
+  lastSeenAt: number;
+}
+
+const PRESENCE_TTL_MS = 60_000;
+
+const presenceByCanvas = new Map<string, Map<string, CanvasPresenceEntry>>();
+
+function getRoom(roomKey: string): Map<string, CanvasPresenceEntry> {
+  let room = presenceByCanvas.get(roomKey);
+  if (!room) {
+    room = new Map();
+    presenceByCanvas.set(roomKey, room);
+  }
+  return room;
+}
+
+function pruneRoom(room: Map<string, CanvasPresenceEntry>, now: number) {
+  for (const [userId, entry] of room) {
+    if (now - entry.lastSeenAt > PRESENCE_TTL_MS) {
+      room.delete(userId);
+    }
+  }
+}
+
+/** Record or refresh a user's presence in a canvas room. */
+export function recordHeartbeat(
+  roomKey: string,
+  entry: Omit<CanvasPresenceEntry, "lastSeenAt" | "joinedAt"> & {
+    joinedAt?: number;
+  },
+): void {
+  const room = getRoom(roomKey);
+  const now = Date.now();
+  const existing = room.get(entry.userId);
+  room.set(entry.userId, {
+    userId: entry.userId,
+    name: entry.name ?? existing?.name ?? null,
+    color: entry.color ?? existing?.color,
+    joinedAt: existing?.joinedAt ?? entry.joinedAt ?? now,
+    lastSeenAt: now,
+  });
+}
+
+/** Remove a user from a canvas room (e.g. on explicit leave / beforeunload). */
+export function recordLeave(roomKey: string, userId: string): void {
+  const room = presenceByCanvas.get(roomKey);
+  if (!room) return;
+  room.delete(userId);
+  if (room.size === 0) presenceByCanvas.delete(roomKey);
+}
+
+/**
+ * Get the currently-active collaborators for a canvas room, excluding the
+ * caller. Stale entries (older than {@link PRESENCE_TTL_MS}) are pruned.
+ */
+export function getActivePresence(
+  roomKey: string,
+  excludeUserId?: string,
+): CanvasPresenceEntry[] {
+  const room = presenceByCanvas.get(roomKey);
+  if (!room) return [];
+  pruneRoom(room, Date.now());
+  const entries: CanvasPresenceEntry[] = [];
+  for (const entry of room.values()) {
+    if (entry.userId === excludeUserId) continue;
+    entries.push(entry);
+  }
+  return entries;
+}
+
+/** Test helper: clears all presence state. */
+export function __clearCanvasPresenceForTests() {
+  presenceByCanvas.clear();
+}

--- a/src/lib/pusher.ts
+++ b/src/lib/pusher.ts
@@ -75,6 +75,11 @@ export const PUSHER_EVENTS = {
   RESEARCH_UPDATED: "research-updated",
   // Canvas events (system-canvas document on the org)
   CANVAS_UPDATED: "canvas-updated",
+  // Canvas presence events (ephemeral — not persisted)
+  CANVAS_CURSOR_UPDATE: "canvas-cursor-update",
+  CANVAS_USER_JOIN: "canvas-user-join",
+  CANVAS_USER_LEAVE: "canvas-user-leave",
+  CANVAS_SELECTION_UPDATE: "canvas-selection-update",
   // Agent log upserted for a feature — triggers live Logs tab updates in plan view
   AGENT_LOG_UPDATED: "agent-log-updated",
 } as const;


### PR DESCRIPTION
## Summary

Implements the full Pusher transport layer for real-time canvas presence.

### Changes

- **`src/lib/canvas/presence-store.ts`** — In-memory TTL store (60s) keyed by `${githubLogin}:${canvasRef||root}`
- **`src/app/api/orgs/[githubLogin]/canvas/collaboration/route.ts`** — POST endpoint for join/leave/cursor/selection; org-membership gated; senderId always server-sourced (IDOR-safe)
- **`src/lib/pusher.ts`** — Added canvas presence event names to `PUSHER_EVENTS`
- **`src/hooks/useCanvasCollaboration.ts`** — Client hook: join/leave lifecycle, Pusher subscriptions, throttled cursor broadcast, selection broadcast, 15s TTL pruning, self-filtering
- **`src/app/org/[githubLogin]/connections/OrgCanvasBackground.tsx`** — Wired `useCanvasCollaboration` and passes `collaborators` to `<SystemCanvas>`

### Tests
- 26 unit tests across hook and presence-store