### PR TITLE
Fix canvas chat auto-save to wait for stream completion before persisting tool call outputs

### DIFF
--- a/src/__tests__/unit/canvas/canvasChatStore.test.ts
+++ b/src/__tests__/unit/canvas/canvasChatStore.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+import { useCanvasChatStore } from "@/app/org/[githubLogin]/_state/canvasChatStore";
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+const baseContext = {
+  workspaceSlug: null,
+  workspaceSlugs: [],
+  orgId: "org-1",
+  githubLogin: "test-org",
+  currentCanvasRef: "root",
+  currentCanvasBreadcrumb: "",
+  selectedNodeId: null,
+  selectedNodeIds: [],
+};
+
+function freshStore() {
+  // Reset the store to initial state between tests
+  useCanvasChatStore.setState({
+    conversations: {},
+    activeConversationId: null,
+    ephemeralSeedCounts: {},
+    pendingInputDraft: null,
+    proposals: {},
+    subAgentRuns: {},
+    artifacts: {},
+    dismissedArtifactIds: {},
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("canvasChatStore — isStreaming", () => {
+  beforeEach(freshStore);
+
+  it("initialises isStreaming=false when startConversation is called", () => {
+    const id = useCanvasChatStore.getState().startConversation(baseContext);
+    const conv = useCanvasChatStore.getState().conversations[id];
+    expect(conv).toBeDefined();
+    expect(conv.isStreaming).toBe(false);
+  });
+
+  it("setIsStreaming(true) sets isStreaming on the target conversation", () => {
+    const id = useCanvasChatStore.getState().startConversation(baseContext);
+    useCanvasChatStore.getState().setIsStreaming(id, true);
+    const conv = useCanvasChatStore.getState().conversations[id];
+    expect(conv.isStreaming).toBe(true);
+  });
+
+  it("setIsStreaming(false) clears isStreaming on the target conversation", () => {
+    const id = useCanvasChatStore.getState().startConversation(baseContext);
+    // Set to true first
+    useCanvasChatStore.getState().setIsStreaming(id, true);
+    expect(useCanvasChatStore.getState().conversations[id].isStreaming).toBe(true);
+    // Now clear
+    useCanvasChatStore.getState().setIsStreaming(id, false);
+    expect(useCanvasChatStore.getState().conversations[id].isStreaming).toBe(false);
+  });
+
+  it("setIsStreaming does not mutate other conversations", () => {
+    const id1 = useCanvasChatStore.getState().startConversation(baseContext);
+    const id2 = useCanvasChatStore.getState().startConversation(baseContext);
+
+    // Only set streaming on id1
+    useCanvasChatStore.getState().setIsStreaming(id1, true);
+
+    expect(useCanvasChatStore.getState().conversations[id1].isStreaming).toBe(true);
+    // id2 must remain untouched
+    expect(useCanvasChatStore.getState().conversations[id2].isStreaming).toBe(false);
+  });
+
+  it("setIsStreaming is a no-op for an unknown conversationId", () => {
+    const before = { ...useCanvasChatStore.getState().conversations };
+    useCanvasChatStore.getState().setIsStreaming("nonexistent-id", true);
+    // Store should be unchanged
+    expect(useCanvasChatStore.getState().conversations).toEqual(before);
+  });
+
+  it("isStreaming is independent of isLoading", () => {
+    const id = useCanvasChatStore.getState().startConversation(baseContext);
+
+    // They start out both false
+    expect(useCanvasChatStore.getState().conversations[id].isLoading).toBe(false);
+    expect(useCanvasChatStore.getState().conversations[id].isStreaming).toBe(false);
+
+    // Set isLoading=true — isStreaming must remain false
+    useCanvasChatStore.getState().setIsLoading(id, true);
+    expect(useCanvasChatStore.getState().conversations[id].isLoading).toBe(true);
+    expect(useCanvasChatStore.getState().conversations[id].isStreaming).toBe(false);
+
+    // Set isStreaming=true — isLoading must remain true
+    useCanvasChatStore.getState().setIsStreaming(id, true);
+    expect(useCanvasChatStore.getState().conversations[id].isLoading).toBe(true);
+    expect(useCanvasChatStore.getState().conversations[id].isStreaming).toBe(true);
+
+    // Clear isLoading — isStreaming still true
+    useCanvasChatStore.getState().setIsLoading(id, false);
+    expect(useCanvasChatStore.getState().conversations[id].isLoading).toBe(false);
+    expect(useCanvasChatStore.getState().conversations[id].isStreaming).toBe(true);
+  });
+});

--- a/src/__tests__/unit/canvas/useCanvasChatAutoSave.test.ts
+++ b/src/__tests__/unit/canvas/useCanvasChatAutoSave.test.ts
@@ -23,6 +23,7 @@ type ConvState = {
     {
       messages: Array<{ id: string; role: string; content: string }>;
       isLoading: boolean;
+      isStreaming: boolean;
       serverConversationId: string | null;
       context: ConvContext;
     }
@@ -97,12 +98,14 @@ function makeConv(
   overrides: Partial<{
     messages: ReturnType<typeof makeMsg>[];
     isLoading: boolean;
+    isStreaming: boolean;
     serverConversationId: string | null;
   }> = {},
 ) {
   return {
     messages: [],
     isLoading: false,
+    isStreaming: false,
     serverConversationId: null,
     context: baseContext,
     ...overrides,
@@ -215,7 +218,7 @@ describe("useCanvasChatAutoSave", () => {
     );
   });
 
-  it("does not save while isLoading=true (stream in progress)", async () => {
+  it("does not save while isStreaming=true (stream in progress)", async () => {
     const fetchSpy = vi.fn();
     global.fetch = fetchSpy;
 
@@ -229,12 +232,113 @@ describe("useCanvasChatAutoSave", () => {
     act(() => {
       _store.setState({
         conversations: {
-          "conv-1": makeConv({ messages: [makeMsg("user", "m1")], isLoading: true }),
+          "conv-1": makeConv({ messages: [makeMsg("user", "m1")], isStreaming: true }),
         },
       });
     });
 
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("saves even if isLoading=true as long as isStreaming=false", async () => {
+    // isLoading flips to false on first chunk (UX) but isStreaming stays true
+    // until the stream fully finishes. This test verifies the save gate only
+    // cares about isStreaming, not isLoading.
+    const fetchSpy = buildFetch("srv-x");
+    global.fetch = fetchSpy;
+
+    _store.setState({
+      activeConversationId: "conv-1",
+      conversations: { "conv-1": makeConv() },
+    });
+
+    renderHook(() => useCanvasChatAutoSave({ githubLogin: "my-org" }));
+
+    await act(async () => {
+      _store.setState({
+        conversations: {
+          "conv-1": makeConv({
+            messages: [makeMsg("user", "m1")],
+            isLoading: true,   // first-chunk UX flip — still "loading" visually
+            isStreaming: false, // but stream is done
+          }),
+        },
+      });
+      await Promise.resolve();
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/orgs/my-org/chat/conversations",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("does NOT save while isStreaming=true even if isLoading=false", async () => {
+    // Guard against a regression where isLoading-false alone would let
+    // mid-stream saves through.
+    const fetchSpy = vi.fn();
+    global.fetch = fetchSpy;
+
+    _store.setState({
+      activeConversationId: "conv-1",
+      conversations: { "conv-1": makeConv() },
+    });
+
+    renderHook(() => useCanvasChatAutoSave({ githubLogin: "my-org" }));
+
+    act(() => {
+      _store.setState({
+        conversations: {
+          "conv-1": makeConv({
+            messages: [makeMsg("user", "m1")],
+            isLoading: false,  // first-chunk flip has happened
+            isStreaming: true,  // but stream still in flight
+          }),
+        },
+      });
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("fires once isStreaming flips to false after being true", async () => {
+    const fetchSpy = buildFetch("srv-y");
+    global.fetch = fetchSpy;
+
+    _store.setState({
+      activeConversationId: "conv-1",
+      conversations: { "conv-1": makeConv() },
+    });
+
+    renderHook(() => useCanvasChatAutoSave({ githubLogin: "my-org" }));
+
+    // Stream in progress — should not save
+    act(() => {
+      _store.setState({
+        conversations: {
+          "conv-1": makeConv({
+            messages: [makeMsg("user", "m1"), makeMsg("assistant", "m2")],
+            isStreaming: true,
+          }),
+        },
+      });
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    // Stream completes — should now save
+    await act(async () => {
+      _store.setState({
+        conversations: {
+          "conv-1": makeConv({
+            messages: [makeMsg("user", "m1"), makeMsg("assistant", "m2")],
+            isStreaming: false,
+          }),
+        },
+      });
+      await Promise.resolve();
+    });
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
   });
 
   it("calls the org endpoint (not the workspace endpoint)", async () => {

--- a/src/__tests__/unit/canvas/useSendCanvasChatMessage.test.ts
+++ b/src/__tests__/unit/canvas/useSendCanvasChatMessage.test.ts
@@ -1,0 +1,261 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+// ── Mock useStreamProcessor ────────────────────────────────────────────────
+
+// We need to control when processStream resolves (and whether it throws)
+// so we can assert isStreaming mid-flight.
+let resolveStream: () => void = () => {};
+let rejectStream: (err: Error) => void = () => {};
+let streamPromise: Promise<void>;
+
+function resetStreamPromise() {
+  streamPromise = new Promise<void>((res, rej) => {
+    resolveStream = res;
+    rejectStream = rej;
+  });
+}
+
+vi.mock("@/lib/streaming", () => ({
+  useStreamProcessor: () => ({
+    processStream: vi.fn(
+      (_response: unknown, _messageId: unknown, onUpdate: (msg: unknown) => void) => {
+        // Immediately call onUpdate once to simulate a first chunk
+        onUpdate({ timeline: [] });
+        return streamPromise;
+      },
+    ),
+  }),
+}));
+
+// ── Mock canvasChatStore ───────────────────────────────────────────────────
+
+type ConvContext = {
+  workspaceSlug: string | null;
+  workspaceSlugs: string[];
+  orgId: string;
+  githubLogin: string;
+  currentCanvasRef: string;
+  currentCanvasBreadcrumb: string;
+  selectedNodeId: string | null;
+  selectedNodeIds: string[];
+};
+
+interface MockConv {
+  messages: Array<{ id: string; role: string; content: string }>;
+  isLoading: boolean;
+  isStreaming: boolean;
+  activeToolCalls: unknown[];
+  context: ConvContext;
+}
+
+interface MockStoreState {
+  conversations: Record<string, MockConv>;
+  appendUserMessage: ReturnType<typeof vi.fn>;
+  replaceAssistantStream: ReturnType<typeof vi.fn>;
+  setActiveToolCalls: ReturnType<typeof vi.fn>;
+  setIsLoading: ReturnType<typeof vi.fn>;
+  setIsStreaming: ReturnType<typeof vi.fn>;
+  appendAssistantError: ReturnType<typeof vi.fn>;
+}
+
+const baseContext: ConvContext = {
+  workspaceSlug: "ws-1",
+  workspaceSlugs: [],
+  orgId: "org-1",
+  githubLogin: "test-org",
+  currentCanvasRef: "root",
+  currentCanvasBreadcrumb: "",
+  selectedNodeId: null,
+  selectedNodeIds: [],
+};
+
+let mockState: MockStoreState;
+
+function buildMockConv(overrides: Partial<MockConv> = {}): MockConv {
+  return {
+    messages: [],
+    isLoading: false,
+    isStreaming: false,
+    activeToolCalls: [],
+    context: baseContext,
+    ...overrides,
+  };
+}
+
+// Track the isStreaming state as the actions mutate it
+function makeTrackedState(): MockStoreState {
+  const state: MockStoreState = {
+    conversations: {
+      "conv-1": buildMockConv(),
+    },
+    appendUserMessage: vi.fn(),
+    replaceAssistantStream: vi.fn(),
+    setActiveToolCalls: vi.fn(),
+    setIsLoading: vi.fn().mockImplementation((id: string, val: boolean) => {
+      if (state.conversations[id]) {
+        state.conversations[id] = { ...state.conversations[id], isLoading: val };
+      }
+    }),
+    setIsStreaming: vi.fn().mockImplementation((id: string, val: boolean) => {
+      if (state.conversations[id]) {
+        state.conversations[id] = { ...state.conversations[id], isStreaming: val };
+      }
+    }),
+    appendAssistantError: vi.fn(),
+  };
+  return state;
+}
+
+vi.mock("@/app/org/[githubLogin]/_state/canvasChatStore", () => ({
+  useCanvasChatStore: {
+    getState: () => mockState,
+  },
+  toModelMessages: (msgs: unknown[]) => msgs,
+}));
+
+// ── Import after mocks ─────────────────────────────────────────────────────
+
+import { useSendCanvasChatMessage } from "@/app/org/[githubLogin]/_state/useSendCanvasChatMessage";
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+function buildOkFetch() {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    body: {
+      getReader: () => ({
+        read: vi.fn().mockResolvedValue({ done: true, value: undefined }),
+        releaseLock: vi.fn(),
+      }),
+    },
+  });
+}
+
+function buildErrorFetch() {
+  return vi.fn().mockResolvedValue({
+    ok: false,
+    status: 500,
+    headers: { get: () => null },
+    body: null,
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("useSendCanvasChatMessage — isStreaming lifecycle", () => {
+  beforeEach(() => {
+    mockState = makeTrackedState();
+    resetStreamPromise();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sets isStreaming=true immediately when send starts", async () => {
+    global.fetch = buildOkFetch();
+
+    const { result } = renderHook(() => useSendCanvasChatMessage());
+
+    // Start the send — don't await yet
+    let sendPromise: Promise<void>;
+    act(() => {
+      sendPromise = result.current({
+        conversationId: "conv-1",
+        content: "hello",
+      });
+    });
+
+    // setIsStreaming(true) should have been called synchronously before the
+    // await fetch completes
+    expect(mockState.setIsStreaming).toHaveBeenCalledWith("conv-1", true);
+
+    // Clean up by resolving the stream
+    resolveStream();
+    await act(async () => { await sendPromise!; });
+  });
+
+  it("sets isStreaming=false in finally on successful stream completion", async () => {
+    global.fetch = buildOkFetch();
+
+    const { result } = renderHook(() => useSendCanvasChatMessage());
+
+    resolveStream(); // stream completes immediately
+
+    await act(async () => {
+      await result.current({ conversationId: "conv-1", content: "hello" });
+    });
+
+    // Both setIsStreaming calls: true (start) then false (finally)
+    const calls = (mockState.setIsStreaming as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls).toContainEqual(["conv-1", true]);
+    expect(calls).toContainEqual(["conv-1", false]);
+
+    // false must be the last call
+    const lastCall = calls[calls.length - 1];
+    expect(lastCall).toEqual(["conv-1", false]);
+  });
+
+  it("sets isStreaming=false in finally even when fetch returns a non-OK status", async () => {
+    global.fetch = buildErrorFetch();
+
+    const { result } = renderHook(() => useSendCanvasChatMessage());
+
+    await act(async () => {
+      await result.current({ conversationId: "conv-1", content: "hello" });
+    });
+
+    const calls = (mockState.setIsStreaming as ReturnType<typeof vi.fn>).mock.calls;
+    // Must have been set to true at start
+    expect(calls).toContainEqual(["conv-1", true]);
+    // And cleared to false in finally
+    const lastCall = calls[calls.length - 1];
+    expect(lastCall).toEqual(["conv-1", false]);
+  });
+
+  it("sets isStreaming=false in finally when the stream itself throws", async () => {
+    global.fetch = buildOkFetch();
+
+    const { result } = renderHook(() => useSendCanvasChatMessage());
+
+    // Make the stream reject
+    rejectStream(new Error("stream broke"));
+
+    await act(async () => {
+      await result.current({ conversationId: "conv-1", content: "hello" });
+    });
+
+    const calls = (mockState.setIsStreaming as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls).toContainEqual(["conv-1", true]);
+    const lastCall = calls[calls.length - 1];
+    expect(lastCall).toEqual(["conv-1", false]);
+  });
+
+  it("does NOT touch the first-chunk setIsLoading(false) call — UX is unchanged", async () => {
+    global.fetch = buildOkFetch();
+    resolveStream();
+
+    const { result } = renderHook(() => useSendCanvasChatMessage());
+
+    await act(async () => {
+      await result.current({ conversationId: "conv-1", content: "hello" });
+    });
+
+    const isLoadingCalls = (mockState.setIsLoading as ReturnType<typeof vi.fn>).mock.calls;
+
+    // setIsLoading(true) called at start
+    expect(isLoadingCalls).toContainEqual(["conv-1", true]);
+    // setIsLoading(false) called in finally
+    expect(isLoadingCalls).toContainEqual(["conv-1", false]);
+
+    // isStreaming calls are separate and don't interfere
+    const isStreamingCalls = (mockState.setIsStreaming as ReturnType<typeof vi.fn>).mock.calls;
+    expect(isStreamingCalls).toContainEqual(["conv-1", true]);
+    expect(isStreamingCalls).toContainEqual(["conv-1", false]);
+  });
+});

--- a/src/app/org/[githubLogin]/_state/canvasChatStore.ts
+++ b/src/app/org/[githubLogin]/_state/canvasChatStore.ts
@@ -140,6 +140,15 @@ export interface CanvasConversation {
   forkedFromShareId: string | null;
   messages: CanvasChatMessage[];
   isLoading: boolean;
+  /**
+   * `true` for the full lifetime of a streaming response — from the
+   * initial fetch until the stream's `finally` block. Unlike
+   * `isLoading` (which flips to `false` on the first chunk for UX),
+   * `isStreaming` stays `true` until tool call outputs have fully
+   * arrived. Auto-save gates on this flag so it never persists
+   * partial tool call data.
+   */
+  isStreaming: boolean;
   activeToolCalls: ToolCall[];
   /** Hint context used when building `/api/ask/quick` requests. */
   context: ConversationContext;
@@ -292,6 +301,8 @@ interface CanvasChatState {
     toolCalls: ToolCall[],
   ) => void;
   setIsLoading: (conversationId: string, isLoading: boolean) => void;
+  /** Mirror of `setIsLoading` but for the streaming gate. See `CanvasConversation.isStreaming`. */
+  setIsStreaming: (conversationId: string, streaming: boolean) => void;
   /** Append a synthetic assistant error message to a conversation. */
   appendAssistantError: (
     conversationId: string,
@@ -351,6 +362,7 @@ export const useCanvasChatStore = create<CanvasChatState>()(
           forkedFromShareId: forkedFromShareId ?? null,
           messages: seedMessages ?? [],
           isLoading: false,
+          isStreaming: false,
           activeToolCalls: [],
           context,
         };
@@ -523,6 +535,22 @@ export const useCanvasChatStore = create<CanvasChatState>()(
           },
           false,
           "setIsLoading",
+        ),
+
+      setIsStreaming: (conversationId, isStreaming) =>
+        set(
+          (s) => {
+            const conv = s.conversations[conversationId];
+            if (!conv) return s;
+            return {
+              conversations: {
+                ...s.conversations,
+                [conversationId]: { ...conv, isStreaming },
+              },
+            };
+          },
+          false,
+          "setIsStreaming",
         ),
 
       appendAssistantError: (conversationId, content) =>

--- a/src/app/org/[githubLogin]/_state/useCanvasChatAutoSave.ts
+++ b/src/app/org/[githubLogin]/_state/useCanvasChatAutoSave.ts
@@ -54,12 +54,15 @@ export function useCanvasChatAutoSave({ githubLogin }: AutoSaveArgs) {
       const conv =
         useCanvasChatStore.getState().conversations[conversationId];
       if (!conv) return;
-      // Only save when not actively streaming. Mid-stream the
-      // assistant's messages are still being built; we'd be saving
-      // partial state. Wait for the stream to finish (`isLoading`
-      // flips back to false after `onResponseStart` and again at
-      // stream end via `setIsLoading(false)`).
-      if (conv.isLoading) return;
+      // Only save when the stream has fully settled. `isStreaming`
+      // stays `true` for the entire lifetime of a fetch — from the
+      // initial request until the `finally` block in
+      // `useSendCanvasChatMessage`. Unlike `isLoading` (which flips
+      // to `false` on the first chunk for UX), `isStreaming` covers
+      // tool call outputs that arrive later in the stream. Saving
+      // mid-stream would persist tool calls with `output: undefined`,
+      // which causes ProposalCards to disappear from history.
+      if (conv.isStreaming) return;
 
       const totalMsgs = conv.messages.length;
       if (totalMsgs === 0) return;

--- a/src/app/org/[githubLogin]/_state/useSendCanvasChatMessage.ts
+++ b/src/app/org/[githubLogin]/_state/useSendCanvasChatMessage.ts
@@ -75,6 +75,7 @@ export function useSendCanvasChatMessage() {
         replaceAssistantStream,
         setActiveToolCalls,
         setIsLoading,
+        setIsStreaming,
         appendAssistantError,
       } = useCanvasChatStore.getState();
 
@@ -97,6 +98,7 @@ export function useSendCanvasChatMessage() {
 
       appendUserMessage(conversationId, userMessage);
       setIsLoading(conversationId, true);
+      setIsStreaming(conversationId, true);
 
       let firstChunk = true;
       const ctx = conv.context;
@@ -304,6 +306,7 @@ export function useSendCanvasChatMessage() {
         );
       } finally {
         setIsLoading(conversationId, false);
+        setIsStreaming(conversationId, false);
       }
     },
     [processStream],


### PR DESCRIPTION
Generated with Hive: Fix canvas chat auto-save to wait for stream completion before persisting tool call outputs