### PR TITLE
Canvas chat: cache prompt concepts to skip per-message swarm fetch

### DIFF
--- a/src/app/api/ask/quick/route.ts
+++ b/src/app/api/ask/quick/route.ts
@@ -27,6 +27,7 @@ import type {
 import {
   runCanvasAgent,
   extractConceptIdsFromStep,
+  type CachedConcepts,
 } from "@/lib/ai/runCanvasAgent";
 import type { DispatchedResearchIntent } from "@/lib/ai/researchTools";
 import { swarmFetch } from "@/lib/ai/concepts";
@@ -306,6 +307,22 @@ export async function POST(request: NextRequest) {
       anonymousId: publicAnonymousId,
     });
 
+    // Org-canvas prompt-prefix cache. The prefix (system prompt + the
+    // pre-seeded `list_concepts` results) is identical turn-to-turn for a
+    // conversation, but rebuilding it re-hits the swarm (`listConcepts`)
+    // on every message — slow, and a hard failure when the swarm is
+    // offline. So on the first turn we persist the assembled prefix to
+    // `SharedConversation.settings.promptPrefix` and on later turns reuse
+    // it, skipping the swarm round-trip entirely. Org-canvas rows are
+    // org-scoped (workspaceId null), so the workspace-keyed
+    // `resolveTokenAttributionRowId` above never matches them — we resolve
+    // + load via the org-aware path here. Only the canvas chat (orgId set)
+    // participates; the dashboard chat keeps rebuilding fresh.
+    const promptCache =
+      orgId && userId
+        ? await loadOrgCanvasPromptCache({ conversationId, userId, orgId })
+        : null;
+
     try {
       // Tracks concept ids learned in this turn so the `after()` block
       // can fetch their provenance from stakgraph after the stream
@@ -322,10 +339,17 @@ export async function POST(request: NextRequest) {
         primarySwarmApiKey,
         primaryWorkspaceId,
         primaryUserId,
+        assembledPrefix,
+        cacheableConcepts,
+        cacheHit,
       } = await runCanvasAgent({
           userId,
           orgId: orgId && isMultiWorkspace ? orgId : undefined,
           workspaceSlugs: slugs,
+          // Reuse cached concepts (skips the swarm `listConcepts` call)
+          // when we have them for this org-canvas conversation. The prefix
+          // is still rebuilt fresh each turn for an accurate scope hint.
+          cachedConcepts: promptCache?.cachedConcepts ?? null,
           publicViewer: isPublicViewerRequest
             ? { workspaceId: publicViewerWorkspaceId!, primarySlug }
             : undefined,
@@ -383,6 +407,32 @@ export async function POST(request: NextRequest) {
             },
           },
         });
+
+      // Persist the freshly-fetched concepts so the next turn of this
+      // conversation can reuse them and skip the swarm `listConcepts`
+      // call. Also snapshot the rendered prefix for the Agent Logs detail
+      // view. Only on a cache MISS, with a validated org-canvas row id,
+      // and only when the concepts are NON-EMPTY — a swarm outage on the
+      // first turn yields an empty list, and caching that would poison
+      // the cache into permanently serving nothing (we retry next turn).
+      // Best-effort + off the response path via `after()`.
+      if (promptCache?.rowId && !cacheHit && hasConcepts(cacheableConcepts)) {
+        const rowId = promptCache.rowId;
+        after(async () => {
+          try {
+            await persistOrgCanvasPromptCache(
+              rowId,
+              cacheableConcepts,
+              assembledPrefix,
+            );
+          } catch (err) {
+            console.error(
+              "❌ [quick-ask] Failed to persist prompt cache:",
+              err,
+            );
+          }
+        });
+      }
 
       after(async () => {
         // Surfaces that don't render follow-ups or provenance opt out
@@ -620,6 +670,81 @@ async function resolveOrgConversationRowId(args: {
     select: { id: true },
   });
   return row?.id ?? null;
+}
+
+/**
+ * Load the cached concepts for an org-canvas conversation, while
+ * validating that the row belongs to this org and either to this caller
+ * or is an explicitly shared room (same ownership rule as
+ * `resolveOrgConversationRowId`). Returns the validated row id plus the
+ * cached concepts (or null when there's no usable cache yet). IDOR-safe:
+ * a mismatched/missing id yields `null` indistinguishably.
+ *
+ * The concepts live at `settings.promptConcepts` (`CachedConcepts`).
+ * They're the expensive swarm `listConcepts` result; reusing them lets
+ * later turns skip that round-trip. The rendered prefix is rebuilt fresh
+ * each turn (for an accurate scope hint), so it is NOT what we cache for
+ * reuse — `settings.promptPrefix` is only a display snapshot.
+ */
+async function loadOrgCanvasPromptCache(args: {
+  conversationId: unknown;
+  userId: string;
+  orgId: string;
+}): Promise<{ rowId: string; cachedConcepts: CachedConcepts | null } | null> {
+  const { conversationId, userId, orgId } = args;
+  if (typeof conversationId !== "string" || conversationId.length === 0) {
+    return null;
+  }
+  const row = await db.sharedConversation.findFirst({
+    where: {
+      id: conversationId,
+      sourceControlOrgId: orgId,
+      OR: [{ userId }, { isShared: true }],
+    },
+    select: { id: true, settings: true },
+  });
+  if (!row) return null;
+  const settings = (row.settings ?? {}) as Record<string, unknown>;
+  const pc = settings.promptConcepts;
+  const cachedConcepts =
+    pc && typeof pc === "object" ? (pc as CachedConcepts) : null;
+  return { rowId: row.id, cachedConcepts };
+}
+
+/** True when a cache holds at least one concept (defensive: never cache
+ *  an empty result from a swarm outage). */
+function hasConcepts(c: CachedConcepts): boolean {
+  if (Array.isArray(c.features)) return c.features.length > 0;
+  if (c.conceptsByWorkspace) {
+    return Object.values(c.conceptsByWorkspace).some(
+      (list) => Array.isArray(list) && list.length > 0,
+    );
+  }
+  return false;
+}
+
+/**
+ * Atomically merge the cached concepts (for reuse) + the rendered prefix
+ * snapshot (for the Agent Logs detail view) into
+ * `SharedConversation.settings` via a jsonb `||` merge. Using a single
+ * UPDATE (rather than read-modify-write) keeps it race-free against the
+ * client autosave's concurrent `settings` writes — both sides merge into
+ * the same blob instead of overwriting it. Caller has validated `rowId`.
+ */
+async function persistOrgCanvasPromptCache(
+  rowId: string,
+  concepts: CachedConcepts,
+  prefixSnapshot: ModelMessage[],
+): Promise<void> {
+  const patch = JSON.stringify({
+    promptConcepts: concepts,
+    promptPrefix: prefixSnapshot,
+  });
+  await db.$executeRaw`
+    UPDATE shared_conversations
+    SET settings = COALESCE(settings, '{}'::jsonb) || ${patch}::jsonb
+    WHERE id = ${rowId}
+  `;
 }
 
 // ─── Agent-proposal: synthetic SSE stream for Approve / Reject ─────

--- a/src/app/api/orgs/[githubLogin]/chat/conversations/[conversationId]/route.ts
+++ b/src/app/api/orgs/[githubLogin]/chat/conversations/[conversationId]/route.ts
@@ -170,8 +170,10 @@ export async function PUT(
 
     // SELECT FOR UPDATE serializes concurrent appends (same pattern as workspace route)
     const updated = await db.$transaction(async (tx) => {
-      const locked = await tx.$queryRaw<{ messages: unknown; title: string | null }[]>`
-        SELECT messages, title FROM shared_conversations WHERE id = ${conversationId} FOR UPDATE
+      const locked = await tx.$queryRaw<
+        { messages: unknown; title: string | null; settings: unknown }[]
+      >`
+        SELECT messages, title, settings FROM shared_conversations WHERE id = ${conversationId} FOR UPDATE
       `;
       if (locked.length === 0) {
         throw new Error("Conversation disappeared mid-transaction");
@@ -208,7 +210,18 @@ export async function PUT(
             ? { title: healedTitle }
             : {}),
           ...(body.source && { source: body.source }),
-          ...(body.settings !== undefined && { settings: body.settings as any }),
+          // MERGE settings instead of overwriting. The client autosave
+          // sends `settings: { extraWorkspaceSlugs }` on every PUT; a
+          // blind overwrite would wipe server-written keys like
+          // `promptPrefix` (the cached agent prompt prefix written by
+          // `/api/ask/quick`). Spreading the locked row's settings first
+          // preserves those while still applying the client's keys.
+          ...(body.settings !== undefined && {
+            settings: {
+              ...((locked[0].settings as Record<string, unknown> | null) ?? {}),
+              ...(body.settings as Record<string, unknown>),
+            } as any,
+          }),
           // Only the owner can change the shared-room flag (typically the
           // Share button turning it on). Joiners can append but can't
           // un-share someone else's conversation.

--- a/src/app/w/[slug]/agent-logs/chat/[conversationId]/page.tsx
+++ b/src/app/w/[slug]/agent-logs/chat/[conversationId]/page.tsx
@@ -13,6 +13,25 @@ import {
 import { parseAgentLogStats } from "@/lib/utils/agent-log-stats";
 import type { ConversationDetail } from "@/types/shared-conversation";
 
+// Minimal shape of an AI SDK `ModelMessage` as persisted in
+// `settings.promptPrefix`. We only read enough to render it; the full
+// type lives in the `ai` package (server-only) and we avoid importing
+// it into this page.
+interface PrefixMessage {
+  role?: string;
+  content?: unknown;
+}
+
+/**
+ * Pull the system-prompt text out of a cached prefix for a friendlier
+ * top-of-panel display. The system message's `content` is a plain
+ * string in our prefix builders; fall back to null otherwise.
+ */
+function extractSystemText(prefix: PrefixMessage[]): string | null {
+  const sys = prefix.find((m) => m?.role === "system");
+  return typeof sys?.content === "string" ? sys.content : null;
+}
+
 interface ChatDetailPageProps {
   params: Promise<{
     slug: string;
@@ -97,6 +116,16 @@ export default async function ChatDetailPage({ params, searchParams }: ChatDetai
   const rawContent = JSON.stringify(parsedMessages);
   const { conversation, stats } = parseAgentLogStats(rawContent);
 
+  // Cached agent prompt prefix (system prompt + pre-seeded `list_concepts`
+  // results) — the exact context the model received ahead of the visible
+  // conversation. Written server-side by `/api/ask/quick`; surfaced here
+  // read-only (it never appears in the live chat). See
+  // `ConversationSettings.promptPrefix`.
+  const promptPrefix = (data.settings?.promptPrefix as PrefixMessage[]) ?? null;
+  const promptSystemText = promptPrefix
+    ? extractSystemText(promptPrefix)
+    : null;
+
   return (
     <div className="min-h-screen bg-background">
       <div className="max-w-4xl mx-auto px-6 py-6">
@@ -110,6 +139,35 @@ export default async function ChatDetailPage({ params, searchParams }: ChatDetai
 
         {data.title && (
           <h1 className="text-xl font-semibold mt-4">{data.title}</h1>
+        )}
+
+        {promptPrefix && promptPrefix.length > 0 && (
+          <details className="mt-4 rounded-lg border border-border bg-muted/30">
+            <summary className="cursor-pointer select-none px-4 py-3 text-sm font-medium text-muted-foreground hover:text-foreground">
+              Agent prompt context ({promptPrefix.length} messages) — cached
+              prefix sent to the model each turn
+            </summary>
+            <div className="space-y-4 border-t border-border px-4 py-4">
+              {promptSystemText && (
+                <div>
+                  <div className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    System prompt
+                  </div>
+                  <pre className="max-h-96 overflow-auto whitespace-pre-wrap rounded bg-background p-3 text-xs leading-relaxed">
+                    {promptSystemText}
+                  </pre>
+                </div>
+              )}
+              <div>
+                <div className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Full prefix (incl. seeded concepts)
+                </div>
+                <pre className="max-h-96 overflow-auto whitespace-pre-wrap rounded bg-background p-3 text-xs leading-relaxed">
+                  {JSON.stringify(promptPrefix, null, 2)}
+                </pre>
+              </div>
+            </div>
+          </details>
         )}
       </div>
 

--- a/src/lib/ai/runCanvasAgent.ts
+++ b/src/lib/ai/runCanvasAgent.ts
@@ -153,6 +153,19 @@ export interface CanvasAgentHooks {
   onFinish?: (args: { usage: unknown }) => void | Promise<void>;
 }
 
+/**
+ * Cached swarm concept data, keyed to match the two `runCanvasAgent`
+ * branches. Exactly one shape is populated per conversation depending on
+ * whether it's single- or multi-workspace. Stored verbatim in the
+ * conversation's `settings.promptConcepts` for reuse across turns.
+ */
+export interface CachedConcepts {
+  /** Multi-workspace: concepts keyed by workspace slug. */
+  conceptsByWorkspace?: Record<string, Record<string, unknown>[]>;
+  /** Single-workspace: the flat concept/feature list. */
+  features?: Record<string, unknown>[];
+}
+
 export interface RunCanvasAgentOptions {
   /** NextAuth user id. Required unless `publicViewer` is set. */
   userId: string | null;
@@ -171,6 +184,27 @@ export interface RunCanvasAgentOptions {
   };
   /** User-visible chat messages, in AI SDK ModelMessage[] form. */
   messages: ModelMessage[];
+  /**
+   * Cached concepts from a previous turn of the SAME conversation. When
+   * provided, we SKIP the slow per-workspace `listConcepts` swarm
+   * round-trip (a swarm can be slow or offline, and re-fetching the
+   * concept list on every message adds that latency/failure to every
+   * turn) and feed these cached concepts to BOTH the prompt prefix and
+   * the tools instead.
+   *
+   * We deliberately cache the *concepts* (the expensive swarm result),
+   * NOT the rendered prefix — so the prefix is rebuilt fresh each turn,
+   * keeping the per-turn-dynamic canvas scope hint (current canvas /
+   * selected node) accurate. Rebuilding is pure string work; the swarm
+   * call is the only thing skipped. The cheap DB work
+   * (`buildWorkspaceConfigs`, for tool creds) still runs every turn.
+   *
+   * Shape mirrors the two code branches: `conceptsByWorkspace` (multi-
+   * workspace) or `features` (single-workspace). Null/undefined → fetch
+   * fresh from the swarm (and the caller should persist the returned
+   * `cacheableConcepts`).
+   */
+  cachedConcepts?: CachedConcepts | null;
   /**
    * Pre-validated `SharedConversation.id` for the active canvas
    * conversation. Forwarded to `buildInitiativeTools` so
@@ -265,6 +299,25 @@ export interface RunCanvasAgentResult {
    * `readonly` was passed; useful for logging / metrics.
    */
   readonly: boolean;
+  /**
+   * The prefix messages actually used this turn (system prompt + seeded
+   * concepts), rebuilt fresh every turn with the current scope. Surfaced
+   * so the caller can persist a snapshot for the Agent Logs detail view
+   * ("what the model saw").
+   */
+  assembledPrefix: ModelMessage[];
+  /**
+   * The concepts used this turn, in cache shape. When `cacheHit` is
+   * false, the caller should persist this so the next turn can pass it
+   * back as `cachedConcepts` and skip the swarm fetch.
+   */
+  cacheableConcepts: CachedConcepts;
+  /**
+   * True when `cachedConcepts` was supplied and reused (the swarm fetch
+   * was skipped). False when concepts were fetched fresh this turn — the
+   * signal for the caller to persist `cacheableConcepts`.
+   */
+  cacheHit: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -426,7 +479,16 @@ export async function runCanvasAgent(
     currentCanvasConversationId,
     additionalTools,
     dispatchedResearch,
+    cachedConcepts,
   } = opts;
+
+  // When cached concepts are supplied we skip the slow per-workspace
+  // `listConcepts` swarm round-trip and feed the cache to the prefix +
+  // tools instead. `buildWorkspaceConfigs` still runs (DB-only; needed
+  // for swarm creds), and the prefix is still rebuilt fresh each turn so
+  // the canvas scope hint stays accurate — only the swarm fetch (the one
+  // external/offline-prone HTTP call) is elided. Each branch checks its
+  // own cache shape below (`conceptsByWorkspace` vs `features`).
 
   if (!Array.isArray(workspaceSlugs) || workspaceSlugs.length === 0) {
     throw new Error("runCanvasAgent: workspaceSlugs must be a non-empty array");
@@ -454,6 +516,9 @@ export async function runCanvasAgent(
   let tools: ToolSet;
   let prefixMessages: ModelMessage[];
   let features: Record<string, unknown>[];
+  // Concept-cache bookkeeping, assigned per branch below.
+  let cacheHit = false;
+  let cacheableConcepts: CachedConcepts = {};
   let primarySwarmUrl: string;
   let primarySwarmApiKey: string;
   // Workspace + user identity for the **primary** slug (slugs[0]).
@@ -485,7 +550,14 @@ export async function runCanvasAgent(
       );
     }
     const workspaceConfigs = await buildWorkspaceConfigs(workspaceSlugs, userId);
-    const conceptsByWorkspace = await fetchConceptsForWorkspaces(workspaceConfigs);
+    // Cache hit → reuse cached concepts and skip the swarm fetch. The
+    // cached concepts still flow into `askToolsMulti` (so the 3+ workspace
+    // `read_concepts_for_repo` tool keeps working) AND into the prefix
+    // builder below.
+    const multiCacheHit = !!cachedConcepts?.conceptsByWorkspace;
+    const conceptsByWorkspace =
+      cachedConcepts?.conceptsByWorkspace ??
+      (await fetchConceptsForWorkspaces(workspaceConfigs));
 
     tools = askToolsMulti(workspaceConfigs, apiKey, conceptsByWorkspace);
 
@@ -509,7 +581,9 @@ export async function runCanvasAgent(
     }
 
     // Initiative scope → look up visually-linked workspaces on root
-    // canvas. Only fires when the user is on `initiative:*`.
+    // canvas. Only fires when the user is on `initiative:*`. Runs every
+    // turn (even on a concept-cache hit) because it feeds the fresh scope
+    // hint — it's a cheap DB lookup, not a swarm call.
     let linkedWorkspaces: Array<{ id: string; slug: string; name: string }> = [];
     if (
       orgId &&
@@ -525,6 +599,8 @@ export async function runCanvasAgent(
       }
     }
 
+    // Always rebuilt fresh (cheap string work) so the scope hint reflects
+    // the user's CURRENT canvas/selection, even on a concept-cache hit.
     prefixMessages = getMultiWorkspacePrefixMessages(
       workspaceConfigs,
       conceptsByWorkspace,
@@ -532,6 +608,8 @@ export async function runCanvasAgent(
       orgId,
       buildScopeHint(scope, linkedWorkspaces),
     );
+    cacheHit = multiCacheHit;
+    cacheableConcepts = { conceptsByWorkspace };
     primarySwarmUrl = workspaceConfigs[0].swarmUrl;
     primarySwarmApiKey = workspaceConfigs[0].swarmApiKey;
     primaryWorkspaceId = workspaceConfigs[0].workspaceId;
@@ -556,16 +634,24 @@ export async function runCanvasAgent(
     // pre-seeded features) instead of throwing a 500. Mirrors the
     // multi-workspace path's `fetchConceptsForWorkspaces`, which
     // already swallows per-workspace failures.
-    let concepts: Record<string, unknown> = {};
-    try {
-      concepts = await listConcepts(ws.swarmUrl, ws.swarmApiKey);
-    } catch (e) {
-      console.error(
-        `[runCanvasAgent] Failed to pre-fetch concepts for ${ws.slug}; continuing without them:`,
-        e,
-      );
+    // Cache hit → reuse cached features and skip the swarm fetch.
+    const singleCacheHit = !!cachedConcepts?.features;
+    if (singleCacheHit) {
+      features = cachedConcepts!.features!;
+    } else {
+      let concepts: Record<string, unknown> = {};
+      try {
+        concepts = await listConcepts(ws.swarmUrl, ws.swarmApiKey);
+      } catch (e) {
+        console.error(
+          `[runCanvasAgent] Failed to pre-fetch concepts for ${ws.slug}; continuing without them:`,
+          e,
+        );
+      }
+      features = (concepts.features as Record<string, unknown>[]) || [];
     }
-    features = (concepts.features as Record<string, unknown>[]) || [];
+    cacheHit = singleCacheHit;
+    cacheableConcepts = { features };
 
     // Single-workspace + orgId: an org-scope caller (e.g. the org-MCP
     // `org_agent` tool, or the org SidebarChat for an org that
@@ -588,15 +674,14 @@ export async function runCanvasAgent(
       };
     }
 
+    // Always rebuilt fresh so the scope hint stays current on cache hits.
     prefixMessages = getQuickAskPrefixMessages(
       features,
       ws.repoUrls,
       [],
       ws.description,
       ws.members,
-      orgId
-        ? { orgId, scope: buildScopeHint(scope, []) }
-        : undefined,
+      orgId ? { orgId, scope: buildScopeHint(scope, []) } : undefined,
       ws.currentUserGithubUsername,
     );
     primarySwarmUrl = ws.swarmUrl;
@@ -773,6 +858,9 @@ export async function runCanvasAgent(
     primaryWorkspaceId: primaryWorkspaceId!,
     primaryUserId: primaryUserId!,
     readonly,
+    assembledPrefix: prefixMessages,
+    cacheableConcepts,
+    cacheHit,
   };
 }
 

--- a/src/types/shared-conversation.ts
+++ b/src/types/shared-conversation.ts
@@ -2,6 +2,19 @@
 
 export interface ConversationSettings {
   extraWorkspaceSlugs?: string[];
+  // Cached swarm concepts (the expensive `listConcepts` result) for
+  // org-canvas conversations. Written server-side by `/api/ask/quick` on
+  // the first turn and reused on later turns to skip the swarm fetch. The
+  // prompt prefix is rebuilt fresh each turn (so the canvas scope hint
+  // stays accurate) — this is just the concept data it's seeded with.
+  // Shape: `CachedConcepts` from runCanvasAgent; typed loosely here since
+  // this module is shared with the client.
+  promptConcepts?: unknown;
+  // Read-only snapshot of the fully rendered prompt prefix (system prompt
+  // + seeded concepts) from the most recent cache write, for display in
+  // the Agent Logs chat detail view. Never shown in the live chat. AI SDK
+  // `ModelMessage[]` shape.
+  promptPrefix?: unknown[];
 }
 
 export interface SharedConversationData {


### PR DESCRIPTION
## Problem

The canvas/org chat is **stateless server-side** — every turn rebuilds the full prompt prefix (system prompt + pre-seeded `list_concepts` results) and re-hits the swarm via `listConcepts`. That swarm call is the one slow / offline-prone step in prefix assembly, so paying it on **every single message** adds that latency (and a hard failure when the swarm is down) to every turn.

## Approach

Cache the **concepts** (the expensive swarm result), not the rendered prefix — so the prefix is rebuilt fresh each turn (keeping the per-turn-dynamic canvas **scope hint** accurate) while the swarm round-trip is skipped.

- **`runCanvasAgent`** takes a `cachedConcepts` option. On a hit it skips `listConcepts` and feeds the cache into **both** the prefix builder **and** `askToolsMulti` (so the 3+ workspace `read_concepts_for_repo` tool still registers). Returns `cacheableConcepts` + `cacheHit`.
- **`/api/ask/quick`** loads `settings.promptConcepts` for the org-canvas conversation (validated via the org-scoped ownership rule, since these rows are `workspaceId: null`), passes it in, and on a **miss with non-empty concepts** persists `promptConcepts` (reuse) + a `promptPrefix` snapshot (display) via an **atomic jsonb `||` merge** in `after()`. The non-empty guard prevents a turn-1 swarm outage from poisoning the cache.
- **Org conversation PUT** now **merges** `settings` instead of overwriting — the client autosave sends `settings: { extraWorkspaceSlugs }` on every write, which would otherwise clobber the server-written cache keys.
- **Agent Logs chat detail page** renders a read-only, collapsed **"Agent prompt context"** panel (system prompt + full seeded prefix) from `settings.promptPrefix`. Never shown in the live chat.

## Scope / behavior notes

- Org-canvas only (`orgId` present); the dashboard chat keeps rebuilding fresh.
- First cache **hit** lands on the **3rd user message**: turn 1 has no server conversation id yet (the autosave creates the row and returns the id asynchronously), turn 2 populates the cache, turn 3 reads it back. The detail-page panel appears from message 2.
- Concepts are cached for the conversation's lifetime (no staleness refresh — intentional, per discussion).

## Test plan

- [x] `tsc` clean on changed files; eslint clean
- [x] Related unit tests pass (`canvas-agent-autoturn`, `build-scope-hint`, `useCanvasChatAutoSave`)
- [x] Manual: org canvas chat — confirm swarm `listConcepts` is skipped from the 3rd message; scope hint updates when navigating nodes mid-conversation; `read_concepts_for_repo` present in 3+ workspace orgs; prefix panel visible under Agent Logs → Canvas tab.