### PR TITLE
Generated with Hive: Fix code block long line wrapping in MarkdownRenderer

### DIFF
--- a/src/__tests__/unit/components/MarkdownRenderer.test.tsx
+++ b/src/__tests__/unit/components/MarkdownRenderer.test.tsx
@@ -8,6 +8,31 @@ vi.mock('@/hooks/use-theme', () => ({
   useTheme: () => ({ resolvedTheme: 'light' }),
 }));
 
+// Mock SyntaxHighlighter to capture props
+vi.mock('react-syntax-highlighter', () => ({
+  Prism: (props: Record<string, unknown>) => {
+    return React.createElement('pre', { 'data-wrap-long-lines': String(props.wrapLongLines) }, props.children as React.ReactNode);
+  },
+}));
+vi.mock('react-syntax-highlighter/dist/cjs/styles/prism', () => ({
+  tomorrow: {},
+}));
+
+describe('MarkdownRenderer — code block wrapLongLines', () => {
+  it('passes wrapLongLines={true} to SyntaxHighlighter for fenced code blocks', async () => {
+    const longLine = 'a'.repeat(300);
+    const markdown = `\`\`\`js\n${longLine}\n\`\`\``;
+    const { container } = render(
+      <MarkdownRenderer>{markdown}</MarkdownRenderer>
+    );
+    await waitFor(() => {
+      const pre = container.querySelector('pre[data-wrap-long-lines]');
+      expect(pre).not.toBeNull();
+      expect(pre?.getAttribute('data-wrap-long-lines')).toBe('true');
+    });
+  });
+});
+
 describe('MarkdownRenderer — feature image URL resolution', () => {
   beforeEach(() => {
     vi.resetAllMocks();

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -353,6 +353,7 @@ const createComponents = (
       <SyntaxHighlighter
         PreTag="pre"
         wrapLines={true}
+        wrapLongLines={true}
         language={match[1]}
         style={tomorrow}
       >


### PR DESCRIPTION
Fix code block long line wrapping in MarkdownRenderer