### PR TITLE
Backend-driven canvas chat turns (Tier 1)

### DIFF
--- a/docs/plans/backend-driven-canvas-turns.md
+++ b/docs/plans/backend-driven-canvas-turns.md
@@ -1,0 +1,159 @@
+# Backend-Driven Canvas Chat Turns
+
+Today the canvas chat's **user-initiated** turn only completes if the browser stays open: `/api/ask/quick` streams SSE, and the *client* (`useSendCanvasChatMessage`) assembles the assistant timeline while `useCanvasChatAutoSave` PUTs it back to `SharedConversation.messages`. Close the tab mid-stream and that turn is **lost** — the server streams into a dead socket and nothing persists it, because persistence is client-driven.
+
+This plan makes the server author and persist the turn itself, so a user can send a message, close the tab, and re-open the conversation later to find the completed turn. The browser stream is demoted from *source of truth* to *live-preview optimization*.
+
+Status: **implemented (Tier 1)** — server is the single writer for org-canvas turns; the browser stream is a live-preview. See "Implementation notes" at the bottom for what shipped.
+
+> **Code-review finding that sharpens the problem.** It's worse than "the assistant turn is lost." `useCanvasChatAutoSave.flush()` early-returns `if (conv.isStreaming) return`, and `useSendCanvasChatMessage` sets `isStreaming = true` *before* the fetch and back to `false` only in its `finally`. So **nothing from a turn persists until the stream fully completes** — not even the user's own message. Close the tab mid-stream and the question itself is gone, not just the answer. The autosave POST/PUT only ever fires on the *settled* turn. This is why the fix has to move the *user message* write server-side too, not just the assistant turn.
+
+> **The key realization: we already built this.** The fully backend-driven path exists and ships today for *autonomous* (planner-woken) turns:
+> - `src/services/canvas-agent-autoturn.ts` runs `runCanvasAgent` server-side, drives generation to completion with `await result.text` / `await result.steps` (no browser socket), assembles rows with `messagesFromSteps`, persists them under a `SELECT … FOR UPDATE` lock (`appendAutoTurnMessages`), and fires a `CANVAS_CONVERSATION_UPDATED` Pusher nudge.
+> - `useCanvasChatAutoSave` live-sync merges those rows by id (`mergeServerMessages`) into an open browser, with zero refresh.
+>
+> The "agent runs → DB row written → Pusher nudge → client merges" loop is real, unit-tested, and the source of truth for planner / auto-turn messages. **This plan generalizes that exact path to user-initiated turns.** No new transport, no new store slice, no new merge logic.
+
+> **Companion docs — read first.**
+> - `src/app/org/[githubLogin]/CANVAS_CHAT.md` — the chat subsystem: the Zustand store, identity-based autosave + live-sync (`canvasChatPersistence.ts`), the send/stream path. This plan changes the autosave contract described there.
+> - `docs/plans/canvas-agent-manages-planners.md` — the backend-driven auto-turn (`canvas-agent-autoturn.ts`), the fan-out worker (`canvas-planner-fanout.ts`), the `CANVAS_CONVERSATION_UPDATED` nudge, the row-lock serialization. This plan reuses all of it.
+> - `docs/plans/canvas-sidebar-chat.md` — `CanvasChatMessage` shape, `SharedConversation.messages` JSON round-trip, `?chat=<shareId>` share/fork.
+
+## Goal
+
+Three UX moments this unlocks:
+
+1. **Send and leave.** User asks the canvas agent a question, then closes the tab before the answer finishes. They re-open the conversation 10 minutes later and the completed answer (including any tool calls / research) is there.
+2. **Flaky connection, no loss.** A laptop sleeps or the network drops mid-stream. The turn still completes server-side and persists; the user's next visit shows it.
+3. **Multi-device continuity.** User starts a turn on desktop, switches to the iOS app. The iOS app reads `SharedConversation.messages` and sees the completed turn — no per-surface streaming protocol.
+
+## Non-goal (explicitly): no streaming regression
+
+The live tab MUST keep streaming character-by-character exactly as today. This is achievable because `runCanvasAgent` returns the raw `streamText` handle, which is multi-consumer:
+
+- The browser keeps receiving `result.toUIMessageStreamResponse()` — unchanged byte-for-byte (`runCanvasAgent.ts:850`, `route.ts:554`).
+- Server-side persistence runs in `after()` off the **same generation** (`await result.steps`, as `canvas-agent-autoturn.ts:627` already does). It's a parallel sink — it does not gate, buffer, or delay bytes to the client.
+
+The only seam is the end-of-turn handoff, solved by a shared `turnId` (see "Reconciliation" below).
+
+## The animating principle
+
+**The server writes the turn; the browser stream is an optional live preview of a write that happens regardless.**
+
+Corollaries:
+
+- **One generation, two consumers.** Never re-run the agent for persistence. The HTTP response and the server-side persist both read the *same* `result` handle from a single `runCanvasAgent` call. (`runCanvasAgent`'s `streamText` passes **no `abortSignal`**, so a client disconnect does not cancel generation — confirmed in code review. `result.consumeStream()` in `after()` drives it to completion regardless of the socket.)
+- **The server is the single writer for org-canvas turns.** The client stops POSTing/PUTting messages entirely (see "Resolved design decisions" #1 for why single-writer beats dual-writer here). This collapses to *one* persistence path for every agent turn — user-driven and autonomous — exactly the `canvas-agent-autoturn.ts` path, now shared.
+- **The browser stream is a purely visual preview.** The client's live-rendered rows are ephemeral and need **not** share ids with the server's persisted rows (they can't — see the reconciliation section: client splits the timeline at tool boundaries, server splits per step). Dedup on the active tab is by `turnId` *prefix*, not by exact row id.
+
+## What gets added vs. unchanged
+
+| Layer | New | Unchanged |
+| --- | --- | --- |
+| `src/app/org/[githubLogin]/_state/useSendCanvasChatMessage.ts` | Generate a `turnId` per send; include it (plus the new user message and the existing `conversationId`) in the `/api/ask/quick` body. Register `turnId` in the store's `locallyAuthoredTurnIds` set. Read the new `X-Conversation-Id` response header and call `setServerConversationId` when the server just created the row. The live-rendered rows stay client-local/ephemeral. | The whole `useStreamProcessor` → timeline-split → `replaceAssistantStream` rendering path. The user still sees char-by-char streaming. |
+| `src/app/api/ask/quick/route.ts` (orgId branch) | **(1) Synchronously, before streaming:** ensure the conversation row (create if no valid `conversationId`, generating title + `settings.extraWorkspaceSlugs` like the POST route does) and append the **user** message under the row lock, idempotent on `${turnId}-u`. Return the row id in an `X-Conversation-Id` header. **(2) In `after()`:** `await result.consumeStream()`, then `messagesFromSteps(steps, turnId)` → `appendTurnMessages` (row lock, idempotent on `${turnId}-` prefix) → `notifyCanvasConversationUpdated`. Stream to the browser as today. | The streaming response shape, token-attribution `onFinish`, prompt-cache load/persist. |
+| `src/app/api/ask/quick/route.ts` (approval/rejection branch) | Persist the user approve/reject-click row **and** the synthetic assistant row (carrying `approvalResult` + summary) server-side under `${turnId}-`, then nudge. The client no longer stamps/persists `approvalResult`. | The `handleApproval`/`handleRejection` logic, the synthetic SSE stream, the `X-Approval-Result` header (kept for the live tab's immediate card flip). |
+| `src/services/canvas-turn-persistence.ts` *(new)* | Extract `messagesFromSteps` + the row-locked, idempotent-by-id-prefix append + nudge out of `canvas-agent-autoturn.ts` into a shared writer (`appendTurnMessages(conversationId, rows, idPrefix)`). Both the user-turn path and the auto-turn path call it. | — |
+| `src/services/canvas-agent-autoturn.ts` | Call the shared writer instead of its private `messagesFromSteps`/`appendAutoTurnMessages`. | The wake-message / advisory-lock / per-user-opt-in logic. |
+| `src/app/org/[githubLogin]/_state/useCanvasChatAutoSave.ts` | **Remove the POST/PUT save path** for org-canvas; keep the Pusher subscription + live-sync merge. Add a `locallyAuthoredTurnIds` filter to the merge (drop incoming server rows whose id starts with a turn this tab authored — it's already showing them live). Idle gate simplifies to `!isStreaming`. | The Pusher subscription lifecycle, `mergeServerMessages`, `setConversationMessages`, the re-check-after-await idleness guard. |
+| `src/app/org/[githubLogin]/_state/canvasChatStore.ts` | Add `locallyAuthoredTurnIds: Set<string>` + a `markTurnAuthored(turnId)` action. | Everything else. |
+| `src/lib/ai/runCanvasAgent.ts` | None — `result` already exposes `.steps` / `.consumeStream()` / `.toUIMessageStreamResponse()`, and passes no abort signal. | Everything. |
+| `prisma/schema.prisma` | None — `messages` is `Json`; `${turnId}-` ids are just strings. | Everything. |
+
+## The flow
+
+```
+User sends in canvas chat
+        │
+        ▼
+useSendCanvasChatMessage
+  • turnId = uuid();  markTurnAuthored(turnId)
+  • render ephemeral user + assistant rows locally (live, visual only)
+  • POST /api/ask/quick { messages, conversationId?, turnId, workspaceSlugs, ... }
+        │
+        ▼
+/api/ask/quick (orgId branch)
+  • ensureRow + append USER msg  ── row lock, idempotent `${turnId}-u` ──┐  (SYNC, before stream)
+  • respond header: X-Conversation-Id: <rowId>  ──► client setServerConversationId (if new)
+  • result = runCanvasAgent(...)                                         │
+  • return result.toUIMessageStreamResponse()  ──────────────► browser streams (live preview)
+  • after(async () => {                                                  │
+      await result.consumeStream()   // finishes even if client gone     │
+      rows = messagesFromSteps(await result.steps, turnId)               ▼
+      appendTurnMessages(convId, rows, `${turnId}-`)  ── row lock + prefix-idempotent ──
+      notifyCanvasConversationUpdated(convId, "user-turn")  ── Pusher nudge ──┐
+    })                                                                        │
+        ┌─────────────────────────────────────────────────────────────────────┘
+        ▼
+useCanvasChatAutoSave live-sync (every viewer on the channel)
+  • refetch conversation → mergeServerMessages(local, server, locallyAuthoredTurnIds)
+  • THIS tab authored turnId → server `${turnId}-*` rows filtered out → keep live rows (no flicker)
+  • OTHER tab / reopened tab → didn't author it → server rows merge in normally
+```
+
+## Reconciliation: why there's no flicker, no dup, no loss
+
+The naive "share one id scheme between client and server so the merge dedups by id" does **not** work: the client splits an assistant turn at tool-call boundaries *inside* the stream timeline (`useSendCanvasChatMessage`), while the server splits *per agent step* (`messagesFromSteps`). The row counts and boundaries differ, so the ids can't be made to line up. Trying to force it would produce duplicate rows on the active tab.
+
+Instead, dedup is by **`turnId` prefix**, and the client's live rows are never persisted:
+
+- **The tab that sent the turn** records `turnId` in `locallyAuthoredTurnIds`. When the post-turn nudge fires, the merge filters out every server row whose id starts with `${turnId}-` — this tab is already showing its own visual version. Result: no append, no flicker, no dup. The client's live rows can have any ids; they never need to match the server's.
+- **A different tab / device** (shared room) or **the same tab after reload** has an empty `locallyAuthoredTurnIds` for that turn → the server `${turnId}-*` rows merge in normally and render the authoritative copy.
+- **Planner / auto-turn / other-user rows** carry `planner-` / `autoturn-` / other turn prefixes never in *this* tab's authored set, so they always merge in (unchanged behavior).
+- **Never lost:** the user message is persisted server-side synchronously at turn start; the assistant turn is persisted in `after()` after `consumeStream()` finishes generation independent of the socket.
+
+## Robustness tiers
+
+**Decision: ship Tier 1.** It delivers the stated goal (close tab → reopen → see the completed turn) with zero streaming compromise.
+
+- **Tier 1 — `after()` + `consumeStream` (this plan, CHOSEN).** The browser reads the LLM stream natively from its own request (full char-by-char). Persistence runs server-side off the same `result`, independent of the socket. Survives tab-close, sleep, network drop. **Set `maxDuration` explicitly on `/api/ask/quick`** (e.g. 300s) — that's the one real bound, since (a) `streamText` passes no abort signal so a client disconnect can't cancel generation, and (b) Vercel does **not** kill in-flight functions on deploy (running invocations finish on the old deployment; deploys only reroute *new* requests). So the only way an open-tab turn is lost is a turn exceeding `maxDuration`, which is far longer than a realistic canvas turn.
+- **Tier 2 — Redis resumable streams (future seam, NOT now).** If we later want *reload-mid-turn keeps streaming live* or turns longer than `maxDuration`, the better path than a Pusher-delta worker is the AI-SDK `resumable-stream` pattern over the existing `ioredis`: generation publishes chunks to a Redis stream keyed by a `streamId`; a thin SSE relay route subscribes and replays buffered chunks on reconnect. Keeps native streaming, adds reload-resume, no new infra. The single-writer persistence in this plan is orthogonal and stays valid — Tier 2 only changes the *delivery* layer. (A Pusher-delta relay is the alternative but trades streaming smoothness for a model we don't need yet.)
+
+## Resolved design decisions (from code review)
+
+1. **Single writer = server; client save path removed (not "narrowed").** Considered dual-writer (keep client save for the open tab + server fallback for tab-close, deduped). Rejected: it requires *both* writers to dedup against each other, which only works if they emit identical row ids — impossible given the different client/server split (see Reconciliation). Forcing idempotent-by-id appends on top of mismatched ids is fragile. Single-writer collapses to one persistence path (the proven auto-turn path), no write race, no dual-dedup. **Trade-off accepted:** if the serverless function is killed mid-generation (deploy/timeout), the assistant turn can be lost *even with the tab open* — a narrow regression from today's "open tab always persists." Mitigated by (a) the synchronous user-message write (the question is never lost) and (b) Tier 2 as the durable fix. The window is seconds-wide and bounded by function max-duration.
+
+2. **User message + row creation happen server-side, synchronously, before the stream.** Title generation and `settings.extraWorkspaceSlugs` already live in the POST/PUT routes — moving creation into `/api/ask/quick` reuses `generateTitle` / `getLastMessageTimestamp`. The new `X-Conversation-Id` response header returns the row id to the client (same pattern as `X-Approval-Result`). The client's `useCanvasChatAutoSave` POST/PUT is deleted, so there's no longer two creators racing.
+
+3. **Reconciliation is by `turnId` prefix, not by row id.** The client's live rows are visual-only and never persisted; `locallyAuthoredTurnIds` filters the matching server rows out of the merge on the authoring tab. This is the decision that makes "no streaming regression" + "no end-of-turn flicker" + "no duplicate" all hold simultaneously.
+
+4. **Approvals get the same server-write treatment.** The approval branch already runs server-side and resolves the conversation id (`resolveOrgConversationRowId`). It now also persists the click + synthetic assistant row (with `approvalResult`) under `${turnId}-`. The `X-Approval-Result` header stays so the live tab flips the card instantly; persistence no longer rides on the client autosave.
+
+5. **`ephemeralSeedCount` / `persistedIdsRef` / `computeUnsaved` / `seedPersistedIds` become dead for org-canvas.** With no client save path, the attention-intro seed is simply never sent (the server only persists this turn's rows), and joined-share rows already exist in the adopted row. Plan: leave `canvasChatPersistence.ts` + its tests in place but stop wiring `computeUnsaved`/`seedPersistedIds` from the hook; keep `mergeServerMessages` (now extended with the prefix filter). Revisit deleting the dead helpers in a follow-up to keep this PR's blast radius contained.
+
+## Remaining risks / edge cases
+
+- **Reload between user-write and `after()`-write.** User sends, reloads immediately. The user message is already persisted (sync); the assistant `after()` write may land *after* the reload's GET. The reloaded tab is subscribed to the channel, so the post-turn nudge refetches it in — *unless* the nudge fires in the gap between GET and subscribe. Acceptable (same class as the existing planner-fan-out gap); a belt-and-suspenders "refetch once on subscribe" can close it later.
+- **Mid-stream error.** `messagesFromSteps` must emit a trailing error row when `result` errored, so the persisted turn matches what the live viewer saw (the client already renders `${messageId}-error`). Pull the error off the finished `result` in `after()`.
+- **Concurrency.** The new user-write and turn-write MUST use the same `SELECT … FOR UPDATE` lock as `appendAutoTurnMessages` / `fanOutPlannerMessageToCanvas` / the conversations PUT. The shared `canvas-turn-persistence.ts` writer owns that lock.
+- **Id prefixes.** `${turnId}-u` / `${turnId}-N` must not collide with `planner-` / `autoturn-`. Use a uuid `turnId`; render-side filters in `SidebarChat` / `CanvasHistoryPopover` key on `source.kind`, not id shape, so they're unaffected.
+- **Public-viewer / dashboard chat: out of scope.** Org-canvas only (`orgId` present, auth-required). Dashboard chat keeps client-driven autosave; public-viewer rows have no durable re-open identity.
+
+## Testing
+
+- Unit (`canvasChatPersistence.test.ts`): `mergeServerMessages` with the new prefix filter — a server `${turnId}-*` row is dropped when `turnId ∈ locallyAuthoredTurnIds` (no-flicker invariant), and merged when it isn't (reopen/other-tab).
+- Unit (`canvas-turn-persistence`): shared `messagesFromSteps` + `appendTurnMessages` — idempotency on `${turnId}-` prefix (a retried `after()` never double-appends); a `stay_silent`-only / empty turn appends nothing.
+- Unit: auto-turn still works after the writer extraction (its existing tests should pass unchanged).
+- Integration: POST `/api/ask/quick` with `orgId` + no `conversationId` → row created, `X-Conversation-Id` returned, user message persisted before the stream body; after stream, assistant rows present + nudge fired.
+- Integration: same, with the client aborting the stream early → assistant turn still lands (proves socket-independence).
+- Manual: send + immediately close tab → reopen → completed turn present; send with tab open → no end-of-turn flicker; shared room second viewer sees the turn appear live.
+
+## Implementation order
+
+1. Extract `canvas-turn-persistence.ts` from `canvas-agent-autoturn.ts`; keep auto-turn green (pure refactor, no behavior change).
+2. Server: `/api/ask/quick` orgId branch — sync ensure-row + user-message write + `X-Conversation-Id`; `after()` turn write + nudge. Behind a check so non-orgId paths are untouched.
+3. Server: approval/rejection branch — persist click + synthetic row under `turnId`.
+4. Client: `turnId` + `markTurnAuthored` in store; send `turnId` + read header in `useSendCanvasChatMessage`; remove save path + add prefix filter in `useCanvasChatAutoSave`.
+5. Tests + manual verification.
+
+## Implementation notes (shipped)
+
+- **`src/services/canvas-turn-persistence.ts`** *(new)* — `messagesFromSteps(steps, idPrefix, stripToolNames?)` + `appendTurnMessages({conversationId, rows, idPrefix, reason})` (row-locked, idempotent on the id prefix, fires the nudge). `canvas-agent-autoturn.ts` now calls these (its private copies deleted); its 11 tests pass unchanged.
+- **`src/app/api/ask/quick/route.ts`** — `export const maxDuration = 300`. Org-canvas turns (gated on `orgId && userId && turnId`): `persistCanvasUserMessage` writes the user row as `${turnId}-u` (creating the `SharedConversation` if `conversationId` is absent/invalid, titled via `generateTitle`, `settings.extraWorkspaceSlugs = slugs`) *before* the stream; `X-Conversation-Id` header returns the row id; an `after()` block does `result.consumeStream()` → `messagesFromSteps(steps, \`${turnId}-a\`)` → `appendTurnMessages(..., reason: "user-turn")`, with a trailing error row on failure. `currentCanvasConversationId` now also resolves from the org-canvas row (so `send_to_feature_planner`'s lazy claim works on the main path, not just approvals). The approval/rejection branch persists the click row + synthetic `approvalResult` row under `${turnId}-`.
+- **`src/lib/pusher.ts`** — added the `"user-turn"` `CanvasConversationUpdateReason`.
+- **Store (`canvasChatStore.ts`)** — `locallyAuthoredTurnIds: Set<string>` + `markTurnAuthored(turnId)`.
+- **`useSendCanvasChatMessage.ts`** — generates a `crypto.randomUUID()` `turnId`, `markTurnAuthored`s it, sends it in the body, and adopts the `X-Conversation-Id` header on the first turn. Live-render path otherwise unchanged (full streaming preserved).
+- **`useCanvasChatAutoSave.ts`** — **POST/PUT save path removed**; now live-sync only. The merge passes `${turnId}-` prefixes for `locallyAuthoredTurnIds`, so the authoring tab never double-renders its own turn; idle check simplified to `!isStreaming`; a mid-stream nudge is deferred and run when the stream settles.
+- **`mergeServerMessages`** — added optional `skipServerIdPrefixes` (filters incoming server rows only; never local rows).
+- **Tests** — new `canvas-turn-persistence.test.ts` (9); rewrote `useCanvasChatAutoSave.test.ts` for the live-sync-only contract (5); extended `canvasChatPersistence.test.ts` with the prefix-filter cases; fixed `useSendCanvasChatMessage.test.ts` mock to include the two new store actions. 40 tests across the affected files pass; touched source files typecheck clean.
+- **Not done (deliberately):** `canvasChatPersistence.ts`'s `seedPersistedIds`/`computeUnsaved` and the store's `ephemeralSeedCounts` are now dead for the save path but left in place (still exported/tested) to keep the diff contained — a follow-up can delete them. Integration tests require a live Postgres (not run here); they exercise non-org workspace paths unaffected by the gated change.

--- a/src/__tests__/unit/canvas/canvasChatPersistence.test.ts
+++ b/src/__tests__/unit/canvas/canvasChatPersistence.test.ts
@@ -108,6 +108,50 @@ describe("mergeServerMessages — never loses a local message", () => {
   });
 });
 
+describe("mergeServerMessages — authored-turn prefix filter", () => {
+  test("server rows for a turn THIS tab authored are not merged (no double-render)", () => {
+    // The authoring tab shows its own optimistic stream under local ids;
+    // the server persisted that turn as `turn-1-u` / `turn-1-a0`.
+    const local = [msg("local-u"), msg("local-a", "assistant")];
+    const server = [
+      msg("turn-1-u"),
+      msg("turn-1-a0", "assistant"),
+      msg("planner-x", "assistant"),
+    ];
+
+    const merged = mergeServerMessages(local, server, ["turn-1-"]);
+
+    // Authored turn's server rows filtered out; the planner row (not
+    // authored) merges in; local optimistic rows untouched.
+    expect(merged.messages.map((m) => m.id)).toEqual([
+      "local-u",
+      "local-a",
+      "planner-x",
+    ]);
+    expect(merged.added.map((m) => m.id)).toEqual(["planner-x"]);
+  });
+
+  test("a tab that authored nothing merges the full server turn (reopen/other viewer)", () => {
+    const local: ReturnType<typeof msg>[] = [];
+    const server = [msg("turn-1-u"), msg("turn-1-a0", "assistant")];
+
+    const merged = mergeServerMessages(local, server, []);
+
+    expect(merged.messages.map((m) => m.id)).toEqual(["turn-1-u", "turn-1-a0"]);
+  });
+
+  test("prefix filter only skips incoming server rows, never local rows", () => {
+    // Even if a local row shares the prefix, it is preserved (the filter is
+    // server-side only).
+    const local = [msg("turn-1-u")];
+    const server = [msg("turn-1-u"), msg("planner-x", "assistant")];
+
+    const merged = mergeServerMessages(local, server, ["turn-1-"]);
+
+    expect(merged.messages.map((m) => m.id)).toEqual(["turn-1-u", "planner-x"]);
+  });
+});
+
 describe("full turn lifecycle stays consistent", () => {
   test("seed → first user turn → planner nudge keeps a complete, ordered list", () => {
     const seedCount = 1;

--- a/src/__tests__/unit/canvas/useCanvasChatAutoSave.test.ts
+++ b/src/__tests__/unit/canvas/useCanvasChatAutoSave.test.ts
@@ -3,6 +3,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { create } from "zustand";
 
+// Backend-driven canvas turns (docs/plans/backend-driven-canvas-turns.md):
+// the SERVER is the single writer. This hook NO LONGER POSTs/PUTs — it only
+// live-syncs server-appended rows on a Pusher nudge, filtering out rows for
+// turns THIS tab authored (it's already showing them optimistically). These
+// tests cover that contract.
+
 // ── Store factory ──────────────────────────────────────────────────────────
 
 type ConvContext = {
@@ -16,12 +22,14 @@ type ConvContext = {
   selectedNodeIds: string[];
 };
 
+type Msg = { id: string; role: string; content: string };
+
 type ConvState = {
   activeConversationId: string | null;
   conversations: Record<
     string,
     {
-      messages: Array<{ id: string; role: string; content: string }>;
+      messages: Msg[];
       isLoading: boolean;
       isStreaming: boolean;
       serverConversationId: string | null;
@@ -29,11 +37,9 @@ type ConvState = {
     }
   >;
   ephemeralSeedCounts: Record<string, number>;
+  locallyAuthoredTurnIds: Set<string>;
   setServerConversationId: (conversationId: string, serverId: string) => void;
-  setConversationMessages: (
-    conversationId: string,
-    messages: Array<{ id: string; role: string; content: string }>,
-  ) => void;
+  setConversationMessages: (conversationId: string, messages: Msg[]) => void;
 };
 
 function makeStore(initial?: Partial<ConvState>) {
@@ -41,6 +47,7 @@ function makeStore(initial?: Partial<ConvState>) {
     activeConversationId: null,
     conversations: {},
     ephemeralSeedCounts: {},
+    locallyAuthoredTurnIds: new Set<string>(),
     setServerConversationId: (conversationId, serverId) =>
       set((s) => ({
         conversations: {
@@ -99,7 +106,6 @@ vi.mock("@/lib/pusher", () => ({
 var _store: ReturnType<typeof makeStore>;
 
 vi.mock("@/app/org/[githubLogin]/_state/canvasChatStore", () => {
-  const zustand = require("zustand");
   // Will be overwritten in beforeEach
   _store = makeStore();
   const proxy: any = new Proxy(() => {}, {
@@ -119,11 +125,11 @@ import { useCanvasChatAutoSave } from "@/app/org/[githubLogin]/_state/useCanvasC
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
-function makeMsg(role: "user" | "assistant", id = "m1") {
+function makeMsg(role: "user" | "assistant", id = "m1"): Msg {
   return { id, role, content: "Hello" };
 }
 
-const baseContext = {
+const baseContext: ConvContext = {
   workspaceSlug: null,
   workspaceSlugs: [],
   orgId: "org-1",
@@ -136,7 +142,7 @@ const baseContext = {
 
 function makeConv(
   overrides: Partial<{
-    messages: ReturnType<typeof makeMsg>[];
+    messages: Msg[];
     isLoading: boolean;
     isStreaming: boolean;
     serverConversationId: string | null;
@@ -152,16 +158,16 @@ function makeConv(
   };
 }
 
-function buildFetch(responseId: string) {
+function fetchReturning(messages: Msg[]) {
   return vi.fn().mockResolvedValue({
     ok: true,
-    json: () => Promise.resolve({ id: responseId }),
+    json: () => Promise.resolve({ messages }),
   });
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────
 
-describe("useCanvasChatAutoSave", () => {
+describe("useCanvasChatAutoSave (live-sync)", () => {
   beforeEach(() => {
     _store = makeStore();
     vi.clearAllMocks();
@@ -171,94 +177,30 @@ describe("useCanvasChatAutoSave", () => {
     vi.restoreAllMocks();
   });
 
-  it("does not fetch when githubLogin is null/empty", () => {
+  it("does nothing when githubLogin is null/empty", () => {
     const fetchSpy = vi.fn();
     global.fetch = fetchSpy;
 
-    // Set up a conversation with a message
     _store.setState({
       activeConversationId: "conv-1",
       conversations: {
-        "conv-1": makeConv({ messages: [makeMsg("user")] }),
+        "conv-1": makeConv({
+          messages: [makeMsg("user")],
+          serverConversationId: "server-1",
+        }),
       },
     });
 
     renderHook(() => useCanvasChatAutoSave({ githubLogin: null }));
 
-    // Trigger the subscription by updating the store
     act(() => {
-      _store.setState((s) => ({ ...s })); // no-op update
+      _store.setState((s) => ({ ...s }));
     });
 
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("POSTs to org endpoint on first message (no serverConversationId)", async () => {
-    const fetchSpy = buildFetch("server-id-1");
-    global.fetch = fetchSpy;
-
-    _store.setState({
-      activeConversationId: "conv-1",
-      conversations: { "conv-1": makeConv() },
-      ephemeralSeedCounts: {},
-    });
-
-    renderHook(() => useCanvasChatAutoSave({ githubLogin: "my-org" }));
-
-    // Simulate: message added, not loading
-    await act(async () => {
-      _store.setState({
-        conversations: {
-          "conv-1": makeConv({ messages: [makeMsg("user", "m1")] }),
-        },
-      });
-      // Let microtasks settle
-      await Promise.resolve();
-    });
-
-    expect(fetchSpy).toHaveBeenCalledWith(
-      "/api/orgs/my-org/chat/conversations",
-      expect.objectContaining({ method: "POST" }),
-    );
-  });
-
-  it("PUTs to org endpoint on subsequent messages (serverConversationId set)", async () => {
-    const fetchSpy = vi.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({}),
-    });
-    global.fetch = fetchSpy;
-
-    _store.setState({
-      activeConversationId: "conv-1",
-      conversations: {
-        "conv-1": makeConv({ messages: [makeMsg("user", "m1")], serverConversationId: "already-saved" }),
-      },
-      ephemeralSeedCounts: { "conv-1": 1 }, // m1 already saved
-    });
-
-    renderHook(() => useCanvasChatAutoSave({ githubLogin: "my-org" }));
-
-    // Simulate: assistant reply added
-    await act(async () => {
-      _store.setState({
-        conversations: {
-          "conv-1": makeConv({
-            messages: [makeMsg("user", "m1"), makeMsg("assistant", "m2")],
-            serverConversationId: "already-saved",
-          }),
-        },
-      });
-      await Promise.resolve();
-    });
-
-    expect(fetchSpy).toHaveBeenCalledWith(
-      "/api/orgs/my-org/chat/conversations/already-saved",
-      expect.objectContaining({ method: "PUT" }),
-    );
-  });
-
-  it("does not save while isStreaming=true (stream in progress)", async () => {
+  it("never POSTs/PUTs — persistence is server-side now", async () => {
     const fetchSpy = vi.fn();
     global.fetch = fetchSpy;
 
@@ -269,147 +211,23 @@ describe("useCanvasChatAutoSave", () => {
 
     renderHook(() => useCanvasChatAutoSave({ githubLogin: "my-org" }));
 
-    act(() => {
-      _store.setState({
-        conversations: {
-          "conv-1": makeConv({ messages: [makeMsg("user", "m1")], isStreaming: true }),
-        },
-      });
-    });
-
-    expect(fetchSpy).not.toHaveBeenCalled();
-  });
-
-  it("saves even if isLoading=true as long as isStreaming=false", async () => {
-    // isLoading flips to false on first chunk (UX) but isStreaming stays true
-    // until the stream fully finishes. This test verifies the save gate only
-    // cares about isStreaming, not isLoading.
-    const fetchSpy = buildFetch("srv-x");
-    global.fetch = fetchSpy;
-
-    _store.setState({
-      activeConversationId: "conv-1",
-      conversations: { "conv-1": makeConv() },
-    });
-
-    renderHook(() => useCanvasChatAutoSave({ githubLogin: "my-org" }));
-
-    await act(async () => {
-      _store.setState({
-        conversations: {
-          "conv-1": makeConv({
-            messages: [makeMsg("user", "m1")],
-            isLoading: true,   // first-chunk UX flip — still "loading" visually
-            isStreaming: false, // but stream is done
-          }),
-        },
-      });
-      await Promise.resolve();
-    });
-
-    expect(fetchSpy).toHaveBeenCalledWith(
-      "/api/orgs/my-org/chat/conversations",
-      expect.objectContaining({ method: "POST" }),
-    );
-  });
-
-  it("does NOT save while isStreaming=true even if isLoading=false", async () => {
-    // Guard against a regression where isLoading-false alone would let
-    // mid-stream saves through.
-    const fetchSpy = vi.fn();
-    global.fetch = fetchSpy;
-
-    _store.setState({
-      activeConversationId: "conv-1",
-      conversations: { "conv-1": makeConv() },
-    });
-
-    renderHook(() => useCanvasChatAutoSave({ githubLogin: "my-org" }));
-
-    act(() => {
-      _store.setState({
-        conversations: {
-          "conv-1": makeConv({
-            messages: [makeMsg("user", "m1")],
-            isLoading: false,  // first-chunk flip has happened
-            isStreaming: true,  // but stream still in flight
-          }),
-        },
-      });
-    });
-
-    expect(fetchSpy).not.toHaveBeenCalled();
-  });
-
-  it("fires once isStreaming flips to false after being true", async () => {
-    const fetchSpy = buildFetch("srv-y");
-    global.fetch = fetchSpy;
-
-    _store.setState({
-      activeConversationId: "conv-1",
-      conversations: { "conv-1": makeConv() },
-    });
-
-    renderHook(() => useCanvasChatAutoSave({ githubLogin: "my-org" }));
-
-    // Stream in progress — should not save
-    act(() => {
-      _store.setState({
-        conversations: {
-          "conv-1": makeConv({
-            messages: [makeMsg("user", "m1"), makeMsg("assistant", "m2")],
-            isStreaming: true,
-          }),
-        },
-      });
-    });
-    expect(fetchSpy).not.toHaveBeenCalled();
-
-    // Stream completes — should now save
+    // A new user message + assistant reply appended locally — old hook would
+    // POST then PUT. New hook writes nothing.
     await act(async () => {
       _store.setState({
         conversations: {
           "conv-1": makeConv({
             messages: [makeMsg("user", "m1"), makeMsg("assistant", "m2")],
-            isStreaming: false,
           }),
         },
       });
       await Promise.resolve();
     });
 
-    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("calls the org endpoint (not the workspace endpoint)", async () => {
-    const fetchSpy = buildFetch("srv-1");
-    global.fetch = fetchSpy;
-
-    _store.setState({
-      activeConversationId: "conv-1",
-      conversations: { "conv-1": makeConv() },
-    });
-
-    renderHook(() => useCanvasChatAutoSave({ githubLogin: "acme-corp" }));
-
-    await act(async () => {
-      _store.setState({
-        conversations: {
-          "conv-1": makeConv({ messages: [makeMsg("user", "m1")] }),
-        },
-      });
-      await Promise.resolve();
-    });
-
-    const [url] = fetchSpy.mock.calls[0] as [string, ...unknown[]];
-    expect(url).toMatch(/\/api\/orgs\/acme-corp\/chat\/conversations/);
-    expect(url).not.toMatch(/\/api\/workspaces\//);
-  });
-
-  // ── Live-sync (Pusher nudge → refetch → merge) ───────────────────────────
-  it("on a CANVAS_CONVERSATION_UPDATED nudge, refetches and replaces messages when idle", async () => {
-    // Idle conversation: 2 messages already persisted (seedSkip = 2 makes
-    // `saved == length` so no unsaved local messages).
+  it("on a nudge, refetches and merges server-appended rows when idle", async () => {
     _store.setState({
       activeConversationId: "conv-1",
       conversations: {
@@ -418,58 +236,134 @@ describe("useCanvasChatAutoSave", () => {
           serverConversationId: "server-1",
         }),
       },
-      ephemeralSeedCounts: { "conv-1": 2 },
     });
 
-    // GET returns the server's authoritative copy — a superset that now
-    // includes a fanned-out planner row.
-    const serverMessages = [
+    const serverMessages: Msg[] = [
       { id: "m1", role: "user", content: "Hello" },
       { id: "a1", role: "assistant", content: "Hi" },
       {
         id: "planner-x",
         role: "assistant",
         content: "Plan ready",
+        // @ts-expect-error extra field tolerated by hydration
         source: { kind: "planner", featureId: "f1", plannerMessageId: "x" },
       },
     ];
-    const fetchSpy = vi.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ messages: serverMessages }),
-    });
+    const fetchSpy = fetchReturning(serverMessages);
     global.fetch = fetchSpy;
 
     renderHook(() => useCanvasChatAutoSave({ githubLogin: "my-org" }));
 
-    // Trigger the store.subscribe callback so the hook subscribes to the
-    // conversation's Pusher channel and binds the handler.
+    // Trigger subscription, then fire the nudge.
     act(() => {
       _store.setState((s) => ({ ...s }));
     });
-
-    // Simulate the server-side nudge.
     await act(async () => {
       fakePusher.fire("canvas-conversation-updated");
       await Promise.resolve();
       await Promise.resolve();
     });
 
-    // It refetched via GET on the org route…
     expect(fetchSpy).toHaveBeenCalledWith(
       "/api/orgs/my-org/chat/conversations/server-1",
     );
-    // …and replaced the local messages with the server superset (the
-    // planner row is now visible to a user sitting on the page).
     const msgs = _store.getState().conversations["conv-1"].messages;
     expect(msgs).toHaveLength(3);
     expect(msgs[2].id).toBe("planner-x");
-    // No PUT/POST was issued (idle conversation → nothing to save, and the
-    // synced rows must not be re-persisted as a delta).
-    const writeCalls = fetchSpy.mock.calls.filter(
-      ([, init]) =>
-        init && ((init as RequestInit).method === "PUT" ||
-          (init as RequestInit).method === "POST"),
+  });
+
+  it("filters out server rows for turns THIS tab authored (no double-render)", async () => {
+    // The tab authored `turn-1` (it's showing its own optimistic stream
+    // under `local-*` ids). The server persisted that turn as `turn-1-u` /
+    // `turn-1-a0`, and separately fanned out a planner row.
+    _store.setState({
+      activeConversationId: "conv-1",
+      conversations: {
+        "conv-1": makeConv({
+          messages: [
+            { id: "local-u", role: "user", content: "Q" },
+            { id: "local-a", role: "assistant", content: "A (streamed)" },
+          ],
+          serverConversationId: "server-1",
+        }),
+      },
+      locallyAuthoredTurnIds: new Set(["turn-1"]),
+    });
+
+    const serverMessages: Msg[] = [
+      { id: "turn-1-u", role: "user", content: "Q" },
+      { id: "turn-1-a0", role: "assistant", content: "A (server)" },
+      { id: "planner-x", role: "assistant", content: "Plan ready" },
+    ];
+    global.fetch = fetchReturning(serverMessages);
+
+    renderHook(() => useCanvasChatAutoSave({ githubLogin: "my-org" }));
+    act(() => {
+      _store.setState((s) => ({ ...s }));
+    });
+    await act(async () => {
+      fakePusher.fire("canvas-conversation-updated");
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const msgs = _store.getState().conversations["conv-1"].messages;
+    const ids = msgs.map((m) => m.id);
+    // Local optimistic rows kept; the planner row (not authored) merged in;
+    // the authored turn's server rows filtered out.
+    expect(ids).toEqual(["local-u", "local-a", "planner-x"]);
+    expect(ids).not.toContain("turn-1-u");
+    expect(ids).not.toContain("turn-1-a0");
+  });
+
+  it("defers a mid-stream nudge and syncs once the stream settles", async () => {
+    _store.setState({
+      activeConversationId: "conv-1",
+      conversations: {
+        "conv-1": makeConv({
+          messages: [makeMsg("user", "m1")],
+          serverConversationId: "server-1",
+          isStreaming: true,
+        }),
+      },
+    });
+
+    global.fetch = fetchReturning([
+      { id: "m1", role: "user", content: "Hello" },
+      { id: "planner-y", role: "assistant", content: "Update" },
+    ]);
+
+    renderHook(() => useCanvasChatAutoSave({ githubLogin: "my-org" }));
+    act(() => {
+      _store.setState((s) => ({ ...s }));
+    });
+
+    // Nudge arrives mid-stream → must NOT fetch/merge yet.
+    await act(async () => {
+      fakePusher.fire("canvas-conversation-updated");
+      await Promise.resolve();
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+
+    // Stream settles → deferred sync runs.
+    await act(async () => {
+      _store.setState({
+        conversations: {
+          "conv-1": makeConv({
+            messages: [makeMsg("user", "m1")],
+            serverConversationId: "server-1",
+            isStreaming: false,
+          }),
+        },
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/orgs/my-org/chat/conversations/server-1",
     );
-    expect(writeCalls).toHaveLength(0);
+    const msgs = _store.getState().conversations["conv-1"].messages;
+    expect(msgs.map((m) => m.id)).toContain("planner-y");
   });
 });

--- a/src/__tests__/unit/canvas/useSendCanvasChatMessage.test.ts
+++ b/src/__tests__/unit/canvas/useSendCanvasChatMessage.test.ts
@@ -58,6 +58,8 @@ interface MockStoreState {
   setIsLoading: ReturnType<typeof vi.fn>;
   setIsStreaming: ReturnType<typeof vi.fn>;
   appendAssistantError: ReturnType<typeof vi.fn>;
+  markTurnAuthored: ReturnType<typeof vi.fn>;
+  setServerConversationId: ReturnType<typeof vi.fn>;
 }
 
 const baseContext: ConvContext = {
@@ -104,6 +106,8 @@ function makeTrackedState(): MockStoreState {
       }
     }),
     appendAssistantError: vi.fn(),
+    markTurnAuthored: vi.fn(),
+    setServerConversationId: vi.fn(),
   };
   return state;
 }

--- a/src/__tests__/unit/services/canvas-turn-persistence.test.ts
+++ b/src/__tests__/unit/services/canvas-turn-persistence.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Unit tests for the shared canvas-turn persistence writer
+ * (`src/services/canvas-turn-persistence.ts`), used by BOTH the
+ * user-driven `/api/ask/quick` turn and the autonomous auto-turn.
+ *
+ * Coverage:
+ *   - `messagesFromSteps`: id-prefix scheme, text/tool-call split,
+ *     stripped control tools, content-less turns.
+ *   - `appendTurnMessages`: idempotency on the id prefix (a retried
+ *     `after()` / re-delivered webhook must not double-append), the
+ *     row-lock read path, and the Pusher nudge firing only on a fresh
+ *     append.
+ */
+
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+// ─── Mocks ──────────────────────────────────────────────────────────
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    sharedConversation: { update: vi.fn() },
+    $queryRaw: vi.fn(),
+    $transaction: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/pusher", () => ({
+  notifyCanvasConversationUpdated: vi.fn(),
+}));
+
+import { db } from "@/lib/db";
+import { notifyCanvasConversationUpdated } from "@/lib/pusher";
+import {
+  messagesFromSteps,
+  appendTurnMessages,
+} from "@/services/canvas-turn-persistence";
+
+const queryRaw = db.$queryRaw as ReturnType<typeof vi.fn>;
+const txn = db.$transaction as ReturnType<typeof vi.fn>;
+const update = db.sharedConversation.update as ReturnType<typeof vi.fn>;
+const notify = notifyCanvasConversationUpdated as ReturnType<typeof vi.fn>;
+
+/** Run the `$transaction` callback against a tx whose locked read returns `existing`. */
+function withLockedRows(existing: unknown[]) {
+  txn.mockImplementation(async (cb: (tx: unknown) => Promise<void>) => {
+    const tx = {
+      $queryRaw: vi.fn().mockResolvedValue([{ messages: existing }]),
+      sharedConversation: { update },
+    };
+    return cb(tx);
+  });
+}
+
+/** Run the `$transaction` callback against a tx whose locked read is empty (row gone). */
+function withNoRow() {
+  txn.mockImplementation(async (cb: (tx: unknown) => Promise<void>) => {
+    const tx = {
+      $queryRaw: vi.fn().mockResolvedValue([]),
+      sharedConversation: { update },
+    };
+    return cb(tx);
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  queryRaw.mockResolvedValue([]);
+  update.mockResolvedValue({ id: "conv-1" });
+});
+
+describe("messagesFromSteps", () => {
+  test("splits text and tool calls into separate rows under the id prefix", () => {
+    const steps = [
+      {
+        text: "Looking into it.",
+        toolCalls: [
+          { toolCallId: "tc1", toolName: "search", input: { q: "x" } },
+        ],
+        toolResults: [{ toolCallId: "tc1", output: { hits: 2 } }],
+      },
+      { text: "Here's the answer." },
+    ];
+
+    const rows = messagesFromSteps(steps, "turn-1-a");
+
+    expect(rows.map((r) => r.id)).toEqual([
+      "turn-1-a0",
+      "turn-1-a1",
+      "turn-1-a2",
+    ]);
+    expect(rows[0]).toMatchObject({ role: "assistant", content: "Looking into it." });
+    expect(rows[1].toolCalls?.[0]).toMatchObject({
+      id: "tc1",
+      toolName: "search",
+      status: "output-available",
+    });
+    expect(rows[2]).toMatchObject({ content: "Here's the answer." });
+  });
+
+  test("strips control tools and yields nothing for a control-only turn", () => {
+    const steps = [
+      { toolCalls: [{ toolCallId: "s1", toolName: "stay_silent", input: {} }] },
+    ];
+    const rows = messagesFromSteps(steps, "autoturn-x-", new Set(["stay_silent"]));
+    expect(rows).toEqual([]);
+  });
+
+  test("marks errored tool results as output-error", () => {
+    const steps = [
+      {
+        toolCalls: [{ toolCallId: "tc1", toolName: "do", input: {} }],
+        toolResults: [{ toolCallId: "tc1", output: { error: "boom" } }],
+      },
+    ];
+    const rows = messagesFromSteps(steps, "turn-1-a");
+    expect(rows[0].toolCalls?.[0]).toMatchObject({
+      status: "output-error",
+      errorText: "Tool call failed",
+    });
+  });
+});
+
+describe("appendTurnMessages", () => {
+  const rows = [
+    { id: "turn-1-a0", role: "assistant" as const, content: "Hi" },
+  ];
+
+  test("appends and fires a nudge on a fresh write", async () => {
+    withLockedRows([{ id: "turn-1-u", role: "user", content: "Q" }]);
+
+    const did = await appendTurnMessages({
+      conversationId: "conv-1",
+      rows,
+      idPrefix: "turn-1-a",
+      reason: "user-turn",
+    });
+
+    expect(did).toBe(true);
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(notify).toHaveBeenCalledWith("conv-1", "user-turn");
+  });
+
+  test("is idempotent: a row already under the prefix → no write, no nudge", async () => {
+    withLockedRows([
+      { id: "turn-1-a0", role: "assistant", content: "Hi (already)" },
+    ]);
+
+    const did = await appendTurnMessages({
+      conversationId: "conv-1",
+      rows,
+      idPrefix: "turn-1-a",
+      reason: "user-turn",
+    });
+
+    expect(did).toBe(false);
+    expect(update).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  test("no-ops on an empty rows array", async () => {
+    const did = await appendTurnMessages({
+      conversationId: "conv-1",
+      rows: [],
+      idPrefix: "turn-1-a",
+      reason: "user-turn",
+    });
+    expect(did).toBe(false);
+    expect(txn).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  test("no-ops when the conversation row was deleted mid-turn", async () => {
+    withNoRow();
+
+    const did = await appendTurnMessages({
+      conversationId: "conv-1",
+      rows,
+      idPrefix: "turn-1-a",
+      reason: "user-turn",
+    });
+
+    expect(did).toBe(false);
+    expect(update).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/ask/quick/route.ts
+++ b/src/app/api/ask/quick/route.ts
@@ -31,6 +31,21 @@ import {
 } from "@/lib/ai/runCanvasAgent";
 import type { DispatchedResearchIntent } from "@/lib/ai/researchTools";
 import { swarmFetch } from "@/lib/ai/concepts";
+import { generateTitle } from "@/lib/ai/conversationHelpers";
+import {
+  messagesFromSteps,
+  appendTurnMessages,
+  type StoredMessage,
+} from "@/services/canvas-turn-persistence";
+
+// Tier-1 backend-driven canvas turns (docs/plans/backend-driven-canvas-turns.md):
+// the org-canvas turn is persisted server-side in `after()` so it survives the
+// browser closing mid-stream. `after()` runs inside this invocation, so give
+// the function generous headroom — a turn longer than this is the only case a
+// closed-tab turn can be lost (Vercel doesn't kill in-flight functions on
+// deploy, and `runCanvasAgent` passes no abort signal, so a client disconnect
+// can't cancel generation).
+export const maxDuration = 300;
 
 /**
  * Provenance data types
@@ -123,6 +138,13 @@ export async function POST(request: NextRequest) {
       // rate-limit gate sums recent spend, so passing it through is
       // important from message 2+.
       conversationId,
+      // Backend-driven canvas turns (org-canvas only). A client-
+      // generated id stamped on every send; the server persists the
+      // user row as `${turnId}-u` and the assistant rows as
+      // `${turnId}-a*`, and the client filters its own turn out of the
+      // live-sync merge by this prefix. Absent → legacy client-driven
+      // persistence (dashboard chat, public viewers, older clients).
+      turnId,
     } = body;
 
     if (!messages || !Array.isArray(messages) || messages.length === 0) {
@@ -251,6 +273,7 @@ export async function POST(request: NextRequest) {
         approvalIntent,
         rejectionIntent,
         ...(approvalConversationId ? { conversationId: approvalConversationId } : {}),
+        ...(typeof turnId === "string" && turnId ? { turnId } : {}),
       });
     }
 
@@ -323,6 +346,46 @@ export async function POST(request: NextRequest) {
         ? await loadOrgCanvasPromptCache({ conversationId, userId, orgId })
         : null;
 
+    // ============================================================
+    // Backend-driven canvas turn — server-side persistence (Tier 1).
+    //
+    // For the org-canvas chat, the SERVER owns the conversation row:
+    // it persists the user message synchronously here (before the
+    // stream), and the assistant turn in `after()` below. This makes a
+    // turn survive the browser closing mid-stream — the client no
+    // longer POSTs/PUTs messages (it just live-syncs server rows by
+    // Pusher nudge). Gated on a `turnId` from the client; absent it,
+    // we leave the legacy client-driven path untouched (dashboard chat,
+    // public viewers, older clients).
+    //
+    // `${turnId}-u` = the user row id (idempotency key for this write);
+    // `${turnId}-a*` = the assistant rows (written in `after()`). The
+    // client filters server rows by the `${turnId}-` prefix in its
+    // live-sync merge so the authoring tab never double-renders.
+    // ============================================================
+    const turnIdStr: string | null =
+      typeof turnId === "string" && turnId.length > 0 ? turnId : null;
+    const newUserContent = (() => {
+      const last = convertedMessages[convertedMessages.length - 1];
+      return last && last.role === "user" && typeof last.content === "string"
+        ? last.content
+        : "";
+    })();
+    let canvasConversationRowId: string | null = null;
+    if (orgId && userId && turnIdStr && newUserContent.trim()) {
+      canvasConversationRowId = await persistCanvasUserMessage({
+        orgId,
+        userId,
+        // `promptCache?.rowId` is the validated *existing* org-canvas
+        // row (or null on the first turn / an IDOR-mismatched id, in
+        // which case we create a fresh row owned by this caller).
+        existingRowId: promptCache?.rowId ?? null,
+        turnId: turnIdStr,
+        content: newUserContent,
+        workspaceSlugs: slugs,
+      });
+    }
+
     try {
       // Tracks concept ids learned in this turn so the `after()` block
       // can fetch their provenance from stakgraph after the stream
@@ -376,8 +439,14 @@ export async function POST(request: NextRequest) {
           // fan-out. Using the validated id (not the raw body field)
           // prevents a malicious caller from laundering ownership
           // claims into someone else's conversation.
-          ...(tokenAttributionRowId
-            ? { currentCanvasConversationId: tokenAttributionRowId }
+          // Org-canvas rows are workspace-null, so `tokenAttributionRowId`
+          // never matches them — `canvasConversationRowId` (the
+          // server-owned org-canvas row) is the one fan-out needs.
+          ...((canvasConversationRowId ?? tokenAttributionRowId)
+            ? {
+                currentCanvasConversationId:
+                  canvasConversationRowId ?? tokenAttributionRowId ?? undefined,
+              }
             : {}),
           // The HTTP chat is a live UI surface; emit HIGHLIGHT_NODES so
           // open clients animate the researched node.
@@ -416,12 +485,14 @@ export async function POST(request: NextRequest) {
       // first turn yields an empty list, and caching that would poison
       // the cache into permanently serving nothing (we retry next turn).
       // Best-effort + off the response path via `after()`.
-      if (promptCache?.rowId && !cacheHit && hasConcepts(cacheableConcepts)) {
-        const rowId = promptCache.rowId;
+      // `canvasConversationRowId` covers the first turn (the row was just
+      // created in this request, so `promptCache.rowId` was null at load).
+      const cacheRowId = promptCache?.rowId ?? canvasConversationRowId;
+      if (cacheRowId && !cacheHit && hasConcepts(cacheableConcepts)) {
         after(async () => {
           try {
             await persistOrgCanvasPromptCache(
-              rowId,
+              cacheRowId,
               cacheableConcepts,
               assembledPrefix,
             );
@@ -430,6 +501,55 @@ export async function POST(request: NextRequest) {
               "❌ [quick-ask] Failed to persist prompt cache:",
               err,
             );
+          }
+        });
+      }
+
+      // ── Backend-driven turn: persist the assistant turn server-side ──
+      // Drive the stream to completion off the client socket and write
+      // the assistant rows under the `${turnId}-a` prefix. This is what
+      // survives the browser closing mid-stream. Idempotent on the
+      // prefix; the client filters these rows out of its own live-sync
+      // merge (it's already showing them optimistically).
+      if (canvasConversationRowId && turnIdStr) {
+        const rowId = canvasConversationRowId;
+        const assistantPrefix = `${turnIdStr}-a`;
+        after(async () => {
+          try {
+            // `consumeStream()` drives generation to completion even if
+            // the client disconnected (no abort signal is wired, so the
+            // run isn't cancelled by a closed socket). Then `steps`
+            // resolves with the full tool-call trace.
+            await result.consumeStream();
+            const steps = await result.steps;
+            const rows = messagesFromSteps(
+              steps as Parameters<typeof messagesFromSteps>[0],
+              assistantPrefix,
+            );
+            await appendTurnMessages({
+              conversationId: rowId,
+              rows,
+              idPrefix: assistantPrefix,
+              reason: "user-turn",
+            });
+          } catch (err) {
+            console.error("❌ [quick-ask] Turn persist failed:", err);
+            // Persist a trailing error row so a reopened tab sees the
+            // failure instead of a silently-missing answer (mirrors the
+            // client's inline error message).
+            const errorRow: StoredMessage = {
+              id: `${assistantPrefix}error`,
+              role: "assistant",
+              content:
+                "I'm sorry, but I encountered an error while processing your question. Please try again.",
+              timestamp: new Date().toISOString(),
+            };
+            await appendTurnMessages({
+              conversationId: rowId,
+              rows: [errorRow],
+              idPrefix: assistantPrefix,
+              reason: "user-turn",
+            }).catch(() => {});
           }
         });
       }
@@ -552,6 +672,17 @@ export async function POST(request: NextRequest) {
       }
 
       return result.toUIMessageStreamResponse({
+        // Hand the server-created/validated org-canvas row id back to the
+        // client (same pattern as `X-Approval-Result`) so it can stamp
+        // `serverConversationId` on the first turn without a separate POST.
+        ...(canvasConversationRowId
+          ? {
+              headers: {
+                "X-Conversation-Id": canvasConversationRowId,
+                "Access-Control-Expose-Headers": "X-Conversation-Id",
+              },
+            }
+          : {}),
         // By default the AI SDK masks mid-stream errors as the literal
         // string "An error occurred." — useless for diagnosis and
         // indistinguishable from a clean finish on the client. Forward
@@ -673,6 +804,69 @@ async function resolveOrgConversationRowId(args: {
 }
 
 /**
+ * Persist the user's message for a backend-driven org-canvas turn,
+ * creating the conversation row on the first turn. Returns the row id
+ * the rest of the request (fan-out, the `after()` assistant-turn write,
+ * the `X-Conversation-Id` header) keys off.
+ *
+ * - **Existing row** (validated org-canvas id from the prompt cache):
+ *   append the user row under the shared row lock, idempotent on
+ *   `${turnId}-u` so a retry / double-send doesn't duplicate it.
+ * - **No / mismatched id:** create a fresh `SharedConversation` owned by
+ *   this caller (workspace-null, org-scoped), titled from the message,
+ *   seeded with the user row, and carrying the full workspace-slug set
+ *   in `settings.extraWorkspaceSlugs` (what the auto-turn reconstruction
+ *   and later turns read — org rows have no `workspaceId` to recover the
+ *   slugs from). Creating a new row on an IDOR-mismatched id is safe:
+ *   the caller can only ever write to their own conversation.
+ */
+async function persistCanvasUserMessage(args: {
+  orgId: string;
+  userId: string;
+  existingRowId: string | null;
+  turnId: string;
+  content: string;
+  workspaceSlugs: string[];
+}): Promise<string> {
+  const { orgId, userId, existingRowId, turnId, content, workspaceSlugs } =
+    args;
+
+  const userRow: StoredMessage = {
+    id: `${turnId}-u`,
+    role: "user",
+    content,
+    timestamp: new Date().toISOString(),
+  };
+
+  if (existingRowId) {
+    await appendTurnMessages({
+      conversationId: existingRowId,
+      rows: [userRow],
+      idPrefix: `${turnId}-u`,
+      reason: "user-message",
+    });
+    return existingRowId;
+  }
+
+  const created = await db.sharedConversation.create({
+    data: {
+      sourceControlOrgId: orgId,
+      userId,
+      workspaceId: null,
+      messages: [userRow] as unknown as never,
+      title: generateTitle([userRow]),
+      lastMessageAt: new Date(),
+      source: "org-canvas",
+      settings: { extraWorkspaceSlugs: workspaceSlugs } as unknown as never,
+      followUpQuestions: [],
+      isShared: false,
+    },
+    select: { id: true },
+  });
+  return created.id;
+}
+
+/**
  * Load the cached concepts for an org-canvas conversation, while
  * validating that the row belongs to this org and either to this caller
  * or is an explicitly shared room (same ownership rule as
@@ -772,6 +966,14 @@ async function runProposalIntent(args: {
    * un-validated — the caller is the trust boundary.
    */
   conversationId?: string;
+  /**
+   * Backend-driven persistence id (org-canvas). When present alongside
+   * `conversationId`, the click row + synthetic assistant row (carrying
+   * `approvalResult`) are written server-side under `${turnId}-`, so the
+   * proposal-card "approved" state survives a refresh without the client
+   * autosave. Mirrors the LLM turn's persistence.
+   */
+  turnId?: string;
 }): Promise<Response> {
   const {
     orgId,
@@ -780,10 +982,12 @@ async function runProposalIntent(args: {
     approvalIntent,
     rejectionIntent,
     conversationId,
+    turnId,
   } = args;
 
   let summaryText: string;
   let approvalResultHeader: string | null = null;
+  let approvalResultObj: unknown = null;
   let alreadyApproved = false;
 
   if (approvalIntent) {
@@ -806,6 +1010,7 @@ async function runProposalIntent(args: {
       const r = outcome.result;
       alreadyApproved = outcome.alreadyApproved;
       approvalResultHeader = JSON.stringify(r);
+      approvalResultObj = r;
       // Prefer the resolved entity name ("Auth Refactor") over the
       // generic kind label ("an initiative canvas") so the user knows
       // exactly which workspace / initiative the new row landed
@@ -846,6 +1051,42 @@ async function runProposalIntent(args: {
   } else {
     // Defensive — shouldn't happen given the caller guard.
     summaryText = "No proposal intent provided.";
+  }
+
+  // Persist the click + synthetic assistant row server-side (org-canvas
+  // backend-driven turns). Single locked write under the `${turnId}-`
+  // prefix (idempotent) so a re-click never double-appends. The client
+  // filters its own `${turnId}-*` rows out of the live-sync merge.
+  if (conversationId && turnId) {
+    const lastUser = [...transcript]
+      .reverse()
+      .find((m) => m.role === "user") as
+      | { content?: unknown; approval?: unknown; rejection?: unknown }
+      | undefined;
+    const clickRow: StoredMessage = {
+      id: `${turnId}-u`,
+      role: "user",
+      content:
+        typeof lastUser?.content === "string" ? lastUser.content : "",
+      timestamp: new Date().toISOString(),
+      ...(approvalIntent ? { approval: approvalIntent } : {}),
+      ...(rejectionIntent ? { rejection: rejectionIntent } : {}),
+    };
+    const resultRow: StoredMessage = {
+      id: `${turnId}-a0`,
+      role: "assistant",
+      content: summaryText,
+      timestamp: new Date().toISOString(),
+      ...(approvalResultObj ? { approvalResult: approvalResultObj } : {}),
+    };
+    await appendTurnMessages({
+      conversationId,
+      rows: [clickRow, resultRow],
+      idPrefix: `${turnId}-`,
+      reason: "user-turn",
+    }).catch((err) =>
+      console.error("❌ [quick-ask] Proposal persist failed:", err),
+    );
   }
 
   // Build a minimal SSE stream of UIMessageChunk parts.

--- a/src/app/org/[githubLogin]/_state/canvasChatPersistence.ts
+++ b/src/app/org/[githubLogin]/_state/canvasChatPersistence.ts
@@ -64,13 +64,28 @@ export interface MergeResult<T> {
  * newest, so appending them in server order is chronological — and the
  * `<SubAgentRunCard>`'s `source.kind === "planner"` rows land in the
  * conversation this way.
+ *
+ * `skipServerIdPrefixes` filters out server rows whose id starts with any
+ * of the given prefixes — the backend-driven-turn dedup. The authoring
+ * tab passes `${turnId}-` for every turn it sent (see
+ * `locallyAuthoredTurnIds`): the SERVER persists those turns' rows under
+ * that prefix, but this tab is already showing its own optimistic stream
+ * for them, so merging the server copies would double-render. Other tabs
+ * / a reopened tab pass no prefixes and merge everything. Local rows are
+ * never affected — only incoming server rows are skipped.
  */
 export function mergeServerMessages<T extends PersistableMessage>(
   local: T[],
   server: T[],
+  skipServerIdPrefixes: readonly string[] = [],
 ): MergeResult<T> {
   const localIds = new Set(local.map((m) => m.id));
-  const added = server.filter((m) => !localIds.has(m.id));
+  const isSkipped = (id: string) =>
+    skipServerIdPrefixes.length > 0 &&
+    skipServerIdPrefixes.some((p) => id.startsWith(p));
+  const added = server.filter(
+    (m) => !localIds.has(m.id) && !isSkipped(m.id),
+  );
   return {
     messages: added.length > 0 ? [...local, ...added] : local,
     added,

--- a/src/app/org/[githubLogin]/_state/canvasChatStore.ts
+++ b/src/app/org/[githubLogin]/_state/canvasChatStore.ts
@@ -303,6 +303,19 @@ interface CanvasChatState {
   ephemeralSeedCounts: Record<string, number>;
 
   /**
+   * Turn ids this client authored (sent via `useSendCanvasChatMessage`).
+   * Backend-driven persistence (docs/plans/backend-driven-canvas-turns.md):
+   * the SERVER writes each turn's rows under `${turnId}-u` / `${turnId}-a*`
+   * and broadcasts a Pusher nudge. The authoring tab is already showing its
+   * own optimistic stream for those turns, so `useCanvasChatAutoSave`'s
+   * live-sync filters server rows whose id starts with `${turnId}-` for any
+   * id in this set — preventing a double-render. Other tabs / a reopened tab
+   * have an empty set and merge the server rows normally. Grow-only per
+   * session (ids are unique; stale entries simply never match).
+   */
+  locallyAuthoredTurnIds: Set<string>;
+
+  /**
    * One-shot text the chat input should adopt the next time it
    * renders. `null` means "no draft pending"; non-null means "set
    * the textarea to this string, focus it, then clear this slot."
@@ -358,6 +371,8 @@ interface CanvasChatState {
     serverConversationId?: string,
   ) => string;
   setActiveConversation: (conversationId: string | null) => void;
+  /** Record a turn id this client just sent (see `locallyAuthoredTurnIds`). */
+  markTurnAuthored: (turnId: string) => void;
   /** Update the context of the active conversation (canvas-scope changes). */
   updateActiveContext: (patch: Partial<ConversationContext>) => void;
   /** Wipe the active conversation's messages but keep the conversation row. */
@@ -440,6 +455,7 @@ export const useCanvasChatStore = create<CanvasChatState>()(
       conversations: {},
       activeConversationId: null,
       ephemeralSeedCounts: {},
+      locallyAuthoredTurnIds: new Set<string>(),
       pendingInputDraft: null,
       proposals: {},
       subAgentRuns: {},
@@ -481,6 +497,18 @@ export const useCanvasChatStore = create<CanvasChatState>()(
 
       setActiveConversation: (conversationId) =>
         set({ activeConversationId: conversationId }, false, "setActiveConversation"),
+
+      markTurnAuthored: (turnId) =>
+        set(
+          (s) => {
+            if (s.locallyAuthoredTurnIds.has(turnId)) return s;
+            const next = new Set(s.locallyAuthoredTurnIds);
+            next.add(turnId);
+            return { locallyAuthoredTurnIds: next };
+          },
+          false,
+          "markTurnAuthored",
+        ),
 
       updateActiveContext: (patch) =>
         set(

--- a/src/app/org/[githubLogin]/_state/useCanvasChatAutoSave.ts
+++ b/src/app/org/[githubLogin]/_state/useCanvasChatAutoSave.ts
@@ -1,37 +1,28 @@
 /**
- * Auto-save + live-sync side effect for the canvas chat.
+ * Live-sync side effect for the canvas chat.
  *
- * Two responsibilities, sharing one source of truth (`persistedIdsRef`,
- * a per-conversation set of message ids already on the server):
+ * **Backend-driven turns** (docs/plans/backend-driven-canvas-turns.md):
+ * the SERVER is the single writer for org-canvas conversations. It
+ * persists the user message synchronously and the assistant turn in
+ * `after()` (both in `/api/ask/quick`), planner fan-out / auto-turn /
+ * planner-form answers write their own rows, and every server-side
+ * append fires a `CANVAS_CONVERSATION_UPDATED` Pusher nudge. This hook no
+ * longer POSTs/PUTs anything — it ONLY live-syncs: on a nudge it refetches
+ * the conversation and **merges** server-appended rows into the local
+ * list (by id, never a wholesale replace).
  *
- * 1. **Auto-save** — persists message deltas to
- *    `/api/orgs/[githubLogin]/chat/conversations` with
- *    `source: "org-canvas"`. (See "Persistence rules" below.)
+ * The merge filters out rows for turns THIS tab authored
+ * (`locallyAuthoredTurnIds`, by `${turnId}-` prefix): the tab that sent a
+ * turn is already showing its own optimistic stream for it, so re-merging
+ * the server's copy would double-render. Other tabs / a reopened tab
+ * authored nothing, so they merge everything — which is how a user who
+ * closed the tab mid-turn sees the completed turn when they return, and
+ * how a second viewer of a shared room sees turns appear live.
  *
- * 2. **Live-sync** — subscribes to the active conversation's Pusher
- *    channel (`canvas-conversation-<id>`) and, on a
- *    `CANVAS_CONVERSATION_UPDATED` nudge, refetches the conversation and
- *    **merges** server-appended rows into the local message list (by id,
- *    never a wholesale replace). This is how a user *sitting on the page*
- *    sees planner messages and the canvas agent's autonomous responses
- *    appear immediately — the server appends them (planner fan-out,
- *    auto-turn, planner-form answer) and broadcasts a nudge.
- *
- * Why these live together: the auto-save tracks which message *ids* are
- * already persisted (`persistedIdsRef`). The live-sync brings in
- * server-appended rows; it marks their ids persisted so the next
- * auto-save doesn't re-PUT them as duplicates. Both operate on message
- * identity, so a mid-turn nudge can never drop a local message: merge
- * only adds, and the delta only sends ids not yet on the server. The
- * merge runs only when the conversation is **idle** (no unsaved local
- * messages, not streaming, no save in flight); a nudge that arrives
- * mid-turn is deferred and retried after the next successful save.
- *
- * Persistence rules (mirrored from `DashboardChat`):
- *   - First message: POST creates the row, server returns id.
- *   - Subsequent messages: PUT *delta only*.
- *   - Saves fire-and-forget: failures are logged but never block the UI.
- *   - Trigger: "messages added & not currently streaming."
+ * The merge runs only when the conversation is **idle** (not streaming);
+ * a nudge that arrives mid-stream is deferred and retried when the stream
+ * settles. Merging is identity-based (append-only), so a mid-turn nudge
+ * can never drop a local message.
  *
  * Mounted once per page (in `OrgCanvasView`).
  */
@@ -42,11 +33,7 @@ import {
   useCanvasChatStore,
   type CanvasChatMessage,
 } from "./canvasChatStore";
-import {
-  seedPersistedIds,
-  computeUnsaved,
-  mergeServerMessages,
-} from "./canvasChatPersistence";
+import { mergeServerMessages } from "./canvasChatPersistence";
 import {
   getPusherClient,
   getCanvasConversationChannelName,
@@ -89,19 +76,8 @@ function hydrateServerMessages(raw: unknown[]): CanvasChatMessage[] {
 }
 
 export function useCanvasChatAutoSave({ githubLogin }: AutoSaveArgs) {
-  // Track which message *ids* are already persisted (on the server) per
-  // conversation. Identity-based — NOT a count. A count plus a seed-skip
-  // offset is fragile: any one-off desync (a Pusher nudge interleaving
-  // with a PUT, an ephemeral seed miscount) shifts the save window by
-  // one and silently drops the lead message — historically the user's
-  // first question. Keying by id makes "already saved?" unambiguous and
-  // makes message loss structurally impossible: a message is sent iff
-  // its id isn't in this set.
-  const persistedIdsRef = useRef<Map<string, Set<string>>>(new Map());
-  // Avoid double-saving while a save is in flight for the same convo.
-  const inFlightRef = useRef<Set<string>>(new Set());
-  // Conversations that got a live-sync nudge while busy — synced after
-  // the next successful save.
+  // Conversations that got a live-sync nudge while busy (streaming) —
+  // synced after the stream settles.
   const pendingSyncRef = useRef<Set<string>>(new Set());
   // Conversations with a sync fetch in flight (avoid overlap).
   const syncInFlightRef = useRef<Set<string>>(new Set());
@@ -114,52 +90,20 @@ export function useCanvasChatAutoSave({ githubLogin }: AutoSaveArgs) {
   useEffect(() => {
     if (!githubLogin) return;
 
-    // ─── Persisted-id bookkeeping ────────────────────────────────────
-    // Lazily initialize the persisted-id set for a conversation. Leading
-    // ephemeral seed messages (the AttentionList intro, or the messages
-    // a joined/share conversation already has on the server) are seeded
-    // in as "already persisted" so they're never POSTed/PUT again. The
-    // seeds are always the leading `ephemeralSeedCount` messages, so we
-    // snapshot their ids on first touch.
-    const getPersistedIds = (
-      conversationId: string,
-      conv: { messages: CanvasChatMessage[] },
-    ): Set<string> => {
-      let set = persistedIdsRef.current.get(conversationId);
-      if (!set) {
-        const seedSkip =
-          useCanvasChatStore.getState().ephemeralSeedCounts[conversationId] ??
-          0;
-        set = seedPersistedIds(conv.messages, seedSkip);
-        persistedIdsRef.current.set(conversationId, set);
-      }
-      return set;
-    };
-
-    // The local messages not yet on the server, in order. The lead of
-    // this list is always a genuinely-unsaved message — never an
-    // already-saved one — so a creating POST always carries the real
-    // first user message (never a placeholder-titled assistant lead).
-    const unsavedMessages = (
-      conversationId: string,
-      conv: { messages: CanvasChatMessage[] },
-    ): CanvasChatMessage[] => {
-      const persisted = getPersistedIds(conversationId, conv);
-      return computeUnsaved(conv.messages, persisted);
-    };
-
     // ─── Idle check ──────────────────────────────────────────────────
-    // A conversation is safe to merge server rows into only when it has
-    // no unsaved local messages, isn't streaming, and has no save in
-    // flight.
-    const isIdle = (
-      conv: { messages: CanvasChatMessage[]; isStreaming: boolean },
-      conversationId: string,
-    ): boolean => {
-      if (conv.isStreaming) return false;
-      if (inFlightRef.current.has(conversationId)) return false;
-      return unsavedMessages(conversationId, conv).length === 0;
-    };
+    // Safe to merge server rows only when the conversation isn't
+    // mid-stream (so we never clobber the optimistic stream the user is
+    // watching). With server-side persistence there's no client save in
+    // flight to coordinate with — streaming is the only busy state.
+    const isIdle = (conv: { isStreaming: boolean }): boolean =>
+      !conv.isStreaming;
+
+    // Prefixes for turns this tab authored — their server rows are
+    // filtered out of the merge (we already show them optimistically).
+    const authoredPrefixes = (): string[] =>
+      Array.from(useCanvasChatStore.getState().locallyAuthoredTurnIds).map(
+        (t) => `${t}-`,
+      );
 
     // ─── Live-sync ───────────────────────────────────────────────────
     const syncFromServer = async (
@@ -173,8 +117,8 @@ export function useCanvasChatAutoSave({ githubLogin }: AutoSaveArgs) {
       const conv =
         useCanvasChatStore.getState().conversations[conversationId];
       if (!conv || conv.serverConversationId !== serverId) return;
-      if (!isIdle(conv, conversationId)) {
-        // Busy (user mid-turn) — defer; the flush `.then` re-triggers.
+      if (!isIdle(conv)) {
+        // Busy (user mid-turn) — defer; the settle handler re-triggers.
         pendingSyncRef.current.add(conversationId);
         return;
       }
@@ -196,42 +140,36 @@ export function useCanvasChatAutoSave({ githubLogin }: AutoSaveArgs) {
         const now =
           useCanvasChatStore.getState().conversations[conversationId];
         if (!now || now.serverConversationId !== serverId) return;
-        if (!isIdle(now, conversationId)) {
+        if (!isIdle(now)) {
           pendingSyncRef.current.add(conversationId);
           return;
         }
 
-        // Merge by id, never replace. We keep every local message (so
-        // ephemeral seeds and any not-yet-saved local rows survive) and
-        // append the server messages we don't already have. Server-
-        // appended rows (planner fan-out → `source.kind === "planner"`,
-        // autonomous canvas-agent turns, planner-form answers) are always
-        // the newest, so appending them in server order is chronological.
-        // This is what surfaces the `<SubAgentRunCard>` after an approved
-        // feature's planner posts its plan back into the conversation.
-        const merged = mergeServerMessages(now.messages, mapped);
-
-        // Mark every server id as persisted BEFORE writing messages. The
-        // store's `set` fires subscribers synchronously, re-running
-        // `flush`; if these weren't already marked, that flush would
-        // re-POST the just-synced rows as a bogus delta.
-        const persisted = getPersistedIds(conversationId, now);
-        for (const id of merged.serverIds) persisted.add(id);
+        // Merge by id, never replace. Keep every local message (the
+        // optimistic stream for turns this tab authored, ephemeral seeds,
+        // anything not yet on the server) and append server rows we don't
+        // already have — EXCEPT rows for turns this tab authored, which
+        // we're already showing live (filtered by `${turnId}-` prefix).
+        const merged = mergeServerMessages(
+          now.messages,
+          mapped,
+          authoredPrefixes(),
+        );
 
         if (merged.added.length === 0) return; // in sync, nothing to do
         useCanvasChatStore
           .getState()
           .setConversationMessages(conversationId, merged.messages);
       } catch {
-        // Network hiccup — a later nudge (or the next planner message)
-        // will resync.
+        // Network hiccup — a later nudge (or the next server append) will
+        // resync.
       } finally {
         syncInFlightRef.current.delete(conversationId);
         // A nudge that landed during the fetch → run once more.
         if (pendingSyncRef.current.has(conversationId)) {
           const c =
             useCanvasChatStore.getState().conversations[conversationId];
-          if (c?.serverConversationId) {
+          if (c?.serverConversationId && isIdle(c)) {
             const sid = c.serverConversationId;
             void Promise.resolve().then(() =>
               syncFromServer(conversationId, sid),
@@ -241,88 +179,11 @@ export function useCanvasChatAutoSave({ githubLogin }: AutoSaveArgs) {
       }
     };
 
-    // ─── Auto-save flush ─────────────────────────────────────────────
-    const flush = (conversationId: string) => {
-      if (inFlightRef.current.has(conversationId)) return;
-
-      const conv =
-        useCanvasChatStore.getState().conversations[conversationId];
-      if (!conv) return;
-      // Only save once the stream has fully settled (see store comment).
-      if (conv.isStreaming) return;
-
-      if (conv.messages.length === 0) return;
-
-      const delta = unsavedMessages(conversationId, conv);
-      if (delta.length === 0) {
-        // Nothing to save. If a sync was deferred (e.g. we just settled
-        // from a stream), run it now.
-        if (
-          pendingSyncRef.current.has(conversationId) &&
-          conv.serverConversationId
-        ) {
-          syncFromServer(conversationId, conv.serverConversationId);
-        }
-        return;
-      }
-
-      // Snapshot the ids we're about to persist so `afterSave` marks
-      // exactly what was sent — independent of any messages appended
-      // while the request is in flight (those get the next flush).
-      const deltaIds = delta.map((m) => m.id);
-      inFlightRef.current.add(conversationId);
-
-      const afterSave = (serverId: string) => {
-        const persisted = getPersistedIds(conversationId, conv);
-        for (const id of deltaIds) persisted.add(id);
-        // A live-sync nudge that arrived while we were busy can run now.
-        if (pendingSyncRef.current.has(conversationId)) {
-          syncFromServer(conversationId, serverId);
-        }
-      };
-
-      if (conv.serverConversationId == null) {
-        fetch(`/api/orgs/${githubLogin}/chat/conversations`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            messages: delta,
-            settings: { extraWorkspaceSlugs: conv.context.workspaceSlugs },
-            source: "org-canvas",
-          }),
-        })
-          .then((res) => (res.ok ? res.json() : null))
-          .then((data) => {
-            if (data?.id) {
-              useCanvasChatStore
-                .getState()
-                .setServerConversationId(conversationId, data.id);
-              afterSave(data.id);
-            }
-          })
-          .catch(() => {})
-          .finally(() => inFlightRef.current.delete(conversationId));
-      } else {
-        const serverId = conv.serverConversationId;
-        fetch(`/api/orgs/${githubLogin}/chat/conversations/${serverId}`, {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            messages: delta,
-            settings: { extraWorkspaceSlugs: conv.context.workspaceSlugs },
-          }),
-        })
-          .then(() => afterSave(serverId))
-          .catch(() => {})
-          .finally(() => inFlightRef.current.delete(conversationId));
-      }
-    };
-
     // ─── Pusher subscription management ───────────────────────────────
     // Subscribe to the active conversation's channel; resubscribe when
     // the active conversation (or its server id) changes. Wrapped in
     // try/catch so a missing Pusher config disables live-sync without
-    // breaking auto-save.
+    // breaking the page.
     const syncActiveSubscription = (activeServerId: string | null) => {
       if (activeServerId === subRef.current.serverId) return;
       // Tear down the old subscription.
@@ -353,33 +214,36 @@ export function useCanvasChatAutoSave({ githubLogin }: AutoSaveArgs) {
         });
         subRef.current = { serverId: activeServerId, channel };
       } catch {
-        // Pusher unavailable — live-sync disabled; auto-save still works.
+        // Pusher unavailable — live-sync disabled.
       }
     };
 
     // Imperative subscription — fine-grained reaction without re-render.
     const unsub = useCanvasChatStore.subscribe((state, prev) => {
-      // Reset the persisted-id set when a conversation is dropped or its
-      // server row is recycled (clear button) — a recycled row will get
-      // a fresh server id, so the old persisted ids no longer apply.
+      // Forget pending syncs for dropped conversations.
       for (const id of Object.keys(prev.conversations)) {
-        const before = prev.conversations[id];
-        const after = state.conversations[id];
-        if (!after) {
-          persistedIdsRef.current.delete(id);
+        if (!state.conversations[id]) {
           pendingSyncRef.current.delete(id);
-          continue;
-        }
-        if (
-          before.serverConversationId !== null &&
-          after.serverConversationId === null
-        ) {
-          persistedIdsRef.current.delete(id);
         }
       }
 
       const activeId = state.activeConversationId;
-      if (activeId) flush(activeId);
+
+      // A stream that just settled (isStreaming true → false) may have a
+      // deferred nudge waiting — run it now that we're idle.
+      if (activeId) {
+        const before = prev.conversations[activeId];
+        const after = state.conversations[activeId];
+        if (
+          before?.isStreaming &&
+          after &&
+          !after.isStreaming &&
+          after.serverConversationId &&
+          pendingSyncRef.current.has(activeId)
+        ) {
+          void syncFromServer(activeId, after.serverConversationId);
+        }
+      }
 
       // Keep the live-sync subscription pointed at the active convo.
       const activeServerId = activeId

--- a/src/app/org/[githubLogin]/_state/useSendCanvasChatMessage.ts
+++ b/src/app/org/[githubLogin]/_state/useSendCanvasChatMessage.ts
@@ -78,7 +78,22 @@ export function useSendCanvasChatMessage() {
         setIsLoading,
         setIsStreaming,
         appendAssistantError,
+        markTurnAuthored,
+        setServerConversationId,
       } = useCanvasChatStore.getState();
+
+      // Backend-driven persistence id for this turn
+      // (docs/plans/backend-driven-canvas-turns.md). The server persists
+      // the user row as `${turnId}-u` and the assistant rows as
+      // `${turnId}-a*`; we register the id so the live-sync filters those
+      // server rows out of the merge (this tab already shows them live).
+      const turnId =
+        typeof crypto !== "undefined" && "randomUUID" in crypto
+          ? crypto.randomUUID()
+          : `turn-${Date.now().toString(36)}-${Math.random()
+              .toString(36)
+              .slice(2)}`;
+      markTurnAuthored(turnId);
 
       // Snapshot the conversation BEFORE we mutate so the request
       // body sees a consistent message list. We also need its
@@ -151,11 +166,26 @@ export function useSendCanvasChatMessage() {
             ...(approval || rejection
               ? { canvasChatMessages: updatedMessages }
               : {}),
+            // Backend-driven persistence: the server writes this turn's
+            // rows under `${turnId}-*` and returns the (possibly newly-
+            // created) row id in `X-Conversation-Id`.
+            turnId,
           }),
         });
 
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        // First turn of a fresh conversation: the server created the
+        // `SharedConversation` row and handed its id back here. Adopt it
+        // so the live-sync subscribes to the right channel and later
+        // turns/approvals reference the same row. (Same pattern as the
+        // old autosave POST setting it — now server-driven.)
+        const serverConversationIdHeader =
+          response.headers.get("X-Conversation-Id");
+        if (serverConversationIdHeader && !conv.serverConversationId) {
+          setServerConversationId(conversationId, serverConversationIdHeader);
         }
 
         // The proposal-approval endpoint stamps the structured

--- a/src/lib/pusher.ts
+++ b/src/lib/pusher.ts
@@ -108,7 +108,12 @@ export type CanvasConversationUpdateReason =
   // A human appended a message to a shared conversation. Fires from the
   // autosave PUT so other people sitting on the same shared room refetch
   // and see the new turn live.
-  | "user-message";
+  | "user-message"
+  // A user-driven canvas-agent turn was persisted server-side (the
+  // `/api/ask/quick` org path, in `after()`). The authoring tab filters
+  // its own turn out of the merge by id prefix; other viewers / a
+  // reopened tab live-sync it in.
+  | "user-turn";
 
 /**
  * Fire-and-forget broadcast that a canvas conversation's `messages` JSON

--- a/src/services/canvas-agent-autoturn.ts
+++ b/src/services/canvas-agent-autoturn.ts
@@ -42,7 +42,11 @@ import { tool, type ModelMessage, type ToolSet } from "ai";
 import { z } from "zod";
 import { db } from "@/lib/db";
 import { runCanvasAgent, type CachedConcepts } from "@/lib/ai/runCanvasAgent";
-import { notifyCanvasConversationUpdated } from "@/lib/pusher";
+import {
+  messagesFromSteps,
+  appendTurnMessages,
+  type StoredMessage,
+} from "@/services/canvas-turn-persistence";
 
 /** Why the agent was woken. Surfaced verbatim in the synthetic prompt. */
 export type AutoTurnWakeReason =
@@ -109,29 +113,10 @@ function buildStaySilentTool(ctx: {
   };
 }
 
-// ───────────────────────────────────────────────────────────────────
-// Stored-message types (the `CanvasChatMessage` JSON shape inside
-// `SharedConversation.messages`). Kept loose — the column is `Json`
-// and the canonical render-side type lives in `canvasChatStore.ts`.
-// ───────────────────────────────────────────────────────────────────
-
-interface StoredToolCall {
-  id: string;
-  toolName: string;
-  input?: unknown;
-  status?: string;
-  output?: unknown;
-  errorText?: string;
-}
-
-interface StoredMessage {
-  id: string;
-  role: "user" | "assistant";
-  content: string;
-  timestamp?: string;
-  toolCalls?: StoredToolCall[];
-  source?: { kind: string; featureId?: string; plannerMessageId?: string };
-}
+// Stored-message types (`StoredMessage` / `StoredToolCall`) and the
+// turn writer (`messagesFromSteps` / `appendTurnMessages`) now live in
+// `@/services/canvas-turn-persistence` so the user-driven `/api/ask/quick`
+// path and this auto-turn path share one persistence code path.
 
 /**
  * Server-side mirror of `toModelMessages` from `canvasChatStore.ts`.
@@ -189,134 +174,8 @@ function toModelMessages(messages: StoredMessage[]): ModelMessage[] {
     });
 }
 
-/**
- * Reconstruct the agent's output as `CanvasChatMessage`-shaped rows
- * from the finished stream's `steps`. Mirrors the client-side timeline
- * split in `useSendCanvasChatMessage.ts`: text becomes a text message,
- * tool calls become a tool-call message (so `SubAgentRunCard` can
- * extract `send_to_feature_planner` calls as outbound thread entries).
- *
- * The `stay_silent` tool call is stripped — it's a control signal, not
- * a transcript entry. A turn that did nothing but `stay_silent`
- * produces an empty array, and the caller appends nothing.
- */
-function messagesFromSteps(
-  steps: Array<{
-    text?: string;
-    toolCalls?: Array<{ toolCallId: string; toolName: string; input?: unknown }>;
-    toolResults?: Array<{ toolCallId: string; output?: unknown; result?: unknown }>;
-  }>,
-  plannerMessageId: string,
-): StoredMessage[] {
-  const rows: StoredMessage[] = [];
-  let idx = 0;
-  const nextId = () => `autoturn-${plannerMessageId}-${idx++}`;
-  const now = new Date().toISOString();
-
-  for (const step of steps) {
-    if (step.text && step.text.trim()) {
-      rows.push({
-        id: nextId(),
-        role: "assistant",
-        content: step.text,
-        timestamp: now,
-      });
-    }
-
-    const calls = step.toolCalls ?? [];
-    if (calls.length === 0) continue;
-
-    const resultByCallId = new Map(
-      (step.toolResults ?? []).map((r) => [r.toolCallId, r] as const),
-    );
-
-    const toolCalls: StoredToolCall[] = calls
-      .filter((tc) => tc.toolName !== STAY_SILENT_TOOL)
-      .map((tc) => {
-        const r = resultByCallId.get(tc.toolCallId);
-        const output = r ? (r.output ?? r.result) : undefined;
-        const isError =
-          !!output &&
-          typeof output === "object" &&
-          "error" in (output as Record<string, unknown>);
-        return {
-          id: tc.toolCallId,
-          toolName: tc.toolName,
-          input: tc.input,
-          output,
-          status:
-            output === undefined
-              ? "input-available"
-              : isError
-                ? "output-error"
-                : "output-available",
-          ...(isError ? { errorText: "Tool call failed" } : {}),
-        };
-      });
-
-    if (toolCalls.length > 0) {
-      rows.push({
-        id: nextId(),
-        role: "assistant",
-        content: "",
-        timestamp: now,
-        toolCalls,
-      });
-    }
-  }
-
-  return rows;
-}
-
-/**
- * Append agent-produced rows into the canvas conversation under the
- * same row-level lock the fan-out worker and the autosave PUT use, so
- * all three writers serialize on the conversation row. Idempotent on
- * the `autoturn-<plannerMessageId>-` id prefix.
- */
-async function appendAutoTurnMessages(
-  conversationId: string,
-  rows: StoredMessage[],
-  plannerMessageId: string,
-): Promise<void> {
-  if (rows.length === 0) return;
-  const idPrefix = `autoturn-${plannerMessageId}-`;
-
-  let didAppend = false;
-  await db.$transaction(async (tx) => {
-    const locked = await tx.$queryRaw<{ messages: unknown }[]>`
-      SELECT messages FROM shared_conversations WHERE id = ${conversationId} FOR UPDATE
-    `;
-    if (locked.length === 0) return; // conversation deleted mid-turn
-
-    const existing = Array.isArray(locked[0].messages)
-      ? (locked[0].messages as StoredMessage[])
-      : [];
-
-    // Idempotency: if a prior run for this planner message already
-    // committed rows, don't double-append.
-    const alreadyAppended = existing.some(
-      (m) => typeof m.id === "string" && m.id.startsWith(idPrefix),
-    );
-    if (alreadyAppended) return;
-
-    await tx.sharedConversation.update({
-      where: { id: conversationId },
-      data: {
-        messages: [...existing, ...rows] as unknown as never,
-        lastMessageAt: new Date(),
-      },
-    });
-    didAppend = true;
-  });
-
-  // Push the agent's response to an open browser immediately. The
-  // auto-turn runs in the webhook's `after()` (seconds after the
-  // planner message), so this is the second live update the user sees.
-  if (didAppend) {
-    notifyCanvasConversationUpdated(conversationId, "autoturn");
-  }
-}
+/** Tool names stripped from the persisted transcript (control signals). */
+const AUTOTURN_STRIP_TOOLS: ReadonlySet<string> = new Set([STAY_SILENT_TOOL]);
 
 /**
  * Build the short, context-only synthetic wake message that tells the
@@ -629,10 +488,16 @@ async function runAutoTurn(args: AutoTurnArgs): Promise<void> {
 
   const rows = messagesFromSteps(
     steps as Parameters<typeof messagesFromSteps>[0],
-    plannerMessageId,
+    idPrefix,
+    AUTOTURN_STRIP_TOOLS,
   );
 
-  await appendAutoTurnMessages(conversationId, rows, plannerMessageId);
+  await appendTurnMessages({
+    conversationId,
+    rows,
+    idPrefix,
+    reason: "autoturn",
+  });
 
   console.log("[canvas-autoturn] completed", {
     conversationId,

--- a/src/services/canvas-turn-persistence.ts
+++ b/src/services/canvas-turn-persistence.ts
@@ -1,0 +1,198 @@
+/**
+ * Shared server-side persistence for canvas-chat agent turns.
+ *
+ * Extracted from `canvas-agent-autoturn.ts` so BOTH the autonomous
+ * planner-woken turn AND the user-driven `/api/ask/quick` turn write
+ * through one code path. The contract is identical for both:
+ *
+ *   - Reconstruct `CanvasChatMessage`-shaped rows from a finished
+ *     `streamText` run's `steps` (`messagesFromSteps`).
+ *   - Append them to `SharedConversation.messages` under a
+ *     `SELECT … FOR UPDATE` row lock so the write serializes against the
+ *     other writers on that row (the planner fan-out, the conversations
+ *     PUT route), and is idempotent on a caller-chosen id prefix so a
+ *     retried `after()` / re-delivered webhook never double-appends.
+ *   - Fire a `CANVAS_CONVERSATION_UPDATED` Pusher nudge on a fresh
+ *     append so open browsers live-sync the new rows in.
+ *
+ * The id prefix is the dedup key. Callers pick a prefix unique to the
+ * turn: the user-driven path uses `${turnId}-a` (assistant rows) and
+ * `${turnId}-u` (the user row); the auto-turn path uses
+ * `autoturn-${plannerMessageId}-`. The org-canvas client filters server
+ * rows by `${turnId}-` prefix in its live-sync merge so the authoring
+ * tab never double-renders its own optimistic stream.
+ */
+
+import { db } from "@/lib/db";
+import {
+  notifyCanvasConversationUpdated,
+  type CanvasConversationUpdateReason,
+} from "@/lib/pusher";
+
+// ───────────────────────────────────────────────────────────────────
+// Stored-message types (the `CanvasChatMessage` JSON shape inside
+// `SharedConversation.messages`). Kept loose — the column is `Json`
+// and the canonical render-side type lives in `canvasChatStore.ts`.
+// ───────────────────────────────────────────────────────────────────
+
+export interface StoredToolCall {
+  id: string;
+  toolName: string;
+  input?: unknown;
+  status?: string;
+  output?: unknown;
+  errorText?: string;
+}
+
+export interface StoredMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  timestamp?: string;
+  toolCalls?: StoredToolCall[];
+  source?: { kind: string; featureId?: string; plannerMessageId?: string };
+  // Approval-flow metadata round-tripping through the JSON. Untyped here
+  // (the canonical types live in `src/lib/proposals/types.ts`); the
+  // render-side store re-narrows them.
+  approval?: unknown;
+  rejection?: unknown;
+  approvalResult?: unknown;
+}
+
+type StepLike = {
+  text?: string;
+  toolCalls?: Array<{ toolCallId: string; toolName: string; input?: unknown }>;
+  toolResults?: Array<{ toolCallId: string; output?: unknown; result?: unknown }>;
+};
+
+const NO_STRIP: ReadonlySet<string> = new Set();
+
+/**
+ * Reconstruct the agent's output as `CanvasChatMessage`-shaped rows from
+ * the finished stream's `steps`. Mirrors the client-side timeline split
+ * in `useSendCanvasChatMessage.ts`: text becomes a text message, tool
+ * calls become a tool-call message (so `SubAgentRunCard` can extract
+ * `send_to_feature_planner` calls as outbound thread entries).
+ *
+ * Row ids are `${idPrefix}${n}` (n = 0,1,2,…), so `idPrefix` doubles as
+ * the idempotency key for `appendTurnMessages`.
+ *
+ * `stripToolNames` removes control-signal tool calls that aren't real
+ * transcript entries (the auto-turn's `stay_silent`). A turn that did
+ * nothing but a stripped tool produces an empty array, and the caller
+ * appends nothing.
+ */
+export function messagesFromSteps(
+  steps: StepLike[],
+  idPrefix: string,
+  stripToolNames: ReadonlySet<string> = NO_STRIP,
+): StoredMessage[] {
+  const rows: StoredMessage[] = [];
+  let idx = 0;
+  const nextId = () => `${idPrefix}${idx++}`;
+  const now = new Date().toISOString();
+
+  for (const step of steps) {
+    if (step.text && step.text.trim()) {
+      rows.push({
+        id: nextId(),
+        role: "assistant",
+        content: step.text,
+        timestamp: now,
+      });
+    }
+
+    const calls = step.toolCalls ?? [];
+    if (calls.length === 0) continue;
+
+    const resultByCallId = new Map(
+      (step.toolResults ?? []).map((r) => [r.toolCallId, r] as const),
+    );
+
+    const toolCalls: StoredToolCall[] = calls
+      .filter((tc) => !stripToolNames.has(tc.toolName))
+      .map((tc) => {
+        const r = resultByCallId.get(tc.toolCallId);
+        const output = r ? (r.output ?? r.result) : undefined;
+        const isError =
+          !!output &&
+          typeof output === "object" &&
+          "error" in (output as Record<string, unknown>);
+        return {
+          id: tc.toolCallId,
+          toolName: tc.toolName,
+          input: tc.input,
+          output,
+          status:
+            output === undefined
+              ? "input-available"
+              : isError
+                ? "output-error"
+                : "output-available",
+          ...(isError ? { errorText: "Tool call failed" } : {}),
+        };
+      });
+
+    if (toolCalls.length > 0) {
+      rows.push({
+        id: nextId(),
+        role: "assistant",
+        content: "",
+        timestamp: now,
+        toolCalls,
+      });
+    }
+  }
+
+  return rows;
+}
+
+/**
+ * Append rows into a canvas conversation under the same row-level lock
+ * the fan-out worker and the autosave PUT use, so all writers serialize
+ * on the conversation row. Idempotent on the `idPrefix`: if any existing
+ * row id already starts with it, this is a no-op (a retried `after()`,
+ * a re-delivered webhook). Returns whether THIS call appended.
+ *
+ * Fires a `CANVAS_CONVERSATION_UPDATED` nudge only on a fresh append, so
+ * open browsers live-sync the new rows in. Never throws on the Pusher
+ * side (the helper swallows that); the DB write is the contract.
+ */
+export async function appendTurnMessages(args: {
+  conversationId: string;
+  rows: StoredMessage[];
+  idPrefix: string;
+  reason: CanvasConversationUpdateReason;
+}): Promise<boolean> {
+  const { conversationId, rows, idPrefix, reason } = args;
+  if (rows.length === 0) return false;
+
+  let didAppend = false;
+  await db.$transaction(async (tx) => {
+    const locked = await tx.$queryRaw<{ messages: unknown }[]>`
+      SELECT messages FROM shared_conversations WHERE id = ${conversationId} FOR UPDATE
+    `;
+    if (locked.length === 0) return; // conversation deleted mid-turn
+
+    const existing = Array.isArray(locked[0].messages)
+      ? (locked[0].messages as StoredMessage[])
+      : [];
+
+    const alreadyAppended = existing.some(
+      (m) => typeof m.id === "string" && m.id.startsWith(idPrefix),
+    );
+    if (alreadyAppended) return;
+
+    await tx.sharedConversation.update({
+      where: { id: conversationId },
+      data: {
+        messages: [...existing, ...rows] as unknown as never,
+        lastMessageAt: new Date(),
+      },
+    });
+    didAppend = true;
+  });
+
+  if (didAppend) notifyCanvasConversationUpdated(conversationId, reason);
+  return didAppend;
+}


### PR DESCRIPTION
## Problem

The org-canvas chat only completes a turn if the browser stays open. `/api/ask/quick` streams SSE, and the **client** assembles the assistant timeline while `useCanvasChatAutoSave` PUTs it back. Worse: `flush()` early-returns while `isStreaming`, and `isStreaming` is set before the fetch — so **nothing persists until the turn fully settles**. Close the tab mid-stream and you lose the answer *and* the question.

## Approach (Tier 1)

Make the **server the single writer** for org-canvas turns; the browser stream becomes a live preview. This generalizes the path the autonomous planner/auto-turn already uses (`canvas-agent-autoturn.ts` → row-locked append → Pusher nudge → live-sync merge).

- The user message is persisted **synchronously before** streaming (creating the `SharedConversation` row if needed); the row id comes back in an `X-Conversation-Id` header.
- The assistant turn is persisted in `after()` via `result.consumeStream()` → `messagesFromSteps` → `appendTurnMessages`. `runCanvasAgent`'s `streamText` passes **no abort signal**, so a client disconnect can't cancel generation, and Vercel doesn't kill in-flight functions on deploy — the only real bound is `maxDuration` (set to 300s).
- The client stops POSTing/PUTting; `useCanvasChatAutoSave` is live-sync-only.

### Streaming is not degraded
The browser still reads the LLM stream natively from its own request (full char-by-char). Persistence runs in parallel off the same `result`. The authoring tab filters the server's copy of **its own** turn out of the live-sync merge by `${turnId}-` prefix → **no flicker, no duplicate**. Other tabs / a reopened tab merge it in normally — which is how a closed-tab turn shows up on return, and how a shared-room second viewer sees it live.

## Changes

- **New** `src/services/canvas-turn-persistence.ts` — shared `messagesFromSteps` + row-locked, prefix-idempotent `appendTurnMessages` (+ nudge). `canvas-agent-autoturn.ts` refactored to use it (behavior unchanged; its 11 tests pass).
- `src/app/api/ask/quick/route.ts` — `maxDuration = 300`; org-canvas user-message + assistant-turn persistence; `X-Conversation-Id` header; approval/rejection branch persists its click + `approvalResult` row. Bonus: `send_to_feature_planner`'s lazy claim now works on the main chat path for org-canvas, not just approvals.
- `src/lib/pusher.ts` — `"user-turn"` reason.
- `canvasChatStore.ts` — `locallyAuthoredTurnIds` + `markTurnAuthored`.
- `useSendCanvasChatMessage.ts` — generate/send `turnId`, adopt `X-Conversation-Id`.
- `useCanvasChatAutoSave.ts` — remove save path; live-sync only with the authored-prefix filter.
- `mergeServerMessages` — optional `skipServerIdPrefixes`.

## Trade-off (accepted)

A turn longer than `maxDuration` could still be lost even with the tab open — 300s is far beyond a realistic canvas turn. Tier 2 (Redis resumable streams) is the documented escape hatch if ever needed.

## Tests

- New `canvas-turn-persistence.test.ts` (writer + idempotency).
- Rewrote `useCanvasChatAutoSave.test.ts` for the live-sync-only contract (incl. authored-turn filter, mid-stream-nudge defer).
- Extended `canvasChatPersistence.test.ts` with prefix-filter cases.
- 40 tests across affected files pass; auto-turn's 11 unchanged; touched source typechecks clean.
- Integration tests need a live Postgres (not run here) and cover non-org workspace paths unaffected by the gated change.

## Manual smoke (recommended)

- Send → close tab immediately → reopen conversation → completed turn present.
- Send with tab open → no end-of-turn flicker.
- Shared room: second viewer sees the turn appear live.

Plan doc: `docs/plans/backend-driven-canvas-turns.md`