### PR TITLE
Preserve workflowTaskType and workflowVersionId when duplicating workflow tasks

### DIFF
--- a/src/__tests__/unit/components/features/CompactTasksList.test.tsx
+++ b/src/__tests__/unit/components/features/CompactTasksList.test.tsx
@@ -2468,6 +2468,8 @@ describe("CompactTasksList", () => {
           workflowId: 99,
           workflowName: "My Workflow",
           workflowRefId: "ref-abc",
+          workflowTaskType: null,
+          workflowVersionId: null,
         },
       });
       const feature = createMockFeature([task]);
@@ -2533,6 +2535,147 @@ describe("CompactTasksList", () => {
       expect(capturedBodies[0].workflowId).toBeUndefined();
       expect(capturedBodies[0].workflowName).toBeUndefined();
       expect(capturedBodies[0].workflowRefId).toBeUndefined();
+    });
+
+    test("9. workflow_editor task — POST body includes workflowTaskType and workflowVersionId", async () => {
+      const user = userEvent.setup();
+      const task = createMockTask({
+        id: "task-wf-type-dup",
+        dependsOnTaskIds: [],
+        workflowTask: {
+          id: "wt-type-dup",
+          taskId: "task-wf-type-dup",
+          workflowId: 55,
+          workflowName: "Prompt Workflow",
+          workflowRefId: "ref-prompt",
+          workflowTaskType: "PROMPT",
+          workflowVersionId: "version-v1-abc",
+        },
+      });
+      const feature = createMockFeature([task]);
+      const capturedBodies: any[] = [];
+
+      vi.spyOn(globalThis, "fetch").mockImplementation((url: any, init: any) => {
+        const urlStr = typeof url === "string" ? url : String(url);
+        if (urlStr.includes("/api/llm-models")) {
+          return Promise.resolve(new Response(JSON.stringify({ models: [] }), { status: 200 }));
+        }
+        if (urlStr.includes("/api/features/feature-1/tickets") && init?.method === "POST") {
+          capturedBodies.push(JSON.parse(init.body));
+          return Promise.resolve(new Response(JSON.stringify({ success: true, data: { id: "new-prompt-task-id", title: task.title, dependsOnTaskIds: [] } }), { status: 200 }));
+        }
+        return Promise.resolve(new Response(JSON.stringify({ success: true, data: { id: "feature-1", phases: [{ id: "phase-1", tasks: [] }] } }), { status: 200 }));
+      });
+
+      render(
+        <CompactTasksList feature={feature} featureId="feature-1" isGenerating={false} onUpdate={vi.fn()} />
+      );
+
+      const duplicateBtn = await screen.findByTestId("action-duplicate");
+      await user.click(duplicateBtn);
+
+      await waitFor(() => {
+        expect(capturedBodies).toHaveLength(1);
+      });
+
+      expect(capturedBodies[0].workflowId).toBe(55);
+      expect(capturedBodies[0].workflowTaskType).toBe("PROMPT");
+      expect(capturedBodies[0].workflowVersionId).toBe("version-v1-abc");
+    });
+
+    test("10. isNewWorkflow task — POST body includes workflowTaskType, omits workflowVersionId", async () => {
+      const user = userEvent.setup();
+      const task = createMockTask({
+        id: "task-new-wf-dup",
+        dependsOnTaskIds: [],
+        workflowTask: {
+          id: "wt-new-dup",
+          taskId: "task-new-wf-dup",
+          workflowId: null,
+          workflowName: null,
+          workflowRefId: null,
+          workflowTaskType: "SCRIPT",
+          workflowVersionId: null,
+        },
+      });
+      const feature = createMockFeature([task]);
+      const capturedBodies: any[] = [];
+
+      vi.spyOn(globalThis, "fetch").mockImplementation((url: any, init: any) => {
+        const urlStr = typeof url === "string" ? url : String(url);
+        if (urlStr.includes("/api/llm-models")) {
+          return Promise.resolve(new Response(JSON.stringify({ models: [] }), { status: 200 }));
+        }
+        if (urlStr.includes("/api/features/feature-1/tickets") && init?.method === "POST") {
+          capturedBodies.push(JSON.parse(init.body));
+          return Promise.resolve(new Response(JSON.stringify({ success: true, data: { id: "new-script-task-id", title: task.title, dependsOnTaskIds: [] } }), { status: 200 }));
+        }
+        return Promise.resolve(new Response(JSON.stringify({ success: true, data: { id: "feature-1", phases: [{ id: "phase-1", tasks: [] }] } }), { status: 200 }));
+      });
+
+      render(
+        <CompactTasksList feature={feature} featureId="feature-1" isGenerating={false} onUpdate={vi.fn()} />
+      );
+
+      const duplicateBtn = await screen.findByTestId("action-duplicate");
+      await user.click(duplicateBtn);
+
+      await waitFor(() => {
+        expect(capturedBodies).toHaveLength(1);
+      });
+
+      expect(capturedBodies[0].isNewWorkflow).toBe(true);
+      expect(capturedBodies[0].workflowTaskType).toBe("SCRIPT");
+      expect(capturedBodies[0].workflowId).toBeUndefined();
+    });
+
+    test("11. workflow_editor task with null workflowTaskType/workflowVersionId — POST body omits both", async () => {
+      const user = userEvent.setup();
+      const task = createMockTask({
+        id: "task-null-fields-dup",
+        dependsOnTaskIds: [],
+        workflowTask: {
+          id: "wt-null-dup",
+          taskId: "task-null-fields-dup",
+          workflowId: 77,
+          workflowName: "Null Fields Workflow",
+          workflowRefId: "ref-null",
+          workflowTaskType: null,
+          workflowVersionId: null,
+        },
+      });
+      const feature = createMockFeature([task]);
+      const capturedBodies: any[] = [];
+
+      vi.spyOn(globalThis, "fetch").mockImplementation((url: any, init: any) => {
+        const urlStr = typeof url === "string" ? url : String(url);
+        if (urlStr.includes("/api/llm-models")) {
+          return Promise.resolve(new Response(JSON.stringify({ models: [] }), { status: 200 }));
+        }
+        if (urlStr.includes("/api/features/feature-1/tickets") && init?.method === "POST") {
+          capturedBodies.push(JSON.parse(init.body));
+          return Promise.resolve(new Response(JSON.stringify({ success: true, data: { id: "new-null-task-id", title: task.title, dependsOnTaskIds: [] } }), { status: 200 }));
+        }
+        return Promise.resolve(new Response(JSON.stringify({ success: true, data: { id: "feature-1", phases: [{ id: "phase-1", tasks: [] }] } }), { status: 200 }));
+      });
+
+      render(
+        <CompactTasksList feature={feature} featureId="feature-1" isGenerating={false} onUpdate={vi.fn()} />
+      );
+
+      const duplicateBtn = await screen.findByTestId("action-duplicate");
+      await user.click(duplicateBtn);
+
+      await waitFor(() => {
+        expect(capturedBodies).toHaveLength(1);
+      });
+
+      // null fields become undefined (not included in JSON serialization)
+      expect(capturedBodies[0].workflowTaskType).toBeUndefined();
+      expect(capturedBodies[0].workflowVersionId).toBeUndefined();
+      // Existing fields still present
+      expect(capturedBodies[0].workflowId).toBe(77);
+      expect(capturedBodies[0].workflowName).toBe("Null Fields Workflow");
     });
   });
 

--- a/src/__tests__/unit/services/roadmap/tickets-workflow-task-type.test.ts
+++ b/src/__tests__/unit/services/roadmap/tickets-workflow-task-type.test.ts
@@ -211,6 +211,67 @@ describe("createTicket — workflowTaskType", () => {
       data: expect.objectContaining({ workflowTaskType: "PROMPT" }),
     });
   });
+
+  it("persists workflowVersionId on WorkflowTask when workflowId is provided", async () => {
+    await createTicket("feature-1", "user-1", {
+      title: "Versioned Task",
+      workflowId: 10,
+      workflowName: "my-workflow",
+      workflowRefId: "ref-1",
+      workflowTaskType: "PROMPT",
+      workflowVersionId: "version-abc-123",
+    });
+
+    expect(mockDbWorkflowTask.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        workflowTaskType: "PROMPT",
+        workflowVersionId: "version-abc-123",
+      }),
+    });
+  });
+
+  it("persists workflowVersionId on isNewWorkflow task", async () => {
+    await createTicket("feature-1", "user-1", {
+      title: "New Workflow Versioned",
+      isNewWorkflow: true,
+      workflowTaskType: "SCRIPT",
+      workflowVersionId: "version-xyz-456",
+    });
+
+    expect(mockDbWorkflowTask.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        taskId: "task-1",
+        workflowId: null,
+        workflowTaskType: "SCRIPT",
+        workflowVersionId: "version-xyz-456",
+      }),
+    });
+  });
+
+  it("persists null workflowVersionId when not provided (workflowId branch)", async () => {
+    await createTicket("feature-1", "user-1", {
+      title: "No Version Task",
+      workflowId: 99,
+      workflowName: "untyped",
+      workflowTaskType: "WORKFLOW",
+    });
+
+    expect(mockDbWorkflowTask.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ workflowVersionId: null }),
+    });
+  });
+
+  it("persists null workflowVersionId when not provided (isNewWorkflow branch)", async () => {
+    await createTicket("feature-1", "user-1", {
+      title: "No Version New Workflow",
+      isNewWorkflow: true,
+      workflowTaskType: "PROMPT",
+    });
+
+    expect(mockDbWorkflowTask.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ workflowVersionId: null }),
+    });
+  });
 });
 
 describe("updateTicket — workflowTaskType", () => {

--- a/src/components/features/CompactTasksList/index.tsx
+++ b/src/components/features/CompactTasksList/index.tsx
@@ -379,11 +379,16 @@ export function CompactTasksList({ featureId, feature, onUpdate, isGenerating }:
           dependsOnTaskIds: task.dependsOnTaskIds ?? [],
           // Carry forward workflow identity for workflow_editor tasks
           ...(task.workflowTask && task.workflowTask.workflowId == null
-            ? { isNewWorkflow: true }
+            ? {
+                isNewWorkflow: true,
+                workflowTaskType: task.workflowTask?.workflowTaskType ?? undefined,
+              }
             : {
                 workflowId: task.workflowTask?.workflowId ?? undefined,
                 workflowName: task.workflowTask?.workflowName ?? undefined,
                 workflowRefId: task.workflowTask?.workflowRefId ?? undefined,
+                workflowTaskType: task.workflowTask?.workflowTaskType ?? undefined,
+                workflowVersionId: task.workflowTask?.workflowVersionId ?? undefined,
               }),
         }),
       });

--- a/src/services/roadmap/tickets.ts
+++ b/src/services/roadmap/tickets.ts
@@ -298,6 +298,7 @@ export async function createTicket(
         workflowName: data.workflowName ?? null,
         workflowRefId: data.workflowRefId ?? null,
         workflowTaskType: data.workflowTaskType ?? null,
+        workflowVersionId: data.workflowVersionId ?? null,
       },
     });
 
@@ -316,6 +317,7 @@ export async function createTicket(
         workflowName: null,
         workflowRefId: null,
         workflowTaskType: data.workflowTaskType ?? null,
+        workflowVersionId: data.workflowVersionId ?? null,
       },
     });
   }

--- a/src/types/roadmap.tsx
+++ b/src/types/roadmap.tsx
@@ -698,6 +698,7 @@ export interface CreateRoadmapTaskRequest {
   workflowId?: number;
   workflowName?: string;
   workflowRefId?: string;
+  workflowVersionId?: string;
   /** true = workflow_editor task targeting a brand-new workflow; mutually exclusive with workflowId */
   isNewWorkflow?: boolean;
   workflowTaskType?: import("@prisma/client").WorkflowTaskType;


### PR DESCRIPTION
Generated with Hive: Preserve workflowTaskType and workflowVersionId when duplicating workflow tasks