### PR TITLE
Generated with Hive: Add Cancel button to exit Custom Summary mode in workflow inspector

### DIFF
--- a/src/__tests__/unit/components/workflow/SummariseChangesButton.test.tsx
+++ b/src/__tests__/unit/components/workflow/SummariseChangesButton.test.tsx
@@ -80,6 +80,7 @@ const defaultProps = {
   workspaceSlug: "my-ws",
   workflowId: 10,
   customSelectedIds: [],
+  isCustomMode: false,
   onCustomModeToggle: vi.fn(),
   onCustomSelectionConfirm: vi.fn(),
 };
@@ -290,5 +291,71 @@ describe("SummariseChangesButton", () => {
 
     fireEvent.click(screen.getByText("Custom Summary…"));
     expect(onCustomModeToggle).toHaveBeenCalledWith(true);
+  });
+
+  it("Cancel button is visible when isCustomMode=true with 0 selections, Generate Summary is not", () => {
+    render(
+      <SummariseChangesButton
+        {...defaultProps}
+        versions={[makeVersion("v1"), makeVersion("v2")]}
+        isCustomMode={true}
+        customSelectedIds={[]}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /generate summary/i })).not.toBeInTheDocument();
+  });
+
+  it("Cancel button is visible when isCustomMode=true with 1 selection, Generate Summary is not", () => {
+    render(
+      <SummariseChangesButton
+        {...defaultProps}
+        versions={[makeVersion("v1"), makeVersion("v2")]}
+        isCustomMode={true}
+        customSelectedIds={["v1"]}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /generate summary/i })).not.toBeInTheDocument();
+  });
+
+  it("Cancel and Generate Summary both visible when isCustomMode=true with 2+ selections", () => {
+    render(
+      <SummariseChangesButton
+        {...defaultProps}
+        versions={[makeVersion("v1"), makeVersion("v2")]}
+        isCustomMode={true}
+        customSelectedIds={["v1", "v2"]}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /generate summary/i })).toBeInTheDocument();
+  });
+
+  it("Cancel button is absent when isCustomMode=false", () => {
+    render(
+      <SummariseChangesButton
+        {...defaultProps}
+        versions={[makeVersion("v1"), makeVersion("v2")]}
+        isCustomMode={false}
+        customSelectedIds={[]}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /cancel/i })).not.toBeInTheDocument();
+  });
+
+  it("clicking Cancel calls onCustomModeToggle(false)", () => {
+    const onCustomModeToggle = vi.fn();
+    render(
+      <SummariseChangesButton
+        {...defaultProps}
+        versions={[makeVersion("v1"), makeVersion("v2")]}
+        isCustomMode={true}
+        customSelectedIds={[]}
+        onCustomModeToggle={onCustomModeToggle}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onCustomModeToggle).toHaveBeenCalledWith(false);
   });
 });

--- a/src/__tests__/unit/pages/workflow-inspector-page.test.tsx
+++ b/src/__tests__/unit/pages/workflow-inspector-page.test.tsx
@@ -57,15 +57,27 @@ vi.mock("@/components/workflow/inspector/WorkflowVersionList", () => ({
 vi.mock("@/components/workflow/inspector/SummariseChangesButton", () => ({
   SummariseChangesButton: ({
     onCustomModeToggle,
+    isCustomMode,
   }: {
     onCustomModeToggle: (enabled: boolean) => void;
+    isCustomMode: boolean;
   }) => (
-    <button
-      data-testid="summarise-btn"
-      onClick={() => onCustomModeToggle(true)}
-    >
-      Summarise
-    </button>
+    <>
+      <button
+        data-testid="summarise-btn"
+        onClick={() => onCustomModeToggle(true)}
+      >
+        Summarise
+      </button>
+      {isCustomMode && (
+        <button
+          data-testid="summarise-cancel-btn"
+          onClick={() => onCustomModeToggle(false)}
+        >
+          Cancel
+        </button>
+      )}
+    </>
   ),
 }));
 vi.mock("@/components/workflow/inspector/WorkflowStatsPanel", () => ({
@@ -217,6 +229,26 @@ describe("WorkflowInspectorPage — custom picker mode (SummariseChangesButton)"
 
     await waitFor(() => {
       expect(screen.getByTestId("version-list").getAttribute("data-selectable")).toBe("true");
+    });
+  });
+
+  it("deactivates selectable mode when Cancel calls onCustomModeToggle(false)", async () => {
+    await renderWithVersions([makeVersion("v1"), makeVersion("v2")]);
+
+    // Enter custom mode
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("summarise-btn"));
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("version-list").getAttribute("data-selectable")).toBe("true");
+    });
+
+    // Cancel — exits custom mode
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("summarise-cancel-btn"));
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("version-list").getAttribute("data-selectable")).toBe("false");
     });
   });
 });

--- a/src/app/w/[slug]/workflows/[workflowId]/page.tsx
+++ b/src/app/w/[slug]/workflows/[workflowId]/page.tsx
@@ -276,6 +276,7 @@ export default function WorkflowInspectorPage() {
                     workspaceSlug={slug}
                     workflowId={workflowIdNum}
                     customSelectedIds={customSelectedIds}
+                    isCustomMode={customPickerActive}
                     onCustomModeToggle={(enabled) => {
                       setCustomPickerActive(enabled);
                       if (!enabled) setCustomSelectedIds([]);

--- a/src/components/workflow/inspector/SummariseChangesButton.tsx
+++ b/src/components/workflow/inspector/SummariseChangesButton.tsx
@@ -33,6 +33,7 @@ export interface SummariseChangesButtonProps {
   customSelectedIds: string[];
   onCustomModeToggle: (enabled: boolean) => void;
   onCustomSelectionConfirm: () => void;
+  isCustomMode: boolean;
 }
 
 export function SummariseChangesButton({
@@ -41,6 +42,7 @@ export function SummariseChangesButton({
   workflowId,
   customSelectedIds,
   onCustomModeToggle,
+  isCustomMode,
 }: SummariseChangesButtonProps) {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [dialogState, setDialogState] = useState<"loading" | "error" | "content">("loading");
@@ -215,15 +217,18 @@ export function SummariseChangesButton({
           </Tooltip>
         </TooltipProvider>
 
-        {/* When custom mode is active, show a confirm button */}
-        {customSelectedIds.length >= 2 && (
-          <Button
-            size="sm"
-            variant="default"
-            onClick={triggerWithCustomIds}
-          >
-            Generate Summary ({customSelectedIds.length} selected)
-          </Button>
+        {/* When custom mode is active, show Cancel and optionally Generate Summary */}
+        {isCustomMode && (
+          <>
+            <Button size="sm" variant="ghost" onClick={() => onCustomModeToggle(false)}>
+              Cancel
+            </Button>
+            {customSelectedIds.length >= 2 && (
+              <Button size="sm" variant="default" onClick={triggerWithCustomIds}>
+                Generate Summary ({customSelectedIds.length} selected)
+              </Button>
+            )}
+          </>
         )}
       </div>
 


### PR DESCRIPTION
Add Cancel button to exit Custom Summary mode in workflow inspector