### PR TITLE
Fix send_to_task_agent routing to wrong Stakwork workflow

### DIFF
--- a/src/__tests__/unit/services/task-workflow.test.ts
+++ b/src/__tests__/unit/services/task-workflow.test.ts
@@ -711,9 +711,14 @@ describe("createChatMessageAndTriggerStakwork (via sendMessageToStakwork)", () =
   });
 
   describe("Mode-Based Workflow Selection", () => {
-    test("should use default workflow ID when mode not specified", async () => {
+    test("should inherit the task's mode (defaulting to 'live') when mode not specified", async () => {
       MockSetup.setupSuccessfulWorkflow();
 
+      // sendMessageToStakwork is only used by the MCP send_message /
+      // send_to_task_agent tools, which target a live task agent. It
+      // inherits task.mode and falls back to "live" (not the "default"
+      // test-mode workflow). The mock task has no `mode`, so this
+      // exercises the "live" fallback → workflowIds[0].
       await sendMessageToStakwork({
         taskId: "test-task-id",
         message: "Test message",
@@ -722,7 +727,7 @@ describe("createChatMessageAndTriggerStakwork (via sendMessageToStakwork)", () =
 
       const fetchCall = mockFetch.mock.calls[0];
       const payload = JSON.parse(fetchCall[1]?.body as string);
-      expect(payload.workflow_id).toBe(456); // Second ID in "123,456,789"
+      expect(payload.workflow_id).toBe(123); // First ID in "123,456,789" for live mode
     });
 
     test("should use workflow ID at index 0 for 'live' mode", async () => {

--- a/src/services/task-workflow.ts
+++ b/src/services/task-workflow.ts
@@ -233,6 +233,13 @@ export async function sendMessageToStakwork(params: {
     attachments,
     generateChatTitle,
     featureContext,
+    // This path only ever feeds the MCP `send_message` / `send_to_task_agent`
+    // tools (the function's sole callers). Inherit the target task's own mode
+    // so the workflow-selection ladder in callStakworkAPI routes to the right
+    // workflow — `live` → STAKWORK_TASK_WORKFLOW_ID, `workflow_editor` → the
+    // editor workflow, etc. Fall back to "live" (not the "default" test-mode
+    // workflow) when the task has no explicit mode.
+    mode: task.mode ?? "live",
   });
 }
 


### PR DESCRIPTION
## Problem

`sendMessageToStakwork` is used **only** by the MCP `send_message` and `send_to_task_agent` tools (every other reference is a test). It never forwarded a `mode`, so it defaulted to `"default"`.

In `callStakworkAPI`, the workflow-selection ladder treats `"default"` as a fall-through to the final `else` → `STAKWORK_WORKFLOW_ID[1]` (the **test-mode** workflow), rather than `STAKWORK_TASK_WORKFLOW_ID`. As a result, plan-agent callbacks (e.g. "send a message to the task agent to publish/re-run workflow X") were dispatched to the **wrong workflow**.

## Fix

`sendMessageToStakwork` now inherits the target task's own `mode`, falling back to `"live"` when null:

```ts
mode: task.mode ?? "live",
```

The task is fetched with `include`, so `task.mode` (Prisma `String @default("live")`) is already available — no schema/select change needed. This:

- routes live tasks → `STAKWORK_TASK_WORKFLOW_ID` (the real task agent),
- routes `workflow_editor` tasks → the editor workflow,
- never lands on the test-mode workflow again.

This matches how the chat UI dispatches follow-up messages (it sends `mode` from the task).

## Scope check (other MCP create paths)

- `mcpCreateFeatureTask` → `createTicket` passes `mode: undefined` for coding tasks → Prisma column default `"live"`. Already correct.
- `mcpCreateWorkflowTask` → `createTicket` sets `mode: "workflow_editor"`. Already correct, and now preserved on the message path too.

## Tests

- Updated the stale "default workflow ID when mode not specified" unit test to assert the new intended routing (live → `workflowIds[0]`).
- All 172 task-workflow tests and 19 mcpTools tests pass.