### PR TITLE
Canvas chat: surface mid-stream errors + render rich tool-call timeline

### DIFF
--- a/src/app/api/ask/quick/route.ts
+++ b/src/app/api/ask/quick/route.ts
@@ -480,7 +480,24 @@ export async function POST(request: NextRequest) {
         }
       });
 
-      return result.toUIMessageStreamResponse();
+      return result.toUIMessageStreamResponse({
+        // By default the AI SDK masks mid-stream errors as the literal
+        // string "An error occurred." — useless for diagnosis and
+        // indistinguishable from a clean finish on the client. Forward
+        // the real message instead. `runCanvasAgent`'s `onError` logs the
+        // full error + stack server-side; this surfaces a readable
+        // message to the chat so the user sees *why* it failed rather
+        // than a generic fallback.
+        onError: (error) => {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          console.error("❌ [quick-ask] Mid-stream error:", {
+            workspaces: slugs,
+            message,
+          });
+          return message;
+        },
+      });
     } catch (streamError) {
       // Preserve typed ApiError statuses (forbidden, notFound,
       // validation, etc.) from the inner pipeline. The original code

--- a/src/app/org/[githubLogin]/_components/CanvasHistoryPopover.tsx
+++ b/src/app/org/[githubLogin]/_components/CanvasHistoryPopover.tsx
@@ -84,6 +84,7 @@ export function CanvasHistoryPopover({ githubLogin }: CanvasHistoryPopoverProps)
           content: typeof m.content === "string" ? m.content : "",
           timestamp: m.timestamp ? new Date(m.timestamp) : new Date(),
           toolCalls: m.toolCalls,
+          timeline: m.timeline,
           artifactIds: m.artifactIds,
           approval: m.approval,
           rejection: m.rejection,

--- a/src/app/org/[githubLogin]/_components/SidebarChat.tsx
+++ b/src/app/org/[githubLogin]/_components/SidebarChat.tsx
@@ -15,7 +15,7 @@ import { CanvasHistoryPopover } from "./CanvasHistoryPopover";
 import { CanvasAgentSettingsPopover } from "./CanvasAgentSettingsPopover";
 import { toast } from "sonner";
 import { useShallow } from "zustand/react/shallow";
-import { ToolCallIndicator } from "@/components/dashboard/DashboardChat/ToolCallIndicator";
+import { StreamingMessage } from "@/components/streaming";
 import { Button } from "@/components/ui/button";
 import { SidebarChatMessage } from "./SidebarChatMessage";
 import { ProposalCard, getProposalsFromMessage } from "./ProposalCard";
@@ -290,12 +290,33 @@ export function SidebarChat({ githubLogin }: SidebarChatProps) {
 
             const proposals = getProposalsFromMessage(message);
 
+            // A streamed tool-call row carries a `timeline` (and empty
+            // text content). Render it as rich, expandable tool cards via
+            // the shared `<StreamingMessage>` — names, args, outputs, and
+            // live status, in order with any interleaved text. Plain text
+            // rows fall through to `SidebarChatMessage` so the bubble look
+            // and the `?r=`/`?c=` deep-link interceptor are preserved.
+            const hasTimeline = !!message.timeline?.length;
+
             return (
               <div key={message.id} className="space-y-1.5">
-                <SidebarChatMessage
-                  message={message}
-                  isStreaming={isMessageStreaming}
-                />
+                {hasTimeline ? (
+                  <div className="w-full text-foreground/90">
+                    <StreamingMessage
+                      message={{
+                        id: message.id,
+                        content: message.content,
+                        timeline: message.timeline,
+                        isStreaming: isMessageStreaming,
+                      }}
+                    />
+                  </div>
+                ) : (
+                  <SidebarChatMessage
+                    message={message}
+                    isStreaming={isMessageStreaming}
+                  />
+                )}
                 {proposals.length > 0 && (
                   <div className="space-y-1.5">
                     {proposals.map((p) => (
@@ -343,9 +364,6 @@ export function SidebarChat({ githubLogin }: SidebarChatProps) {
                 </div>
               </div>
             </motion.div>
-          )}
-          {activeToolCalls.length > 0 && (
-            <ToolCallIndicator toolCalls={activeToolCalls} />
           )}
         </div>
       </div>

--- a/src/app/org/[githubLogin]/_state/canvasChatStore.ts
+++ b/src/app/org/[githubLogin]/_state/canvasChatStore.ts
@@ -62,6 +62,7 @@ import type {
   RejectionIntent,
 } from "@/lib/proposals/types";
 import type { ClarifyingQuestion } from "@/types/stakwork";
+import type { StreamTimelineItem } from "@/types/streaming";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -146,6 +147,21 @@ export interface CanvasChatMessage {
   content: string;
   timestamp: Date;
   toolCalls?: ToolCall[];
+  /**
+   * Interleaved render timeline (text / reasoning / tool-call items) for
+   * an assistant turn, in the AI-SDK `StreamToolCall` shape — i.e. richer
+   * than `toolCalls` (carries `inputText` + the typed `ToolCallStatus`).
+   * `SidebarChat` renders this via `<StreamingMessage>` so tool calls show
+   * as expandable cards with names / args / outputs, in order with text.
+   *
+   * Populated by `useSendCanvasChatMessage` for streamed tool-call rows
+   * and round-trips through `SharedConversation.messages` JSON (so reload,
+   * share, and live-sync all keep the rich rendering). `toolCalls` stays
+   * the source of truth for the model context (`toModelMessages`) and the
+   * sub-agent projection (`getSubAgentRunsFromMessages`); `timeline` is the
+   * display layer only.
+   */
+  timeline?: StreamTimelineItem[];
   /**
    * Forward-compat: ids referencing entries in `state.artifacts`.
    * Empty in PR 1; populated when the first artifact type ships.

--- a/src/app/org/[githubLogin]/_state/useCanvasChatAutoSave.ts
+++ b/src/app/org/[githubLogin]/_state/useCanvasChatAutoSave.ts
@@ -79,6 +79,7 @@ function hydrateServerMessages(raw: unknown[]): CanvasChatMessage[] {
       content: typeof m.content === "string" ? m.content : "",
       timestamp: m.timestamp ? new Date(m.timestamp as string) : new Date(),
       toolCalls: m.toolCalls as CanvasChatMessage["toolCalls"],
+      timeline: m.timeline as CanvasChatMessage["timeline"],
       artifactIds: m.artifactIds as string[] | undefined,
       approval: m.approval as CanvasChatMessage["approval"],
       rejection: m.rejection as CanvasChatMessage["rejection"],

--- a/src/app/org/[githubLogin]/_state/useSendCanvasChatMessage.ts
+++ b/src/app/org/[githubLogin]/_state/useSendCanvasChatMessage.ts
@@ -28,6 +28,7 @@
 
 import { useCallback } from "react";
 import { useStreamProcessor } from "@/lib/streaming";
+import type { StreamTimelineItem } from "@/types/streaming";
 import type {
   ApprovalIntent,
   ApprovalResult,
@@ -189,6 +190,12 @@ export function useSendCanvasChatMessage() {
           const timelineMessages: CanvasChatMessage[] = [];
           let currentText = "";
           let currentToolCalls: ToolCall[] = [];
+          // Raw stream timeline items for the current tool-call run, kept
+          // alongside `currentToolCalls` so the tool message carries the
+          // rich `StreamToolCall` data (`inputText`, typed status) that
+          // `<StreamingMessage>` renders. `toolCalls` stays the lossy
+          // model/sub-agent projection; this is the display layer.
+          let currentToolItems: StreamTimelineItem[] = [];
           let msgCounter = 0;
 
           for (const item of timeline) {
@@ -258,6 +265,7 @@ export function useSendCanvasChatMessage() {
                     ? "Tool call failed"
                     : undefined,
               });
+              currentToolItems.push(item);
             }
           }
 
@@ -268,8 +276,10 @@ export function useSendCanvasChatMessage() {
               content: "",
               timestamp: new Date(),
               toolCalls: currentToolCalls,
+              timeline: currentToolItems,
             });
             currentToolCalls = [];
+            currentToolItems = [];
           }
 
           if (currentText.trim()) {
@@ -295,6 +305,23 @@ export function useSendCanvasChatMessage() {
                 break;
               }
             }
+          }
+
+          // Surface a mid-stream error part. The server forwards the
+          // real message via `toUIMessageStreamResponse({ onError })`,
+          // and `useStreamProcessor` exposes it as `updatedMessage.error`.
+          // Without this the error part is dropped (the timeline rebuild
+          // above ignores it), so a stream that errored *after* the 200
+          // headers — e.g. an Anthropic request rejection — would render
+          // nothing at all. Append it as a trailing assistant message so
+          // it shows inline after whatever partial content streamed.
+          if (updatedMessage.error) {
+            timelineMessages.push({
+              id: `${messageId}-error`,
+              role: "assistant",
+              content: updatedMessage.error,
+              timestamp: new Date(),
+            });
           }
 
           const lastMsg = timelineMessages[timelineMessages.length - 1];

--- a/src/app/org/[githubLogin]/chat/shared/[shareId]/page.tsx
+++ b/src/app/org/[githubLogin]/chat/shared/[shareId]/page.tsx
@@ -3,8 +3,10 @@ import { getServerSession } from "next-auth/next";
 import { redirect, notFound } from "next/navigation";
 import { ChatMessage } from "@/components/dashboard/DashboardChat/ChatMessage";
 import { ToolCallIndicator } from "@/components/dashboard/DashboardChat/ToolCallIndicator";
+import { StreamingMessage } from "@/components/streaming";
 import { db } from "@/lib/db";
 import { SharedConversationData } from "@/types/shared-conversation";
+import type { StreamTimelineItem } from "@/types/streaming";
 import { Badge } from "@/components/ui/badge";
 
 interface Message {
@@ -21,6 +23,7 @@ interface Message {
     output?: unknown;
     errorText?: string;
   }>;
+  timeline?: StreamTimelineItem[];
 }
 
 interface OrgSharedConversationPageProps {
@@ -201,6 +204,25 @@ export default async function OrgSharedConversationPage({ params }: OrgSharedCon
         <div className="max-w-4xl mx-auto px-6 py-8">
           <div className="space-y-4">
             {messages.map((message) => {
+              // Streamed tool-call rows persist their rich render timeline —
+              // show the expandable cards (names / args / outputs) just like
+              // the live canvas chat.
+              if (message.timeline && message.timeline.length > 0) {
+                return (
+                  <div key={message.id} className="text-foreground/90">
+                    <StreamingMessage
+                      message={{
+                        id: message.id,
+                        content: message.content,
+                        timeline: message.timeline,
+                      }}
+                    />
+                  </div>
+                );
+              }
+
+              // Legacy rows (saved before the timeline landed) fall back to
+              // the generic indicator.
               if (message.toolCalls && message.toolCalls.length > 0 && !message.content) {
                 return (
                   <div key={message.id}>

--- a/src/lib/ai/runCanvasAgent.ts
+++ b/src/lib/ai/runCanvasAgent.ts
@@ -716,6 +716,25 @@ export async function runCanvasAgent(
         await hooks.onFinish({ usage });
       }
     },
+    // Surface errors that occur DURING streaming (after the 200 response
+    // headers are already sent). Without this, the AI SDK silently masks
+    // the failure into a generic error part and the real cause (e.g. an
+    // Anthropic `invalid_request_error` from an oversized request, or a
+    // tool throwing) never lands in the logs — the stream just goes quiet
+    // right after the `streamText:` line above. Log the full error so
+    // operators can diagnose; the message is also propagated to the client
+    // via `toUIMessageStreamResponse({ onError })` in the HTTP route.
+    onError: (event) => {
+      const err = (event as { error?: unknown })?.error ?? event;
+      console.error("[runCanvasAgent] streamText error:", {
+        workspaces: workspaceSlugs,
+        orgId: orgId ?? null,
+        message: err instanceof Error ? err.message : String(err),
+        name: err instanceof Error ? err.name : undefined,
+        stack: err instanceof Error ? err.stack : undefined,
+        error: err,
+      });
+    },
   });
 
   return {


### PR DESCRIPTION
## Summary

Two related canvas-chat changes bundled together.

### 1. Surface mid-stream stream errors (diagnosability)

When the canvas chat showed *"I'm sorry, but I encountered an error…"*, the real cause was invisible: `streamText` in `runCanvasAgent` and `result.toUIMessageStreamResponse()` in the `ask/quick` route both lacked an `onError`. Any failure that occurred **after** the 200 response headers were sent (e.g. an Anthropic `invalid_request_error` from an oversized request, or a tool throwing) was masked into a generic error part by the AI SDK and never logged — server logs went quiet right after the `streamText:` line.

- `runCanvasAgent.ts` — add `onError` to `streamText` that logs the full error (message + name + stack + workspaces + orgId).
- `api/ask/quick/route.ts` — add `onError` to `toUIMessageStreamResponse` so the **real** error message is forwarded to the client (instead of `"An error occurred."`) and logged route-side.
- `useSendCanvasChatMessage.ts` — the stream `onUpdate` now reads `updatedMessage.error` and appends it as a trailing assistant message, so a clean mid-stream error part renders inline instead of being silently dropped.

### 2. Render rich tool-call timeline in canvas chat

Persist an interleaved `timeline` (text / reasoning / tool-call items) on canvas chat messages so tool calls render as expandable cards (names / args / outputs / live status), in order with text — via the shared `<StreamingMessage>` component.

- `canvasChatStore.ts` — add `timeline?: StreamTimelineItem[]` to `CanvasChatMessage`.
- `useSendCanvasChatMessage.ts` — populate `timeline` for streamed tool-call rows.
- `SidebarChat.tsx` — render timeline rows via `<StreamingMessage>`; plain text rows still use `SidebarChatMessage` (preserving the bubble look + deep-link interceptor). Removes the old bottom `ToolCallIndicator`.
- `CanvasHistoryPopover.tsx`, `useCanvasChatAutoSave.ts`, `chat/shared/[shareId]/page.tsx` — carry/hydrate/render `timeline` so it round-trips through `SharedConversation.messages` JSON (reload, share, live-sync, history popover). Legacy rows fall back to the prior rendering.

`toolCalls` remains the source of truth for model context (`toModelMessages`) and the sub-agent projection (`getSubAgentRunsFromMessages`); `timeline` is the display layer only.

## Test plan

- [ ] Trigger a failing canvas chat turn — verify `[runCanvasAgent] streamText error:` appears in server logs with the real message + stack, and the real error renders in the chat.
- [ ] Run a normal multi-tool canvas chat turn — verify tool calls render as expandable cards inline with text.
- [ ] Reload / open a shared conversation — verify the tool-call cards persist.