### PR TITLE
Build DeferredCheckCard UI and cancel endpoint

### DIFF
--- a/src/__tests__/unit/app/org/components/DeferredCheckCard.test.tsx
+++ b/src/__tests__/unit/app/org/components/DeferredCheckCard.test.tsx
@@ -1,0 +1,201 @@
+// @vitest-environment jsdom
+/**
+ * Unit tests for `DeferredCheckCard`.
+ *
+ * Covers:
+ *   - countdown renders from a future fireAt
+ *   - countdown hits 0 → "Checking…" spinner
+ *   - Cancel button calls DELETE and flips to Cancelled optimistically
+ *   - API error reverts optimistic state
+ *   - FIRED state renders "Completed ✓"
+ *   - CANCELLED state renders "Cancelled" text
+ *   - FAILED state renders "Check failed"
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import { DeferredCheckCard } from "@/app/org/[githubLogin]/_components/DeferredCheckCard";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeDeferredCheck(overrides: Partial<{
+  id: string;
+  description: string;
+  fireAt: string;
+  status: "PENDING" | "FIRED" | "CANCELLED" | "FAILED";
+}> = {}) {
+  return {
+    id: "action-1",
+    description: "Check PR logs for feature X",
+    fireAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(), // 5 min from now
+    status: "PENDING" as const,
+    ...overrides,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("DeferredCheckCard", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true }),
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("renders description and countdown for PENDING status", () => {
+    const check = makeDeferredCheck();
+    render(<DeferredCheckCard deferredCheck={check} githubLogin="my-org" />);
+
+    expect(screen.getByText("Check PR logs for feature X")).toBeTruthy();
+    expect(screen.getByText("Scheduled check")).toBeTruthy();
+    // Countdown should be present (shows "Fires in X:XX")
+    expect(screen.getByText("Fires in")).toBeTruthy();
+  });
+
+  it("shows Cancel button in PENDING state", () => {
+    const check = makeDeferredCheck();
+    render(<DeferredCheckCard deferredCheck={check} githubLogin="my-org" />);
+
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeTruthy();
+  });
+
+  it("updates countdown every second", () => {
+    const fireAt = new Date(Date.now() + 2 * 60 * 1000).toISOString(); // 2 min
+    const check = makeDeferredCheck({ fireAt });
+    render(<DeferredCheckCard deferredCheck={check} githubLogin="my-org" />);
+
+    // Initially shows ~2:00
+    expect(screen.getByText(/2:0/)).toBeTruthy();
+
+    // After 30s tick
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+    });
+
+    expect(screen.getByText(/1:[3-9]/)).toBeTruthy();
+  });
+
+  it("shows Checking… spinner when countdown reaches 0", () => {
+    // Fire at already in the past
+    const fireAt = new Date(Date.now() - 1000).toISOString();
+    const check = makeDeferredCheck({ fireAt });
+    render(<DeferredCheckCard deferredCheck={check} githubLogin="my-org" />);
+
+    expect(screen.getByText("Checking…")).toBeTruthy();
+    // Cancel button should not be present when countdown is done
+    expect(screen.queryByRole("button", { name: /cancel/i })).toBeNull();
+  });
+
+  it("Cancel button optimistically flips to Cancelled and calls DELETE", async () => {
+    // Use real timers for async tests — fake timers block waitFor's internal setTimeout.
+    vi.useRealTimers();
+    const check = makeDeferredCheck();
+    render(<DeferredCheckCard deferredCheck={check} githubLogin="test-org" />);
+
+    const cancelBtn = screen.getByRole("button", { name: /cancel/i });
+    await act(async () => {
+      fireEvent.click(cancelBtn);
+    });
+
+    // Optimistic: card should immediately show Cancelled state
+    expect(screen.getByText("Cancelled")).toBeTruthy();
+
+    // API should have been called
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/orgs/test-org/chat/deferred-actions/action-1",
+      { method: "DELETE" },
+    );
+  });
+
+  it("reverts optimistic state on API error", async () => {
+    vi.useRealTimers();
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "Network error" }),
+    });
+
+    const { toast } = await import("sonner");
+    const check = makeDeferredCheck();
+    render(<DeferredCheckCard deferredCheck={check} githubLogin="my-org" />);
+
+    const cancelBtn = screen.getByRole("button", { name: /cancel/i });
+    await act(async () => {
+      fireEvent.click(cancelBtn);
+    });
+
+    // After API rejects, should revert to PENDING with Cancel button visible again
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /cancel/i })).toBeTruthy();
+    });
+
+    expect(toast.error).toHaveBeenCalled();
+  });
+
+  it("FIRED state renders Completed ✓ without cancel button", () => {
+    const check = makeDeferredCheck({ status: "FIRED" });
+    render(<DeferredCheckCard deferredCheck={check} githubLogin="my-org" />);
+
+    expect(screen.getByText(/Completed ✓/)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /cancel/i })).toBeNull();
+  });
+
+  it("CANCELLED state renders Cancelled text", () => {
+    const check = makeDeferredCheck({ status: "CANCELLED" });
+    render(<DeferredCheckCard deferredCheck={check} githubLogin="my-org" />);
+
+    // Both the StatusBadge ("Cancelled") and the footer ("This check was cancelled.")
+    // should be present — assert at least one of them is visible.
+    const cancelleds = screen.getAllByText(/cancelled/i);
+    expect(cancelleds.length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByRole("button", { name: /cancel/i })).toBeNull();
+  });
+
+  it("FAILED state renders Check failed", () => {
+    const check = makeDeferredCheck({ status: "FAILED" });
+    render(<DeferredCheckCard deferredCheck={check} githubLogin="my-org" />);
+
+    expect(screen.getByText(/Check failed/i)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /cancel/i })).toBeNull();
+  });
+
+  it("syncs status from props when it changes externally (Pusher update)", () => {
+    const check = makeDeferredCheck({ status: "PENDING" });
+    const { rerender } = render(
+      <DeferredCheckCard deferredCheck={check} githubLogin="my-org" />,
+    );
+
+    // Simulate Pusher causing a re-render with FIRED status
+    rerender(
+      <DeferredCheckCard
+        deferredCheck={{ ...check, status: "FIRED" }}
+        githubLogin="my-org"
+      />,
+    );
+
+    expect(screen.getByText(/Completed ✓/)).toBeTruthy();
+  });
+
+  it("does not show countdown when status is not PENDING", () => {
+    const check = makeDeferredCheck({ status: "FIRED" });
+    render(<DeferredCheckCard deferredCheck={check} githubLogin="my-org" />);
+
+    expect(screen.queryByText("Fires in")).toBeNull();
+  });
+});

--- a/src/app/api/orgs/[githubLogin]/chat/deferred-actions/[deferredActionId]/route.ts
+++ b/src/app/api/orgs/[githubLogin]/chat/deferred-actions/[deferredActionId]/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getMiddlewareContext, requireAuth } from "@/lib/middleware/utils";
+import { validateUserBelongsToOrg } from "@/services/workspace";
+import { db } from "@/lib/db";
+import { notifyCanvasConversationUpdated } from "@/lib/pusher";
+import { updateDeferredCheckStatus } from "@/services/deferred-check";
+
+/**
+ * DELETE /api/orgs/[githubLogin]/chat/deferred-actions/[deferredActionId]
+ *
+ * Cancel a pending deferred chat action. Returns 404 (not 403) for IDOR
+ * safety when the action doesn't exist or belongs to another user.
+ */
+export async function DELETE(
+  request: NextRequest,
+  {
+    params,
+  }: { params: Promise<{ githubLogin: string; deferredActionId: string }> },
+) {
+  const context = getMiddlewareContext(request);
+  const userOrResponse = requireAuth(context);
+  if (userOrResponse instanceof NextResponse) return userOrResponse;
+
+  const { githubLogin, deferredActionId } = await params;
+
+  const isMember = await validateUserBelongsToOrg(githubLogin, userOrResponse.id);
+  if (!isMember) {
+    return NextResponse.json({ error: "Organization not found" }, { status: 404 });
+  }
+
+  try {
+    // Resolve org id for the scoping check
+    const org = await db.sourceControlOrg.findUnique({
+      where: { githubLogin },
+      select: { id: true },
+    });
+    if (!org) {
+      return NextResponse.json({ error: "Organization not found" }, { status: 404 });
+    }
+
+    // Fetch the action — scope to org and ownership for IDOR safety.
+    // Return 404 (not 403) regardless of why it's missing so callers
+    // can't distinguish "doesn't exist" from "not yours".
+    const action = await db.deferredChatAction.findFirst({
+      where: {
+        id: deferredActionId,
+        orgId: org.id,
+      },
+      select: {
+        id: true,
+        userId: true,
+        status: true,
+        conversationId: true,
+      },
+    });
+
+    if (!action || action.userId !== userOrResponse.id) {
+      return NextResponse.json({ error: "Deferred action not found" }, { status: 404 });
+    }
+
+    if (action.status !== "PENDING") {
+      return NextResponse.json(
+        { error: "Action is not cancellable" },
+        { status: 400 },
+      );
+    }
+
+    // Flip the DeferredChatAction row -> CANCELLED and patch the matching
+    // deferredCheck.status in the conversation messages JSON. Both writes
+    // happen atomically inside `updateDeferredCheckStatus` (single
+    // transaction). Ownership/scope was already validated above via the
+    // org-scoped `findFirst` + userId check, so updating by id is safe.
+    await updateDeferredCheckStatus(
+      action.conversationId,
+      deferredActionId,
+      "CANCELLED",
+    );
+
+    // Live-sync: notify other open tabs so their card updates immediately.
+    notifyCanvasConversationUpdated(
+      action.conversationId,
+      "deferred-check-cancelled",
+    );
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error(
+      "[DELETE /api/orgs/[githubLogin]/chat/deferred-actions/[id]] Error:",
+      error,
+    );
+    return NextResponse.json(
+      { error: "Failed to cancel deferred action" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/org/[githubLogin]/_components/DeferredCheckCard.tsx
+++ b/src/app/org/[githubLogin]/_components/DeferredCheckCard.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+/**
+ * Renders a deferred-check confirmation card below an assistant message.
+ *
+ * The card has four display states driven by `deferredCheck.status`:
+ *   - PENDING  — live countdown timer + Cancel button
+ *   - PENDING (countdown reached 0) — "Checking…" spinner (cron hasn't fired yet)
+ *   - FIRED    — "Completed ✓" in green
+ *   - CANCELLED — "Cancelled" muted
+ *   - FAILED   — "Check failed" in red
+ *
+ * Visual language is intentionally aligned with `<AttentionList>` and
+ * `<ProposalCard>` (rounded-lg border, bg-card, compact text-sm, tracking-wide
+ * uppercase meta row) so all card types share a coherent vocabulary in the
+ * sidebar chat.
+ */
+
+import React, { useEffect, useState } from "react";
+import { CheckCircle2, Clock, Loader2, X, XCircle } from "lucide-react";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+
+interface DeferredCheck {
+  id: string;
+  description: string;
+  fireAt: string; // ISO timestamp
+  status: "PENDING" | "FIRED" | "CANCELLED" | "FAILED";
+}
+
+interface DeferredCheckCardProps {
+  deferredCheck: DeferredCheck;
+  githubLogin: string;
+}
+
+/**
+ * Format remaining milliseconds as a compact countdown string.
+ *   < 1 min  → "0:SS"
+ *   < 1 hour → "M:SS"
+ *   ≥ 1 hour → "Xh Xm"
+ */
+function formatRemaining(ms: number): string {
+  if (ms <= 0) return "0:00";
+  const totalSec = Math.ceil(ms / 1000);
+  const hours = Math.floor(totalSec / 3600);
+  const mins = Math.floor((totalSec % 3600) / 60);
+  const secs = totalSec % 60;
+  if (hours > 0) {
+    return `${hours}h ${mins}m`;
+  }
+  return `${mins}:${secs.toString().padStart(2, "0")}`;
+}
+
+export function DeferredCheckCard({
+  deferredCheck,
+  githubLogin,
+}: DeferredCheckCardProps) {
+  const [localStatus, setLocalStatus] = useState(deferredCheck.status);
+  const [remaining, setRemaining] = useState<number>(
+    () => new Date(deferredCheck.fireAt).getTime() - Date.now(),
+  );
+  const [isCancelling, setIsCancelling] = useState(false);
+
+  // Keep the countdown ticking while status is PENDING.
+  useEffect(() => {
+    if (localStatus !== "PENDING") return;
+
+    const interval = setInterval(() => {
+      setRemaining(new Date(deferredCheck.fireAt).getTime() - Date.now());
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [localStatus, deferredCheck.fireAt]);
+
+  // Sync external status changes (e.g. Pusher live-update flips PENDING→FIRED).
+  useEffect(() => {
+    setLocalStatus(deferredCheck.status);
+  }, [deferredCheck.status]);
+
+  const handleCancel = async () => {
+    // Optimistic update
+    setLocalStatus("CANCELLED");
+    setIsCancelling(true);
+
+    try {
+      const res = await fetch(
+        `/api/orgs/${githubLogin}/chat/deferred-actions/${deferredCheck.id}`,
+        { method: "DELETE" },
+      );
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? "Failed to cancel");
+      }
+    } catch (err) {
+      // Revert optimistic update on error
+      setLocalStatus("PENDING");
+      toast.error("Could not cancel scheduled check", {
+        description: err instanceof Error ? err.message : "Unknown error",
+      });
+    } finally {
+      setIsCancelling(false);
+    }
+  };
+
+  const isPending = localStatus === "PENDING";
+  const isCountdownDone = isPending && remaining <= 0;
+
+  return (
+    <div
+      className={cn(
+        "rounded-lg border bg-card text-card-foreground text-sm",
+        localStatus === "FIRED" && "border-emerald-500/30 bg-emerald-500/5",
+        localStatus === "FAILED" && "border-destructive/30 bg-destructive/5",
+        localStatus === "CANCELLED" && "opacity-60",
+      )}
+    >
+      {/* Header row */}
+      <div className="flex items-center justify-between px-3 pt-2 pb-1">
+        <span className="text-[10px] uppercase tracking-wide text-muted-foreground font-medium">
+          Scheduled check
+        </span>
+        <StatusBadge status={localStatus} />
+      </div>
+
+      {/* Description */}
+      <p className="px-3 pb-2 text-[13px] leading-snug text-foreground/80">
+        {deferredCheck.description}
+      </p>
+
+      {/* Footer — countdown or status message */}
+      <div
+        className={cn(
+          "flex items-center justify-between gap-2 border-t px-3 py-2",
+          localStatus === "CANCELLED" && "border-t-transparent",
+        )}
+      >
+        <Footer
+          status={localStatus}
+          remaining={remaining}
+          isCountdownDone={isCountdownDone}
+          fireAt={deferredCheck.fireAt}
+        />
+
+        {isPending && !isCountdownDone && (
+          <button
+            type="button"
+            onClick={handleCancel}
+            disabled={isCancelling}
+            className="flex items-center gap-1 rounded-md border px-2 py-1 text-[11px] text-muted-foreground transition-colors hover:border-destructive/50 hover:bg-destructive/10 hover:text-destructive disabled:cursor-not-allowed disabled:opacity-50"
+            aria-label="Cancel scheduled check"
+          >
+            <X className="h-3 w-3" />
+            Cancel
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Sub-components ─────────────────────────────────────────────────────────────
+
+function StatusBadge({ status }: { status: DeferredCheck["status"] }) {
+  switch (status) {
+    case "PENDING":
+      return (
+        <span className="flex items-center gap-1 text-[10px] text-amber-500">
+          <Clock className="h-3 w-3" />
+          Pending
+        </span>
+      );
+    case "FIRED":
+      return (
+        <span className="flex items-center gap-1 text-[10px] text-emerald-500">
+          <CheckCircle2 className="h-3 w-3" />
+          Done
+        </span>
+      );
+    case "CANCELLED":
+      return (
+        <span className="flex items-center gap-1 text-[10px] text-muted-foreground">
+          <XCircle className="h-3 w-3" />
+          Cancelled
+        </span>
+      );
+    case "FAILED":
+      return (
+        <span className="flex items-center gap-1 text-[10px] text-destructive">
+          <XCircle className="h-3 w-3" />
+          Failed
+        </span>
+      );
+  }
+}
+
+interface FooterProps {
+  status: DeferredCheck["status"];
+  remaining: number;
+  isCountdownDone: boolean;
+  fireAt: string;
+}
+
+function Footer({ status, remaining, isCountdownDone, fireAt }: FooterProps) {
+  if (status === "FIRED") {
+    return (
+      <span className="flex items-center gap-1.5 text-[12px] font-medium text-emerald-500">
+        <CheckCircle2 className="h-3.5 w-3.5" />
+        Completed ✓
+      </span>
+    );
+  }
+
+  if (status === "CANCELLED") {
+    return (
+      <span className="text-[12px] text-muted-foreground italic">
+        This check was cancelled.
+      </span>
+    );
+  }
+
+  if (status === "FAILED") {
+    return (
+      <span className="flex items-center gap-1.5 text-[12px] text-destructive">
+        <XCircle className="h-3.5 w-3.5" />
+        Check failed
+      </span>
+    );
+  }
+
+  // PENDING
+  if (isCountdownDone) {
+    return (
+      <span className="flex items-center gap-1.5 text-[12px] text-muted-foreground">
+        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        Checking…
+      </span>
+    );
+  }
+
+  return (
+    <span className="flex items-center gap-1.5 text-[12px] tabular-nums text-muted-foreground">
+      <Clock className="h-3.5 w-3.5 text-amber-500/80" />
+      <span>
+        Fires in{" "}
+        <span className="font-medium text-foreground/80">
+          {formatRemaining(remaining)}
+        </span>
+      </span>
+    </span>
+  );
+}

--- a/src/app/org/[githubLogin]/_components/SidebarChat.tsx
+++ b/src/app/org/[githubLogin]/_components/SidebarChat.tsx
@@ -37,6 +37,7 @@ import {
 import { PlannerFormSlot } from "./PlannerFormSlot";
 import { StartTasksSlot } from "./StartTasksSlot";
 import { AttentionList } from "./AttentionList";
+import { DeferredCheckCard } from "./DeferredCheckCard";
 import type { AttentionItem } from "@/services/attention/topItems";
 import {
   useCanvasChatStore,
@@ -436,6 +437,12 @@ export function SidebarChat({ githubLogin }: SidebarChatProps) {
                       />
                     ))}
                   </div>
+                )}
+                {message.deferredCheck && (
+                  <DeferredCheckCard
+                    deferredCheck={message.deferredCheck}
+                    githubLogin={githubLogin}
+                  />
                 )}
                 {subAgentRuns &&
                   subAgentRuns.length > 0 &&


### PR DESCRIPTION
## What

Lands the **UI + cancel half** of the deferred-chat-actions feature. This content was originally PR #4376, but that PR squash-merged into the intermediate dispatcher branch (its retargeted base) rather than master, so it never reached `master`. This PR re-lands it cleanly on top of current master.

The backend half is already in master:
- #4373 — `DeferredChatAction` model + `schedule_check` tool
- #4375 — dispatcher service, cron endpoint, shared `deferred-check.ts` + `pusher.ts`

## Changes (556 lines, 4 files)
- `DeferredCheckCard.tsx` + tests — renders a scheduled-check's status with a cancel button
- `SidebarChat.tsx` (+7) — renders the card under messages carrying `deferredCheck`
- `DELETE /api/orgs/[githubLogin]/chat/deferred-actions/[id]` — cancel endpoint (404-on-not-found IDOR guard)

## Notes
- **No schema/migration changes** — the model already exists in master (single migration `20260616004851`); no duplicates.
- The cancel endpoint uses the shared `updateDeferredCheckStatus` (from #4375), which flips the DB row and patches the messages JSON atomically. The earlier nested-transaction + redundant `updateMany` (which risked a self-deadlock on the same row) was removed.
- Falls through to the `protected` middleware default (requires auth) — no `ROUTE_POLICIES` entry needed.

## Tests
- `DeferredCheckCard.test.tsx` — 11 passing
- Typecheck clean on all new files