### PR TITLE
Align canvas Tasks card status colors with rest of app

### DIFF
--- a/src/app/org/[githubLogin]/_components/StartTasksSlot.tsx
+++ b/src/app/org/[githubLogin]/_components/StartTasksSlot.tsx
@@ -110,10 +110,11 @@ function countTasks(tasks: TaskView[]): TaskCounts {
   return { done, inProgress, pending, total: done + inProgress + pending };
 }
 
-/** Tailwind bg for a task's status — done purple, running orange, pending grey. */
+/** Tailwind bg for a task's status — done emerald, running amber, pending grey.
+ * Matches the app-wide task status dots (see CompactTasksList STATUS_DOT). */
 const STATUS_BG: Record<"done" | "inProgress" | "pending", string> = {
-  done: "bg-purple-500",
-  inProgress: "bg-orange-500",
+  done: "bg-emerald-500",
+  inProgress: "bg-amber-500",
   pending: "bg-zinc-300 dark:bg-zinc-600",
 };
 


### PR DESCRIPTION
## Summary
The "Tasks" card in the canvas chat sidebar (`StartTasksSlot`) used a purple/orange status color scheme that diverged from every other task surface in the app.

This aligns it with the app-wide task status dots (`CompactTasksList` `STATUS_DOT`):
- **DONE**: `bg-purple-500` → `bg-emerald-500`
- **IN_PROGRESS**: `bg-orange-500` → `bg-amber-500`
- pending: unchanged (already `bg-zinc-300`, matching TODO)

Applies to both the segmented progress bar and the expanded checklist dots.

## Test plan
- [ ] Open the org canvas chat sidebar, generate a feature's tasks, and confirm the Tasks card progress bar / checklist now show green (done) and amber (in-progress).