### PR TITLE
Wake canvas agent on PLAN-artifact planner messages + classification logging

### DIFF
--- a/src/__tests__/unit/services/canvas-agent-autoturn.test.ts
+++ b/src/__tests__/unit/services/canvas-agent-autoturn.test.ts
@@ -199,6 +199,33 @@ describe("actionableWakeReason", () => {
     ).toBe("failed");
   });
 
+  test("real PLAN artifact (plan ready for review) → 'completed' even when not terminal and no trailing '?'", () => {
+    expect(
+      actionableWakeReason(
+        baseFeature, // workflowStatus IN_PROGRESS — the webhook race
+        makeMessage({
+          message:
+            "Requirements are scoped tight. Confirm and I'll go deep into the architecture.",
+          artifacts: [{ type: "PLAN", content: { summary: "the plan" } }],
+        }),
+      ),
+    ).toBe("completed");
+  });
+
+  test("clarifying-questions PLAN does NOT count as a plan-ready signal (stays 'form')", () => {
+    // Same artifact type (PLAN) but the clarifying variant → 'form', not
+    // 'completed'. Guards the `plannerMessageHasPlan` exclusion.
+    expect(
+      actionableWakeReason(
+        baseFeature,
+        makeMessage({
+          message: "Which provider?",
+          artifacts: [clarifyingArtifact],
+        }),
+      ),
+    ).toBe("form");
+  });
+
   test("trailing '?' → 'question' when not terminal and no FORM", () => {
     expect(
       actionableWakeReason(

--- a/src/app/api/chat/response/route.ts
+++ b/src/app/api/chat/response/route.ts
@@ -580,6 +580,12 @@ export async function POST(request: NextRequest) {
           // (off by default) and is failure-tolerant.
           const conversationId = fanOutFeature.parentCanvasConversationId;
           if (wakeReason && conversationId) {
+            console.log("[chat/response] scheduling canvas auto-turn", {
+              conversationId,
+              featureId: fanOutFeature.id,
+              plannerMessageId: chatMessage.id,
+              wakeReason,
+            });
             after(async () => {
               try {
                 const { invokeCanvasAgentOnPlannerMessage } = await import(
@@ -597,6 +603,22 @@ export async function POST(request: NextRequest) {
                   e,
                 );
               }
+            });
+          } else {
+            // No turn scheduled — log WHY so this is diagnosable without
+            // any `[canvas-autoturn]` line appearing. Two distinct cases:
+            // the feature isn't owned by a canvas conversation, or the
+            // planner message wasn't classified as actionable (see the
+            // `[canvas-planner-fanout] classified planner message` log for
+            // the per-signal breakdown).
+            console.log("[chat/response] canvas auto-turn NOT scheduled", {
+              featureId: fanOutFeature.id,
+              plannerMessageId: chatMessage.id,
+              conversationId,
+              wakeReason,
+              reason: !conversationId
+                ? "feature not owned by a canvas conversation (no parentCanvasConversationId)"
+                : "planner message not actionable (see [canvas-planner-fanout] classification log)",
             });
           }
         }

--- a/src/app/org/[githubLogin]/_components/StartTasksSlot.tsx
+++ b/src/app/org/[githubLogin]/_components/StartTasksSlot.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { Loader2, Play, CheckCircle2 } from "lucide-react";
+import { Loader2, Play, CheckCircle2, Zap } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 /**
@@ -97,36 +97,39 @@ export function StartTasksSlot({ featureId, featureTitle }: StartTasksSlotProps)
   if (readyCount === null || readyCount === 0) return null;
 
   return (
-    <div className="flex items-center justify-between gap-2 rounded-lg border bg-card px-3 py-2">
-      <div className="min-w-0 text-xs text-muted-foreground">
-        <span className="font-medium text-foreground">
-          {readyCount} task{readyCount === 1 ? "" : "s"} ready
-        </span>
-        {featureTitle && (
-          <>
-            <span aria-hidden="true" className="mx-1">
-              ·
+    <div className="rounded-lg border border-primary/40 bg-primary/[0.06] px-3 py-2.5 ring-1 ring-inset ring-primary/10">
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-1.5 text-xs font-semibold text-foreground">
+            <Zap className="h-3.5 w-3.5 flex-shrink-0 text-primary" />
+            <span>
+              {readyCount} task{readyCount === 1 ? "" : "s"} ready to run
             </span>
-            <span className="truncate">{featureTitle}</span>
-          </>
-        )}
+          </div>
+          <p className="mt-0.5 truncate text-[11px] text-muted-foreground">
+            Starts agents on real compute
+            {featureTitle ? ` · ${featureTitle}` : ""}
+          </p>
+        </div>
+        <Button
+          size="sm"
+          variant="default"
+          onClick={handleStart}
+          disabled={starting}
+          className="h-8 flex-shrink-0 gap-1.5 px-3 text-xs font-semibold shadow-sm"
+        >
+          {starting ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Play className="h-3.5 w-3.5" />
+          )}
+          Start {readyCount} task{readyCount === 1 ? "" : "s"}
+        </Button>
       </div>
-      <Button
-        size="sm"
-        variant="default"
-        onClick={handleStart}
-        disabled={starting}
-        className="h-7 flex-shrink-0 gap-1 px-2.5 text-xs"
-      >
-        {starting ? (
-          <Loader2 className="h-3.5 w-3.5 animate-spin" />
-        ) : (
-          <Play className="h-3.5 w-3.5" />
-        )}
-        Start tasks
-      </Button>
       {error && (
-        <span className="text-xs text-rose-600 dark:text-rose-400">{error}</span>
+        <p className="mt-2 text-[11px] text-rose-600 dark:text-rose-400">
+          {error}
+        </p>
       )}
     </div>
   );

--- a/src/services/canvas-planner-fanout.ts
+++ b/src/services/canvas-planner-fanout.ts
@@ -88,6 +88,28 @@ export function plannerMessageHasTasks(
   return plannerMessage.artifacts.some((a) => a.type === "TASKS");
 }
 
+/**
+ * Did this planner message carry a *real* plan — a `PLAN` artifact that
+ * is NOT the clarifying-questions variant? This is the "the planner
+ * delivered a plan ready for review" signal: it's exactly what fires the
+ * `PLAN_AWAITING_APPROVAL` notification, and it's the substantive
+ * deliverable the canvas agent should react to (read it, and if it's
+ * solid, nudge the planner to generate tasks).
+ *
+ * A clarifying-questions message is *also* `PLAN`-typed (see
+ * `extractClarifyingQuestions`), so we exclude it here — that case is
+ * handled separately as the stronger `"form"` signal. The result: this
+ * returns true only for genuine plan summaries, not for the question
+ * variant and not for pure-prose status chatter (which has no artifact).
+ */
+export function plannerMessageHasPlan(
+  plannerMessage: { artifacts: Artifact[] },
+): boolean {
+  return plannerMessage.artifacts.some(
+    (a) => a.type === "PLAN" && !isClarifyingQuestions(a.content),
+  );
+}
+
 /** Subset of `Feature` the fan-out needs. */
 export interface FanOutFeatureRef {
   id: string;
@@ -306,7 +328,37 @@ export async function fanOutPlannerMessageToCanvas(
     // caller can schedule the autonomous canvas-agent turn in `after()`
     // (off the webhook's critical path). The turn itself is gated behind
     // `CANVAS_AUTONOMOUS_TURNS_ENABLED` (off by default).
-    return actionableWakeReason(feature, plannerMessage);
+    const wakeReason = actionableWakeReason(feature, plannerMessage);
+
+    // ALWAYS log the classification — incl. when `wakeReason` is null —
+    // so "the agent didn't auto-respond" is diagnosable from Vercel logs
+    // WITHOUT a turn ever being scheduled (a null reason means no
+    // `[canvas-autoturn]` line will ever appear). Surfaces each raw
+    // signal so the exact reason is obvious (e.g. a planner that asks a
+    // question mid-message but ends on a period → `endsWithQuestionMark:
+    // false` → not actionable via the trailing-`?` heuristic).
+    const trimmed = plannerMessage.message.trim();
+    console.log("[canvas-planner-fanout] classified planner message", {
+      featureId: feature.id,
+      plannerMessageId: plannerMessage.id,
+      conversationId,
+      wakeReason,
+      signals: {
+        hasClarifyingForm: !!extractClarifyingQuestions(plannerMessage),
+        workflowStatus: feature.workflowStatus ?? null,
+        endsWithQuestionMark: trimmed.endsWith("?"),
+        messagePreview: trimmed.slice(-80),
+      },
+      ...(wakeReason
+        ? {}
+        : {
+            notActionable:
+              "no clarifying-questions FORM, non-terminal workflowStatus, " +
+              "and message does not end with '?' — auto-turn NOT scheduled",
+          }),
+    });
+
+    return wakeReason;
   } catch (e) {
     // Non-fatal: the planner's own write succeeded; the canvas
     // conversation is just incomplete for this one message. The user
@@ -338,11 +390,24 @@ export async function fanOutPlannerMessageToCanvas(
  *   2. The feature's `workflowStatus` is terminal
  *      (`COMPLETED` / `FAILED` / `HALTED` / `ERROR`). → mapped reason.
  *      Deterministic.
- *   3. The message text ends with `?` (heuristic for "asked a question
+ *   3. The message carried a real `PLAN` artifact (a plan ready for
+ *      review — the same signal that fires `PLAN_AWAITING_APPROVAL`).
+ *      → `"completed"`. Deterministic, and independent of the
+ *      `workflowStatus` race: the plan-message webhook and the
+ *      run-completion webhook arrive separately, so the feature may
+ *      still read `IN_PROGRESS` when the plan lands. Keying off the
+ *      artifact catches "plan is done, keep it moving" reliably. The
+ *      `"completed"` prompt branch guards against premature task-pushing
+ *      (it only nudges when brief/requirements/architecture are all
+ *      populated), so an intermediate plan just gets read, not actioned.
+ *   4. The message text ends with `?` (heuristic for "asked a question
  *      without a FORM"). → `"question"`. Fragile-but-cheap; a false
  *      positive costs one extra turn the agent can `stay_silent` on.
  *
  * FORM takes precedence over the others (it's the strongest signal).
+ * Note we deliberately do NOT wake on a bare `TASKS` artifact: once
+ * tasks are generated the next step ("Start Tasks") is the user's
+ * button, so a turn there is just noise.
  */
 export function actionableWakeReason(
   feature: FanOutFeatureRef,
@@ -364,7 +429,11 @@ export function actionableWakeReason(
       break;
   }
 
-  // 3. Trailing-`?` question heuristic.
+  // 3. A real plan artifact — a plan ready for review. Treated as
+  // `completed` so the agent reads it and keeps it moving.
+  if (plannerMessageHasPlan(plannerMessage)) return "completed";
+
+  // 4. Trailing-`?` question heuristic.
   if (plannerMessage.message.trim().endsWith("?")) return "question";
 
   return null;


### PR DESCRIPTION
## Problem

The canvas-agent auto-turn (\"Auto-respond to planners\") never fired for a **plan ready for review**. Observed in production: a planner posted a plan summary, the only log was a `PLAN_AWAITING_APPROVAL` notification, and no `[canvas-autoturn]` line ever appeared — even with the per-user toggle on.

Two root causes:

1. **The classifier missed plan deliverables.** `actionableWakeReason` only flagged a message as actionable on a clarifying-question FORM, a terminal `workflowStatus`, or text ending in `?`. The real message carried a `PLAN` artifact (the same signal behind `PLAN_AWAITING_APPROVAL`) but its prose ended in a period, so the trailing-`?` heuristic — which only inspects the last character — returned `null`.
2. **The `workflowStatus` terminal check loses a race.** The plan-message webhook (`/api/chat/response`) and the run-completion webhook (`stakwork-run`) arrive separately, so the feature frequently still reads `IN_PROGRESS` when the plan lands → no `completed` wake reason.

## Fix

- **`actionableWakeReason`**: treat a real `PLAN` artifact (`PLAN` type, **not** the clarifying-questions variant) as `\"completed\"`. Deterministic and independent of the webhook race. The `completed` prompt branch already guards against premature task-pushing (only nudges when brief/requirements/architecture are populated), so an intermediate plan is just read, not actioned. Bare `TASKS` artifacts still do **not** wake — the next step there is the user's *Start Tasks* button.
- New `plannerMessageHasPlan()` helper.

## Diagnosability

The original reason this was invisible: a `null` wake reason means no turn is scheduled and therefore **no `[canvas-autoturn]` log ever appears**. Added:

- `[canvas-planner-fanout] classified planner message` — logged **unconditionally** (incl. `wakeReason: null`) with the per-signal breakdown (`hasClarifyingForm`, `workflowStatus`, `endsWithQuestionMark`, `messagePreview`) and a `notActionable` explainer.
- `[chat/response] scheduling canvas auto-turn` / `canvas auto-turn NOT scheduled` (with reason: not-owned-by-a-canvas-conversation vs. not-actionable).

## Tests

- `PLAN`-ready → `completed` (even when `IN_PROGRESS` and no trailing `?`).
- clarifying-questions `PLAN` still → `form` (guards the `plannerMessageHasPlan` exclusion).
- Existing 10 classifier/gating tests pass.

## Notes

- No behavior change when the per-user `canvasAutonomousTurns` opt-in is off or the `CANVAS_AUTONOMOUS_TURNS_ENABLED` master kill switch is `\"false\"`.