### PR TITLE
window undefined issue

### DIFF
--- a/src/components/workflow/index.tsx
+++ b/src/components/workflow/index.tsx
@@ -34,8 +34,8 @@ import WorkflowEdit from "./channels/WorkflowEdit";
 import EdgeButtons from "./EdgeButtons";
 
 let manualNavigation = false;
-let windowWidth = window.innerWidth;
-let windowHeight = window.innerHeight * 0.8;
+let windowWidth = typeof window !== "undefined" ? window.innerWidth : 1024;
+let windowHeight = typeof window !== "undefined" ? window.innerHeight * 0.8 : 800;
 
 const edgeTypes = {
   "custom-edge": EdgeButtons,


### PR DESCRIPTION
in vercel logs:

```
Unhandled Rejection: ReferenceError: window is not defined
    at 13499 (/var/task/.next/server/chunks/90157.js:133:11404)
    at c (/var/task/.next/server/webpack-runtime.js:1:205)
    at /var/task/.next/server/chunks/90157.js:141:34988
    at c.a (/var/task/.next/server/webpack-runtime.js:1:777)
    at 47002 (/var/task/.next/server/chunks/90157.js:141:34823)
    at c (/var/task/.next/server/webpack-runtime.js:1:205)
    at /var/task/.next/server/app/w/[slug]/task/[...taskParams]/page.js:20:25085
    at c.a (/var/task/.next/server/webpack-runtime.js:1:777)
    at 77971 (/var/task/.next/server/app/w/[slug]/task/[...taskParams]/page.js:20:24972)
    at c (/var/task/.next/server/webpack-runtime.js:1:205)
    at /var/task/.next/server/app/w/[slug]/task/[...taskParams]/page.js:2:15411
    at c.a (/var/task/.next/server/webpack-runtime.js:1:777)
    at 49005 (/var/task/.next/server/app/w/[slug]/task/[...taskParams]/page.js:2:15212)
    at Object.c [as require] (/var/task/.next/server/webpack-runtime.js:1:205)
    at Object.require (/var/task/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:21:17460)
    at globalThis.__next_require__ (/var/task/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:21:18029)
    at l (/var/task/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:2:134995)
    at c (/var/task/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:2:135418)
    at ep (/var/task/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:2:156363)
    at /var/task/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:2:159033
    at em (/var/task/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:2:159059)
    at t (/var/task/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:2:159902)
```