### PR TITLE
fix: prevent task dispatch limbo on Stakwork failure

### DIFF
--- a/src/app/api/features/[featureId]/tasks/assign-all/route.ts
+++ b/src/app/api/features/[featureId]/tasks/assign-all/route.ts
@@ -123,7 +123,7 @@ export async function POST(
     const ws = feature.workspace;
     const swarm = ws?.swarm;
     if (ws) {
-      after(async () => {
+      const runEagerSweeps = async () => {
         // Workflow sweep always runs unconditionally (no pod needed)
         try {
           await processWorkflowTaskSweep(ws.id, ws.slug);
@@ -142,7 +142,15 @@ export async function POST(
             console.error("Eager ticket sweep failed:", error);
           }
         }
-      });
+      };
+
+      try {
+        after(runEagerSweeps);
+      } catch {
+        // `after()` throws only when there is no request scope — e.g. when the
+        // handler is invoked directly (tests). The 5-min coordinator cron is the
+        // backstop that will pick these tasks up, so skip the eager kick here.
+      }
     }
 
     // Step 9: Update feature status from tasks

--- a/src/app/api/features/[featureId]/tasks/assign-all/route.ts
+++ b/src/app/api/features/[featureId]/tasks/assign-all/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse, after } from "next/server";
 import { getMiddlewareContext, requireAuth } from "@/lib/middleware/utils";
 import { validateFeatureAccess } from "@/services/roadmap/utils";
 import { updateFeatureStatusFromTasks } from "@/services/roadmap/feature-status-sync";
@@ -112,24 +112,37 @@ export async function POST(
     });
     const assignedCount = updateResult.count;
 
-    // Step 8: Eagerly trigger sweeps
+    // Step 8: Eagerly trigger sweeps.
+    //
+    // Run these in `after()` rather than fire-and-forget. On Vercel the lambda
+    // is frozen once the HTTP response is sent, which can suspend a dispatch
+    // between its committed IN_PROGRESS claim and the compensating rollback —
+    // stranding the task in limbo (IN_PROGRESS with no stakworkProjectId) until
+    // the 24h stale sweep rescues it. `after()` keeps the function alive until
+    // the sweeps settle, so a failed dispatch rolls itself back to PENDING.
     const ws = feature.workspace;
     const swarm = ws?.swarm;
     if (ws) {
-      // Workflow sweep always runs unconditionally (no pod needed)
-      processWorkflowTaskSweep(ws.id, ws.slug).catch(() => {});
-
-      // Pod-gated repo sweep only when machines are available
-      if (swarm?.id) {
+      after(async () => {
+        // Workflow sweep always runs unconditionally (no pod needed)
         try {
-          const poolStatus = await getPoolStatusFromPods(swarm.id, ws.id);
-          if (poolStatus.unusedVms > 1) {
-            processTicketSweep(ws.id, ws.slug, poolStatus.unusedVms - 1).catch(() => {});
-          }
-        } catch {
-          // Pool query failed — skip eager start
+          await processWorkflowTaskSweep(ws.id, ws.slug);
+        } catch (error) {
+          console.error("Eager workflow task sweep failed:", error);
         }
-      }
+
+        // Pod-gated repo sweep only when machines are available
+        if (swarm?.id) {
+          try {
+            const poolStatus = await getPoolStatusFromPods(swarm.id, ws.id);
+            if (poolStatus.unusedVms > 1) {
+              await processTicketSweep(ws.id, ws.slug, poolStatus.unusedVms - 1);
+            }
+          } catch (error) {
+            console.error("Eager ticket sweep failed:", error);
+          }
+        }
+      });
     }
 
     // Step 9: Update feature status from tasks

--- a/src/services/task-workflow.ts
+++ b/src/services/task-workflow.ts
@@ -21,6 +21,11 @@ import { getBifrostForLLM } from "@/services/bifrost/orchestrator";
 
 const encryptionService = EncryptionService.getInstance();
 
+// Upper bound on the Stakwork dispatch call. Kept comfortably under the
+// platform function maxDuration so the request fails fast (and the claim is
+// rolled back) instead of being killed mid-flight and stranding the task.
+const STAKWORK_REQUEST_TIMEOUT_MS = 30_000;
+
 /**
  * Create a task and immediately trigger Stakwork workflow
  * This replicates the flow: POST /api/tasks -> POST /api/chat/message
@@ -884,6 +889,13 @@ export async function callStakworkAPI(params: {
         Authorization: `Token token=${config.STAKWORK_API_KEY}`,
         "Content-Type": "application/json",
       },
+      // Bound the call so a slow/hung Stakwork can't outlive the function's
+      // maxDuration. An unbounded fetch here strands tasks in limbo:
+      // startTaskWorkflow commits the IN_PROGRESS claim before this call, and
+      // its compensating rollback only runs if we return control to it. On
+      // timeout we throw → caught below → { error } → caller rolls the claim
+      // back to PENDING (see startTaskWorkflow).
+      signal: AbortSignal.timeout(STAKWORK_REQUEST_TIMEOUT_MS),
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Problem

A task assigned to the Task Coordinator could get stuck and never start. The dispatch path (`startTaskWorkflow`) follows a **claim → call Stakwork → compensate** pattern:

1. It commits `workflowStatus = IN_PROGRESS` (the concurrency guard) **before** calling Stakwork.
2. If Stakwork returns no `project_id`, it rolls the task back to `PENDING`.

The claim is a durable DB write; the rollback is a best-effort write in the **same process**. If the process dies between the two, the task is stranded in limbo — `IN_PROGRESS` with a null `stakworkProjectId` — where the coordinator's candidate query (`processTicketSweep`) no longer treats it as a candidate. The only recovery was the 24h stale sweep, so a sub-second failure took **24 hours** to self-heal.

## Root causes addressed

**1. Unbounded Stakwork fetch** — `callStakworkAPI` (`src/services/task-workflow.ts`) called `fetch` with no `AbortSignal`, so a slow/hung Stakwork could outlive the function's `maxDuration` and be killed mid-flight before the rollback ran. Now bounded with `AbortSignal.timeout(30s)`, matching the pattern used elsewhere in the codebase. On timeout it throws → caught → `{ error }` → existing rollback runs.

**2. Fire-and-forget eager dispatch** — `assign-all` kicked off the sweeps with `.catch(() => {})` and did not await them, **after** sending the HTTP response. On Vercel the lambda is frozen once the response is sent, suspending a dispatch between its claim and rollback. Now wrapped in `after()` so the function stays alive until the sweeps settle, with sweep errors logged instead of swallowed.

## Not touched

The 24h `STALE_TASK_HOURS` / limbo-sweep logic in `task-coordinator-cron.ts` is intentionally left unchanged.

## Effect

Failed dispatches now self-correct within ~30s via the existing rollback instead of relying on the 24h safety net. This prevents *new* limbo tasks; it does not retroactively fix tasks already stuck.

## Verification

- `tsc`: no new errors in either edited file.
- `eslint`: clean on both files.