### PR TITLE
Attribute MCP feature/workflow tasks to the feature creator, not the workspace owner

### DIFF
--- a/scripts/diagnose-pr-attribution.ts
+++ b/scripts/diagnose-pr-attribution.ts
@@ -1,0 +1,255 @@
+/**
+ * Diagnose why a feature's tasks open PRs as the WORKSPACE OWNER instead
+ * of the person who created/approved the feature.
+ *
+ * Background (the attribution chain):
+ *   1. Approving a feature proposal stamps  Feature.createdById = approver
+ *      (src/lib/proposals/handleApproval.ts → createFeature).
+ *   2. Planner-generated tasks inherit it:  Task.createdById = feature.createdById
+ *      (src/services/stakwork-run.ts:applyAcceptResult).
+ *   3. The task-coordinator sweep dispatches with
+ *        userId = task.createdById ?? task.feature?.createdById
+ *      (src/services/task-coordinator-cron.ts).
+ *   4. That userId's GitHub token authors the PR, resolved via
+ *      getGithubUsernameAndPAT(userId, slug)  (src/lib/auth/nextauth.ts).
+ *
+ * THE FAILURE: getGithubUsernameAndPAT returns NULL when the user has no
+ * per-org SourceControlToken (they never authorized the org's GitHub App,
+ * or it was revoked/expired). With a null token the agent falls back to the
+ * pod's baked-in credentials — which are ALWAYS the workspace owner's PAT
+ * (src/services/pool-manager/sync.ts:230). Result: PR shows as the owner.
+ *
+ * This script reports, per feature: the creator, whether the creator has a
+ * usable org token, the owner (the fallback author), and the RESOLVED PR
+ * author — i.e. who GitHub will actually attribute the PR to.
+ *
+ * Read-only. Does not decrypt or print any tokens — only presence.
+ *
+ * Usage:
+ *   DATABASE_URL=... npx tsx scripts/diagnose-pr-attribution.ts <featureId>
+ *   DATABASE_URL=... npx tsx scripts/diagnose-pr-attribution.ts --org <githubLogin>
+ *   DATABASE_URL=... npx tsx scripts/diagnose-pr-attribution.ts            (auto-discover most recent org)
+ */
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+interface UserTokenStatus {
+  userId: string;
+  label: string; // "name <username>" for display
+  hasGithubAuth: boolean;
+  githubUsername: string | null;
+  hasOrgToken: boolean;
+  orgTokenExpired: boolean;
+}
+
+/**
+ * Mirror getGithubUsernameAndPAT's token-resolution preconditions
+ * (src/lib/auth/nextauth.ts) WITHOUT decrypting anything. The function
+ * returns null (→ owner fallback) unless: GitHubAuth exists with a
+ * non-empty username AND a SourceControlToken row exists for the org.
+ */
+async function resolveUserTokenStatus(
+  userId: string,
+  sourceControlOrgId: string | null,
+): Promise<UserTokenStatus> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { name: true, email: true },
+  });
+  const githubAuth = await prisma.gitHubAuth.findUnique({
+    where: { userId },
+    select: { githubUsername: true },
+  });
+  const githubUsername = githubAuth?.githubUsername?.trim() || null;
+
+  let hasOrgToken = false;
+  let orgTokenExpired = false;
+  if (sourceControlOrgId) {
+    const tok = await prisma.sourceControlToken.findUnique({
+      where: { userId_sourceControlOrgId: { userId, sourceControlOrgId } },
+      select: { token: true, expiresAt: true },
+    });
+    hasOrgToken = !!tok?.token;
+    orgTokenExpired = !!tok?.expiresAt && tok.expiresAt.getTime() < Date.now();
+  }
+
+  const display = user?.name || user?.email || userId;
+  return {
+    userId,
+    label: `${display}${githubUsername ? ` <${githubUsername}>` : ""}`,
+    hasGithubAuth: !!githubAuth,
+    githubUsername,
+    hasOrgToken,
+    orgTokenExpired,
+  };
+}
+
+/** Would getGithubUsernameAndPAT(userId, slug) return a token? */
+function tokenResolves(s: UserTokenStatus): boolean {
+  return !!s.githubUsername && s.hasOrgToken;
+}
+
+function statusLine(s: UserTokenStatus): string {
+  if (!s.hasGithubAuth) return "❌ no GitHubAuth record";
+  if (!s.githubUsername) return "❌ empty GitHub username";
+  if (!s.hasOrgToken) return "❌ NO org SourceControlToken (→ owner fallback)";
+  if (s.orgTokenExpired) return "⚠️  org token present but EXPIRED";
+  return "✅ has usable org token";
+}
+
+async function diagnoseFeature(featureId: string): Promise<void> {
+  const feature = await prisma.feature.findUnique({
+    where: { id: featureId },
+    select: {
+      id: true,
+      title: true,
+      createdById: true,
+      workspace: {
+        select: { slug: true, ownerId: true, sourceControlOrgId: true },
+      },
+    },
+  });
+  if (!feature) {
+    console.log(`\n❓ Feature ${featureId} not found`);
+    return;
+  }
+
+  const orgId = feature.workspace.sourceControlOrgId;
+  const ownerId = feature.workspace.ownerId;
+
+  const creator = await resolveUserTokenStatus(feature.createdById, orgId);
+  const owner = await resolveUserTokenStatus(ownerId, orgId);
+
+  console.log(`\n━━ Feature: "${feature.title}"  [${feature.id}]`);
+  console.log(`   workspace=${feature.workspace.slug}  org=${orgId ?? "—"}`);
+  console.log(`   creator: ${creator.label}`);
+  console.log(`            ${statusLine(creator)}`);
+  console.log(`   owner  : ${owner.label}  (pod's baked-in fallback)`);
+
+  const creatorResolves = tokenResolves(creator);
+  if (creatorResolves) {
+    console.log(`   ⇒ Feature-level PRs attributed to CREATOR (${creator.githubUsername}) ✅`);
+  } else {
+    console.log(
+      `   ⇒ Feature-level PRs FALL BACK to OWNER (${owner.githubUsername ?? owner.label}) ❌`,
+    );
+  }
+
+  // Tasks carry their own createdById — usually == feature.createdById, but
+  // verify per-task since the sweep resolves the token from the task.
+  const tasks = await prisma.task.findMany({
+    where: { featureId: feature.id, deleted: false },
+    orderBy: { createdAt: "asc" },
+    select: {
+      id: true,
+      title: true,
+      status: true,
+      workflowStatus: true,
+      systemAssigneeType: true,
+      createdById: true,
+    },
+  });
+
+  if (tasks.length === 0) {
+    console.log("   (no tasks yet)");
+    return;
+  }
+
+  // Cache token lookups per distinct createdById.
+  const cache = new Map<string, UserTokenStatus>();
+  const getStatus = async (uid: string) => {
+    if (!cache.has(uid)) cache.set(uid, await resolveUserTokenStatus(uid, orgId));
+    return cache.get(uid)!;
+  };
+
+  console.log(`   tasks (${tasks.length}):`);
+  for (const t of tasks) {
+    const s = await getStatus(t.createdById);
+    const resolves = tokenResolves(s);
+    const author = resolves
+      ? s.githubUsername
+      : `${owner.githubUsername ?? "OWNER"} (fallback)`;
+    const flag = resolves ? "✅" : "❌";
+    const diff = t.createdById !== feature.createdById ? " [createdById ≠ feature]" : "";
+    console.log(
+      `     ${flag} ${t.title.slice(0, 48).padEnd(48)} ${t.status}/${t.workflowStatus ?? "—"}` +
+        `  PR→ ${author}${diff}`,
+    );
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  let featureId: string | null = null;
+  let githubLogin: string | null = null;
+
+  const orgFlagIdx = args.indexOf("--org");
+  if (orgFlagIdx !== -1) {
+    githubLogin = args[orgFlagIdx + 1] ?? null;
+  } else if (args[0]) {
+    featureId = args[0];
+  }
+
+  if (featureId) {
+    await diagnoseFeature(featureId);
+    return;
+  }
+
+  // Org mode: auto-discover if needed, then scan recent features.
+  if (!githubLogin) {
+    const recent = await prisma.sharedConversation.findFirst({
+      where: { source: "org-canvas", sourceControlOrgId: { not: null } },
+      orderBy: { lastMessageAt: "desc" },
+      select: { sourceControlOrg: { select: { githubLogin: true } } },
+    });
+    githubLogin = recent?.sourceControlOrg?.githubLogin ?? null;
+    if (!githubLogin) {
+      console.error(
+        "No org-canvas conversations found. Pass a feature id or --org <githubLogin>.",
+      );
+      process.exit(1);
+    }
+    console.log(`(auto-discovered most recently active org: ${githubLogin})`);
+  }
+
+  const org = await prisma.sourceControlOrg.findUnique({
+    where: { githubLogin },
+    select: { id: true, githubLogin: true },
+  });
+  if (!org) {
+    console.error(`No SourceControlOrg for githubLogin="${githubLogin}"`);
+    process.exit(1);
+  }
+  console.log(`Org: ${org.githubLogin} (${org.id})`);
+
+  const features = await prisma.feature.findMany({
+    where: { workspace: { sourceControlOrgId: org.id } },
+    orderBy: { createdAt: "desc" },
+    take: 15,
+    select: { id: true },
+  });
+  if (features.length === 0) {
+    console.log("No features in this org.");
+    return;
+  }
+  for (const f of features) {
+    await diagnoseFeature(f.id);
+  }
+
+  console.log(
+    "\nLegend:\n" +
+      "  ✅ creator has a usable per-org GitHub token → PR attributed to them.\n" +
+      "  ❌ creator lacks the org token → PR falls back to the workspace owner\n" +
+      "     (the pod is always provisioned with the owner's PAT).\n" +
+      "  Fix: have the affected creator authorize the org's GitHub App\n" +
+      "       (so a SourceControlToken row exists for that org).",
+  );
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/src/__tests__/unit/lib/mcp/mcpCreateFeatureTask.test.ts
+++ b/src/__tests__/unit/lib/mcp/mcpCreateFeatureTask.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+const { mockCreateTicket, mockDbFeature, mockDbWorkspace, mockDbRepository } =
+  vi.hoisted(() => ({
+    mockCreateTicket: vi.fn(),
+    mockDbFeature: { findUnique: vi.fn() },
+    mockDbWorkspace: { findUnique: vi.fn() },
+    mockDbRepository: { findFirst: vi.fn() },
+  }));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    feature: mockDbFeature,
+    workspace: mockDbWorkspace,
+    repository: mockDbRepository,
+  },
+}));
+
+vi.mock("@/services/roadmap/tickets", () => ({
+  createTicket: mockCreateTicket,
+}));
+
+// ── Imports ────────────────────────────────────────────────────────────────
+import { mcpCreateFeatureTask } from "@/lib/mcp/mcpTools";
+
+const AUTH = {
+  userId: "user-1",
+  workspaceId: "ws-1",
+  workspaceSlug: "ws",
+};
+
+const BASE_TASK = {
+  id: "task-1",
+  title: "Test Coding Task",
+  status: "TODO",
+  priority: "MEDIUM",
+  featureId: "feature-1",
+  phaseId: null,
+  repository: { id: "repo-1" },
+};
+
+describe("mcpCreateFeatureTask — creator attribution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Feature owned by its creator, distinct from the workspace owner.
+    mockDbFeature.findUnique.mockResolvedValue({
+      workspaceId: "ws-1",
+      createdById: "feature-creator-1",
+    });
+    mockDbRepository.findFirst.mockResolvedValue({ id: "repo-1" });
+    mockCreateTicket.mockResolvedValue(BASE_TASK);
+    mockDbWorkspace.findUnique.mockResolvedValue({
+      ownerId: "owner-1",
+      owner: { id: "owner-1", name: "Tom Smith", sphinxAlias: null },
+      members: [
+        { user: { id: "evan-1", name: "Evan Feenstra", sphinxAlias: "Evanfeenstra" } },
+      ],
+    });
+  });
+
+  it("defaults to the FEATURE CREATOR (not the workspace owner) when no creator hint is given", async () => {
+    await mcpCreateFeatureTask(
+      AUTH,
+      "feature-1",
+      { title: "No hint" },
+      { repositoryId: "repo-1" },
+    );
+
+    expect(mockCreateTicket).toHaveBeenCalledWith(
+      "feature-1",
+      "feature-creator-1",
+      expect.anything(),
+    );
+  });
+
+  it("uses an explicit creator hint when it matches a workspace member (by alias)", async () => {
+    await mcpCreateFeatureTask(
+      AUTH,
+      "feature-1",
+      { title: "With hint" },
+      { repositoryId: "repo-1" },
+      "evanfeenstra",
+    );
+
+    expect(mockCreateTicket).toHaveBeenCalledWith(
+      "feature-1",
+      "evan-1",
+      expect.anything(),
+    );
+  });
+
+  it("falls back to the workspace owner only when there is no hint AND no feature creator", async () => {
+    mockDbFeature.findUnique.mockResolvedValue({
+      workspaceId: "ws-1",
+      createdById: null,
+    });
+
+    await mcpCreateFeatureTask(
+      AUTH,
+      "feature-1",
+      { title: "Orphan feature" },
+      { repositoryId: "repo-1" },
+    );
+
+    expect(mockCreateTicket).toHaveBeenCalledWith(
+      "feature-1",
+      "owner-1",
+      expect.anything(),
+    );
+  });
+
+  it("returns error when feature not found (no attribution attempted)", async () => {
+    mockDbFeature.findUnique.mockResolvedValue(null);
+
+    const result = await mcpCreateFeatureTask(
+      AUTH,
+      "nonexistent",
+      { title: "Task" },
+      { repositoryId: "repo-1" },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(mockCreateTicket).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/unit/lib/mcp/mcpCreateWorkflowTask.test.ts
+++ b/src/__tests__/unit/lib/mcp/mcpCreateWorkflowTask.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
-const { mockCreateTicket, mockDbFeature } = vi.hoisted(() => ({
+const { mockCreateTicket, mockDbFeature, mockDbWorkspace } = vi.hoisted(() => ({
   mockCreateTicket: vi.fn(),
   mockDbFeature: { findUnique: vi.fn() },
+  mockDbWorkspace: { findUnique: vi.fn() },
 }));
 
 vi.mock("@/lib/db", () => ({
-  db: { feature: mockDbFeature },
+  db: { feature: mockDbFeature, workspace: mockDbWorkspace },
 }));
 
 vi.mock("@/services/roadmap/tickets", () => ({
@@ -36,7 +37,11 @@ const BASE_TASK = {
 describe("mcpCreateWorkflowTask — workflowTaskType threading", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockDbFeature.findUnique.mockResolvedValue({ workspaceId: "ws-1" });
+    // Feature is owned by its creator, distinct from the workspace owner.
+    mockDbFeature.findUnique.mockResolvedValue({
+      workspaceId: "ws-1",
+      createdById: "feature-creator-1",
+    });
     mockCreateTicket.mockResolvedValue(BASE_TASK);
   });
 
@@ -50,7 +55,7 @@ describe("mcpCreateWorkflowTask — workflowTaskType threading", () => {
 
     expect(mockCreateTicket).toHaveBeenCalledWith(
       "feature-1",
-      "user-1",
+      "feature-creator-1",
       expect.objectContaining({ workflowTaskType: "SKILL", workflowId: 10 }),
     );
   });
@@ -65,7 +70,7 @@ describe("mcpCreateWorkflowTask — workflowTaskType threading", () => {
 
     expect(mockCreateTicket).toHaveBeenCalledWith(
       "feature-1",
-      "user-1",
+      "feature-creator-1",
       expect.objectContaining({ workflowTaskType: "PROMPT", isNewWorkflow: true }),
     );
   });
@@ -82,36 +87,6 @@ describe("mcpCreateWorkflowTask — workflowTaskType threading", () => {
     expect(call.workflowTaskType).toBeUndefined();
   });
 
-  it("passes workflowTaskType=WORKFLOW to createTicket", async () => {
-    await mcpCreateWorkflowTask(
-      AUTH,
-      "feature-1",
-      { title: "Sub-Workflow Task" },
-      { workflowId: 55, workflowTaskType: "WORKFLOW" },
-    );
-
-    expect(mockCreateTicket).toHaveBeenCalledWith(
-      "feature-1",
-      "user-1",
-      expect.objectContaining({ workflowTaskType: "WORKFLOW" }),
-    );
-  });
-
-  it("passes workflowTaskType=SCRIPT to createTicket", async () => {
-    await mcpCreateWorkflowTask(
-      AUTH,
-      "feature-1",
-      { title: "Script Task" },
-      { workflowId: 33, workflowTaskType: "SCRIPT" },
-    );
-
-    expect(mockCreateTicket).toHaveBeenCalledWith(
-      "feature-1",
-      "user-1",
-      expect.objectContaining({ workflowTaskType: "SCRIPT" }),
-    );
-  });
-
   it("returns error when feature not found", async () => {
     mockDbFeature.findUnique.mockResolvedValue(null);
 
@@ -124,5 +99,76 @@ describe("mcpCreateWorkflowTask — workflowTaskType threading", () => {
 
     expect(result.isError).toBe(true);
     expect(mockCreateTicket).not.toHaveBeenCalled();
+  });
+});
+
+describe("mcpCreateWorkflowTask — creator attribution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDbFeature.findUnique.mockResolvedValue({
+      workspaceId: "ws-1",
+      createdById: "feature-creator-1",
+    });
+    mockCreateTicket.mockResolvedValue(BASE_TASK);
+    // Workspace lookup used by findWorkspaceUser (hint match) and the
+    // owner last-resort fallback.
+    mockDbWorkspace.findUnique.mockResolvedValue({
+      ownerId: "owner-1",
+      owner: { id: "owner-1", name: "Tom Smith", sphinxAlias: null },
+      members: [
+        { user: { id: "evan-1", name: "Evan Feenstra", sphinxAlias: "Evanfeenstra" } },
+      ],
+    });
+  });
+
+  it("defaults to the FEATURE CREATOR (not the workspace owner) when no creator hint is given", async () => {
+    await mcpCreateWorkflowTask(
+      AUTH,
+      "feature-1",
+      { title: "No hint" },
+      { workflowTaskType: "SKILL" },
+    );
+
+    expect(mockCreateTicket).toHaveBeenCalledWith(
+      "feature-1",
+      "feature-creator-1",
+      expect.anything(),
+    );
+  });
+
+  it("uses an explicit creator hint when it matches a workspace member", async () => {
+    await mcpCreateWorkflowTask(
+      AUTH,
+      "feature-1",
+      { title: "With hint" },
+      { workflowTaskType: "SKILL" },
+      "Evan Feenstra",
+    );
+
+    expect(mockCreateTicket).toHaveBeenCalledWith(
+      "feature-1",
+      "evan-1",
+      expect.anything(),
+    );
+  });
+
+  it("falls back to the workspace owner only when there is no hint AND no feature creator", async () => {
+    mockDbFeature.findUnique.mockResolvedValue({
+      workspaceId: "ws-1",
+      createdById: null,
+    });
+
+    await mcpCreateWorkflowTask(
+      AUTH,
+      "feature-1",
+      { title: "Orphan feature" },
+      { workflowTaskType: "SKILL" },
+    );
+
+    expect(mockCreateTicket).toHaveBeenCalledWith(
+      "feature-1",
+      "owner-1",
+      expect.anything(),
+    );
   });
 });

--- a/src/lib/mcp/handler.ts
+++ b/src/lib/mcp/handler.ts
@@ -464,7 +464,7 @@ function createServer(
           .string()
           .optional()
           .describe(
-            "Name of the creator (matched against name or alias). Falls back to workspace owner if not found.",
+            "Name of the creator (matched against name or alias). If omitted or unmatched, defaults to the feature's creator, then the workspace owner.",
           ),
       },
     },
@@ -489,17 +489,17 @@ function createServer(
       extra,
     ) => {
       const authExtra = extra.authInfo?.extra as McpAuthExtra | undefined;
-      const result = await getWorkspaceAuth(
-        authExtra,
-        "create_feature_task",
-        creator,
-      );
+      // Don't resolve `creator` here — mcpCreateFeatureTask owns
+      // attribution so it can default to the feature's creator (not the
+      // workspace owner) when no hint matches.
+      const result = await getWorkspaceAuth(authExtra, "create_feature_task");
       if (result.error) return result.error;
       return mcpCreateFeatureTask(
         result.auth!,
         featureId,
         { title, description, priority },
         { repositoryId, repositoryUrl },
+        creator,
       );
     },
   );
@@ -579,7 +579,7 @@ function createServer(
           .string()
           .optional()
           .describe(
-            "Name of the creator (matched against name or alias). Falls back to workspace owner if not found.",
+            "Name of the creator (matched against name or alias). If omitted or unmatched, defaults to the feature's creator, then the workspace owner.",
           ),
       },
     },
@@ -608,17 +608,17 @@ function createServer(
       extra,
     ) => {
       const authExtra = extra.authInfo?.extra as McpAuthExtra | undefined;
-      const result = await getWorkspaceAuth(
-        authExtra,
-        "create_workflow_task",
-        creator,
-      );
+      // Don't resolve `creator` here — mcpCreateWorkflowTask owns
+      // attribution so it can default to the feature's creator (not the
+      // workspace owner) when no hint matches.
+      const result = await getWorkspaceAuth(authExtra, "create_workflow_task");
       if (result.error) return result.error;
       return mcpCreateWorkflowTask(
         result.auth!,
         featureId,
         { title, description, priority },
         { workflowId, workflowName, workflowRefId, workflowTaskType },
+        creator,
       );
     },
   );

--- a/src/lib/mcp/mcpTools.ts
+++ b/src/lib/mcp/mcpTools.ts
@@ -258,18 +258,30 @@ export async function findWorkspaceUser(
 /**
  * Resolve a user within a workspace by fuzzy-matching the `user` string
  * against User.name and User.sphinxAlias (case-insensitive).
- * Falls back to the workspace owner when no match is found.
+ *
+ * Resolution order:
+ *   1. `userHint` fuzzy-match against workspace members (when supplied).
+ *   2. `fallbackUserId` (when supplied) — a context-specific default,
+ *      e.g. the feature's creator for feature-anchored task tools, so
+ *      attribution (and therefore the GitHub token that authors the PR)
+ *      follows the person who owns the feature rather than collapsing to
+ *      the workspace owner.
+ *   3. The workspace owner — the last resort.
  */
 export async function resolveWorkspaceUser(
   workspaceId: string,
   userHint?: string,
+  fallbackUserId?: string,
 ): Promise<string> {
   if (userHint) {
     const matched = await findWorkspaceUser(workspaceId, userHint);
     if (matched) return matched;
   }
 
-  // No hint or no match — fall back to owner
+  // No hint or no match — prefer the caller-supplied fallback (e.g. the
+  // feature creator) before collapsing to the workspace owner.
+  if (fallbackUserId) return fallbackUserId;
+
   const workspace = await db.workspace.findUnique({
     where: { id: workspaceId },
     select: { ownerId: true },
@@ -738,11 +750,12 @@ export async function mcpCreateFeatureTask(
   featureId: string,
   base: McpRoadmapTaskBase,
   repo: { repositoryId?: string; repositoryUrl?: string },
+  creatorHint?: string,
 ): Promise<McpToolResult> {
   try {
     const feature = await db.feature.findUnique({
       where: { id: featureId },
-      select: { workspaceId: true },
+      select: { workspaceId: true, createdById: true },
     });
     const err = verifyWorkspace(feature, auth, "Feature");
     if (err) return err;
@@ -758,7 +771,16 @@ export async function mcpCreateFeatureTask(
         ? (base.priority as Priority)
         : Priority.MEDIUM;
 
-    const task = await createTicket(featureId, auth.userId, {
+    // Attribution: explicit `creator` hint → the feature's creator →
+    // workspace owner. Defaulting to the feature creator (rather than the
+    // owner) keeps the PR authored by the person who owns the feature.
+    const creatorId = await resolveWorkspaceUser(
+      auth.workspaceId,
+      creatorHint,
+      feature!.createdById,
+    );
+
+    const task = await createTicket(featureId, creatorId, {
       title: base.title,
       description: base.description,
       priority: taskPriority,
@@ -805,11 +827,12 @@ export async function mcpCreateWorkflowTask(
     workflowRefId?: string;
     workflowTaskType?: import("@prisma/client").WorkflowTaskType;
   },
+  creatorHint?: string,
 ): Promise<McpToolResult> {
   try {
     const feature = await db.feature.findUnique({
       where: { id: featureId },
-      select: { workspaceId: true },
+      select: { workspaceId: true, createdById: true },
     });
     const err = verifyWorkspace(feature, auth, "Feature");
     if (err) return err;
@@ -822,7 +845,15 @@ export async function mcpCreateWorkflowTask(
 
     const hasExistingWorkflow = typeof workflow.workflowId === "number";
 
-    const task = await createTicket(featureId, auth.userId, {
+    // Attribution: explicit `creator` hint → the feature's creator →
+    // workspace owner (mirrors mcpCreateFeatureTask).
+    const creatorId = await resolveWorkspaceUser(
+      auth.workspaceId,
+      creatorHint,
+      feature!.createdById,
+    );
+
+    const task = await createTicket(featureId, creatorId, {
       title: base.title,
       description: base.description,
       priority: taskPriority,


### PR DESCRIPTION
## Problem

When a feature is proposed in the org canvas agent chat, approved, planned, and its tasks are started, the resulting GitHub PR was **sometimes** authored by the workspace owner (e.g. \`tomsmith8\`) instead of the person who created/approved the feature.

### Root cause

The plan agent creates tasks by calling the MCP tools \`create_feature_task\` / \`create_workflow_task\`. Both resolve \`Task.createdById\` via \`resolveWorkspaceUser(workspaceId, creatorHint)\`, which **falls straight back to \`workspace.ownerId\`** whenever the agent's optional \`creator\` hint is missing or doesn't fuzzy-match a workspace member. The agent rarely passes a reliable \`creator\`, so tasks got stamped with the owner.

Downstream, the task-coordinator sweep dispatches the workflow with \`userId = task.createdById\`, and \`getGithubUsernameAndPAT(userId)\` resolves that user's GitHub token to author the PR. When the token can't be resolved, the agent falls back to the pod's baked-in credentials — which are **always the workspace owner's PAT** (\`pool-manager/sync.ts\`). Net effect: PRs attributed to the owner.

This explains the intermittency: when the agent happened to pass a matching \`creator\` name → correct; otherwise → owner.

## Fix

Add a feature-creator fallback tier so attribution follows feature ownership. The two tools are feature-anchored and already know the feature, so:

```
explicit creator hint  →  feature.createdById  →  workspace owner
```

- \`resolveWorkspaceUser\` gains an optional \`fallbackUserId\` (preferred before the owner).
- \`mcpCreateFeatureTask\` / \`mcpCreateWorkflowTask\` select \`feature.createdById\` and own attribution; \`handler.ts\` forwards the raw \`creator\` hint instead of pre-collapsing to the owner.
- Tool \`creator\` descriptions updated to reflect the new fallback order.

## Tests

- Updated \`mcpCreateWorkflowTask.test.ts\` and added \`mcpCreateFeatureTask.test.ts\` covering: no-hint → feature creator, matching hint → that member, no-hint-and-no-creator → owner. 30/30 mcp unit tests pass; production typecheck clean.

## Also included

\`scripts/diagnose-pr-attribution.ts\` — a **read-only** diagnostic that prints, per feature, the creator, owner (pod fallback), and the resolved PR author, flagging tasks whose \`createdById\` differs from the feature.

## Notes

- Fixes attribution **going forward**. Tasks already stamped with the owner won't retroactively change.