### PR TITLE
Fix log streaming panel not updating after first message by revising provisional tab logic and race condition

### DIFF
--- a/src/__tests__/integration/api/features-attachments.test.ts
+++ b/src/__tests__/integration/api/features-attachments.test.ts
@@ -142,14 +142,18 @@ describe("GET /api/features/[featureId]/attachments", () => {
 
     const data = await response.json();
     expect(data.attachments).toHaveLength(2);
-    expect(data.attachments[0]).toMatchObject({
+
+    const jpg = data.attachments.find((a: { filename: string }) => a.filename === "screenshot-1.jpg");
+    const png = data.attachments.find((a: { filename: string }) => a.filename === "screenshot-2.png");
+
+    expect(jpg).toMatchObject({
       filename: "screenshot-1.jpg",
       mimeType: "image/jpeg",
       taskId: testTask.id,
       taskTitle: "Test Task",
     });
-    expect(data.attachments[0].url).toBeDefined();
-    expect(data.attachments[1]).toMatchObject({
+    expect(jpg.url).toBeDefined();
+    expect(png).toMatchObject({
       filename: "screenshot-2.png",
       mimeType: "image/png",
       taskId: testTask.id,

--- a/src/__tests__/unit/components/agent-logs/LogsArtifactPanel.test.tsx
+++ b/src/__tests__/unit/components/agent-logs/LogsArtifactPanel.test.tsx
@@ -285,6 +285,7 @@ describe("LogsArtifactPanel", () => {
     const streamingLog = {
       agent: "streaming-agent-task1",
       conversation: [{ role: "assistant", content: "Working…", toolCalls: [] }],
+      status: "streaming" as const,
     };
     // No real logs so provisional tab is shown
     render(
@@ -296,6 +297,34 @@ describe("LogsArtifactPanel", () => {
 
     const tab = screen.getByRole("tab", { name: /Streaming Agent/i });
     expect(tab.getAttribute("title")).toBeNull();
+  });
+
+  it("shows provisional tab for second run even when a canonical log with the same agent name already exists", async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => fakeStats });
+
+    const { LogsArtifactPanel } = await import("@/components/agent-logs/LogsArtifactPanel");
+    const streamingLog = {
+      agent: "plan-agent",
+      conversation: [],
+      status: "streaming" as const,
+    };
+
+    render(
+      React.createElement(LogsArtifactPanel, {
+        logs: [{ id: "log-1", agent: "plan-agent" }],
+        streamingLog,
+      })
+    );
+
+    // Provisional tab should be present despite the canonical log sharing the same agent name
+    const provisionalTab = screen.getByRole("tab", { name: /Plan Agent/i, selected: false });
+    expect(provisionalTab).toBeDefined();
+    // The streaming indicator (animate-pulse dot) is only on the provisional tab
+    const allTabs = screen.getAllByRole("tab");
+    const provisionalTabWithPulse = allTabs.find((tab) =>
+      tab.querySelector("[aria-label='streaming']") !== null
+    );
+    expect(provisionalTabWithPulse).toBeDefined();
   });
 });
 

--- a/src/__tests__/unit/hooks/useStreamContext.test.ts
+++ b/src/__tests__/unit/hooks/useStreamContext.test.ts
@@ -84,7 +84,7 @@ describe("useStreamContext", () => {
     WorkflowStatus.FAILED,
     WorkflowStatus.ERROR,
     WorkflowStatus.HALTED,
-  ])("onWorkflowStatusUpdate clears streamContext for terminal status: %s", (status) => {
+  ])("onWorkflowStatusUpdate preserves streamContext for terminal status: %s", (status) => {
     const { result } = renderHook(() => useStreamContext());
 
     // First set a stream context
@@ -111,7 +111,9 @@ describe("useStreamContext", () => {
       result.current.onWorkflowStatusUpdate({ workflowStatus: status } as WorkflowStatusUpdate);
     });
 
-    expect(result.current.streamContext).toBeNull();
+    // Context should be preserved — no longer cleared on terminal status
+    expect(result.current.streamContext).not.toBeNull();
+    expect(result.current.streamContext?.requestId).toBe("req-1");
   });
 
   it("onWorkflowStatusUpdate does NOT clear streamContext for IN_PROGRESS", () => {
@@ -146,5 +148,44 @@ describe("useStreamContext", () => {
     // Should still be set
     expect(result.current.streamContext).not.toBeNull();
     expect(result.current.streamContext?.requestId).toBe("req-1");
+  });
+
+  it("second STREAM artifact overrides first context even after terminal status", () => {
+    const { result } = renderHook(() => useStreamContext());
+
+    const makeStreamMessage = (requestId: string) =>
+      makeMessage({
+        artifacts: [
+          {
+            type: "STREAM",
+            content: {
+              requestId,
+              eventsToken: "tok-1",
+              baseUrl: "https://example.com",
+            },
+          },
+        ] as ChatMessage["artifacts"],
+      });
+
+    // Run 1: set first context
+    act(() => {
+      result.current.onMessage(makeStreamMessage("req-1"));
+    });
+    expect(result.current.streamContext?.requestId).toBe("req-1");
+
+    // Run 1 completes — should be a no-op now
+    act(() => {
+      result.current.onWorkflowStatusUpdate({
+        workflowStatus: WorkflowStatus.COMPLETED,
+      } as WorkflowStatusUpdate);
+    });
+    expect(result.current.streamContext?.requestId).toBe("req-1");
+
+    // Run 2: new STREAM artifact arrives
+    act(() => {
+      result.current.onMessage(makeStreamMessage("req-2"));
+    });
+
+    expect(result.current.streamContext?.requestId).toBe("req-2");
   });
 });

--- a/src/__tests__/unit/hooks/useStreamedAgentLog.test.ts
+++ b/src/__tests__/unit/hooks/useStreamedAgentLog.test.ts
@@ -56,7 +56,7 @@ describe("useStreamedAgentLog", () => {
     expect(result.current).toBeNull();
   });
 
-  it("returns { agent, conversation: [] } when streaming with no events yet", () => {
+  it("returns { agent, conversation: [], status: 'streaming' } when streaming with no events yet", () => {
     const { result } = renderHook(() =>
       useStreamedAgentLog({
         requestId: "req-1",
@@ -68,6 +68,7 @@ describe("useStreamedAgentLog", () => {
     expect(result.current).not.toBeNull();
     expect(result.current?.agent).toBe("plan-agent-abc");
     expect(result.current?.conversation).toEqual([]);
+    expect(result.current?.status).toBe("streaming");
   });
 
   it("maps text events to assistant conversation messages", () => {
@@ -87,6 +88,7 @@ describe("useStreamedAgentLog", () => {
     expect(result.current?.conversation).toEqual([
       { role: "assistant", content: "Hello world" },
     ]);
+    expect(result.current?.status).toBe("streaming");
   });
 
   it("maps tool_call events with input to formatted assistant messages", () => {
@@ -110,6 +112,7 @@ describe("useStreamedAgentLog", () => {
     expect(result.current?.conversation[0].role).toBe("assistant");
     expect(result.current?.conversation[0].content).toContain("🔧 search_files");
     expect(result.current?.conversation[0].content).toContain("query: test");
+    expect(result.current?.status).toBe("streaming");
   });
 
   it("maps tool_call events without input to simple formatted messages", () => {
@@ -127,6 +130,7 @@ describe("useStreamedAgentLog", () => {
     });
 
     expect(result.current?.conversation[0].content).toBe("🔧 read_file");
+    expect(result.current?.status).toBe("streaming");
   });
 
   it("accumulates multiple events in order", () => {
@@ -150,6 +154,7 @@ describe("useStreamedAgentLog", () => {
     expect(result.current?.conversation[0].content).toBe("First");
     expect(result.current?.conversation[1].content).toBe("🔧 search");
     expect(result.current?.conversation[2].content).toBe("Second");
+    expect(result.current?.status).toBe("streaming");
   });
 
   it("returns null when status is done and no events exist", () => {
@@ -169,7 +174,7 @@ describe("useStreamedAgentLog", () => {
     expect(result.current).toBeNull();
   });
 
-  it("returns conversation when status is done but events exist", () => {
+  it("returns conversation with status 'done' when status is done but events exist", () => {
     const { result } = renderHook(() =>
       useStreamedAgentLog({
         requestId: "req-1",
@@ -188,6 +193,7 @@ describe("useStreamedAgentLog", () => {
     // Has events so should still return conversation
     expect(result.current).not.toBeNull();
     expect(result.current?.conversation).toHaveLength(1);
+    expect(result.current?.status).toBe("done");
   });
 
   it("returns null when status is error and no events exist", () => {
@@ -229,5 +235,6 @@ describe("useStreamedAgentLog", () => {
 
     // New EventSource opened, events reset
     expect(result.current?.conversation).toHaveLength(0);
+    expect(result.current?.status).toBe("streaming");
   });
 });

--- a/src/app/w/[slug]/task/[...taskParams]/components/ArtifactsPanel.tsx
+++ b/src/app/w/[slug]/task/[...taskParams]/components/ArtifactsPanel.tsx
@@ -13,6 +13,7 @@ import { CompactTasksList } from "@/components/features/CompactTasksList";
 import { VerifyPanel } from "@/app/w/[slug]/plan/[featureId]/components/VerifyPanel";
 import { LogsArtifactPanel } from "@/components/agent-logs/LogsArtifactPanel";
 import type { ConversationMessage } from "@/hooks/useStreamedAgentLog";
+import type { AgentEventsStatus } from "@/hooks/useAgentEvents";
 import { ArtifactsHeader } from "./ArtifactsHeader";
 import { WorkflowTransition } from "@/types/stakwork/workflow";
 import { useAutoSave } from "@/hooks/useAutoSave";
@@ -45,7 +46,7 @@ interface ArtifactsPanelProps {
   sectionHighlights?: SectionHighlights | null;
   browserRefreshTrigger?: number;
   isSuperAdmin?: boolean;
-  streamingLog?: { agent: string; conversation: ConversationMessage[] } | null;
+  streamingLog?: { agent: string; conversation: ConversationMessage[]; status: AgentEventsStatus } | null;
   isAgentActive?: boolean;
 }
 

--- a/src/components/agent-logs/LogsArtifactPanel.tsx
+++ b/src/components/agent-logs/LogsArtifactPanel.tsx
@@ -9,6 +9,7 @@ import { toast } from "sonner";
 import { MessageBubble, StatsBar, unescapeLogString } from "./LogDetailContent";
 import type { ParsedMessage, AgentLogStats } from "@/lib/utils/agent-log-stats";
 import type { ConversationMessage } from "@/hooks/useStreamedAgentLog";
+import type { AgentEventsStatus } from "@/hooks/useAgentEvents";
 
 interface AgentLogItem {
   id: string;
@@ -34,7 +35,7 @@ const INSIGHTS_ID = "INSIGHTS";
 interface LogsArtifactPanelProps {
   logs: AgentLogItem[];
   lastUpdated?: Record<string, number>;
-  streamingLog?: { agent: string; conversation: ConversationMessage[] } | null;
+  streamingLog?: { agent: string; conversation: ConversationMessage[]; status: AgentEventsStatus } | null;
   featureId?: string;
   isSuperAdmin?: boolean;
 }
@@ -83,9 +84,7 @@ export function LogsArtifactPanel({
   featureId,
   isSuperAdmin,
 }: LogsArtifactPanelProps) {
-  const hasProvisional =
-    !!streamingLog &&
-    !logs.some((l) => l.agent === streamingLog.agent);
+  const hasProvisional = !!streamingLog && streamingLog.status === "streaming";
 
   const defaultId = logs[logs.length - 1]?.id ?? (hasProvisional ? PROVISIONAL_ID : null);
 

--- a/src/hooks/useStreamContext.ts
+++ b/src/hooks/useStreamContext.ts
@@ -3,13 +3,6 @@ import type { StreamContext } from "@/app/w/[slug]/task/[...taskParams]/componen
 import { type ChatMessage, type StreamContent, WorkflowStatus } from "@/lib/chat";
 import type { WorkflowStatusUpdate } from "@/hooks/usePusherConnection";
 
-const TERMINAL_STATUSES: WorkflowStatus[] = [
-  WorkflowStatus.COMPLETED,
-  WorkflowStatus.FAILED,
-  WorkflowStatus.ERROR,
-  WorkflowStatus.HALTED,
-];
-
 export function useStreamContext() {
   const [streamContext, setStreamContext] = useState<StreamContext | null>(null);
 
@@ -30,10 +23,9 @@ export function useStreamContext() {
 
   function onWorkflowStatusUpdate(update: WorkflowStatusUpdate) {
     console.log("[useStreamContext] onWorkflowStatusUpdate", update.workflowStatus);
-    if (TERMINAL_STATUSES.includes(update.workflowStatus)) {
-      console.log("[useStreamContext] clearing streamContext (terminal status)");
-      setStreamContext(null);
-    }
+    // No-op: terminal statuses no longer clear streamContext.
+    // The EventSource "done" event drives hasProvisional to false via the status-based check,
+    // and clearing here caused a race condition that wiped a freshly-set context for the next run.
   }
 
   return { streamContext, onMessage, onWorkflowStatusUpdate };

--- a/src/hooks/useStreamedAgentLog.ts
+++ b/src/hooks/useStreamedAgentLog.ts
@@ -1,4 +1,4 @@
-import { useAgentEvents } from "@/hooks/useAgentEvents";
+import { useAgentEvents, type AgentEventsStatus } from "@/hooks/useAgentEvents";
 import type { StreamContext } from "@/app/w/[slug]/task/[...taskParams]/components/WorkflowStatusBadge";
 
 export interface ConversationMessage {
@@ -14,7 +14,7 @@ export interface ConversationMessage {
  */
 export function useStreamedAgentLog(
   streamContext: (StreamContext & { agent?: string }) | null,
-): { agent: string; conversation: ConversationMessage[] } | null {
+): { agent: string; conversation: ConversationMessage[]; status: AgentEventsStatus } | null {
   const { events, status } = useAgentEvents(
     streamContext?.requestId ?? null,
     streamContext?.eventsToken ?? null,
@@ -42,5 +42,5 @@ export function useStreamedAgentLog(
     return { role: "assistant" as const, content: e.text };
   });
 
-  return { agent: streamContext.agent, conversation };
+  return { agent: streamContext.agent, conversation, status };
 }


### PR DESCRIPTION
Generated with Hive: Fix log streaming panel not updating after first message by revising provisional tab logic and race condition