### PR TITLE
Instruct search_logs to use Lucene field prefixes

### DIFF
--- a/docs/multi-workspace-chat.md
+++ b/docs/multi-workspace-chat.md
@@ -441,7 +441,7 @@ Tools are prefixed with workspace slugs. For each workspace you have:
 - \`{workspace}:learn_concept\` - Fetch detailed documentation for a feature by ID
 - \`{workspace}:recent_commits\` - Query recent commits
 - \`{workspace}:recent_contributions\` - Query PRs by a contributor
-- \`{workspace}:search_logs\` - Search application logs (Lucene query syntax)
+- \`{workspace}:search_logs\` - Search application logs (Lucene query syntax). Every term MUST have a field prefix (e.g. \`message:CLN\`, \`level:ERROR\`); a bare keyword like \`CLN\` fails with a 400 error.
 - \`{workspace}:repo_agent\` - Deep code analysis (use as LAST RESORT)
 
 If you think information about concepts might help answer the user's question, use these tools to fetch relevant data. When comparing implementations or answering questions that span multiple projects, query the relevant workspaces. Always cite which workspace information came from.

--- a/src/lib/ai/askTools.ts
+++ b/src/lib/ai/askTools.ts
@@ -295,10 +295,12 @@ export function askTools(swarmUrl: string, swarmApiKey: string, repoUrls: string
       },
     }),
     search_logs: tool({
-      description: `Search application logs using Quickwit. Supports Lucene query syntax. Does not support wildcards. 
+      description: `Search application logs using Quickwit. Supports Lucene query syntax. Does not support wildcards.
+IMPORTANT: every term MUST include a field prefix (e.g. "message:", "level:", "path:"). There is no default search field, so a bare query like "CLN" will fail with a 400 error ("query requires a default search field"). To search for a keyword, use "message:CLN".
 Example queries:
 - "path:pool AND path:status" (for searching endpoint like /api/pool/[slug]/status)
-- "message:AuthenticationError",
+- "message:AuthenticationError"
+- "message:CLN AND level:ERROR"
 - "level:ERROR"
 `,
       inputSchema: z.object({

--- a/src/lib/ai/askToolsMulti.ts
+++ b/src/lib/ai/askToolsMulti.ts
@@ -265,7 +265,7 @@ export function askToolsMulti(
 
     // search_logs (via MCP)
     allTools[`${prefix}__search_logs`] = tool({
-      description: `[${ws.slug}] Search application logs for ${ws.slug} using Quickwit. Supports Lucene query syntax.`,
+      description: `[${ws.slug}] Search application logs for ${ws.slug} using Quickwit. Supports Lucene query syntax. Does not support wildcards. IMPORTANT: every term MUST include a field prefix (e.g. "message:", "level:", "path:") — there is no default search field, so a bare query like "CLN" fails with a 400 error. To search a keyword use "message:CLN".`,
       inputSchema: z.object({
         query: z.string().describe("Lucene query string"),
         max_hits: z

--- a/src/lib/constants/prompt.ts
+++ b/src/lib/constants/prompt.ts
@@ -226,7 +226,7 @@ Tools are prefixed with workspace slugs. For each workspace you have:
 ${conceptToolLines}
 - \`{workspace}__recent_commits\` - Query recent commits
 - \`{workspace}__recent_contributions\` - Query PRs by a contributor
-- \`{workspace}__search_logs\` - Search application logs (Lucene query syntax)
+- \`{workspace}__search_logs\` - Search application logs (Lucene query syntax). Every term MUST have a field prefix (e.g. \`message:CLN\`, \`level:ERROR\`); a bare keyword like \`CLN\` fails with a 400 error.
 - \`{workspace}__logs_agent\` - Deep, run-grounded analysis of agent execution logs (debug agent runs/failures). Heavier than search_logs — prefer search_logs for simple keyword lookups. Optionally scope to a featureId/taskId.
 - \`{workspace}__repo_agent\` - Deep code analysis (if you can't find the answer with the other tools)
 - \`{workspace}__list_features\` - List roadmap features/plans for a workspace. Use this if the user asks about features, plans, roadmap, or what's being worked on.


### PR DESCRIPTION
## Problem

The `search_logs` tool (Quickwit-backed) fails on bare keyword queries. When the agent searches for something like `CLN`, Quickwit returns:

```
400 Bad Request - { "message": "query requires a default search field and none was supplied" }
```

There is no default search field configured, so every term must be prefixed with a field name (`message:`, `level:`, `path:`, etc.).

## Fix

Updated the tool descriptions and chat prompts so the agent always prefixes query terms with a field:

- `src/lib/ai/askTools.ts` — expanded `search_logs` description explaining the 400 error and showing `message:CLN` as the keyword-search pattern.
- `src/lib/ai/askToolsMulti.ts` — same guidance on the per-workspace `search_logs` description.
- `src/lib/constants/prompt.ts` — added the prefix requirement to the system prompt tool list.
- `docs/multi-workspace-chat.md` — matching doc note.

## Testing

`npx vitest run src/__tests__/unit/lib/ai/askTools.test.ts src/__tests__/unit/lib/ai/askToolsMulti.test.ts` — 58 passed.