### PR TITLE
Fix canvas Start Tasks for MCP-created tasks + live planner status pill

### DIFF
--- a/src/__tests__/unit/canvas/canvasChatPersistence.test.ts
+++ b/src/__tests__/unit/canvas/canvasChatPersistence.test.ts
@@ -13,6 +13,7 @@ import {
   seedPersistedIds,
   computeUnsaved,
   mergeServerMessages,
+  reconcilePlannerSources,
   type PersistableMessage,
 } from "@/app/org/[githubLogin]/_state/canvasChatPersistence";
 
@@ -188,5 +189,66 @@ describe("full turn lifecycle stays consistent", () => {
     ]);
     // Nothing left to re-save (no duplicate PUTs).
     expect(computeUnsaved(local, persisted)).toEqual([]);
+  });
+});
+
+describe("reconcilePlannerSources — refresh planner status in place", () => {
+  type Row = {
+    id: string;
+    role: "user" | "assistant";
+    source?: { kind?: string; featureId?: string; workflowStatus?: string } | null;
+  };
+  const plannerRow = (id: string, workflowStatus: string): Row => ({
+    id,
+    role: "assistant",
+    source: { kind: "planner", featureId: "feat-1", workflowStatus },
+  });
+
+  test("swaps a stale IN_PROGRESS snapshot for the server's COMPLETED", () => {
+    const local: Row[] = [
+      { id: "user1", role: "user" },
+      plannerRow("planner-x", "IN_PROGRESS"),
+    ];
+    const server: Row[] = [
+      { id: "user1", role: "user" },
+      plannerRow("planner-x", "COMPLETED"),
+    ];
+    const { messages, changed } = reconcilePlannerSources(local, server);
+    expect(changed).toBe(true);
+    expect(messages[1].source?.workflowStatus).toBe("COMPLETED");
+    // Order + non-planner rows untouched.
+    expect(messages.map((m) => m.id)).toEqual(["user1", "planner-x"]);
+  });
+
+  test("no-op (same array, changed=false) when statuses already match", () => {
+    const local: Row[] = [plannerRow("planner-x", "COMPLETED")];
+    const server: Row[] = [plannerRow("planner-x", "COMPLETED")];
+    const result = reconcilePlannerSources(local, server);
+    expect(result.changed).toBe(false);
+    expect(result.messages).toBe(local); // identity preserved → no store write
+  });
+
+  test("never adds or drops rows — only refreshes existing planner ids", () => {
+    const local: Row[] = [plannerRow("planner-x", "IN_PROGRESS")];
+    // Server has an extra row, but reconcile must not append it.
+    const server: Row[] = [
+      plannerRow("planner-x", "FAILED"),
+      plannerRow("planner-y", "COMPLETED"),
+    ];
+    const { messages, changed } = reconcilePlannerSources(local, server);
+    expect(changed).toBe(true);
+    expect(messages.map((m) => m.id)).toEqual(["planner-x"]);
+    expect(messages[0].source?.workflowStatus).toBe("FAILED");
+  });
+
+  test("leaves non-planner rows and rows absent on the server alone", () => {
+    const local: Row[] = [
+      { id: "user1", role: "user" },
+      plannerRow("planner-local-only", "IN_PROGRESS"),
+    ];
+    const server: Row[] = [{ id: "user1", role: "user" }];
+    const result = reconcilePlannerSources(local, server);
+    expect(result.changed).toBe(false);
+    expect(result.messages).toBe(local);
   });
 });

--- a/src/app/api/stakwork/webhook/route.ts
+++ b/src/app/api/stakwork/webhook/route.ts
@@ -6,6 +6,7 @@ import { mapStakworkStatus } from "@/utils/conversions";
 import { StakworkStatusPayload } from "@/types";
 import { updateFeatureStatusFromTasks } from "@/services/roadmap/feature-status-sync";
 import { notifyFeatureCanvasRefresh } from "@/lib/canvas";
+import { syncPlannerWorkflowStatusToCanvas } from "@/services/canvas-planner-fanout";
 import { createAndSendNotification } from "@/services/notifications";
 import { retryWorkflowEditorTask } from "@/services/workflow-editor-retry";
 
@@ -167,6 +168,7 @@ export async function POST(request: NextRequest) {
           assigneeId: true,
           createdById: true,
           title: true,
+          parentCanvasConversationId: true,
           workspace: { select: { slug: true } },
         },
       });
@@ -176,6 +178,21 @@ export async function POST(request: NextRequest) {
           where: { id: feature.id },
           data: buildWorkflowTimestamps(workflowStatus),
         });
+
+        // Patch the (frozen) `source.workflowStatus` snapshot on the
+        // feature's latest planner row in its owning canvas conversation,
+        // so the `SubAgentRunCard` pill reflects the just-written status
+        // (the planner message usually fanned out a few seconds earlier,
+        // while the feature still read IN_PROGRESS). No-ops when there's
+        // no owning conversation / planner row, and self-heals on reload
+        // if missed — so it never blocks the webhook.
+        if (feature.parentCanvasConversationId) {
+          await syncPlannerWorkflowStatusToCanvas(
+            feature.parentCanvasConversationId,
+            feature.id,
+            workflowStatus,
+          );
+        }
 
         // Fire WORKFLOW_HALTED notification for feature path (fire-and-forget)
         if (workflowStatus === WorkflowStatus.HALTED) {

--- a/src/app/org/[githubLogin]/_components/SidebarChat.tsx
+++ b/src/app/org/[githubLogin]/_components/SidebarChat.tsx
@@ -209,17 +209,29 @@ export function SidebarChat({ githubLogin }: SidebarChatProps) {
             />
           )}
           {/*
-            Once the planner has generated tasks, offer a Start Tasks
-            button (it reads the live ready-count itself and hides when
-            none remain). Suppressed while a FORM is pending — answer the
-            planner first.
+            Offer a Start Tasks button once the planner has replied at
+            all — NOT just when a reply carried a `TASKS` artifact.
+            Tasks created by the remote planner over MCP
+            (`create_task` / `create_feature_task`) hit the DB directly
+            with no artifact, no chat message, and no fan-out, so
+            `run.hasGeneratedTasks` (artifact-derived) stays false even
+            though real tasks exist. The slot itself reads the live
+            ready-count (`GET …/tasks/assign-all`) and renders nothing
+            when zero, so showing it for any answered run is safe — the
+            count is the artifact-independent source of truth. We pass
+            `revalidateKey` (the anchor, which moves on each new planner
+            reply) so a closing "tasks created" message re-queries the
+            count and surfaces the button live. Suppressed while a FORM
+            is pending — answer the planner first.
           */}
-          {run.hasGeneratedTasks && !run.pendingForm && (
-            <StartTasksSlot
-              featureId={run.featureId}
-              featureTitle={run.featureTitle}
-            />
-          )}
+          {!run.pendingForm &&
+            run.messages.some((m) => m.direction === "in") && (
+              <StartTasksSlot
+                featureId={run.featureId}
+                featureTitle={run.featureTitle}
+                revalidateKey={run.anchorMessageId}
+              />
+            )}
         </div>
       ))}
     </div>

--- a/src/app/org/[githubLogin]/_components/StartTasksSlot.tsx
+++ b/src/app/org/[githubLogin]/_components/StartTasksSlot.tsx
@@ -7,10 +7,9 @@ import { Button } from "@/components/ui/button";
 /**
  * StartTasksSlot — the canvas-chat "Start Tasks" affordance.
  *
- * Once a feature's planner has generated a task breakdown
- * (`run.hasGeneratedTasks`), this slot sits beside the
- * `SubAgentRunCard` and lets the user kick off execution — assigning
- * the feature's ready tasks to the Task Coordinator — without leaving
+ * Sits beside the `SubAgentRunCard` once a feature's planner has
+ * replied, and lets the user kick off execution — assigning the
+ * feature's ready tasks to the Task Coordinator — without leaving
  * canvas chat. It mirrors the "Start Tasks" button on the full plan
  * page (`/w/<slug>/plan/<featureId>`).
  *
@@ -18,10 +17,20 @@ import { Button } from "@/components/ui/button";
  * spins up real compute (pods / workflow runs). So this is a plain
  * button, not an agent tool.
  *
+ * **The live `readyCount` is the source of truth, NOT a chat
+ * artifact.** Tasks created by the remote planner over MCP
+ * (`create_task` / `create_feature_task`) land in the DB with no
+ * `TASKS` artifact, so the artifact-derived `run.hasGeneratedTasks`
+ * flag can't see them. This slot instead asks the DB directly, so it
+ * surfaces tasks no matter how they were created.
+ *
  * Data flow:
- *   - On mount, GET `…/tasks/assign-all` → `{ readyCount }` (unassigned
- *     TODO tasks in the feature's first phase — the exact set the POST
- *     will assign).
+ *   - GET `…/tasks/assign-all` → `{ readyCount }` (unassigned TODO
+ *     tasks in the feature's first phase — the exact set the POST will
+ *     assign). Re-runs on mount, whenever `revalidateKey` changes (the
+ *     parent passes the run's anchor, which moves on each new planner
+ *     reply — so a closing "tasks created" message refreshes the count),
+ *     and on window focus (covers MCP creates with no closing message).
  *   - Renders nothing while loading or when `readyCount === 0`
  *     (e.g. all tasks already started elsewhere).
  *   - Click → POST `…/tasks/assign-all` → `{ success, count }`, then
@@ -31,9 +40,20 @@ import { Button } from "@/components/ui/button";
 interface StartTasksSlotProps {
   featureId: string;
   featureTitle?: string;
+  /**
+   * Changes whenever the owning run sees new planner activity (the
+   * parent passes `run.anchorMessageId`). A change re-queries the live
+   * ready-count, so tasks the planner just created (incl. via MCP, with
+   * no artifact) surface without a manual refresh.
+   */
+  revalidateKey?: string;
 }
 
-export function StartTasksSlot({ featureId, featureTitle }: StartTasksSlotProps) {
+export function StartTasksSlot({
+  featureId,
+  featureTitle,
+  revalidateKey,
+}: StartTasksSlotProps) {
   const [readyCount, setReadyCount] = useState<number | null>(null);
   const [starting, setStarting] = useState(false);
   const [startedCount, setStartedCount] = useState<number | null>(null);
@@ -52,9 +72,24 @@ export function StartTasksSlot({ featureId, featureTitle }: StartTasksSlotProps)
     }
   }, [featureId]);
 
+  // Re-query on mount and whenever the run advances (`revalidateKey`).
+  // A new planner reply — including the closing message after the agent
+  // created tasks over MCP — bumps the key, so the count refreshes and
+  // the button appears without the user touching anything.
   useEffect(() => {
     void refresh();
-  }, [refresh]);
+  }, [refresh, revalidateKey]);
+
+  // Also revalidate when the user returns to the tab. Covers the case
+  // where tasks were created (MCP or elsewhere) while the conversation
+  // was idle and produced no new message to bump `revalidateKey`. Only
+  // worth polling for while nothing is started yet.
+  useEffect(() => {
+    if (startedCount !== null) return;
+    const onFocus = () => void refresh();
+    window.addEventListener("focus", onFocus);
+    return () => window.removeEventListener("focus", onFocus);
+  }, [refresh, startedCount]);
 
   const handleStart = async () => {
     setStarting(true);

--- a/src/app/org/[githubLogin]/_components/SubAgentRunCard.tsx
+++ b/src/app/org/[githubLogin]/_components/SubAgentRunCard.tsx
@@ -149,9 +149,14 @@ export interface SubAgentRun {
   };
   /**
    * `true` once any planner reply in this run generated a task
-   * breakdown (a `TASKS` artifact). `SidebarChat` renders a
-   * `StartTasksSlot` for the feature, which reads the live ready-count
-   * and offers a **Start Tasks** button. Starting tasks is the user's
+   * breakdown via a `TASKS` artifact. NOTE: this is only the
+   * artifact-derived fast-path — it is NOT what gates the **Start
+   * Tasks** button. The planner can also create tasks over MCP
+   * (`create_task` / `create_feature_task`), which produce no artifact
+   * and leave this `false`. `SidebarChat` therefore renders
+   * `StartTasksSlot` for any run that got a planner reply, and the slot
+   * reads the live ready-count (`…/tasks/assign-all`) as the real,
+   * artifact-independent source of truth. Starting tasks is the user's
    * call (it spins up real compute) — the canvas agent never does it.
    */
   hasGeneratedTasks?: boolean;

--- a/src/app/org/[githubLogin]/_state/canvasChatPersistence.ts
+++ b/src/app/org/[githubLogin]/_state/canvasChatPersistence.ts
@@ -92,3 +92,61 @@ export function mergeServerMessages<T extends PersistableMessage>(
     serverIds: server.map((m) => m.id),
   };
 }
+
+/** Minimal planner-row `source` shape this reconcile compares/refreshes. */
+interface PlannerSourceLike {
+  kind?: string;
+  workflowStatus?: string;
+  hasTasks?: boolean;
+  hasForm?: boolean;
+}
+
+interface ReconcilableMessage {
+  id: string;
+  source?: PlannerSourceLike | { kind?: string } | null;
+}
+
+/**
+ * Server-authoritative refresh of planner-row metadata.
+ *
+ * Planner rows (`source.kind === "planner"`) originate server-side and
+ * are never edited locally, so the server copy is authoritative. The
+ * append-only `mergeServerMessages` can't refresh an already-present
+ * row (it only adds NEW ids), which leaves a planner row's frozen
+ * `source.workflowStatus` snapshot stale when the feature workflow
+ * reaches a terminal state AFTER the message fanned out — the stakwork
+ * webhook updates the row in place (same id) and nudges, but the merge
+ * skips it. This step closes that gap: for each local planner row, if
+ * the server has a row with the SAME id whose tracked `source` fields
+ * differ, swap in the server `source`.
+ *
+ * It never drops, reorders, or adds rows — it only refreshes `source`
+ * on rows already present locally, so the "never lose a local message"
+ * invariant `mergeServerMessages` guarantees is untouched. Returns
+ * `changed: false` (and the original array by reference) when nothing
+ * moved, so callers can skip a no-op store write.
+ */
+export function reconcilePlannerSources<T extends ReconcilableMessage>(
+  local: T[],
+  server: T[],
+): { messages: T[]; changed: boolean } {
+  const serverById = new Map(server.map((m) => [m.id, m]));
+  let changed = false;
+  const messages = local.map((m) => {
+    const localSource = m.source as PlannerSourceLike | null | undefined;
+    if (localSource?.kind !== "planner") return m;
+    const s = serverById.get(m.id);
+    const serverSource = s?.source as PlannerSourceLike | null | undefined;
+    if (serverSource?.kind !== "planner") return m;
+    if (
+      localSource.workflowStatus === serverSource.workflowStatus &&
+      localSource.hasTasks === serverSource.hasTasks &&
+      localSource.hasForm === serverSource.hasForm
+    ) {
+      return m;
+    }
+    changed = true;
+    return { ...m, source: s!.source } as T;
+  });
+  return changed ? { messages, changed: true } : { messages: local, changed: false };
+}

--- a/src/app/org/[githubLogin]/_state/useCanvasChatAutoSave.ts
+++ b/src/app/org/[githubLogin]/_state/useCanvasChatAutoSave.ts
@@ -33,7 +33,10 @@ import {
   useCanvasChatStore,
   type CanvasChatMessage,
 } from "./canvasChatStore";
-import { mergeServerMessages } from "./canvasChatPersistence";
+import {
+  mergeServerMessages,
+  reconcilePlannerSources,
+} from "./canvasChatPersistence";
 import {
   getPusherClient,
   getCanvasConversationChannelName,
@@ -156,10 +159,19 @@ export function useCanvasChatAutoSave({ githubLogin }: AutoSaveArgs) {
           authoredPrefixes(),
         );
 
-        if (merged.added.length === 0) return; // in sync, nothing to do
+        // Append-only merge can't refresh an existing row — so a planner
+        // row whose `source.workflowStatus` the server patched in place
+        // (the `"workflow-status"` nudge: a feature's run reached a
+        // terminal status after its message fanned out) would stay stale.
+        // Reconcile those existing planner rows from the server copy so
+        // the `SubAgentRunCard` pill re-derives live. Never drops/reorders
+        // rows, so the no-message-loss invariant holds.
+        const reconciled = reconcilePlannerSources(merged.messages, mapped);
+
+        if (merged.added.length === 0 && !reconciled.changed) return; // in sync
         useCanvasChatStore
           .getState()
-          .setConversationMessages(conversationId, merged.messages);
+          .setConversationMessages(conversationId, reconciled.messages);
       } catch {
         // Network hiccup — a later nudge (or the next server append) will
         // resync.

--- a/src/lib/pusher.ts
+++ b/src/lib/pusher.ts
@@ -113,7 +113,13 @@ export type CanvasConversationUpdateReason =
   // `/api/ask/quick` org path, in `after()`). The authoring tab filters
   // its own turn out of the merge by id prefix; other viewers / a
   // reopened tab live-sync it in.
-  | "user-turn";
+  | "user-turn"
+  // A feature's planner workflow reached a new (often terminal) status
+  // AFTER its message already fanned out — the stakwork webhook updated
+  // the latest planner row's `source.workflowStatus` in place (same id).
+  // The client reconciles existing planner rows' `source` from the
+  // server copy so the `SubAgentRunCard` pill re-derives live.
+  | "workflow-status";
 
 /**
  * Fire-and-forget broadcast that a canvas conversation's `messages` JSON

--- a/src/services/canvas-planner-fanout.ts
+++ b/src/services/canvas-planner-fanout.ts
@@ -438,3 +438,91 @@ export function actionableWakeReason(
 
   return null;
 }
+
+/**
+ * Refresh the latest planner row's `source.workflowStatus` in a
+ * feature's owning canvas conversation, in place.
+ *
+ * **Why this exists.** The `SubAgentRunCard` pill reads a *frozen*
+ * `source.workflowStatus` snapshot taken when the planner's message
+ * fanned out (`fanOutPlannerMessageToCanvas`). But a feature's terminal
+ * status (`COMPLETED` / `FAILED` / …) is written by a *different*
+ * webhook (`/api/stakwork/webhook`) that typically fires a few seconds
+ * AFTER the planner message already landed — so the snapshot freezes at
+ * `IN_PROGRESS` and the pill is stuck on "Running" forever. This patches
+ * the snapshot the moment the real status arrives.
+ *
+ * It updates the row **in place** (same id, only `source.workflowStatus`)
+ * so fresh loads / reopened tabs / shares / iOS all read the correct
+ * status. Because the client live-sync merge is append-only (it can't
+ * refresh an existing id), the matching `notifyCanvasConversationUpdated`
+ * nudge is paired with a client `reconcilePlannerSources` step
+ * (`canvasChatPersistence.ts`) that swaps the refreshed `source` into an
+ * already-open tab — so the pill flips live, with no reload.
+ *
+ * Idempotent and failure-tolerant, like the fan-out: a no-op when the
+ * conversation is gone, when there's no planner row for the feature, or
+ * when the status already matches. Never throws — the feature's own
+ * `workflowStatus` write is the source of truth; this derived surface
+ * self-heals on the next fresh load if the patch is missed.
+ */
+export async function syncPlannerWorkflowStatusToCanvas(
+  conversationId: string,
+  featureId: string,
+  workflowStatus: WorkflowStatus,
+): Promise<void> {
+  try {
+    let changed = false;
+    await db.$transaction(async (tx) => {
+      // Same row-level lock the fan-out + autosave PUT use — serialize
+      // against a concurrent append so we don't clobber it.
+      const locked = await tx.$queryRaw<{ messages: unknown }[]>`
+        SELECT messages FROM shared_conversations WHERE id = ${conversationId} FOR UPDATE
+      `;
+      if (locked.length === 0) return; // conversation deleted → no-op
+
+      const messages = Array.isArray(locked[0].messages)
+        ? (locked[0].messages as CanvasMessageRow[])
+        : [];
+
+      // The pill derives from the run's LATEST inbound planner entry, so
+      // only the newest planner row for this feature matters.
+      let idx = -1;
+      for (let i = messages.length - 1; i >= 0; i--) {
+        const s = messages[i]?.source;
+        if (s?.kind === "planner" && s.featureId === featureId) {
+          idx = i;
+          break;
+        }
+      }
+      if (idx === -1) return; // no fanned-out planner row yet → nothing to patch
+      if (messages[idx].source.workflowStatus === workflowStatus) return; // already current
+
+      const updated = messages.map((m, i) =>
+        i === idx
+          ? { ...m, source: { ...m.source, workflowStatus } }
+          : m,
+      );
+
+      await tx.sharedConversation.update({
+        where: { id: conversationId },
+        data: { messages: updated as unknown as never },
+      });
+      changed = true;
+    });
+
+    if (changed) {
+      notifyCanvasConversationUpdated(conversationId, "workflow-status");
+    }
+  } catch (e) {
+    console.error(
+      "[canvas-planner-fanout] syncPlannerWorkflowStatusToCanvas failed (non-fatal):",
+      {
+        conversationId,
+        featureId,
+        workflowStatus,
+        error: e instanceof Error ? e.message : String(e),
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Problem

Two related bugs surfaced when a feature's planner generated work but the org-canvas chat didn't reflect it (observed on prod for feature `Add Timestamps to SharedConversation Model`):

1. **"Start Tasks" button never appeared.** The `SubAgentRunCard` gated the button on `run.hasGeneratedTasks`, which is set only when an inbound planner message carries a `TASKS` artifact. But the remote planner can create tasks **directly over MCP** (`create_task` / `create_feature_task` → `db.task.create` / `createTicket`) with **no artifact, no chat message, and no fan-out** — so the flag never flipped, even though real, ready-to-start tasks existed in the DB.

2. **Status pill stuck on "Running".** The pill derives from a **frozen** `source.workflowStatus` snapshot taken when the planner message fanned out (`/api/chat/response`). The feature's terminal status is written ~seconds later by a *different* webhook (`/api/stakwork/webhook`), which never touched the canvas conversation — so the snapshot froze at `IN_PROGRESS` and the card read "Running" forever.

## Fix

**Start Tasks (artifact-independent):**
- `SidebarChat` renders `StartTasksSlot` for any planner run that has an inbound reply (suppressed while a FORM is pending), instead of gating on the artifact flag.
- `StartTasksSlot` already reads the live `readyCount` from `GET …/tasks/assign-all` and self-hides at 0. It now revalidates when the run advances (`revalidateKey` = anchor) and on window focus, so MCP-created tasks surface live.

**Status pill (fix the race at the source + live update):**
- New `syncPlannerWorkflowStatusToCanvas()` patches the latest planner row's `source.workflowStatus` **in place** (locked, idempotent, non-throwing) and fires a new `"workflow-status"` Pusher nudge.
- Wired into the `stakwork/webhook` feature branch after the status write.
- The append-only live-sync merge can't refresh an existing row, so a pure `reconcilePlannerSources()` step swaps the refreshed planner `source` in from the server **without** dropping/reordering local rows — the "never lose a message" invariant is untouched. An already-open tab flips the pill to "Plan ready" with no reload; fresh loads / shares / iOS were already correct.

## Net effect

However the planner produces tasks — `TASKS` artifact **or** MCP straight to the DB — the Start Tasks button appears (live count) and the pill resolves correctly regardless of webhook ordering.

> Note: the button still only assigns first-phase TODO tasks that have a `phaseId`. `create_feature_task` sets one; the generic MCP `create_task` does not, so a phase-less task still wouldn't be counted. Out of scope here.

## Testing
- Typecheck clean on all changed files.
- 33 targeted unit tests pass (canvas persistence + `SubAgentRunCard` + assign-all ready-count), including 4 new `reconcilePlannerSources` cases.
- Full suite: 109 passed; the lone failure (`useTimelineRange.test.ts`, missing `wouter`) is pre-existing and unrelated.

## Files
- `src/app/org/[githubLogin]/_components/SidebarChat.tsx` — ungate slot, pass `revalidateKey`
- `src/app/org/[githubLogin]/_components/StartTasksSlot.tsx` — `revalidateKey` + focus revalidation
- `src/app/org/[githubLogin]/_components/SubAgentRunCard.tsx` — doc clarification
- `src/services/canvas-planner-fanout.ts` — `syncPlannerWorkflowStatusToCanvas()`
- `src/app/api/stakwork/webhook/route.ts` — call updater on feature status write
- `src/lib/pusher.ts` — `"workflow-status"` reason
- `src/app/org/[githubLogin]/_state/canvasChatPersistence.ts` — `reconcilePlannerSources()`
- `src/app/org/[githubLogin]/_state/useCanvasChatAutoSave.ts` — reconcile after merge
- `src/__tests__/unit/canvas/canvasChatPersistence.test.ts` — new tests