### PR TITLE
Fix stale view-only banner after network reconnect and harden session handling

### DIFF
--- a/src/__tests__/unit/components/PublicWorkspaceBanner.test.tsx
+++ b/src/__tests__/unit/components/PublicWorkspaceBanner.test.tsx
@@ -24,18 +24,13 @@ import { useWorkspace } from "@/hooks/useWorkspace";
 const mockUseSession = useSession as ReturnType<typeof vi.fn>;
 const mockUseWorkspace = useWorkspace as ReturnType<typeof vi.fn>;
 
+const publicViewableWorkspace = { isPublicViewable: true };
+const privateWorkspace = { isPublicViewable: false };
+
 describe("PublicWorkspaceBanner", () => {
   it("returns null when status is 'loading'", () => {
     mockUseSession.mockReturnValue({ status: "loading" });
-    mockUseWorkspace.mockReturnValue({ loading: false });
-
-    const { container } = render(<PublicWorkspaceBanner />);
-    expect(container.firstChild).toBeNull();
-  });
-
-  it("returns null when status is 'loading' regardless of workspace loading state", () => {
-    mockUseSession.mockReturnValue({ status: "loading" });
-    mockUseWorkspace.mockReturnValue({ loading: true });
+    mockUseWorkspace.mockReturnValue({ loading: false, isPublicViewer: false, workspace: null });
 
     const { container } = render(<PublicWorkspaceBanner />);
     expect(container.firstChild).toBeNull();
@@ -43,7 +38,7 @@ describe("PublicWorkspaceBanner", () => {
 
   it("returns null when workspace loading is true", () => {
     mockUseSession.mockReturnValue({ status: "unauthenticated" });
-    mockUseWorkspace.mockReturnValue({ loading: true });
+    mockUseWorkspace.mockReturnValue({ loading: true, isPublicViewer: true, workspace: publicViewableWorkspace });
 
     const { container } = render(<PublicWorkspaceBanner />);
     expect(container.firstChild).toBeNull();
@@ -51,15 +46,45 @@ describe("PublicWorkspaceBanner", () => {
 
   it("returns null when status is 'authenticated'", () => {
     mockUseSession.mockReturnValue({ status: "authenticated" });
-    mockUseWorkspace.mockReturnValue({ loading: false });
+    mockUseWorkspace.mockReturnValue({ loading: false, isPublicViewer: false, workspace: publicViewableWorkspace });
 
     const { container } = render(<PublicWorkspaceBanner />);
     expect(container.firstChild).toBeNull();
   });
 
-  it("renders the banner when status is 'unauthenticated' and workspace loading is false", () => {
+  it("returns null when isPublicViewer is false even if status is unauthenticated", () => {
     mockUseSession.mockReturnValue({ status: "unauthenticated" });
-    mockUseWorkspace.mockReturnValue({ loading: false });
+    mockUseWorkspace.mockReturnValue({ loading: false, isPublicViewer: false, workspace: publicViewableWorkspace });
+
+    const { container } = render(<PublicWorkspaceBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns null when workspace is not public-viewable (reconnect regression case)", () => {
+    // Simulates a transient unauthenticated flip on a non-public workspace —
+    // the banner must never appear in this scenario.
+    mockUseSession.mockReturnValue({ status: "unauthenticated" });
+    mockUseWorkspace.mockReturnValue({ loading: false, isPublicViewer: true, workspace: privateWorkspace });
+
+    const { container } = render(<PublicWorkspaceBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns null when workspace is null", () => {
+    mockUseSession.mockReturnValue({ status: "unauthenticated" });
+    mockUseWorkspace.mockReturnValue({ loading: false, isPublicViewer: false, workspace: null });
+
+    const { container } = render(<PublicWorkspaceBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the banner for a genuine public viewer on a public-viewable workspace", () => {
+    mockUseSession.mockReturnValue({ status: "unauthenticated" });
+    mockUseWorkspace.mockReturnValue({
+      loading: false,
+      isPublicViewer: true,
+      workspace: publicViewableWorkspace,
+    });
 
     render(<PublicWorkspaceBanner />);
     expect(

--- a/src/__tests__/unit/components/SessionProvider.test.tsx
+++ b/src/__tests__/unit/components/SessionProvider.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockSessionProvider = vi.fn();
+
+vi.mock("next-auth/react", () => ({
+  SessionProvider: (props: Record<string, unknown>) => {
+    mockSessionProvider(props);
+    return React.createElement(React.Fragment, null, props.children as React.ReactNode);
+  },
+}));
+
+import SessionProvider from "@/providers/SessionProvider";
+
+describe("SessionProvider", () => {
+  beforeEach(() => {
+    mockSessionProvider.mockClear();
+  });
+
+  it("passes refetchOnWindowFocus={false} to NextAuthSessionProvider", () => {
+    render(<SessionProvider><div /></SessionProvider>);
+    expect(mockSessionProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ refetchOnWindowFocus: false })
+    );
+  });
+
+  it("passes refetchWhenOffline={false} to NextAuthSessionProvider", () => {
+    render(<SessionProvider><div /></SessionProvider>);
+    expect(mockSessionProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ refetchWhenOffline: false })
+    );
+  });
+});

--- a/src/components/workspace/PublicWorkspaceBanner.tsx
+++ b/src/components/workspace/PublicWorkspaceBanner.tsx
@@ -10,9 +10,9 @@ import { useWorkspace } from "@/hooks/useWorkspace";
 
 export function PublicWorkspaceBanner() {
   const { status } = useSession();
-  const { loading } = useWorkspace();
+  const { loading, isPublicViewer, workspace } = useWorkspace();
 
-  if (status === "loading" || loading || status !== "unauthenticated") return null;
+  if (status === "loading" || loading || !isPublicViewer || !workspace?.isPublicViewable) return null;
 
   return (
     <Alert className="rounded-none border-x-0 border-t-0 bg-blue-50 dark:bg-blue-950/20 border-blue-200 dark:border-blue-800">

--- a/src/providers/SessionProvider.tsx
+++ b/src/providers/SessionProvider.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import React from "react";
 import { SessionProvider as NextAuthSessionProvider } from "next-auth/react";
 import { ReactNode } from "react";
 
@@ -10,9 +11,8 @@ interface SessionProviderProps {
 export default function SessionProvider({ children }: SessionProviderProps) {
   return (
     <NextAuthSessionProvider
-    // Disable automatic session refetch on window focus to prevent network errors
-    // Reduce refetch interval to prevent excessive requests
-
+      refetchOnWindowFocus={false}
+      refetchWhenOffline={false}
     >
       {children}
     </NextAuthSessionProvider>


### PR DESCRIPTION
Generated with Hive: Fix stale view-only banner after network reconnect and harden session handling