### PR TITLE
Fix SSE chunk-boundary parse bug + add per-workspace logs_agent

### DIFF
--- a/src/__tests__/unit/lib/ai/askToolsMulti.test.ts
+++ b/src/__tests__/unit/lib/ai/askToolsMulti.test.ts
@@ -46,6 +46,21 @@ describe("askToolsMulti", () => {
     });
   });
 
+  describe("per-workspace tool registration", () => {
+    it("registers a slug-prefixed logs_agent for each workspace", () => {
+      const tools = askToolsMulti([ws("alpha"), ws("beta")], "api-key");
+      expect(tools).toHaveProperty("alpha__logs_agent");
+      expect(tools).toHaveProperty("beta__logs_agent");
+    });
+
+    it("keeps logs_agent distinct from the lighter search_logs tool", () => {
+      const tools = askToolsMulti([ws("alpha")], "api-key");
+      expect(tools).toHaveProperty("alpha__logs_agent");
+      expect(tools).toHaveProperty("alpha__search_logs");
+      expect(tools.alpha__logs_agent).not.toBe(tools.alpha__search_logs);
+    });
+  });
+
   describe("read_concepts_for_repo execute", () => {
     const concepts = {
       hive: [

--- a/src/__tests__/unit/lib/streaming/useStreamProcessor.test.ts
+++ b/src/__tests__/unit/lib/streaming/useStreamProcessor.test.ts
@@ -995,6 +995,73 @@ describe("useStreamProcessor", () => {
 
       expect(onUpdate).toHaveBeenCalled();
     });
+
+    // Regression: SSE lines are not guaranteed to align with network
+    // chunk boundaries. A large tool result (e.g. logs_agent) can be
+    // split mid-string across two reader.read() chunks. The processor
+    // must buffer the partial line instead of trying to JSON.parse it,
+    // otherwise the event is dropped and nothing renders.
+    test("should reassemble an SSE line split across chunk boundaries", async () => {
+      const { result } = renderHook(() => useStreamProcessor());
+      const onUpdate = TestUtils.createOnUpdateSpy();
+
+      // A big output string that, when split, leaves the first chunk
+      // ending mid-JSON-string (unterminated string).
+      const bigOutput = "x".repeat(8192);
+      const event = TestDataFactories.createToolResultEvent("call-1", "logs_agent", {
+        answer: bigOutput,
+      });
+
+      // Split the single SSE line roughly in half, inside the string.
+      const splitAt = Math.floor(event.length / 2);
+      const part1 = event.slice(0, splitAt);
+      const part2 = event.slice(splitAt);
+
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        async start(controller) {
+          // Register the tool first so tool-result attaches output.
+          controller.enqueue(
+            encoder.encode(TestDataFactories.createToolCallEvent("call-1", "logs_agent", {})),
+          );
+          controller.enqueue(encoder.encode(part1));
+          controller.enqueue(encoder.encode(part2));
+          controller.close();
+        },
+      });
+
+      const response = { body: stream } as Response;
+
+      await result.current.processStream(response, "msg-1", onUpdate);
+
+      const finalMessage = onUpdate.mock.calls[onUpdate.mock.calls.length - 1][0];
+      const toolCall = finalMessage.toolCalls?.find((t) => t.id === "call-1");
+      expect(toolCall).toBeDefined();
+      expect(toolCall?.status).toBe("output-available");
+      expect(toolCall?.output).toEqual({ answer: bigOutput });
+    });
+
+    test("should process a final line that has no trailing newline", async () => {
+      const { result } = renderHook(() => useStreamProcessor());
+      const onUpdate = TestUtils.createOnUpdateSpy();
+
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        async start(controller) {
+          // No trailing "\n" — the line lives entirely in the buffer
+          // and must be flushed after the read loop ends.
+          controller.enqueue(encoder.encode('data: {"type":"text-start","id":"text-1"}'));
+          controller.close();
+        },
+      });
+
+      const response = { body: stream } as Response;
+
+      await result.current.processStream(response, "msg-1", onUpdate);
+
+      const finalMessage = onUpdate.mock.calls[onUpdate.mock.calls.length - 1][0];
+      expect(finalMessage.textParts).toHaveLength(1);
+    });
   });
 
   describe("Complex Scenarios", () => {

--- a/src/__tests__/unit/lib/utils/chat-conversation-log.test.ts
+++ b/src/__tests__/unit/lib/utils/chat-conversation-log.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+import {
+  chatMessagesToParsedMessages,
+  type StoredChatMessage,
+} from "@/lib/utils/chat-conversation-log";
+import { parseAgentLogStats } from "@/lib/utils/agent-log-stats";
+import { buildToolCallIndex, getConsumedResultIds } from "@/lib/utils/agent-log-pairing";
+
+describe("chatMessagesToParsedMessages", () => {
+  it("passes through plain user/assistant text", () => {
+    const stored: StoredChatMessage[] = [
+      { id: "1", role: "user", content: "hello" },
+      { id: "2", role: "assistant", content: "hi there" },
+    ];
+    expect(chatMessagesToParsedMessages(stored)).toEqual([
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi there" },
+    ]);
+  });
+
+  it("splits a tool batch into a tool-call message + paired tool-result message", () => {
+    const stored: StoredChatMessage[] = [
+      {
+        id: "2",
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          {
+            id: "call-1",
+            toolName: "list_concepts",
+            input: { q: "auth" },
+            output: { features: ["a", "b"] },
+            status: "output-available",
+          },
+        ],
+      },
+    ];
+
+    const out = chatMessagesToParsedMessages(stored);
+    expect(out).toEqual([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "list_concepts",
+            input: { q: "auth" },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-1",
+            toolName: "list_concepts",
+            output: { features: ["a", "b"] },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("appends trailing assistant text after a tool batch", () => {
+    const stored: StoredChatMessage[] = [
+      {
+        id: "2",
+        role: "assistant",
+        content: "Here is what I found",
+        toolCalls: [{ id: "c1", toolName: "search", input: {}, output: "ok" }],
+      },
+    ];
+    const out = chatMessagesToParsedMessages(stored);
+    expect(out).toHaveLength(3);
+    expect(out[2]).toEqual({ role: "assistant", content: "Here is what I found" });
+  });
+
+  it("omits the tool-result message when no call resolved, and uses errorText as fallback output", () => {
+    const unresolved: StoredChatMessage[] = [
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [{ id: "c1", toolName: "search", input: {}, status: "input-available" }],
+      },
+    ];
+    expect(chatMessagesToParsedMessages(unresolved)).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "tool-call", toolCallId: "c1", toolName: "search", input: {} }],
+      },
+    ]);
+
+    const errored: StoredChatMessage[] = [
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [{ id: "c2", toolName: "search", input: {}, errorText: "boom" }],
+      },
+    ];
+    const out = chatMessagesToParsedMessages(errored);
+    expect(out[1]).toEqual({
+      role: "tool",
+      content: [{ type: "tool-result", toolCallId: "c2", toolName: "search", output: "boom" }],
+    });
+  });
+
+  it("inlines image attachments as text", () => {
+    const stored: StoredChatMessage[] = [
+      { role: "user", content: "what is this", imageData: "data:image/png;base64,xxx" },
+      { role: "user", content: "", imageData: "data:image/png;base64,yyy" },
+    ];
+    expect(chatMessagesToParsedMessages(stored)).toEqual([
+      { role: "user", content: "[image attached]\nwhat is this" },
+      { role: "user", content: "[image attached]" },
+    ]);
+  });
+
+  it("produces output the agent-log parser + pairing helpers consume correctly", () => {
+    const stored: StoredChatMessage[] = [
+      { role: "user", content: "find auth" },
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          { id: "call-1", toolName: "list_concepts", input: {}, output: { features: [] } },
+        ],
+      },
+      { role: "assistant", content: "Done" },
+    ];
+
+    const parsed = chatMessagesToParsedMessages(stored);
+    const json = JSON.stringify(parsed);
+    const { conversation, stats } = parseAgentLogStats(json);
+
+    expect(stats.totalToolCalls).toBe(1);
+    expect(stats.toolFrequency.list_concepts).toBe(1);
+
+    const index = buildToolCallIndex(conversation);
+    const consumed = getConsumedResultIds(conversation);
+    // The call is paired with its result, so the standalone result
+    // bubble would be suppressed and shown inline under the call.
+    expect(index.has("call-1")).toBe(true);
+    expect(consumed.has("call-1")).toBe(true);
+  });
+});

--- a/src/app/api/workspaces/[slug]/chat/conversations/[conversationId]/route.ts
+++ b/src/app/api/workspaces/[slug]/chat/conversations/[conversationId]/route.ts
@@ -32,7 +32,7 @@ export async function GET(
       );
     }
 
-    // Get workspace ID
+    // Get workspace ID (+ org link, for the canvas fallback below)
     const workspace = await db.workspace.findFirst({
       where: {
         slug,
@@ -40,6 +40,7 @@ export async function GET(
       },
       select: {
         id: true,
+        sourceControlOrgId: true,
       },
     });
 
@@ -50,34 +51,55 @@ export async function GET(
       );
     }
 
-    // Get conversation - accessible to any workspace member (owner can edit, others read-only)
-    const conversation = await db.sharedConversation.findFirst({
+    const conversationSelect = {
+      id: true,
+      title: true,
+      messages: true,
+      provenanceData: true,
+      followUpQuestions: true,
+      settings: true,
+      isShared: true,
+      lastMessageAt: true,
+      source: true,
+      createdAt: true,
+      updatedAt: true,
+      userId: true,
+      user: {
+        select: {
+          id: true,
+          name: true,
+          email: true,
+        },
+      },
+    } as const;
+
+    // Primary lookup: a chat that belongs to THIS workspace (accessible
+    // to any workspace member).
+    let conversation = await db.sharedConversation.findFirst({
       where: {
         id: conversationId,
         workspaceId: workspace.id,
       },
-      select: {
-        id: true,
-        title: true,
-        messages: true,
-        provenanceData: true,
-        followUpQuestions: true,
-        settings: true,
-        isShared: true,
-        lastMessageAt: true,
-        source: true,
-        createdAt: true,
-        updatedAt: true,
-        userId: true,
-        user: {
-          select: {
-            id: true,
-            name: true,
-            email: true,
-          },
-        },
-      },
+      select: conversationSelect,
     });
+
+    // Fallback: an org-canvas conversation for this workspace's parent
+    // org. These are org-scoped (`workspaceId` null) so they miss the
+    // query above — but the Canvas tab links here, so resolve them too.
+    // Restricted to the caller's own rows (mirrors the canvas list
+    // scope); 404 stays indistinguishable from "missing" for IDOR
+    // safety.
+    if (!conversation && workspace.sourceControlOrgId) {
+      conversation = await db.sharedConversation.findFirst({
+        where: {
+          id: conversationId,
+          sourceControlOrgId: workspace.sourceControlOrgId,
+          source: "org-canvas",
+          userId,
+        },
+        select: conversationSelect,
+      });
+    }
 
     if (!conversation) {
       return NextResponse.json(
@@ -88,6 +110,9 @@ export async function GET(
 
     const response: ConversationDetail = {
       id: conversation.id,
+      // For org-canvas rows this is the workspace the viewer reached
+      // them through, not the row's own (null) workspaceId — fine for
+      // the read-only log view.
       workspaceId: workspace.id,
       userId: conversation.userId,
       title: conversation.title,

--- a/src/app/api/workspaces/[slug]/chat/conversations/route.ts
+++ b/src/app/api/workspaces/[slug]/chat/conversations/route.ts
@@ -37,7 +37,7 @@ export async function GET(
       );
     }
 
-    // Get workspace ID
+    // Get workspace ID (+ org link, for the canvas scope below)
     const workspace = await db.workspace.findFirst({
       where: {
         slug,
@@ -45,6 +45,7 @@ export async function GET(
       },
       select: {
         id: true,
+        sourceControlOrgId: true,
       },
     });
 
@@ -61,13 +62,39 @@ export async function GET(
     const limit = Math.min(parseInt(url.searchParams.get("limit") || "20"), 100);
     const skip = (page - 1) * limit;
 
-    // Get conversations for this user in this workspace
-    const [conversations, total] = await Promise.all([
-      db.sharedConversation.findMany({
-        where: {
+    // Scope selection. Default lists this workspace's own chats. With
+    // `?source=canvas` we instead list the org-canvas conversations for
+    // the workspace's parent org (these are org-scoped — `workspaceId`
+    // is null on them — so they never match the workspace filter and
+    // are invisible to the default "Chats" tab). Always restricted to
+    // the calling user's own rows, so there's no IDOR surface even
+    // though org membership isn't separately checked here.
+    const scope = url.searchParams.get("source");
+    const isCanvasScope = scope === "canvas";
+
+    // A workspace not linked to an org has no canvas chats — short out.
+    if (isCanvasScope && !workspace.sourceControlOrgId) {
+      return NextResponse.json({
+        items: [],
+        pagination: { page, limit, total: 0, totalPages: 0 },
+      });
+    }
+
+    const where = isCanvasScope
+      ? {
+          sourceControlOrgId: workspace.sourceControlOrgId,
+          userId,
+          source: "org-canvas",
+        }
+      : {
           workspaceId: workspace.id,
           userId,
-        },
+        };
+
+    // Get conversations for this user in the selected scope
+    const [conversations, total] = await Promise.all([
+      db.sharedConversation.findMany({
+        where,
         orderBy: {
           lastMessageAt: "desc",
         },
@@ -84,12 +111,7 @@ export async function GET(
           updatedAt: true,
         },
       }),
-      db.sharedConversation.count({
-        where: {
-          workspaceId: workspace.id,
-          userId,
-        },
-      }),
+      db.sharedConversation.count({ where }),
     ]);
 
     // Transform to list items with preview

--- a/src/app/w/[slug]/agent-logs/chat/[conversationId]/page.tsx
+++ b/src/app/w/[slug]/agent-logs/chat/[conversationId]/page.tsx
@@ -4,35 +4,24 @@ import { redirect, notFound } from "next/navigation";
 import { headers } from "next/headers";
 import Link from "next/link";
 import { ChevronLeft } from "lucide-react";
-import { ChatMessage } from "@/components/dashboard/DashboardChat/ChatMessage";
-import { ToolCallIndicator } from "@/components/dashboard/DashboardChat/ToolCallIndicator";
+import { LogDetailContent } from "@/components/agent-logs/LogDetailContent";
 import { getBaseUrl } from "@/lib/utils";
+import {
+  chatMessagesToParsedMessages,
+  type StoredChatMessage,
+} from "@/lib/utils/chat-conversation-log";
+import { parseAgentLogStats } from "@/lib/utils/agent-log-stats";
 import type { ConversationDetail } from "@/types/shared-conversation";
-
-interface Message {
-  id: string;
-  role: "user" | "assistant";
-  content: string;
-  timestamp: Date;
-  imageData?: string;
-  toolCalls?: Array<{
-    id: string;
-    toolName: string;
-    input?: unknown;
-    status: string;
-    output?: unknown;
-    errorText?: string;
-  }>;
-}
 
 interface ChatDetailPageProps {
   params: Promise<{
     slug: string;
     conversationId: string;
   }>;
+  searchParams: Promise<{ from?: string }>;
 }
 
-export default async function ChatDetailPage({ params }: ChatDetailPageProps) {
+export default async function ChatDetailPage({ params, searchParams }: ChatDetailPageProps) {
   const session = await getServerSession(authOptions);
 
   if (!session?.user) {
@@ -45,6 +34,10 @@ export default async function ChatDetailPage({ params }: ChatDetailPageProps) {
   }
 
   const { slug, conversationId } = await params;
+  const { from } = await searchParams;
+  // Return to whichever tab the user came from (Canvas chats link here
+  // with `?from=canvas`; everything else defaults back to Chats).
+  const backTab = from === "canvas" ? "canvas" : "chats";
 
   const headerList = await headers();
   const cookie = headerList.get("cookie") ?? "";
@@ -93,18 +86,22 @@ export default async function ChatDetailPage({ params }: ChatDetailPageProps) {
 
   const data = (await res.json()) as ConversationDetail;
 
-  const messages: Message[] = ((data.messages as unknown[]) || []).map(
-    (msg) => {
-      const m = msg as Message;
-      return { ...m, timestamp: new Date(m.timestamp) };
-    }
-  );
+  // Reuse the Agent Logs detail renderer (`LogDetailContent`) so chat
+  // sessions show the SAME rich tool-call view (call args + paired
+  // result + stats bar) as external agent runs. The chat messages
+  // already persist every tool call's input and output — we just
+  // reshape them into the `ParsedMessage[]` blob format, then run the
+  // shared parser to derive the stats bar.
+  const stored = ((data.messages as unknown[]) || []) as StoredChatMessage[];
+  const parsedMessages = chatMessagesToParsedMessages(stored);
+  const rawContent = JSON.stringify(parsedMessages);
+  const { conversation, stats } = parseAgentLogStats(rawContent);
 
   return (
     <div className="min-h-screen bg-background">
       <div className="max-w-4xl mx-auto px-6 py-6">
         <Link
-          href={`/w/${slug}/agent-logs?tab=chats`}
+          href={`/w/${slug}/agent-logs?tab=${backTab}`}
           className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
         >
           <ChevronLeft className="h-4 w-4" />
@@ -117,39 +114,20 @@ export default async function ChatDetailPage({ params }: ChatDetailPageProps) {
       </div>
 
       <div className="max-w-4xl mx-auto px-6 pb-8">
-        <div className="space-y-4">
-          {messages.map((message) => {
-            if (
-              message.toolCalls &&
-              message.toolCalls.length > 0 &&
-              !message.content
-            ) {
-              return (
-                <div key={message.id}>
-                  <ToolCallIndicator toolCalls={message.toolCalls} />
-                </div>
-              );
-            }
-
-            if (message.content) {
-              return (
-                <ChatMessage
-                  key={message.id}
-                  message={message}
-                  isStreaming={false}
-                />
-              );
-            }
-
-            return null;
-          })}
-
-          {messages.length === 0 && (
-            <div className="text-center text-muted-foreground py-8">
-              No messages in this conversation.
-            </div>
-          )}
-        </div>
+        {conversation.length === 0 ? (
+          <div className="text-center text-muted-foreground py-8">
+            No messages in this conversation.
+          </div>
+        ) : (
+          <LogDetailContent
+            conversation={conversation}
+            stats={stats}
+            rawContent={rawContent}
+            loading={false}
+            error={null}
+            variant="page"
+          />
+        )}
       </div>
     </div>
   );

--- a/src/app/w/[slug]/agent-logs/page.tsx
+++ b/src/app/w/[slug]/agent-logs/page.tsx
@@ -22,10 +22,12 @@ import Link from "next/link";
 const LOGS_PER_PAGE = 20;
 
 type TimeRange = "24h" | "7d" | "30d" | "all";
-type AgentLogsTab = "agents" | "chats" | "sessions";
+type AgentLogsTab = "agents" | "chats" | "canvas" | "sessions";
 
 function parseAgentLogsTab(value: string | null): AgentLogsTab {
-  return value === "chats" || value === "sessions" ? value : "agents";
+  return value === "chats" || value === "canvas" || value === "sessions"
+    ? value
+    : "agents";
 }
 
 function calculateDateRange(range: TimeRange): { start?: string; end?: string } {
@@ -79,6 +81,12 @@ export default function AgentLogsPage() {
   const [chatError, setChatError] = useState<string | null>(null);
   const [chatPage, setChatPage] = useState(1);
   const [chatHasMore, setChatHasMore] = useState(false);
+  // Canvas tab state (org-canvas chats, surfaced for the workspace's org)
+  const [canvasLogs, setCanvasLogs] = useState<AgentLogRecord[]>([]);
+  const [canvasLoading, setCanvasLoading] = useState(false);
+  const [canvasError, setCanvasError] = useState<string | null>(null);
+  const [canvasPage, setCanvasPage] = useState(1);
+  const [canvasHasMore, setCanvasHasMore] = useState(false);
   const [sessionsUrl, setSessionsUrl] = useState<string | null>(null);
   const [sessionsLoading, setSessionsLoading] = useState(false);
   const [sessionsError, setSessionsError] = useState<string | null>(null);
@@ -217,6 +225,55 @@ export default function AgentLogsPage() {
     fetchChats();
   }, [activeTab, slug, chatPage]);
 
+  // Fetch org-canvas chats when the Canvas tab is active. Same endpoint
+  // as Chats but with `?source=canvas`, which lists the org-canvas
+  // conversations for this workspace's parent org (org-scoped rows that
+  // never appear under the workspace-scoped Chats tab).
+  useEffect(() => {
+    if (activeTab !== "canvas") return;
+    if (!slug) return;
+
+    const fetchCanvasChats = async () => {
+      setCanvasLoading(true);
+      setCanvasError(null);
+
+      try {
+        const response = await fetch(
+          `/api/workspaces/${slug}/chat/conversations?source=canvas&page=${canvasPage}&limit=20`,
+        );
+
+        if (!response.ok) {
+          throw new Error("Failed to fetch canvas chats");
+        }
+
+        const data: {
+          items: ConversationListItem[];
+          pagination: { page: number; limit: number; total: number; totalPages: number };
+        } = await response.json();
+
+        const mapped: AgentLogRecord[] = data.items.map((conv) => ({
+          id: conv.id,
+          agent: "canvas",
+          blobUrl: "",
+          createdAt: new Date(conv.lastMessageAt ?? conv.createdAt),
+          featureTitle: conv.title,
+          stakworkRunId: null,
+          taskId: null,
+        }));
+
+        setCanvasLogs(mapped);
+        setCanvasHasMore(canvasPage < data.pagination.totalPages);
+      } catch (err) {
+        console.error("Error fetching canvas chats:", err);
+        setCanvasError(err instanceof Error ? err.message : "Failed to fetch canvas chats");
+      } finally {
+        setCanvasLoading(false);
+      }
+    };
+
+    fetchCanvasChats();
+  }, [activeTab, slug, canvasPage]);
+
   // Mint a short-lived stakgraph sessions URL when the Sessions tab is opened.
   useEffect(() => {
     if (activeTab !== "sessions") return;
@@ -296,6 +353,13 @@ export default function AgentLogsPage() {
     router.push(`/w/${slug}/agent-logs/chat/${convId}`);
   };
 
+  const handleCanvasRowClick = (convId: string) => {
+    // Reuses the chat detail route — its conversation endpoint resolves
+    // org-canvas rows too. `from=canvas` makes the detail page's back
+    // link return to this tab.
+    router.push(`/w/${slug}/agent-logs/chat/${convId}?from=canvas`);
+  };
+
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
@@ -325,6 +389,7 @@ export default function AgentLogsPage() {
                 <TabsList>
                   <TabsTrigger value="agents">Agents</TabsTrigger>
                   <TabsTrigger value="chats">Chats</TabsTrigger>
+                  <TabsTrigger value="canvas">Canvas</TabsTrigger>
                   <TabsTrigger value="sessions">Sessions</TabsTrigger>
                 </TabsList>
               </div>
@@ -567,6 +632,99 @@ export default function AgentLogsPage() {
                           variant="ghost"
                           size="default"
                           onClick={() => setChatPage(chatPage + 1)}
+                          className="gap-1 pr-2.5"
+                        >
+                          <span>Next</span>
+                          <ChevronRight className="h-4 w-4" />
+                        </Button>
+                      </PaginationItem>
+                    )}
+                  </PaginationContent>
+                </Pagination>
+              </div>
+            )}
+
+            {activeTab === "canvas" && canvasLoading && (
+              <div className="rounded-md border">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Timestamp</TableHead>
+                      <TableHead>Agent Name</TableHead>
+                      <TableHead>Feature</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {[1, 2, 3, 4, 5].map((i) => (
+                      <TableRow key={i}>
+                        <TableCell>
+                          <Skeleton className="h-5 w-48" />
+                        </TableCell>
+                        <TableCell>
+                          <Skeleton className="h-5 w-32" />
+                        </TableCell>
+                        <TableCell>
+                          <Skeleton className="h-5 w-28" />
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+
+            {activeTab === "canvas" && canvasError && !canvasLoading && (
+              <div className="text-center py-12">
+                <p className="text-destructive mb-2">Error loading canvas chats</p>
+                <p className="text-sm text-muted-foreground">{canvasError}</p>
+              </div>
+            )}
+
+            {activeTab === "canvas" && !canvasLoading && !canvasError && (
+              <AgentLogsTable
+                logs={canvasLogs}
+                onRowClick={handleCanvasRowClick}
+                onDownload={handleChatDownload}
+              />
+            )}
+
+            {activeTab === "canvas" && !canvasLoading && !canvasError && canvasLogs.length > 0 && (
+              <div className="mt-6">
+                <Pagination>
+                  <PaginationContent>
+                    <PaginationItem>
+                      <Button
+                        variant="ghost"
+                        size="default"
+                        onClick={() => setCanvasPage(Math.max(1, canvasPage - 1))}
+                        disabled={canvasPage === 1}
+                        className="gap-1 pl-2.5"
+                      >
+                        <ChevronLeft className="h-4 w-4" />
+                        <span>Previous</span>
+                      </Button>
+                    </PaginationItem>
+
+                    <PaginationItem>
+                      <Button
+                        variant="outline"
+                        size="icon"
+                        className={buttonVariants({
+                          variant: "outline",
+                          size: "icon",
+                        })}
+                        disabled
+                      >
+                        {canvasPage}
+                      </Button>
+                    </PaginationItem>
+
+                    {canvasHasMore && (
+                      <PaginationItem>
+                        <Button
+                          variant="ghost"
+                          size="default"
+                          onClick={() => setCanvasPage(canvasPage + 1)}
                           className="gap-1 pr-2.5"
                         >
                           <span>Next</span>

--- a/src/lib/ai/askToolsMulti.ts
+++ b/src/lib/ai/askToolsMulti.ts
@@ -397,6 +397,92 @@ export function askToolsMulti(
         }
       },
     });
+
+    // logs_agent — deep, run-grounded analysis of agent execution logs.
+    // Heavier than `${prefix}__search_logs` (a quick Lucene keyword
+    // search); prefer search_logs for simple lookups.
+    allTools[`${prefix}__logs_agent`] = tool({
+      description:
+        `[${ws.slug}] Invoke the Logs Agent for deep, run-grounded analysis of agent execution logs in ${ws.slug}. ` +
+        `Use when the user asks what happened during a run, to debug agent failures, or wants a synthesised explanation backed by real log data. ` +
+        `Heavier than ${prefix}__search_logs — prefer that for simple keyword lookups. ` +
+        `Optionally narrow to a specific feature or task via featureId/taskId.`,
+      inputSchema: z.object({
+        prompt: z.string().describe("The question or debugging query to send to the Logs Agent"),
+        featureId: z
+          .string()
+          .optional()
+          .describe("Optional feature ID to scope the analysis to runs attached to this feature"),
+        taskId: z
+          .string()
+          .optional()
+          .describe("Optional task ID to scope the analysis to runs attached to this task"),
+      }),
+      execute: async ({
+        prompt,
+        featureId,
+        taskId,
+      }: {
+        prompt: string;
+        featureId?: string;
+        taskId?: string;
+      }) => {
+        const scope = {
+          featureIds: featureId ? [featureId] : undefined,
+          taskIds: taskId ? [taskId] : undefined,
+        };
+
+        try {
+          // Lazy imports — these modules pull in heavy deps (Prisma,
+          // EncryptionService, swarm-access). Dynamic import keeps them
+          // out of every test worker that touches askToolsMulti.
+          const [{ runLogsAgent }, { logger }] = await Promise.all([
+            import("@/services/logs-agent"),
+            import("@/lib/logger"),
+          ]);
+
+          logger.info("[LogsAgent] logs_agent tool invoked from dashboard chat", "LogsAgent", {
+            workspace: ws.slug,
+            workspaceId: ws.workspaceId,
+            userId: ws.userId,
+            hasFeatureScope: !!featureId,
+            hasTaskScope: !!taskId,
+          });
+
+          const result = await runLogsAgent({
+            slug: ws.slug,
+            userId: ws.userId,
+            prompt,
+            scope,
+          });
+
+          if (result.success) {
+            return result.data.answer;
+          }
+
+          const { error } = result;
+          if (error.type === "TIMEOUT") {
+            return `The Logs Agent timed out before returning a result for ${ws.slug}. Please try again or narrow your query to a specific feature or task.`;
+          }
+          if (error.type === "AGENT_FAILED") {
+            return `The Logs Agent encountered an error for ${ws.slug}: ${error.message}`;
+          }
+          if (error.type === "ACCESS_DENIED") {
+            return `Access denied to the Logs Agent for ${ws.slug}.`;
+          }
+          if (error.type === "WORKSPACE_NOT_FOUND") {
+            return `Workspace ${ws.slug} not found — the Logs Agent could not be invoked.`;
+          }
+          if (error.type === "SWARM_NOT_ACTIVE" || error.type === "SWARM_NOT_CONFIGURED") {
+            return `The ${ws.slug} swarm is not active. The Logs Agent is unavailable.`;
+          }
+          return `The Logs Agent encountered an unexpected error for ${ws.slug}. Please try again.`;
+        } catch (e) {
+          console.error(`[LogsAgent] logs_agent tool unexpected error for ${ws.slug}`, String(e));
+          return `Could not invoke the Logs Agent for ${ws.slug}. Please try again.`;
+        }
+      },
+    });
   }
 
   // Shared tools (not workspace-specific)

--- a/src/lib/constants/prompt.ts
+++ b/src/lib/constants/prompt.ts
@@ -214,6 +214,7 @@ ${conceptToolLines}
 - \`{workspace}__recent_commits\` - Query recent commits
 - \`{workspace}__recent_contributions\` - Query PRs by a contributor
 - \`{workspace}__search_logs\` - Search application logs (Lucene query syntax)
+- \`{workspace}__logs_agent\` - Deep, run-grounded analysis of agent execution logs (debug agent runs/failures). Heavier than search_logs — prefer search_logs for simple keyword lookups. Optionally scope to a featureId/taskId.
 - \`{workspace}__repo_agent\` - Deep code analysis (if you can't find the answer with the other tools)
 - \`{workspace}__list_features\` - List roadmap features/plans for a workspace. Use this if the user asks about features, plans, roadmap, or what's being worked on.
 - \`{workspace}__read_feature\` - Read a feature's details, brief, requirements, architecture, and chat history

--- a/src/lib/streaming/useStreamProcessor.ts
+++ b/src/lib/streaming/useStreamProcessor.ts
@@ -142,19 +142,21 @@ export function useStreamProcessor<T extends BaseStreamingMessage = BaseStreamin
         debounceTimer = setTimeout(updateMessage, debounceMs);
       };
 
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
+      // SSE lines are not guaranteed to align with network chunk
+      // boundaries: a single large `data:` line (e.g. a big logs_agent
+      // tool result) can be split across multiple reader.read() chunks.
+      // We buffer the trailing partial line and only process complete,
+      // newline-terminated lines, carrying the remainder to the next
+      // read. Without this, JSON.parse throws "Unterminated string in
+      // JSON" on the partial line and the event is silently dropped.
+      let buffer = "";
 
-        const chunk = decoder.decode(value, { stream: true });
-        const lines = chunk.split("\n");
+      const processLine = (line: string) => {
+        const jsonStr = parseSSELine(line);
+        if (!jsonStr) return;
 
-        for (const line of lines) {
-          const jsonStr = parseSSELine(line);
-          if (!jsonStr) continue;
-
-          try {
-            const data = JSON.parse(jsonStr) as StreamEvent;
+        try {
+          const data = JSON.parse(jsonStr) as StreamEvent;
 
             if (data.type === "text-start") {
               // Generate unique ID by combining stream ID with sequence number
@@ -394,10 +396,33 @@ export function useStreamProcessor<T extends BaseStreamingMessage = BaseStreamin
             if (textParts.size > 0 || toolCalls.size > 0 || reasoningParts.size > 0 || error) {
               debouncedUpdate();
             }
-          } catch (parseError) {
-            console.error("Failed to parse stream chunk:", parseError);
-          }
+        } catch (parseError) {
+          console.error("Failed to parse stream chunk:", parseError);
         }
+      };
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+
+        // Split on newlines; the last element is a (possibly empty)
+        // partial line that we keep buffered until its terminating
+        // newline arrives in a later chunk.
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+
+        for (const line of lines) {
+          processLine(line);
+        }
+      }
+
+      // Flush any trailing decoder state and process the final buffered
+      // line (a stream may end without a trailing newline).
+      buffer += decoder.decode();
+      if (buffer) {
+        processLine(buffer);
       }
 
       // Clear any pending debounced updates

--- a/src/lib/utils/chat-conversation-log.ts
+++ b/src/lib/utils/chat-conversation-log.ts
@@ -1,0 +1,101 @@
+import type { ParsedMessage } from "./agent-log-stats";
+
+/**
+ * The stored shape of a dashboard/canvas chat message inside a
+ * `SharedConversation.messages` JSON array. Mirrors the `Message`
+ * interface used by `DashboardChat` — text content plus an optional
+ * batch of tool calls (each carrying its own input AND output).
+ */
+export interface StoredChatToolCall {
+  id: string;
+  toolName: string;
+  input?: unknown;
+  status?: string;
+  output?: unknown;
+  errorText?: string;
+}
+
+export interface StoredChatMessage {
+  id?: string;
+  role: "user" | "assistant" | string;
+  content?: string;
+  imageData?: string;
+  toolCalls?: StoredChatToolCall[];
+}
+
+/**
+ * Convert a SharedConversation's stored chat messages into the
+ * `ParsedMessage[]` blob format that the Agent Logs detail view
+ * (`LogDetailContent`) renders. This unlocks the rich tool-call view
+ * (call args + paired result + stats bar) for chat sessions, which
+ * already persist every tool call's input and output — they just
+ * weren't being surfaced.
+ *
+ * The mapping mirrors how `DashboardChat` serializes a turn back to
+ * the AI SDK when sending: a tool batch becomes a `tool-call`
+ * assistant message + a paired `tool-result` tool message, and text
+ * stays a plain string message. `buildToolCallIndex` /
+ * `getConsumedResultIds` (used by `LogDetailContent`) then pair each
+ * call with its result by `toolCallId`.
+ */
+export function chatMessagesToParsedMessages(
+  messages: StoredChatMessage[],
+): ParsedMessage[] {
+  const out: ParsedMessage[] = [];
+
+  for (const m of messages) {
+    if (!m || typeof m !== "object") continue;
+
+    const toolCalls = Array.isArray(m.toolCalls) ? m.toolCalls : [];
+
+    if (m.role === "assistant" && toolCalls.length > 0) {
+      // 1. tool-call message (the calls the agent made)
+      out.push({
+        role: "assistant",
+        content: toolCalls.map((tc) => ({
+          type: "tool-call" as const,
+          toolCallId: tc.id,
+          toolName: tc.toolName,
+          input: tc.input,
+        })),
+      });
+
+      // 2. paired tool-result message (only for calls that resolved)
+      const resolved = toolCalls.filter(
+        (tc) => tc.output !== undefined || tc.errorText !== undefined,
+      );
+      if (resolved.length > 0) {
+        out.push({
+          role: "tool",
+          content: resolved.map((tc) => ({
+            type: "tool-result" as const,
+            toolCallId: tc.id,
+            toolName: tc.toolName,
+            // Prefer the real output; fall back to the error text so a
+            // failed call still shows *something* in the result pane.
+            output:
+              tc.output !== undefined
+                ? (tc.output as { type: string; value: string } | string)
+                : (tc.errorText as string),
+          })),
+        });
+      }
+
+      // 3. any trailing assistant text that accompanied the batch
+      if (m.content) {
+        out.push({ role: "assistant", content: m.content });
+      }
+      continue;
+    }
+
+    // Plain text message (user or assistant). Note image attachments
+    // inline since the log view is text-only.
+    let content = typeof m.content === "string" ? m.content : "";
+    if (m.imageData) {
+      content = content ? `[image attached]\n${content}` : "[image attached]";
+    }
+    out.push({ role: m.role, content });
+  }
+
+  return out;
+}


### PR DESCRIPTION
## Problem

Dashboard chat (`/api/ask/quick`) would sometimes render **nothing**, with this frontend error:

```
Failed to parse stream chunk: SyntaxError: Unterminated string in JSON at position 8082
```

### Root cause

In `src/lib/streaming/useStreamProcessor.ts`, the stream was read like:

```js
const chunk = decoder.decode(value, { stream: true });
const lines = chunk.split("\n");
for (const line of lines) JSON.parse(...)
```

`reader.read()` returns **arbitrary network chunks**, not line-aligned data. A single large SSE `data:` line can be split across multiple reads. When that happens the trailing partial line is an incomplete JSON string, `JSON.parse` throws "Unterminated string", and the `catch` swallows it with a `console.error` — so the event (and everything after) is lost.

The newly-added `logs_agent` tool exposed this: it returns a large synthesized answer backed by real log data (8KB+, matching "position 8082"), big enough to reliably span chunk boundaries. Smaller tool results fit in one chunk, which is why it stayed hidden.

## Fix

- **Buffer partial SSE lines across reads.** Only process complete, newline-terminated lines; carry the remainder to the next read and flush any trailing line (and decoder state) after the loop ends.

## Also

- **Add `logs_agent` to the multi-workspace toolset** (`src/lib/ai/askToolsMulti.ts`), slug-prefixed per workspace (`${slug}__logs_agent`), mirroring the single-workspace tool in `askTools.ts` (lazy imports, per-workspace error messages). It's read-only, so correctly not added to `READONLY_STRIP_TOOL_NAMES`.
- **Document `{workspace}__logs_agent`** in the multi-workspace prompt (`src/lib/constants/prompt.ts`).

## Tests

- Chunk-boundary: an SSE line split mid-string across chunks is reassembled and the tool output attaches.
- A final line with no trailing newline is still processed.
- `logs_agent` is registered per workspace and distinct from `search_logs`.

All touched suites pass (45 streaming + 11 askToolsMulti) and typecheck is clean.