### PR TITLE
Fix research nodes: sub-agent re-dispatching itself (P2002 on org_id,slug)

### DIFF
--- a/src/__tests__/unit/lib/ai/filterReadonly.test.ts
+++ b/src/__tests__/unit/lib/ai/filterReadonly.test.ts
@@ -57,6 +57,7 @@ describe("filterReadonly", () => {
     update_canvas: makeFakeTool(),
     patch_canvas: makeFakeTool(),
     save_research: makeFakeTool(),
+    dispatch_research: makeFakeTool(),
     update_research: makeFakeTool(),
     save_connection: makeFakeTool(),
     update_connection: makeFakeTool(),
@@ -79,6 +80,10 @@ describe("filterReadonly", () => {
     expect(result).not.toHaveProperty("update_canvas");
     expect(result).not.toHaveProperty("patch_canvas");
     expect(result).not.toHaveProperty("save_research");
+    // dispatch_research is a write tool (creates a Research row); it MUST be
+    // stripped in readonly mode so the research sub-agent can't re-dispatch
+    // itself and collide on the unique (org_id, slug) constraint.
+    expect(result).not.toHaveProperty("dispatch_research");
     expect(result).not.toHaveProperty("update_research");
     expect(result).not.toHaveProperty("save_connection");
     expect(result).not.toHaveProperty("propose_initiative");
@@ -100,6 +105,7 @@ describe("filterReadonly", () => {
     expect(result).toHaveProperty("update_research");
     // other write tools still stripped
     expect(result).not.toHaveProperty("save_research");
+    expect(result).not.toHaveProperty("dispatch_research");
     expect(result).not.toHaveProperty("update_canvas");
     expect(result).not.toHaveProperty("patch_canvas");
     expect(result).not.toHaveProperty("save_connection");

--- a/src/lib/ai/capabilities.ts
+++ b/src/lib/ai/capabilities.ts
@@ -176,8 +176,13 @@ export const CAPABILITY_REGISTRY: Record<OrgCapability, CapabilityDefinition> =
           ctx.currentCanvasConversationId,
         ),
       promptSnippet: getResearchCapabilitySnippet,
-      // dispatch_research survives readonly mode (pre-registry parity).
-      writeToolNames: ["save_research", "update_research"],
+      // dispatch_research creates a Research row, so it's a write tool and
+      // MUST be stripped in readonly mode. Critically, the research
+      // sub-agent (`canvas-research-worker.ts`) runs readonly with only
+      // `update_research` kept — if dispatch_research survived, the
+      // sub-agent (whose prompt hands it the slug) could re-dispatch
+      // itself, colliding on the unique (org_id, slug) constraint (P2002).
+      writeToolNames: ["save_research", "dispatch_research", "update_research"],
     },
     connections: {
       buildTools: (ctx) => buildConnectionTools(ctx.orgId, ctx.userId),


### PR DESCRIPTION
## Problem

Research nodes broke with a `PrismaClientKnownRequestError` (P2002):

```
[researchTools] dispatch_research failed: Error [PrismaClientKnownRequestError]:
Invalid `prisma.research.create()` invocation:
Unique constraint failed on the fields: (`org_id`,`slug`)
```

## Root cause — recursive self-dispatch

`dispatch_research` creates a `Research` row, but in `src/lib/ai/capabilities.ts` the research capability declared its write tools as `["save_research", "update_research"]`, **omitting `dispatch_research`**. The readonly strip set (`runCanvasAgent.ts`) is derived from `writeToolNames`, so `dispatch_research` was *not* stripped in readonly mode.

The research sub-agent worker (`canvas-research-worker.ts`) runs the agent with `readonly: true` keeping only `update_research`. Because `dispatch_research` survived readonly, the sub-agent — handed its own `slug` directly in its prompt — could call `dispatch_research` again, re-running `prisma.research.create()` with that same slug and tripping the unique `(org_id, slug)` constraint.

This regressed when the capability registry was introduced; the "pre-registry parity" comment baked the omission in.

## Fix

- Add `dispatch_research` to the research capability's `writeToolNames` so it's correctly stripped in readonly mode. The interactive canvas chat runs with `readonly: false`, so dispatch still works there exactly as before — only readonly contexts (the research sub-agent, scouts) lose the ability to re-dispatch.
- Add a regression assertion in `filterReadonly.test.ts`.

## Testing

`npx vitest run filterReadonly dispatchResearch` — 12 passed.