### PR TITLE
Render SubAgentRunCard anchored to suppressed planner/form-answer rows

### DIFF
--- a/scripts/diagnose-subagent-card.ts
+++ b/scripts/diagnose-subagent-card.ts
@@ -1,0 +1,120 @@
+/**
+ * Diagnose why a canvas-chat <SubAgentRunCard> isn't showing after a
+ * feature proposal was approved.
+ *
+ * Determines which of the two layers is failing:
+ *   1. DATA layer — did the planner message actually fan out into the
+ *      org-canvas conversation? (requires Feature.parentCanvasConversationId
+ *      to have been stamped at approval)
+ *   2. RENDER layer — the message IS in the conversation but the prod UI
+ *      hid the card (the `return null` bug fixed in this branch).
+ *
+ * Usage:
+ *   DATABASE_URL=... npx tsx scripts/diagnose-subagent-card.ts <githubLogin>
+ *
+ * Prints, for the org's most recent canvas conversations + recently
+ * created features, whether the stamp and the planner-source row exist.
+ */
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  let githubLogin = process.argv[2];
+
+  // Auto-discover: if no login is passed, find the org that owns the
+  // most recently active org-canvas conversation. Read-only.
+  if (!githubLogin) {
+    const recent = await prisma.sharedConversation.findFirst({
+      where: { source: "org-canvas", sourceControlOrgId: { not: null } },
+      orderBy: { lastMessageAt: "desc" },
+      select: { sourceControlOrg: { select: { githubLogin: true } } },
+    });
+    githubLogin = recent?.sourceControlOrg?.githubLogin ?? "";
+    if (!githubLogin) {
+      console.error(
+        "No org-canvas conversations found. Pass a githubLogin explicitly:\n" +
+          "  npx tsx scripts/diagnose-subagent-card.ts <githubLogin>",
+      );
+      process.exit(1);
+    }
+    console.log(`(auto-discovered most recently active org: ${githubLogin})\n`);
+  }
+
+  const org = await prisma.sourceControlOrg.findUnique({
+    where: { githubLogin },
+    select: { id: true, githubLogin: true },
+  });
+  if (!org) {
+    console.error(`No SourceControlOrg for githubLogin="${githubLogin}"`);
+    process.exit(1);
+  }
+  console.log(`Org: ${org.githubLogin} (${org.id})\n`);
+
+  // ── Recent features that should own a canvas conversation ──────────
+  const features = await prisma.feature.findMany({
+    where: { workspace: { sourceControlOrgId: org.id } },
+    orderBy: { createdAt: "desc" },
+    take: 10,
+    select: {
+      id: true,
+      title: true,
+      createdAt: true,
+      workflowStatus: true,
+      parentCanvasConversationId: true,
+    },
+  });
+
+  console.log("=== Recent features ===");
+  for (const f of features) {
+    const stamp = f.parentCanvasConversationId
+      ? `stamped → ${f.parentCanvasConversationId}`
+      : "❌ NO parentCanvasConversationId (will NOT fan out)";
+    console.log(
+      `- ${f.title}  [${f.id}]  ${f.workflowStatus}  ${f.createdAt.toISOString()}\n    ${stamp}`,
+    );
+  }
+
+  // ── Recent org-canvas conversations + planner-row presence ─────────
+  const convos = await prisma.sharedConversation.findMany({
+    where: { sourceControlOrgId: org.id, source: "org-canvas" },
+    orderBy: { lastMessageAt: "desc" },
+    take: 10,
+    select: { id: true, title: true, lastMessageAt: true, messages: true },
+  });
+
+  console.log("\n=== Recent org-canvas conversations ===");
+  for (const c of convos) {
+    const msgs = Array.isArray(c.messages) ? (c.messages as any[]) : [];
+    const plannerRows = msgs.filter(
+      (m) => m && typeof m === "object" && m.source?.kind === "planner",
+    );
+    const formRows = plannerRows.filter((m) => m.source?.hasForm);
+    const verdict =
+      plannerRows.length > 0
+        ? `✅ ${plannerRows.length} planner row(s)${
+            formRows.length ? `, ${formRows.length} with a FORM` : ""
+          } → RENDER layer (deploy the SidebarChat fix)`
+        : "❌ no planner rows → DATA layer (fan-out never happened / stamp missing)";
+    console.log(
+      `- "${c.title}"  [${c.id}]  ${msgs.length} msgs  ${
+        c.lastMessageAt?.toISOString() ?? "—"
+      }\n    ${verdict}`,
+    );
+  }
+
+  console.log(
+    "\nInterpretation:\n" +
+      "  • Feature stamped + conversation has a planner row → it's the RENDER bug; this branch fixes it.\n" +
+      "  • Feature NOT stamped → approval didn't pass/validate the conversation id\n" +
+      "    (approved before the stamp fix deployed, serverConversationId was null,\n" +
+      "     or orgId != sourceControlOrgId). No render fix can help until the stamp lands.",
+  );
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/src/app/org/[githubLogin]/_components/SidebarChat.tsx
+++ b/src/app/org/[githubLogin]/_components/SidebarChat.tsx
@@ -159,6 +159,49 @@ export function SidebarChat({ githubLogin }: SidebarChatProps) {
     return byAnchor;
   }, [messages]);
 
+  // Render the SubAgentRunCard(s) anchored to a message. Extracted so it
+  // can render under BOTH a normal message AND a suppressed fan-out
+  // message (an inbound planner reply / form-answer — whose bubble is
+  // hidden but which is the anchor for an inbound-only run, e.g. the
+  // approval flow where the agent never made an outbound
+  // `send_to_feature_planner` call).
+  const renderSubAgentRuns = (runs: ReturnType<typeof getSubAgentRunsFromMessages>) => (
+    <div className="space-y-1.5">
+      {runs.map((run) => (
+        <div key={run.featureId} className="space-y-1.5">
+          <SubAgentRunCard run={run} />
+          {/*
+            Phase 4: an unanswered planner FORM surfaces OUTSIDE the
+            collapsed card so the user can answer it inline without
+            expanding or leaving canvas chat. Only the run with a
+            `pendingForm` renders a slot.
+          */}
+          {run.pendingForm && (
+            <PlannerFormSlot
+              githubLogin={githubLogin}
+              featureId={run.featureId}
+              featureTitle={run.featureTitle}
+              plannerMessageId={run.pendingForm.plannerMessageId}
+              questions={run.pendingForm.questions}
+            />
+          )}
+          {/*
+            Once the planner has generated tasks, offer a Start Tasks
+            button (it reads the live ready-count itself and hides when
+            none remain). Suppressed while a FORM is pending — answer the
+            planner first.
+          */}
+          {run.hasGeneratedTasks && !run.pendingForm && (
+            <StartTasksSlot
+              featureId={run.featureId}
+              featureTitle={run.featureTitle}
+            />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+
   return (
     <div className="flex h-full flex-col min-h-0">
       <div className="flex items-center justify-between px-3 py-2 border-b">
@@ -211,23 +254,33 @@ export function SidebarChat({ githubLogin }: SidebarChatProps) {
               return null;
             }
 
+            const subAgentRuns = subAgentRunsByAnchor.get(message.id);
+
             // Fan-out messages from planners (and Phase 4's planner-
-            // form answers) render inside their `SubAgentRunCard`,
-            // not as top-level chat bubbles. They stay in the
-            // messages array so `getSubAgentRunsFromMessages` can
-            // walk them and so they round-trip through autosave /
-            // share. Same shape as the approval/rejection early-
-            // return above. See
+            // form answers) don't render as top-level chat bubbles —
+            // BUT they're the anchor for inbound-only runs (the approval
+            // flow: the agent never made an outbound
+            // `send_to_feature_planner` call, so the planner's reply is
+            // the only activity and thus the anchor). Suppress the
+            // bubble, but still render any SubAgentRunCard anchored
+            // here, otherwise the card disappears the moment the planner
+            // replies. They stay in the messages array so
+            // `getSubAgentRunsFromMessages` can walk them and so they
+            // round-trip through autosave / share. See
             // `docs/plans/canvas-agent-manages-planners.md` Phase 2.
             if (
               message.source?.kind === "planner" ||
               message.source?.kind === "user-answered-planner-form"
             ) {
-              return null;
+              if (!subAgentRuns || subAgentRuns.length === 0) return null;
+              return (
+                <div key={message.id} className="space-y-1.5">
+                  {renderSubAgentRuns(subAgentRuns)}
+                </div>
+              );
             }
 
             const proposals = getProposalsFromMessage(message);
-            const subAgentRuns = subAgentRunsByAnchor.get(message.id);
 
             return (
               <div key={message.id} className="space-y-1.5">
@@ -247,44 +300,9 @@ export function SidebarChat({ githubLogin }: SidebarChatProps) {
                     ))}
                   </div>
                 )}
-                {subAgentRuns && subAgentRuns.length > 0 && (
-                  <div className="space-y-1.5">
-                    {subAgentRuns.map((run) => (
-                      <div key={run.featureId} className="space-y-1.5">
-                        <SubAgentRunCard run={run} />
-                        {/*
-                          Phase 4: an unanswered planner FORM surfaces
-                          OUTSIDE the collapsed card so the user can
-                          answer it inline without expanding or leaving
-                          canvas chat. Only the run with a `pendingForm`
-                          renders a slot.
-                        */}
-                        {run.pendingForm && (
-                          <PlannerFormSlot
-                            githubLogin={githubLogin}
-                            featureId={run.featureId}
-                            featureTitle={run.featureTitle}
-                            plannerMessageId={run.pendingForm.plannerMessageId}
-                            questions={run.pendingForm.questions}
-                          />
-                        )}
-                        {/*
-                          Once the planner has generated tasks, offer a
-                          Start Tasks button (it reads the live ready-
-                          count itself and hides when none remain).
-                          Suppressed while a FORM is pending — answer the
-                          planner first.
-                        */}
-                        {run.hasGeneratedTasks && !run.pendingForm && (
-                          <StartTasksSlot
-                            featureId={run.featureId}
-                            featureTitle={run.featureTitle}
-                          />
-                        )}
-                      </div>
-                    ))}
-                  </div>
-                )}
+                {subAgentRuns &&
+                  subAgentRuns.length > 0 &&
+                  renderSubAgentRuns(subAgentRuns)}
                 <MessageArtifacts artifactIds={message.artifactIds} />
               </div>
             );


### PR DESCRIPTION
## The bug

After approving a feature proposal, the planner posts a reply (often clarifying questions) that fans out into the canvas conversation as a `source.kind === "planner"` row — but the `<SubAgentRunCard>` never appears.

Root cause is in the render layer. The card hangs under the message whose id equals `run.anchorMessageId`. For an **inbound-only run** — the approval flow, where the agent never makes an outbound `send_to_feature_planner` tool call, so the planner's reply is the only activity and therefore the anchor — that anchor is the planner message itself, which `SidebarChat` `return null`s (bubble suppressed) **before** it ever renders the anchored card. So the card vanishes the instant the planner replies. Same for `user-answered-planner-form` rows once they're the latest activity.

## The fix

For planner / form-answer messages, suppress the bubble (unchanged) **but still render any `SubAgentRunCard` anchored there** — plus the inline `PlannerFormSlot` (clarifying-question form) and `StartTasksSlot`. Extracted the run-list rendering into a `renderSubAgentRuns` helper shared by normal and suppressed messages.

## Verified against prod (read-only)

Added `scripts/diagnose-subagent-card.ts` (strictly read-only: `findUnique`/`findMany` only) to disambiguate the data layer (did the planner message fan out?) from the render layer. Run output confirmed the earlier `parentCanvasConversationId` stamp fix is working — the affected conversation already contains **2 planner rows (1 with a FORM)**; only the render layer was hiding them. So this change makes the card + inline form appear (no reload needed, the data's already there).

Usage:
```
DATABASE_URL=... npx tsx scripts/diagnose-subagent-card.ts [githubLogin]
```

## Scope
- `SidebarChat.tsx` — render fix (no behavior change for normal messages; planner/form rows now surface their card)
- `scripts/diagnose-subagent-card.ts` — read-only diagnostic