### PR TITLE
Fix canvas auto-turn: drop second system message + reuse concept cache

### DIFF
--- a/src/__tests__/unit/services/canvas-agent-autoturn.test.ts
+++ b/src/__tests__/unit/services/canvas-agent-autoturn.test.ts
@@ -117,6 +117,54 @@ describe("invokeCanvasAgentOnPlannerMessage — gating", () => {
     expect(db.feature.findUnique).toHaveBeenCalledOnce();
     expect(runCanvasAgent).not.toHaveBeenCalled();
   });
+
+  test("wake message rides as a USER turn, never a second system message", async () => {
+    // Regression: a `system`-role wake message lands AFTER
+    // `runCanvasAgent`'s own leading system prompt + concept-seeding
+    // assistant/tool messages, so Anthropic rejects the turn with
+    // `AI_UnsupportedFunctionalityError: 'Multiple system messages that
+    // are separated by user/assistant messages'` — aborting every
+    // auto-turn. The wake context must ride as a `user` message.
+    delete process.env[ENV_KEY];
+    (
+      db.sharedConversation.findUnique as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({
+      ...conversationWith(true),
+      messages: [
+        { id: "u1", role: "user", content: "Manage this feature for me." },
+        {
+          id: "p1",
+          role: "assistant",
+          content: "Plan ready?",
+          source: { kind: "planner" },
+        },
+      ],
+    });
+    (db.feature.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue({
+      title: "Auth Refactor",
+      workspace: { slug: "ws" },
+    });
+    // Empty steps → no rows appended → no $transaction needed.
+    // `cacheableConcepts: {}` + `cacheHit: false` mirrors a real miss
+    // with no concepts (swarm returned nothing) → `hasConcepts` false →
+    // no cache-persist write, so no `$executeRaw` mock needed.
+    (runCanvasAgent as ReturnType<typeof vi.fn>).mockResolvedValue({
+      result: { text: Promise.resolve(""), steps: Promise.resolve([]) },
+      cacheableConcepts: {},
+      cacheHit: false,
+    });
+
+    await invokeCanvasAgentOnPlannerMessage(args);
+
+    expect(runCanvasAgent).toHaveBeenCalledOnce();
+    const passedMessages = (runCanvasAgent as ReturnType<typeof vi.fn>).mock
+      .calls[0][0].messages as Array<{ role: string }>;
+    // runCanvasAgent owns the single system prompt; the auto-turn must
+    // not inject another one into the message stream.
+    expect(passedMessages.some((m) => m.role === "system")).toBe(false);
+    // The wake context is the leading user turn.
+    expect(passedMessages[0].role).toBe("user");
+  });
 });
 
 describe("actionableWakeReason", () => {

--- a/src/services/canvas-agent-autoturn.ts
+++ b/src/services/canvas-agent-autoturn.ts
@@ -17,7 +17,7 @@
  *   - **Stay silent:** call the `stay_silent` tool (terminal no-op).
  *
  * There is deliberately NO policy extractor / classifier here — the
- * agent is the classifier. The synthetic system message below only
+ * agent is the classifier. The synthetic wake message below only
  * supplies *context* (which feature, which wake reason); the prompt
  * paragraph in `getCanvasPromptSuffix` teaches the agent how to behave
  * when the wakeup is machine-driven.
@@ -41,7 +41,7 @@
 import { tool, type ModelMessage, type ToolSet } from "ai";
 import { z } from "zod";
 import { db } from "@/lib/db";
-import { runCanvasAgent } from "@/lib/ai/runCanvasAgent";
+import { runCanvasAgent, type CachedConcepts } from "@/lib/ai/runCanvasAgent";
 import { notifyCanvasConversationUpdated } from "@/lib/pusher";
 
 /** Why the agent was woken. Surfaced verbatim in the synthetic prompt. */
@@ -319,16 +319,29 @@ async function appendAutoTurnMessages(
 }
 
 /**
- * Build the short, context-only synthetic system message that tells
- * the agent WHY it was woken. It does NOT state the user's policy —
- * the agent reads that from the conversation itself.
+ * Build the short, context-only synthetic wake message that tells the
+ * agent WHY it was woken. It does NOT state the user's policy — the
+ * agent reads that from the conversation itself.
+ *
+ * Role is `user`, NOT `system`, on purpose. `runCanvasAgent` already
+ * prepends its own leading `system` prompt followed by assistant/tool
+ * concept-seeding messages (see `getMultiWorkspacePrefixMessages`). A
+ * second `system` message injected here lands *after* those, so the
+ * provider sees "multiple system messages separated by user/assistant
+ * messages" and Anthropic throws `AI_UnsupportedFunctionalityError`,
+ * aborting the whole auto-turn. (The user-driven `/api/ask/quick` path
+ * never hits this because its `messages` start with a `user` turn.)
+ * As a `user` message the wake note rides safely at the head of the
+ * conversation — the AI SDK merges it with the following user turn —
+ * and the planner's reply is still "the most recent assistant entry"
+ * the prompt refers to. Do NOT change this back to `system`.
  */
 function buildWakeMessage(
   featureTitle: string,
   wakeReason: AutoTurnWakeReason,
 ): ModelMessage {
   return {
-    role: "system",
+    role: "user",
     content:
       `You were invoked because the planner for feature **${featureTitle}** ` +
       `just posted a message (wake reason: ${wakeReason}). The planner's ` +
@@ -517,6 +530,7 @@ async function runAutoTurn(args: AutoTurnArgs): Promise<void> {
   // is available to the agent). Deduped, capped at 20.
   const settings = (conversation.settings ?? {}) as {
     extraWorkspaceSlugs?: unknown;
+    promptConcepts?: unknown;
   };
   const extraSlugs = Array.isArray(settings.extraWorkspaceSlugs)
     ? settings.extraWorkspaceSlugs.filter(
@@ -558,11 +572,30 @@ async function runAutoTurn(args: AutoTurnArgs): Promise<void> {
     ...toModelMessages(storedMessages),
   ];
 
-  const { result } = await runCanvasAgent({
+  // Reuse the concepts the user-driven `/api/ask/quick` path already
+  // fetched + persisted to `settings.promptConcepts` for this
+  // conversation (see `loadOrgCanvasPromptCache` /
+  // `persistOrgCanvasPromptCache` in that route). Without this the
+  // auto-turn re-hits every workspace's swarm `list_concepts` on every
+  // wakeup — slow, and a hard failure when a swarm is offline (the
+  // `ConnectTimeoutError`s you see in the logs). A cache hit skips the
+  // swarm fetch entirely. Falls back to a fresh fetch when the cache is
+  // absent (e.g. the conversation never had a user turn). NOTE: this
+  // does NOT skip `buildWorkspaceConfigs` (the per-workspace PAT/swarm
+  // lookups) — those run every turn regardless, since the toolset needs
+  // live swarm credentials.
+  const cachedConcepts =
+    settings.promptConcepts &&
+    typeof settings.promptConcepts === "object"
+      ? (settings.promptConcepts as CachedConcepts)
+      : null;
+
+  const { result, cacheableConcepts, cacheHit } = await runCanvasAgent({
     userId: conversation.userId,
     orgId: conversation.sourceControlOrgId,
     workspaceSlugs,
     messages: modelMessages,
+    cachedConcepts,
     // Machine-driven, no live UI subscriber on this turn — suppress the
     // "researching" highlight Pusher fan-out.
     silentPusher: true,
@@ -572,6 +605,21 @@ async function runAutoTurn(args: AutoTurnArgs): Promise<void> {
     currentCanvasConversationId: conversationId,
     additionalTools: buildStaySilentTool({ conversationId, featureId }),
   });
+
+  // Self-heal the concept cache. On a MISS the auto-turn just paid for a
+  // fresh per-swarm `list_concepts` fetch — persist it so the NEXT
+  // auto-turn (or user turn) reuses it instead of re-hitting every swarm.
+  // Without this the auto-turn would re-fetch on every wakeup whenever the
+  // conversation hadn't yet had a cache-populating user turn. Guarded on
+  // `hasConcepts` so a swarm outage (empty result) never poisons the cache
+  // into permanently serving nothing. Fire-and-forget — never block the
+  // turn on a cache write. Mirrors `persistOrgCanvasPromptCache` in
+  // `/api/ask/quick/route.ts` (same race-safe jsonb `||` merge).
+  if (!cacheHit && hasConcepts(cacheableConcepts)) {
+    void persistPromptConcepts(conversationId, cacheableConcepts).catch((e) =>
+      console.error("[canvas-autoturn] prompt-cache persist failed:", e),
+    );
+  }
 
   // Drive the stream to completion (executes tool calls server-side,
   // e.g. `send_to_feature_planner`). `.text` auto-consumes; `.steps`
@@ -593,4 +641,41 @@ async function runAutoTurn(args: AutoTurnArgs): Promise<void> {
     wakeReason,
     appendedRows: rows.length,
   });
+}
+
+/**
+ * True when a cache holds at least one concept. Defensive: never cache an
+ * empty result (a swarm outage yields an empty list, and caching that
+ * would poison the cache into permanently serving nothing). Mirrors the
+ * `hasConcepts` guard in `/api/ask/quick/route.ts`.
+ */
+function hasConcepts(c: CachedConcepts): boolean {
+  if (Array.isArray(c.features)) return c.features.length > 0;
+  if (c.conceptsByWorkspace) {
+    return Object.values(c.conceptsByWorkspace).some(
+      (list) => Array.isArray(list) && list.length > 0,
+    );
+  }
+  return false;
+}
+
+/**
+ * Persist freshly-fetched concepts to `settings.promptConcepts` so the
+ * next turn (auto or user-driven) reuses them and skips the per-swarm
+ * `list_concepts` fetch. Uses a single jsonb `||` merge (not
+ * read-modify-write) so it's race-free against the client autosave's
+ * concurrent `settings` writes — both sides merge into the same blob
+ * instead of overwriting it. Sibling of `persistOrgCanvasPromptCache` in
+ * `/api/ask/quick/route.ts`.
+ */
+async function persistPromptConcepts(
+  conversationId: string,
+  concepts: CachedConcepts,
+): Promise<void> {
+  const patch = JSON.stringify({ promptConcepts: concepts });
+  await db.$executeRaw`
+    UPDATE shared_conversations
+    SET settings = COALESCE(settings, '{}'::jsonb) || ${patch}::jsonb
+    WHERE id = ${conversationId}
+  `;
 }


### PR DESCRIPTION
## Problem

The canvas-agent auto-turn (autonomous canvas agent waking on a planner reply) **aborted on every wakeup**. Logs showed it correctly scheduled and invoked the turn, then failed inside the LLM call:

```
AI_UnsupportedFunctionalityError: 'Multiple system messages that are
separated by user/assistant messages' functionality not supported.
```

Two issues, both fixed here.

### 1. Second `system` message in the stream (the actual abort)

`buildWakeMessage` returned a `role: "system"` message that `runAutoTurn` prepended to the conversation. But `runCanvasAgent` already prepends its **own** leading system prompt followed by assistant/tool concept-seeding messages (`getMultiWorkspacePrefixMessages`). So the final stream was:

```
system (main) → assistant(tool-call) → tool(result) → … → system (WAKE) → user → …
```

Two system messages separated by assistant/tool turns → Anthropic rejects it. The user-driven `/api/ask/quick` path never hit this because its `messages` start with a `user` turn.

**Fix:** the wake message now rides as a `user` role. The AI SDK merges it with the following user turn, and the planner's reply is still "the most recent assistant entry" the prompt refers to.

### 2. Concept cache never wired into the auto-turn

The auto-turn re-fetched concepts from **every** workspace's swarm on every wakeup — slow, and a hard failure when a swarm is offline (the `ConnectTimeoutError`s in the logs). The prompt-concept cache (`settings.promptConcepts`) lived only in `/api/ask/quick/route.ts`.

**Fix:**
- Read `settings.promptConcepts` and pass it as `cachedConcepts` → skip the swarm fetch on a hit.
- Self-heal on a miss: persist the freshly-fetched concepts via the same race-safe jsonb `||` merge the user-driven route uses, so the per-swarm fetch happens **at most once** per conversation.
- Guarded by `hasConcepts()` so a swarm outage (empty result) never poisons the cache.

Note: `buildWorkspaceConfigs` (per-workspace PAT/swarm lookups) still runs every turn — that's required for live swarm credentials and is unchanged.

## Tests

- Added a regression test asserting the auto-turn never injects a `system`-role message into `runCanvasAgent`'s message stream, and that the wake context leads as a `user` turn.
- All 11 tests in `canvas-agent-autoturn.test.ts` pass.

## Risk

Low. Scoped to the auto-turn path (gated behind `CANVAS_AUTONOMOUS_TURNS_ENABLED` + per-user opt-in). Cache reuse mirrors existing user-driven semantics.