### PR TITLE
Fix canvas chat image-attachment persistence + stop truncating stored chat titles

### DIFF
--- a/src/__tests__/integration/api/conversation-management.test.ts
+++ b/src/__tests__/integration/api/conversation-management.test.ts
@@ -354,7 +354,7 @@ describe("Conversation Management API Integration Tests", () => {
         expect(data.title).toBe("How do I implement authentication in Next.js?");
       });
 
-      test("should truncate long titles to 50 chars", async () => {
+      test("should store the full title up to the 200-char cap (no ellipsis)", async () => {
         const { testUser, testWorkspace } = await createTestUserWithWorkspace();
 
         getMockedSession().mockResolvedValue(
@@ -375,7 +375,34 @@ describe("Conversation Management API Integration Tests", () => {
 
         expect(response.status).toBe(201);
         const data = await response.json();
-        expect(data.title).toBe("A".repeat(50) + "...");
+        // Titles are no longer truncated at the storage layer (UIs truncate
+        // visually); under the 200-char cap the full message is stored.
+        expect(data.title).toBe("A".repeat(100));
+      });
+
+      test("should cap very long titles at 200 chars with no ellipsis", async () => {
+        const { testUser, testWorkspace } = await createTestUserWithWorkspace();
+
+        getMockedSession().mockResolvedValue(
+          createAuthenticatedSession(testUser)
+        );
+
+        const longMessage = "A".repeat(250);
+        const request = createPostRequest(
+          `http://localhost:3000/api/workspaces/${testWorkspace.slug}/chat/conversations`,
+          {
+            messages: [{ role: "user", content: longMessage }],
+          }
+        );
+
+        const response = await POST_CREATE(request, {
+          params: Promise.resolve({ slug: testWorkspace.slug }),
+        });
+
+        expect(response.status).toBe(201);
+        const data = await response.json();
+        expect(data.title).toBe("A".repeat(200));
+        expect(data.title.endsWith("...")).toBe(false);
       });
 
       test("should use provided title if specified", async () => {

--- a/src/__tests__/unit/lib/ai/conversationHelpers.test.ts
+++ b/src/__tests__/unit/lib/ai/conversationHelpers.test.ts
@@ -13,6 +13,7 @@ import { describe, test, expect } from "vitest";
 import {
   generateTitle,
   getMessagePreview,
+  TITLE_MAX_LENGTH,
   UNTITLED_CONVERSATION,
 } from "@/lib/ai/conversationHelpers";
 
@@ -37,10 +38,23 @@ describe("generateTitle", () => {
     );
   });
 
-  test("truncates long titles to 50 chars + ellipsis", () => {
-    const long = "a".repeat(80);
+  test("caps long titles at TITLE_MAX_LENGTH with no ellipsis", () => {
+    const long = "a".repeat(TITLE_MAX_LENGTH + 50);
     const title = generateTitle([{ role: "user", content: long }]);
-    expect(title).toBe("a".repeat(50) + "...");
+    expect(title).toBe("a".repeat(TITLE_MAX_LENGTH));
+    expect(title.endsWith("...")).toBe(false);
+  });
+
+  test("keeps titles under the cap intact (no ellipsis)", () => {
+    const text = "a".repeat(60);
+    expect(generateTitle([{ role: "user", content: text }])).toBe(text);
+  });
+
+  test("collapses internal whitespace to a single line", () => {
+    const messages = [
+      { role: "user", content: "line one\n\n  line two\ttabbed" },
+    ];
+    expect(generateTitle(messages)).toBe("line one line two tabbed");
   });
 
   test("supports array-shaped content with a text part", () => {

--- a/src/app/api/ask/quick/route.ts
+++ b/src/app/api/ask/quick/route.ts
@@ -37,6 +37,7 @@ import {
   messagesFromSteps,
   appendTurnMessages,
   type StoredMessage,
+  type StoredAttachment,
 } from "@/services/canvas-turn-persistence";
 
 // Tier-1 backend-driven canvas turns (docs/plans/backend-driven-canvas-turns.md):
@@ -146,6 +147,11 @@ export async function POST(request: NextRequest) {
       // live-sync merge by this prefix. Absent → legacy client-driven
       // persistence (dashboard chat, public viewers, older clients).
       turnId,
+      // User-uploaded file attachments for THIS turn's user message
+      // (`CanvasAttachment[]` — `{ path, filename, mimeType, size }`).
+      // The model sees them as image parts embedded in `messages`; this
+      // top-level copy is what we persist so they survive reload.
+      attachments,
     } = body;
 
     if (!messages || !Array.isArray(messages) || messages.length === 0) {
@@ -432,14 +438,59 @@ export async function POST(request: NextRequest) {
     // ============================================================
     const turnIdStr: string | null =
       typeof turnId === "string" && turnId.length > 0 ? turnId : null;
+    // The latest user turn's text. With an image attachment the content is
+    // a multi-part array (`{type:"text"} + {type:"image"}`), so pull the
+    // text part out — otherwise a string content collapses to "" and the
+    // whole message (text + image) is skipped from persistence.
     const newUserContent = (() => {
       const last = convertedMessages[convertedMessages.length - 1];
-      return last && last.role === "user" && typeof last.content === "string"
-        ? last.content
-        : "";
+      if (!last || last.role !== "user") return "";
+      if (typeof last.content === "string") return last.content;
+      if (Array.isArray(last.content)) {
+        return last.content
+          .filter(
+            (p): p is { type: "text"; text: string } =>
+              !!p && typeof p === "object" && (p as { type?: unknown }).type === "text",
+          )
+          .map((p) => p.text)
+          .join("\n");
+      }
+      return "";
     })();
+    // Normalize the top-level attachments the client forwarded into the
+    // stored shape so the image survives reload. Defensive: drop anything
+    // missing the required fields.
+    const userAttachments: StoredAttachment[] = Array.isArray(attachments)
+      ? (attachments as unknown[]).flatMap((a) => {
+          if (!a || typeof a !== "object") return [];
+          const r = a as Record<string, unknown>;
+          if (
+            typeof r.path !== "string" ||
+            typeof r.filename !== "string" ||
+            typeof r.mimeType !== "string" ||
+            typeof r.size !== "number"
+          ) {
+            return [];
+          }
+          return [
+            {
+              path: r.path,
+              filename: r.filename,
+              mimeType: r.mimeType,
+              size: r.size,
+            },
+          ];
+        })
+      : [];
     let canvasConversationRowId: string | null = null;
-    if (orgId && userId && turnIdStr && newUserContent.trim()) {
+    // Persist when there's text OR an attachment — an image-only turn has
+    // no text but still must be saved.
+    if (
+      orgId &&
+      userId &&
+      turnIdStr &&
+      (newUserContent.trim() || userAttachments.length > 0)
+    ) {
       canvasConversationRowId = await persistCanvasUserMessage({
         orgId,
         userId,
@@ -449,6 +500,7 @@ export async function POST(request: NextRequest) {
         existingRowId: promptCache?.rowId ?? null,
         turnId: turnIdStr,
         content: newUserContent,
+        attachments: userAttachments,
         workspaceSlugs: slugs,
       });
     }
@@ -893,16 +945,25 @@ async function persistCanvasUserMessage(args: {
   existingRowId: string | null;
   turnId: string;
   content: string;
+  attachments?: StoredAttachment[];
   workspaceSlugs: string[];
 }): Promise<string> {
-  const { orgId, userId, existingRowId, turnId, content, workspaceSlugs } =
-    args;
+  const {
+    orgId,
+    userId,
+    existingRowId,
+    turnId,
+    content,
+    attachments,
+    workspaceSlugs,
+  } = args;
 
   const userRow: StoredMessage = {
     id: `${turnId}-u`,
     role: "user",
     content,
     timestamp: new Date().toISOString(),
+    ...(attachments && attachments.length > 0 ? { attachments } : {}),
   };
 
   if (existingRowId) {

--- a/src/app/api/org/[githubLogin]/chat/share/route.ts
+++ b/src/app/api/org/[githubLogin]/chat/share/route.ts
@@ -1,30 +1,9 @@
 import { authOptions } from "@/lib/auth/nextauth";
 import { db } from "@/lib/db";
 import { CreateSharedConversationRequest, SharedConversationResponse } from "@/types/shared-conversation";
+import { generateTitle } from "@/lib/ai/conversationHelpers";
 import { getServerSession } from "next-auth/next";
 import { NextResponse } from "next/server";
-
-function generateTitle(messages: any[]): string {
-  if (!Array.isArray(messages) || messages.length === 0) {
-    return "Untitled Conversation";
-  }
-  const firstUserMessage = messages.find((msg: any) => msg.role === "user");
-  if (!firstUserMessage) {
-    return "Untitled Conversation";
-  }
-  let text = "";
-  if (typeof firstUserMessage.content === "string") {
-    text = firstUserMessage.content;
-  } else if (Array.isArray(firstUserMessage.content)) {
-    const textPart = firstUserMessage.content.find((part: any) => part.type === "text");
-    text = textPart?.text || "";
-  }
-  const trimmed = text.trim();
-  if (trimmed.length === 0) {
-    return "Untitled Conversation";
-  }
-  return trimmed.length > 50 ? trimmed.substring(0, 50) + "..." : trimmed;
-}
 
 function getLastMessageTimestamp(messages: any[]): Date | null {
   if (!Array.isArray(messages) || messages.length === 0) {

--- a/src/app/api/workspaces/[slug]/chat/share/route.ts
+++ b/src/app/api/workspaces/[slug]/chat/share/route.ts
@@ -2,39 +2,9 @@ import { authOptions } from "@/lib/auth/nextauth";
 import { db } from "@/lib/db";
 import { validateWorkspaceAccess } from "@/services/workspace";
 import { CreateSharedConversationRequest, SharedConversationResponse } from "@/types/shared-conversation";
+import { generateTitle } from "@/lib/ai/conversationHelpers";
 import { getServerSession } from "next-auth/next";
 import { NextResponse } from "next/server";
-
-// Helper to generate title from first user message
-function generateTitle(messages: any[]): string {
-  if (!Array.isArray(messages) || messages.length === 0) {
-    return "Untitled Conversation";
-  }
-
-  // Find first user message
-  const firstUserMessage = messages.find((msg: any) => msg.role === "user");
-  if (!firstUserMessage) {
-    return "Untitled Conversation";
-  }
-
-  // Extract text content from message
-  let text = "";
-  if (typeof firstUserMessage.content === "string") {
-    text = firstUserMessage.content;
-  } else if (Array.isArray(firstUserMessage.content)) {
-    // Handle multi-part messages
-    const textPart = firstUserMessage.content.find((part: any) => part.type === "text");
-    text = textPart?.text || "";
-  }
-
-  // Take first 50 chars and add ellipsis if needed
-  const trimmed = text.trim();
-  if (trimmed.length === 0) {
-    return "Untitled Conversation";
-  }
-  
-  return trimmed.length > 50 ? trimmed.substring(0, 50) + "..." : trimmed;
-}
 
 // Helper to get last message timestamp
 function getLastMessageTimestamp(messages: any[]): Date | null {

--- a/src/app/org/[githubLogin]/_components/CanvasHistoryPopover.tsx
+++ b/src/app/org/[githubLogin]/_components/CanvasHistoryPopover.tsx
@@ -86,6 +86,7 @@ export function CanvasHistoryPopover({ githubLogin }: CanvasHistoryPopoverProps)
           toolCalls: m.toolCalls,
           timeline: m.timeline,
           artifactIds: m.artifactIds,
+          attachments: m.attachments,
           approval: m.approval,
           rejection: m.rejection,
           approvalResult: m.approvalResult,

--- a/src/app/org/[githubLogin]/_state/useCanvasChatAutoSave.ts
+++ b/src/app/org/[githubLogin]/_state/useCanvasChatAutoSave.ts
@@ -71,6 +71,7 @@ function hydrateServerMessages(raw: unknown[]): CanvasChatMessage[] {
       toolCalls: m.toolCalls as CanvasChatMessage["toolCalls"],
       timeline: m.timeline as CanvasChatMessage["timeline"],
       artifactIds: m.artifactIds as string[] | undefined,
+      attachments: m.attachments as CanvasChatMessage["attachments"],
       approval: m.approval as CanvasChatMessage["approval"],
       rejection: m.rejection as CanvasChatMessage["rejection"],
       approvalResult: m.approvalResult as CanvasChatMessage["approvalResult"],

--- a/src/lib/ai/conversationHelpers.ts
+++ b/src/lib/ai/conversationHelpers.ts
@@ -6,7 +6,20 @@
 /** Placeholder title for a conversation with no usable first user message. */
 export const UNTITLED_CONVERSATION = "Untitled Conversation";
 
-/** Generate a title from the first user message (max 50 chars). */
+/**
+ * Upper bound for stored titles. This is a storage guard, not a display
+ * concern — UIs truncate titles visually (CSS `truncate`) so the title is
+ * stored whole (no trailing ellipsis) up to this generous single-line cap.
+ */
+export const TITLE_MAX_LENGTH = 200;
+
+/**
+ * Generate a title from the first user message.
+ *
+ * The full message text is used (whitespace collapsed to a single line) up to
+ * {@link TITLE_MAX_LENGTH} characters, with no trailing ellipsis. Display
+ * surfaces are responsible for visually truncating long titles.
+ */
 export function generateTitle(messages: unknown[]): string {
   if (!Array.isArray(messages) || messages.length === 0) {
     return UNTITLED_CONVERSATION;
@@ -24,9 +37,9 @@ export function generateTitle(messages: unknown[]): string {
     text = textPart?.text || "";
   }
 
-  const trimmed = text.trim();
-  if (!trimmed) return UNTITLED_CONVERSATION;
-  return trimmed.length > 50 ? trimmed.substring(0, 50) + "..." : trimmed;
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (!normalized) return UNTITLED_CONVERSATION;
+  return normalized.slice(0, TITLE_MAX_LENGTH);
 }
 
 /** Return a short preview string from the first user message. */

--- a/src/services/canvas-turn-persistence.ts
+++ b/src/services/canvas-turn-persistence.ts
@@ -44,12 +44,26 @@ export interface StoredToolCall {
   errorText?: string;
 }
 
+/**
+ * A user-uploaded file attached to a message (image/doc). Mirrors the
+ * render-side `CanvasAttachment` shape (`canvasChatStore.ts`): `path` is the
+ * S3 key the client turns into a presigned download URL. Persisted in the
+ * `SharedConversation.messages` JSON so attachments survive reload.
+ */
+export interface StoredAttachment {
+  path: string;
+  filename: string;
+  mimeType: string;
+  size: number;
+}
+
 export interface StoredMessage {
   id: string;
   role: "user" | "assistant";
   content: string;
   timestamp?: string;
   toolCalls?: StoredToolCall[];
+  attachments?: StoredAttachment[];
   source?: { kind: string; featureId?: string; plannerMessageId?: string };
   // Approval-flow metadata round-tripping through the JSON. Untyped here
   // (the canonical types live in `src/lib/proposals/types.ts`); the


### PR DESCRIPTION
## Summary

Two related fixes to the org-canvas chat persistence path.

### 1. Image attachments dropped on reload (real bug)
Uploading an image to a canvas chat worked in-session, but on reload the image message disappeared and the conversation title showed the *second* message.

**Root cause:** `/api/ask/quick` persists the user message server-side, but it only handled string content:
```ts
typeof last.content === "string" ? last.content : ""
```
A message with an image is a multi-part array (`{type:"text"} + {type:"image"}`), so `newUserContent` collapsed to `""`, the persistence gate failed, and the user row was never written. That also meant the conversation row got created on the *next* (text) turn and titled from it.

Attachments were additionally dropped at two client reload mappers.

**Fixes (4 touch points):**
- `canvas-turn-persistence.ts` — add `StoredAttachment` type + `attachments?` on `StoredMessage`.
- `ask/quick/route.ts` — read top-level `attachments`, extract the text part from multi-part content, persist when **text OR attachment** is present, and thread attachments onto the stored user row.
- `CanvasHistoryPopover.tsx` — carry `attachments` in the reload mapper.
- `useCanvasChatAutoSave.ts` — carry `attachments` in `hydrateServerMessages` (live-sync).

The send (`useSendCanvasChatMessage`) and render (`SidebarChatMessage`) paths already handled attachments.

### 2. Stored chat titles no longer truncated with `...`
`generateTitle` hard-truncated to 50 chars + `"..."`, so the planner's `read_user_activity` tool and the UI saw baked-in ellipses. Now it stores the full first user message (whitespace-collapsed, capped at `TITLE_MAX_LENGTH = 200`, no ellipsis); UI surfaces already truncate visually via CSS. Also deduped two copy-pasted `generateTitle` implementations in the share routes in favor of the shared helper.

## Notes
- Forward fix only — already-saved conversations keep their old truncated titles / dropped images.
- Image-only first messages title as "Untitled Conversation" until a text message arrives (existing self-heal logic handles it).

## Testing
- `conversationHelpers` (14), `user-activity` (18), `read-user-activity-tool` (7), `canvas-turn-persistence` (7) — all pass.
- No new type errors introduced (3139 pre-existing in the repo, unchanged).