### PR TITLE
Canvas chat: fix DeferredCheckCard + add recurring Automations

### DIFF
--- a/env.example
+++ b/env.example
@@ -189,6 +189,10 @@ NOTIFICATION_DISPATCHER_ENABLED="true"
 # that fires DeferredChatAction records and re-injects results into conversations
 DEFERRED_CHAT_ACTIONS_ENABLED="true"
 
+# Automations Cron - set to "true" to enable the per-minute dispatcher that runs
+# recurring Automation prompts as fresh org-canvas conversations
+AUTOMATIONS_ENABLED="true"
+
 
 # Stripe Payment Integration
 STRIPE_SECRET_KEY="sk_test_..."

--- a/prisma/migrations/20260616160000_add_automation/migration.sql
+++ b/prisma/migrations/20260616160000_add_automation/migration.sql
@@ -1,0 +1,31 @@
+-- CreateTable
+CREATE TABLE "automations" (
+    "id" TEXT NOT NULL,
+    "source_control_org_id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "prompt" TEXT NOT NULL,
+    "time_of_day" TEXT NOT NULL,
+    "timezone" TEXT NOT NULL DEFAULT 'UTC',
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "next_run_at" TIMESTAMP(3) NOT NULL,
+    "last_run_at" TIMESTAMP(3),
+    "last_run_conversation_id" TEXT,
+    "last_run_seen_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "automations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "automations_enabled_next_run_at_idx" ON "automations"("enabled", "next_run_at");
+
+-- CreateIndex
+CREATE INDEX "automations_source_control_org_id_user_id_idx" ON "automations"("source_control_org_id", "user_id");
+
+-- AddForeignKey
+ALTER TABLE "automations" ADD CONSTRAINT "automations_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "automations" ADD CONSTRAINT "automations_source_control_org_id_fkey" FOREIGN KEY ("source_control_org_id") REFERENCES "source_control_orgs"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -112,6 +112,7 @@ model User {
   initiativeAssignments    Initiative[]             @relation("InitiativeAssignee")
   milestoneAssignments     Milestone[]              @relation("MilestoneAssignee")
   createdMilestones        Milestone[]              @relation("MilestoneCreator")
+  automations              Automation[]
 
   @@index([createdAt])
   @@index([deleted])
@@ -192,6 +193,7 @@ model SourceControlOrg {
   canvases             Canvas[]
   initiatives          Initiative[]
   researches           Research[]
+  automations          Automation[]
 
   @@index([githubLogin])
   @@index([githubInstallationId])
@@ -1838,6 +1840,44 @@ model DeferredChatAction {
 
   @@index([status, fireAt])
   @@map("deferred_chat_actions")
+}
+
+/// A recurring scheduled prompt for the org canvas chat. The per-minute
+/// automation cron (`/api/cron/automations`) finds rows whose `nextRunAt`
+/// has passed, creates a brand-new org-canvas `SharedConversation`, runs the
+/// canvas agent with `prompt`, then advances `nextRunAt` to the next
+/// occurrence of `timeOfDay` in `timezone`. The freshly-created conversation
+/// is recorded on `lastRunConversationId` with `lastRunSeenAt = null` so the
+/// canvas page can auto-open the most recent unseen run on load.
+model Automation {
+  id                    String    @id @default(cuid())
+  sourceControlOrgId    String    @map("source_control_org_id")
+  userId                String    @map("user_id")
+  name                  String
+  prompt                String
+  /// 24-hour wall-clock time "HH:MM", interpreted in `timezone`.
+  timeOfDay             String    @map("time_of_day")
+  /// IANA timezone, e.g. "America/Los_Angeles". The wall-clock `timeOfDay`
+  /// is resolved against this zone (DST-aware) to compute `nextRunAt`.
+  timezone              String    @default("UTC")
+  enabled               Boolean   @default(true)
+  /// UTC instant of the next scheduled fire. Indexed for the cron sweep.
+  nextRunAt             DateTime  @map("next_run_at")
+  lastRunAt             DateTime? @map("last_run_at")
+  /// The org-canvas SharedConversation created by the most recent run.
+  lastRunConversationId String?   @map("last_run_conversation_id")
+  /// Null while the most recent run hasn't been surfaced to the user yet;
+  /// set once the canvas auto-opens (or the user dismisses) that run.
+  lastRunSeenAt         DateTime? @map("last_run_seen_at")
+  createdAt             DateTime  @default(now()) @map("created_at")
+  updatedAt             DateTime  @updatedAt @map("updated_at")
+
+  user             User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  sourceControlOrg SourceControlOrg @relation(fields: [sourceControlOrgId], references: [id], onDelete: Cascade)
+
+  @@index([enabled, nextRunAt])
+  @@index([sourceControlOrgId, userId])
+  @@map("automations")
 }
 
 model WorkflowSummary {

--- a/src/__tests__/unit/lib/automations/schedule.test.ts
+++ b/src/__tests__/unit/lib/automations/schedule.test.ts
@@ -1,0 +1,82 @@
+import { describe, test, expect } from "vitest";
+import {
+  computeNextRunAt,
+  describeSchedule,
+  isValidTimeOfDay,
+  isValidTimezone,
+} from "@/lib/automations/schedule";
+
+describe("isValidTimeOfDay", () => {
+  test("accepts valid 24h times", () => {
+    expect(isValidTimeOfDay("00:00")).toBe(true);
+    expect(isValidTimeOfDay("04:30")).toBe(true);
+    expect(isValidTimeOfDay("23:59")).toBe(true);
+  });
+  test("rejects invalid times", () => {
+    expect(isValidTimeOfDay("24:00")).toBe(false);
+    expect(isValidTimeOfDay("4:00")).toBe(false);
+    expect(isValidTimeOfDay("12:60")).toBe(false);
+    expect(isValidTimeOfDay("noon")).toBe(false);
+  });
+});
+
+describe("isValidTimezone", () => {
+  test("accepts IANA zones", () => {
+    expect(isValidTimezone("UTC")).toBe(true);
+    expect(isValidTimezone("America/New_York")).toBe(true);
+  });
+  test("rejects garbage", () => {
+    expect(isValidTimezone("Not/AZone")).toBe(false);
+    expect(isValidTimezone("")).toBe(false);
+  });
+});
+
+describe("computeNextRunAt — UTC", () => {
+  test("uses today's occurrence when still in the future", () => {
+    const from = new Date("2026-01-01T03:00:00.000Z");
+    const next = computeNextRunAt("04:00", "UTC", from);
+    expect(next.toISOString()).toBe("2026-01-01T04:00:00.000Z");
+  });
+
+  test("rolls to tomorrow when the time already passed", () => {
+    const from = new Date("2026-01-01T05:00:00.000Z");
+    const next = computeNextRunAt("04:00", "UTC", from);
+    expect(next.toISOString()).toBe("2026-01-02T04:00:00.000Z");
+  });
+
+  test("rolls across month boundary", () => {
+    const from = new Date("2026-01-31T05:00:00.000Z");
+    const next = computeNextRunAt("04:00", "UTC", from);
+    expect(next.toISOString()).toBe("2026-02-01T04:00:00.000Z");
+  });
+});
+
+describe("computeNextRunAt — zoned (DST-aware)", () => {
+  test("America/New_York standard time (UTC-5): 04:00 local = 09:00Z", () => {
+    const from = new Date("2026-01-01T00:00:00.000Z");
+    const next = computeNextRunAt("04:00", "America/New_York", from);
+    expect(next.toISOString()).toBe("2026-01-01T09:00:00.000Z");
+  });
+
+  test("America/New_York daylight time (UTC-4): 04:00 local = 08:00Z", () => {
+    // July is DST in New York.
+    const from = new Date("2026-07-01T00:00:00.000Z");
+    const next = computeNextRunAt("04:00", "America/New_York", from);
+    expect(next.toISOString()).toBe("2026-07-01T08:00:00.000Z");
+  });
+
+  test("always returns an instant strictly after `from`", () => {
+    const from = new Date("2026-03-15T12:34:00.000Z");
+    const next = computeNextRunAt("09:00", "America/Los_Angeles", from);
+    expect(next.getTime()).toBeGreaterThan(from.getTime());
+  });
+});
+
+describe("describeSchedule", () => {
+  test("formats 12-hour label", () => {
+    expect(describeSchedule("04:00")).toBe("Daily at 4:00 AM");
+    expect(describeSchedule("00:00")).toBe("Daily at 12:00 AM");
+    expect(describeSchedule("13:30")).toBe("Daily at 1:30 PM");
+    expect(describeSchedule("12:00")).toBe("Daily at 12:00 PM");
+  });
+});

--- a/src/app/api/cron/automations/route.ts
+++ b/src/app/api/cron/automations/route.ts
@@ -15,13 +15,19 @@ import { NextRequest, NextResponse } from "next/server";
  */
 export async function GET(request: NextRequest) {
   try {
+    console.log("[Automations] Cron endpoint hit");
     const authHeader = request.headers.get("authorization");
     if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+      console.warn(
+        "[Automations] Unauthorized — missing/incorrect CRON_SECRET bearer",
+      );
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
     if (process.env.AUTOMATIONS_ENABLED !== "true") {
-      console.log("[Automations] Disabled via AUTOMATIONS_ENABLED");
+      console.log(
+        "[Automations] Disabled via AUTOMATIONS_ENABLED (set it to \"true\" to enable)",
+      );
       return NextResponse.json({
         success: true,
         message: "Disabled",

--- a/src/app/api/cron/automations/route.ts
+++ b/src/app/api/cron/automations/route.ts
@@ -1,0 +1,56 @@
+import { dispatchDueAutomations } from "@/services/automation-dispatcher";
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * GET /api/cron/automations
+ *
+ * Vercel cron endpoint (runs every minute) that picks up enabled
+ * `Automation` records whose `nextRunAt` has passed, creates a fresh
+ * org-canvas conversation, runs the canvas agent with the automation's
+ * prompt, and re-arms the schedule for the next day.
+ *
+ * Gated by:
+ *   - `CRON_SECRET` Authorization header (standard cron guard)
+ *   - `AUTOMATIONS_ENABLED=true` environment flag
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const authHeader = request.headers.get("authorization");
+    if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    if (process.env.AUTOMATIONS_ENABLED !== "true") {
+      console.log("[Automations] Disabled via AUTOMATIONS_ENABLED");
+      return NextResponse.json({
+        success: true,
+        message: "Disabled",
+        fired: 0,
+        failed: 0,
+        errors: [],
+      });
+    }
+
+    const result = await dispatchDueAutomations();
+
+    return NextResponse.json({
+      success: result.failed === 0,
+      fired: result.fired,
+      failed: result.failed,
+      errors: result.errors,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    console.error("[Automations] Unhandled error:", errorMessage);
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Internal server error",
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/orgs/[githubLogin]/automations/[automationId]/route.ts
+++ b/src/app/api/orgs/[githubLogin]/automations/[automationId]/route.ts
@@ -1,0 +1,173 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getMiddlewareContext, requireAuth } from "@/lib/middleware/utils";
+import { validateUserBelongsToOrg } from "@/services/workspace";
+import { db } from "@/lib/db";
+import type { Automation, Prisma } from "@prisma/client";
+import {
+  computeNextRunAt,
+  describeSchedule,
+  isValidTimeOfDay,
+  isValidTimezone,
+} from "@/lib/automations/schedule";
+import type { AutomationDTO } from "@/types/automation";
+
+async function resolveOrg(githubLogin: string) {
+  return db.sourceControlOrg.findUnique({
+    where: { githubLogin },
+    select: { id: true },
+  });
+}
+
+function toDTO(a: Automation): AutomationDTO {
+  return {
+    id: a.id,
+    name: a.name,
+    prompt: a.prompt,
+    timeOfDay: a.timeOfDay,
+    timezone: a.timezone,
+    enabled: a.enabled,
+    schedule: describeSchedule(a.timeOfDay, a.timezone),
+    nextRunAt: a.nextRunAt?.toISOString() ?? null,
+    lastRunAt: a.lastRunAt?.toISOString() ?? null,
+    createdAt: a.createdAt.toISOString(),
+  };
+}
+
+/** Resolve org + load the caller-owned automation, or a NextResponse error. */
+async function loadOwned(
+  request: NextRequest,
+  githubLogin: string,
+  automationId: string,
+): Promise<{ userId: string; automation: Automation } | NextResponse> {
+  const context = getMiddlewareContext(request);
+  const userOrResponse = requireAuth(context);
+  if (userOrResponse instanceof NextResponse) return userOrResponse;
+
+  const isMember = await validateUserBelongsToOrg(githubLogin, userOrResponse.id);
+  if (!isMember) {
+    return NextResponse.json({ error: "Organization not found" }, { status: 404 });
+  }
+
+  const org = await resolveOrg(githubLogin);
+  if (!org) {
+    return NextResponse.json({ error: "Organization not found" }, { status: 404 });
+  }
+
+  // findFirst scoped to org + owner; return 404 (not 403) on any miss so a
+  // caller can't probe for automations they don't own.
+  const automation = await db.automation.findFirst({
+    where: {
+      id: automationId,
+      sourceControlOrgId: org.id,
+      userId: userOrResponse.id,
+    },
+  });
+  if (!automation) {
+    return NextResponse.json({ error: "Automation not found" }, { status: 404 });
+  }
+
+  return { userId: userOrResponse.id, automation };
+}
+
+/**
+ * PATCH /api/orgs/[githubLogin]/automations/[automationId]
+ * Update an automation (name, prompt, timeOfDay, timezone, enabled).
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ githubLogin: string; automationId: string }> },
+) {
+  const { githubLogin, automationId } = await params;
+  const loaded = await loadOwned(request, githubLogin, automationId);
+  if (loaded instanceof NextResponse) return loaded;
+  const { automation } = loaded;
+
+  try {
+    const body = await request.json();
+    const data: Prisma.AutomationUpdateInput = {};
+
+    if (typeof body.name === "string") {
+      const name = body.name.trim();
+      if (!name) {
+        return NextResponse.json({ error: "name cannot be empty" }, { status: 400 });
+      }
+      data.name = name;
+    }
+    if (typeof body.prompt === "string") {
+      const prompt = body.prompt.trim();
+      if (!prompt) {
+        return NextResponse.json({ error: "prompt cannot be empty" }, { status: 400 });
+      }
+      data.prompt = prompt;
+    }
+
+    // The effective schedule after this patch — used to recompute nextRunAt.
+    let timeOfDay = automation.timeOfDay;
+    let timezone = automation.timezone;
+    let scheduleChanged = false;
+
+    if (typeof body.timeOfDay === "string") {
+      const t = body.timeOfDay.trim();
+      if (!isValidTimeOfDay(t)) {
+        return NextResponse.json(
+          { error: "timeOfDay must be a 24-hour HH:MM string" },
+          { status: 400 },
+        );
+      }
+      data.timeOfDay = t;
+      timeOfDay = t;
+      scheduleChanged = true;
+    }
+    if (typeof body.timezone === "string") {
+      const tz = body.timezone.trim();
+      if (!isValidTimezone(tz)) {
+        return NextResponse.json({ error: "Invalid timezone" }, { status: 400 });
+      }
+      data.timezone = tz;
+      timezone = tz;
+      scheduleChanged = true;
+    }
+
+    let enabling = false;
+    if (typeof body.enabled === "boolean") {
+      data.enabled = body.enabled;
+      enabling = body.enabled && !automation.enabled;
+    }
+
+    // Re-arm nextRunAt when the schedule changed or we're re-enabling a
+    // paused automation (so a stale past nextRunAt doesn't fire immediately).
+    if (scheduleChanged || enabling) {
+      data.nextRunAt = computeNextRunAt(timeOfDay, timezone);
+    }
+
+    const updated = await db.automation.update({
+      where: { id: automation.id },
+      data,
+    });
+
+    return NextResponse.json(toDTO(updated));
+  } catch (error) {
+    console.error("[PATCH /api/orgs/[githubLogin]/automations/[id]] Error:", error);
+    return NextResponse.json({ error: "Failed to update automation" }, { status: 500 });
+  }
+}
+
+/**
+ * DELETE /api/orgs/[githubLogin]/automations/[automationId]
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ githubLogin: string; automationId: string }> },
+) {
+  const { githubLogin, automationId } = await params;
+  const loaded = await loadOwned(request, githubLogin, automationId);
+  if (loaded instanceof NextResponse) return loaded;
+
+  try {
+    await db.automation.delete({ where: { id: loaded.automation.id } });
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("[DELETE /api/orgs/[githubLogin]/automations/[id]] Error:", error);
+    return NextResponse.json({ error: "Failed to delete automation" }, { status: 500 });
+  }
+}

--- a/src/app/api/orgs/[githubLogin]/automations/inbox/route.ts
+++ b/src/app/api/orgs/[githubLogin]/automations/inbox/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getMiddlewareContext, requireAuth } from "@/lib/middleware/utils";
+import { validateUserBelongsToOrg } from "@/services/workspace";
+import { db } from "@/lib/db";
+
+async function resolveOrg(githubLogin: string) {
+  return db.sourceControlOrg.findUnique({
+    where: { githubLogin },
+    select: { id: true },
+  });
+}
+
+/**
+ * GET /api/orgs/[githubLogin]/automations/inbox
+ *
+ * Returns the conversation id of the most recent UNSEEN automation run for
+ * the calling user (so the canvas can auto-open it), and marks all currently
+ * unseen runs as seen. Reading the inbox IS the "seen" signal — the canvas
+ * fetches this once on load.
+ *
+ * Response: { conversationId: string | null, automationId?, automationName? }
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ githubLogin: string }> },
+) {
+  const context = getMiddlewareContext(request);
+  const userOrResponse = requireAuth(context);
+  if (userOrResponse instanceof NextResponse) return userOrResponse;
+
+  const { githubLogin } = await params;
+
+  const isMember = await validateUserBelongsToOrg(githubLogin, userOrResponse.id);
+  if (!isMember) {
+    return NextResponse.json({ error: "Organization not found" }, { status: 404 });
+  }
+
+  try {
+    const org = await resolveOrg(githubLogin);
+    if (!org) {
+      return NextResponse.json({ error: "Organization not found" }, { status: 404 });
+    }
+
+    const unseen = await db.automation.findMany({
+      where: {
+        sourceControlOrgId: org.id,
+        userId: userOrResponse.id,
+        lastRunSeenAt: null,
+        lastRunConversationId: { not: null },
+      },
+      orderBy: { lastRunAt: "desc" },
+      select: { id: true, name: true, lastRunConversationId: true },
+    });
+
+    if (unseen.length === 0) {
+      return NextResponse.json({ conversationId: null });
+    }
+
+    // Mark every unseen run as seen; only the most recent one is auto-opened.
+    const now = new Date();
+    await db.automation.updateMany({
+      where: { id: { in: unseen.map((a) => a.id) } },
+      data: { lastRunSeenAt: now },
+    });
+
+    const latest = unseen[0];
+    return NextResponse.json({
+      conversationId: latest.lastRunConversationId,
+      automationId: latest.id,
+      automationName: latest.name,
+    });
+  } catch (error) {
+    console.error("[GET /api/orgs/[githubLogin]/automations/inbox] Error:", error);
+    return NextResponse.json({ error: "Failed to load inbox" }, { status: 500 });
+  }
+}

--- a/src/app/api/orgs/[githubLogin]/automations/route.ts
+++ b/src/app/api/orgs/[githubLogin]/automations/route.ts
@@ -1,0 +1,153 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getMiddlewareContext, requireAuth } from "@/lib/middleware/utils";
+import { validateUserBelongsToOrg } from "@/services/workspace";
+import { db } from "@/lib/db";
+import type { Automation } from "@prisma/client";
+import {
+  computeNextRunAt,
+  describeSchedule,
+  isValidTimeOfDay,
+  isValidTimezone,
+} from "@/lib/automations/schedule";
+import type { AutomationDTO } from "@/types/automation";
+
+async function resolveOrg(githubLogin: string) {
+  return db.sourceControlOrg.findUnique({
+    where: { githubLogin },
+    select: { id: true },
+  });
+}
+
+function toDTO(a: Automation): AutomationDTO {
+  return {
+    id: a.id,
+    name: a.name,
+    prompt: a.prompt,
+    timeOfDay: a.timeOfDay,
+    timezone: a.timezone,
+    enabled: a.enabled,
+    schedule: describeSchedule(a.timeOfDay, a.timezone),
+    nextRunAt: a.nextRunAt?.toISOString() ?? null,
+    lastRunAt: a.lastRunAt?.toISOString() ?? null,
+    createdAt: a.createdAt.toISOString(),
+  };
+}
+
+/**
+ * GET /api/orgs/[githubLogin]/automations
+ * List the calling user's automations for this org.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ githubLogin: string }> },
+) {
+  const context = getMiddlewareContext(request);
+  const userOrResponse = requireAuth(context);
+  if (userOrResponse instanceof NextResponse) return userOrResponse;
+
+  const { githubLogin } = await params;
+
+  const isMember = await validateUserBelongsToOrg(githubLogin, userOrResponse.id);
+  if (!isMember) {
+    return NextResponse.json({ error: "Organization not found" }, { status: 404 });
+  }
+
+  try {
+    const org = await resolveOrg(githubLogin);
+    if (!org) {
+      return NextResponse.json({ error: "Organization not found" }, { status: 404 });
+    }
+
+    const automations = await db.automation.findMany({
+      where: { sourceControlOrgId: org.id, userId: userOrResponse.id },
+      orderBy: { createdAt: "desc" },
+    });
+
+    return NextResponse.json({ items: automations.map(toDTO) });
+  } catch (error) {
+    console.error("[GET /api/orgs/[githubLogin]/automations] Error:", error);
+    return NextResponse.json({ error: "Failed to list automations" }, { status: 500 });
+  }
+}
+
+/**
+ * POST /api/orgs/[githubLogin]/automations
+ * Create a recurring automation.
+ * Body: { name, prompt, timeOfDay ("HH:MM"), timezone? (IANA) }
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ githubLogin: string }> },
+) {
+  const context = getMiddlewareContext(request);
+  const userOrResponse = requireAuth(context);
+  if (userOrResponse instanceof NextResponse) return userOrResponse;
+
+  const { githubLogin } = await params;
+
+  const isMember = await validateUserBelongsToOrg(githubLogin, userOrResponse.id);
+  if (!isMember) {
+    return NextResponse.json({ error: "Organization not found" }, { status: 404 });
+  }
+
+  try {
+    const org = await resolveOrg(githubLogin);
+    if (!org) {
+      return NextResponse.json({ error: "Organization not found" }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const name = typeof body.name === "string" ? body.name.trim() : "";
+    const prompt = typeof body.prompt === "string" ? body.prompt.trim() : "";
+    const timeOfDay = typeof body.timeOfDay === "string" ? body.timeOfDay.trim() : "";
+
+    if (!name) {
+      return NextResponse.json({ error: "name is required" }, { status: 400 });
+    }
+    if (!prompt) {
+      return NextResponse.json({ error: "prompt is required" }, { status: 400 });
+    }
+    if (!isValidTimeOfDay(timeOfDay)) {
+      return NextResponse.json(
+        { error: "timeOfDay must be a 24-hour HH:MM string" },
+        { status: 400 },
+      );
+    }
+
+    // Default to the user's saved timezone, falling back to UTC.
+    let timezone =
+      typeof body.timezone === "string" && body.timezone.trim()
+        ? body.timezone.trim()
+        : null;
+    if (!timezone) {
+      const user = await db.user.findUnique({
+        where: { id: userOrResponse.id },
+        select: { timezone: true },
+      });
+      timezone = user?.timezone || "UTC";
+    }
+    if (!isValidTimezone(timezone)) {
+      return NextResponse.json({ error: "Invalid timezone" }, { status: 400 });
+    }
+
+    const nextRunAt = computeNextRunAt(timeOfDay, timezone);
+
+    const created = await db.automation.create({
+      data: {
+        sourceControlOrgId: org.id,
+        userId: userOrResponse.id,
+        name,
+        prompt,
+        timeOfDay,
+        timezone,
+        enabled: true,
+        nextRunAt,
+      },
+    });
+
+    return NextResponse.json(toDTO(created), { status: 201 });
+  } catch (error) {
+    console.error("[POST /api/orgs/[githubLogin]/automations] Error:", error);
+    return NextResponse.json({ error: "Failed to create automation" }, { status: 500 });
+  }
+}

--- a/src/app/org/[githubLogin]/_components/AutomationsSection.tsx
+++ b/src/app/org/[githubLogin]/_components/AutomationsSection.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+/**
+ * Automations manager embedded in the canvas Agent gear popover.
+ *
+ * Lists the user's recurring automations and lets them add a new one with
+ * the `+` button: a name, a time of day (interpreted in the browser's
+ * timezone), and a prompt. Each automation runs as a fresh org-canvas
+ * conversation at the scheduled time (see `src/services/automation-dispatcher.ts`);
+ * the canvas auto-opens the most recent unseen run on load.
+ */
+
+import React, { useCallback, useEffect, useState } from "react";
+import { Plus, Trash2, Clock, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { Switch } from "@/components/ui/switch";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import type { AutomationDTO } from "@/types/automation";
+
+interface AutomationsSectionProps {
+  githubLogin: string;
+}
+
+function browserTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  } catch {
+    return "UTC";
+  }
+}
+
+export function AutomationsSection({ githubLogin }: AutomationsSectionProps) {
+  const [items, setItems] = useState<AutomationDTO[] | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  // New-automation form fields.
+  const [name, setName] = useState("");
+  const [timeOfDay, setTimeOfDay] = useState("09:00");
+  const [prompt, setPrompt] = useState("");
+
+  const base = `/api/orgs/${githubLogin}/automations`;
+
+  const fetchList = useCallback(async () => {
+    try {
+      const res = await fetch(base);
+      if (res.ok) {
+        const data = await res.json();
+        setItems(data.items ?? []);
+      } else {
+        setItems([]);
+      }
+    } catch {
+      setItems([]);
+    }
+  }, [base]);
+
+  useEffect(() => {
+    fetchList();
+  }, [fetchList]);
+
+  const resetForm = () => {
+    setName("");
+    setTimeOfDay("09:00");
+    setPrompt("");
+    setCreating(false);
+  };
+
+  const handleCreate = async () => {
+    if (!name.trim() || !prompt.trim()) {
+      toast.error("Name and prompt are required");
+      return;
+    }
+    setSaving(true);
+    try {
+      const res = await fetch(base, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim(),
+          prompt: prompt.trim(),
+          timeOfDay,
+          timezone: browserTimezone(),
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? "Failed to create");
+      }
+      const created: AutomationDTO = await res.json();
+      setItems((prev) => [created, ...(prev ?? [])]);
+      resetForm();
+    } catch (err) {
+      toast.error("Couldn't create automation", {
+        description: err instanceof Error ? err.message : "Please try again.",
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleToggle = async (a: AutomationDTO, enabled: boolean) => {
+    setItems((prev) =>
+      (prev ?? []).map((x) => (x.id === a.id ? { ...x, enabled } : x)),
+    );
+    try {
+      const res = await fetch(`${base}/${a.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled }),
+      });
+      if (!res.ok) throw new Error("Request failed");
+      const updated: AutomationDTO = await res.json();
+      setItems((prev) =>
+        (prev ?? []).map((x) => (x.id === a.id ? updated : x)),
+      );
+    } catch {
+      setItems((prev) =>
+        (prev ?? []).map((x) =>
+          x.id === a.id ? { ...x, enabled: !enabled } : x,
+        ),
+      );
+      toast.error("Couldn't update automation");
+    }
+  };
+
+  const handleDelete = async (a: AutomationDTO) => {
+    const prev = items;
+    setItems((cur) => (cur ?? []).filter((x) => x.id !== a.id));
+    try {
+      const res = await fetch(`${base}/${a.id}`, { method: "DELETE" });
+      if (!res.ok) throw new Error("Request failed");
+    } catch {
+      setItems(prev ?? []);
+      toast.error("Couldn't delete automation");
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <p className="text-[10px] uppercase tracking-wide text-muted-foreground font-medium">
+          Automations
+        </p>
+        <button
+          type="button"
+          onClick={() => setCreating((c) => !c)}
+          className="flex items-center gap-1 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+          title="Add automation"
+          aria-label="Add automation"
+        >
+          <Plus className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      {/* Existing automations */}
+      {items === null ? (
+        <p className="text-xs text-muted-foreground">Loading…</p>
+      ) : items.length === 0 && !creating ? (
+        <p className="text-xs text-muted-foreground leading-snug">
+          Schedule a prompt to run automatically — e.g. summarize the last 24h
+          every morning. It opens as a new chat when you visit.
+        </p>
+      ) : (
+        <div className="space-y-1.5">
+          {items.map((a) => (
+            <div
+              key={a.id}
+              className={cn(
+                "rounded-md border bg-card px-2.5 py-2 text-sm",
+                !a.enabled && "opacity-60",
+              )}
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0 space-y-0.5">
+                  <p className="truncate text-[13px] font-medium leading-none">
+                    {a.name}
+                  </p>
+                  <p className="flex items-center gap-1 text-[11px] text-muted-foreground">
+                    <Clock className="h-3 w-3" />
+                    {a.schedule}
+                  </p>
+                </div>
+                <div className="flex shrink-0 items-center gap-1.5">
+                  <Switch
+                    checked={a.enabled}
+                    onCheckedChange={(v) => handleToggle(a, v)}
+                    aria-label="Enable automation"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => handleDelete(a)}
+                    className="rounded p-1 text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors"
+                    title="Delete automation"
+                    aria-label="Delete automation"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* New automation form */}
+      {creating && (
+        <div className="space-y-2 rounded-md border bg-muted/30 p-2.5">
+          <Input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Name (e.g. Morning digest)"
+            className="h-8 text-sm"
+          />
+          <div className="flex items-center gap-2">
+            <label className="text-[11px] text-muted-foreground">
+              Run daily at
+            </label>
+            <Input
+              type="time"
+              value={timeOfDay}
+              onChange={(e) => setTimeOfDay(e.target.value)}
+              className="h-8 w-28 text-sm"
+            />
+          </div>
+          <Textarea
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            placeholder="Prompt to run, e.g. Read recent activity, summarize the past 24 hours, and suggest next steps."
+            className="min-h-[72px] text-sm"
+          />
+          <div className="flex items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={resetForm}
+              disabled={saving}
+              className="rounded-md px-2.5 py-1 text-xs text-muted-foreground hover:bg-muted disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleCreate}
+              disabled={saving}
+              className="flex items-center gap-1 rounded-md bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            >
+              {saving && <Loader2 className="h-3 w-3 animate-spin" />}
+              Save
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/org/[githubLogin]/_components/AutomationsSection.tsx
+++ b/src/app/org/[githubLogin]/_components/AutomationsSection.tsx
@@ -11,7 +11,7 @@
  */
 
 import React, { useCallback, useEffect, useState } from "react";
-import { Plus, Trash2, Clock, Loader2 } from "lucide-react";
+import { Plus, Trash2, Clock, Loader2, ChevronRight } from "lucide-react";
 import { toast } from "sonner";
 import { Switch } from "@/components/ui/switch";
 import { Input } from "@/components/ui/input";
@@ -35,6 +35,8 @@ export function AutomationsSection({ githubLogin }: AutomationsSectionProps) {
   const [items, setItems] = useState<AutomationDTO[] | null>(null);
   const [creating, setCreating] = useState(false);
   const [saving, setSaving] = useState(false);
+  // Which automation card is expanded to reveal its prompt (one at a time).
+  const [expandedId, setExpandedId] = useState<string | null>(null);
 
   // New-automation form fields.
   const [name, setName] = useState("");
@@ -63,7 +65,7 @@ export function AutomationsSection({ githubLogin }: AutomationsSectionProps) {
 
   const resetForm = () => {
     setName("");
-    setTimeOfDay("09:00");
+    setTimeOfDay("05:00");
     setPrompt("");
     setCreating(false);
   };
@@ -165,43 +167,71 @@ export function AutomationsSection({ githubLogin }: AutomationsSectionProps) {
         </p>
       ) : (
         <div className="space-y-1.5">
-          {items.map((a) => (
-            <div
-              key={a.id}
-              className={cn(
-                "rounded-md border bg-card px-2.5 py-2 text-sm",
-                !a.enabled && "opacity-60",
-              )}
-            >
-              <div className="flex items-start justify-between gap-2">
-                <div className="min-w-0 space-y-0.5">
-                  <p className="truncate text-[13px] font-medium leading-none">
-                    {a.name}
-                  </p>
-                  <p className="flex items-center gap-1 text-[11px] text-muted-foreground">
-                    <Clock className="h-3 w-3" />
-                    {a.schedule}
-                  </p>
-                </div>
-                <div className="flex shrink-0 items-center gap-1.5">
-                  <Switch
-                    checked={a.enabled}
-                    onCheckedChange={(v) => handleToggle(a, v)}
-                    aria-label="Enable automation"
-                  />
+          {items.map((a) => {
+            const expanded = expandedId === a.id;
+            return (
+              <div
+                key={a.id}
+                className={cn(
+                  "rounded-md border bg-card text-sm",
+                  !a.enabled && "opacity-60",
+                )}
+              >
+                <div className="flex items-start justify-between gap-2 px-2.5 py-2">
                   <button
                     type="button"
-                    onClick={() => handleDelete(a)}
-                    className="rounded p-1 text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors"
-                    title="Delete automation"
-                    aria-label="Delete automation"
+                    onClick={() => setExpandedId(expanded ? null : a.id)}
+                    aria-expanded={expanded}
+                    className="flex min-w-0 flex-1 items-start gap-1.5 text-left"
+                    title={expanded ? "Hide prompt" : "Show prompt"}
                   >
-                    <Trash2 className="h-3.5 w-3.5" />
+                    <ChevronRight
+                      className={cn(
+                        "mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform",
+                        expanded && "rotate-90",
+                      )}
+                    />
+                    <span className="min-w-0 space-y-0.5">
+                      <span className="block truncate text-[13px] font-medium leading-none">
+                        {a.name}
+                      </span>
+                      <span className="flex items-center gap-1 text-[11px] text-muted-foreground">
+                        <Clock className="h-3 w-3" />
+                        {a.schedule}
+                      </span>
+                    </span>
                   </button>
+                  <div className="flex shrink-0 items-center gap-1.5">
+                    <Switch
+                      checked={a.enabled}
+                      onCheckedChange={(v) => handleToggle(a, v)}
+                      aria-label="Enable automation"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(a)}
+                      className="rounded p-1 text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors"
+                      title="Delete automation"
+                      aria-label="Delete automation"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
                 </div>
+
+                {expanded && (
+                  <div className="border-t px-2.5 py-2">
+                    <p className="mb-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+                      Prompt
+                    </p>
+                    <p className="whitespace-pre-wrap text-[12px] leading-snug text-foreground/80">
+                      {a.prompt}
+                    </p>
+                  </div>
+                )}
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
 

--- a/src/app/org/[githubLogin]/_components/CanvasAgentSettingsPopover.tsx
+++ b/src/app/org/[githubLogin]/_components/CanvasAgentSettingsPopover.tsx
@@ -9,6 +9,7 @@ import {
   PopoverContent,
 } from "@/components/ui/popover";
 import { Switch } from "@/components/ui/switch";
+import { AutomationsSection } from "./AutomationsSection";
 
 /**
  * Gear menu on the canvas Agent chat panel. Hosts per-user preferences
@@ -25,7 +26,11 @@ import { Switch } from "@/components/ui/switch";
  * via `/api/user/preferences`. Fetched once on mount; toggled
  * optimistically with a rollback on failure.
  */
-export function CanvasAgentSettingsPopover() {
+export function CanvasAgentSettingsPopover({
+  githubLogin,
+}: {
+  githubLogin: string;
+}) {
   const [open, setOpen] = useState(false);
   const [enabled, setEnabled] = useState<boolean | null>(null);
   const [saving, setSaving] = useState(false);
@@ -79,7 +84,7 @@ export function CanvasAgentSettingsPopover() {
           <Settings className="w-4 h-4" />
         </button>
       </PopoverTrigger>
-      <PopoverContent align="end" className="w-72">
+      <PopoverContent align="end" className="w-80 space-y-3">
         <div className="flex items-start justify-between gap-3">
           <div className="space-y-0.5">
             <p className="text-sm font-medium leading-none">
@@ -96,6 +101,10 @@ export function CanvasAgentSettingsPopover() {
             disabled={enabled === null || saving}
             aria-label="Auto-respond to planners"
           />
+        </div>
+
+        <div className="border-t pt-3">
+          <AutomationsSection githubLogin={githubLogin} />
         </div>
       </PopoverContent>
     </Popover>

--- a/src/app/org/[githubLogin]/_components/SidebarChat.tsx
+++ b/src/app/org/[githubLogin]/_components/SidebarChat.tsx
@@ -46,6 +46,7 @@ import {
   type ToolCall,
 } from "../_state/canvasChatStore";
 import { useSendCanvasChatMessage } from "../_state/useSendCanvasChatMessage";
+import { useAutomationInbox } from "../_state/useAutomationInbox";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { useCanvasAgentActivity } from "@/hooks/useCanvasAgentActivity";
 import { uploadFileToS3 } from "@/lib/upload-image-to-s3";
@@ -76,6 +77,9 @@ interface SidebarChatProps {
 }
 
 export function SidebarChat({ githubLogin }: SidebarChatProps) {
+  // Auto-open the most recent unseen automation run, if any, once on load.
+  useAutomationInbox(githubLogin);
+
   // ─── Selectors — narrow on purpose ─────────────────────────────────
   // Each selector returns a primitive or a stable reference so
   // streaming text-deltas don't trigger re-renders in selectors that
@@ -293,7 +297,7 @@ export function SidebarChat({ githubLogin }: SidebarChatProps) {
           >
             <Share2 className="w-4 h-4" />
           </button>
-          <CanvasAgentSettingsPopover />
+          <CanvasAgentSettingsPopover githubLogin={githubLogin} />
           <CanvasHistoryPopover githubLogin={githubLogin} />
           <button
             type="button"

--- a/src/app/org/[githubLogin]/_state/useAutomationInbox.ts
+++ b/src/app/org/[githubLogin]/_state/useAutomationInbox.ts
@@ -1,0 +1,116 @@
+"use client";
+
+/**
+ * On canvas load, checks whether a recurring automation produced a new
+ * conversation the user hasn't seen yet (`GET .../automations/inbox`). If so,
+ * it loads that conversation into the chat store and makes it active — so the
+ * scheduled run "opens automatically" the next time the user visits the
+ * canvas. Reading the inbox marks those runs seen server-side, so it fires
+ * at most once per unseen run.
+ *
+ * Skipped when the page was opened via a `?chat=<shareId>` deep link, so an
+ * explicit shared-conversation link always wins over an automation pop-in.
+ */
+
+import { useEffect, useRef } from "react";
+import {
+  useCanvasChatStore,
+  type CanvasChatMessage,
+} from "./canvasChatStore";
+
+async function openServerConversation(
+  githubLogin: string,
+  conversationId: string,
+): Promise<void> {
+  const res = await fetch(
+    `/api/orgs/${githubLogin}/chat/conversations/${conversationId}`,
+  );
+  if (!res.ok) return;
+  const conv = await res.json();
+
+  const rawMessages: unknown[] = Array.isArray(conv.messages)
+    ? conv.messages
+    : [];
+  const messages: CanvasChatMessage[] = rawMessages
+    .filter(
+      (m): m is Record<string, unknown> =>
+        !!m &&
+        typeof m === "object" &&
+        ((m as { role?: string }).role === "user" ||
+          (m as { role?: string }).role === "assistant"),
+    )
+    .map((m, idx) => ({
+      id: (m.id as string) || `automation-${idx}`,
+      role: m.role as "user" | "assistant",
+      content: typeof m.content === "string" ? m.content : "",
+      timestamp: m.timestamp ? new Date(m.timestamp as string) : new Date(),
+      toolCalls: m.toolCalls as CanvasChatMessage["toolCalls"],
+      timeline: m.timeline as CanvasChatMessage["timeline"],
+      artifactIds: m.artifactIds as string[] | undefined,
+      attachments: m.attachments as CanvasChatMessage["attachments"],
+      approval: m.approval as CanvasChatMessage["approval"],
+      rejection: m.rejection as CanvasChatMessage["rejection"],
+      approvalResult: m.approvalResult as CanvasChatMessage["approvalResult"],
+      deferredCheck: m.deferredCheck as CanvasChatMessage["deferredCheck"],
+      source: m.source as CanvasChatMessage["source"],
+    }));
+
+  const store = useCanvasChatStore.getState();
+  const activeId = store.activeConversationId;
+  const context = activeId
+    ? store.conversations[activeId]?.context
+    : undefined;
+
+  const resolvedContext: Parameters<typeof store.startConversation>[0] =
+    context ?? {
+      orgId: "",
+      githubLogin,
+      workspaceSlug: null,
+      workspaceSlugs: conv.settings?.extraWorkspaceSlugs ?? [],
+      currentCanvasRef: "",
+      currentCanvasBreadcrumb: "",
+      selectedNodeId: null,
+      selectedNodeIds: [],
+    };
+
+  const newId = store.startConversation(
+    resolvedContext,
+    messages,
+    undefined,
+    messages.length, // already-persisted — don't re-save
+  );
+  store.setServerConversationId(newId, conversationId);
+}
+
+export function useAutomationInbox(githubLogin: string): void {
+  const ranRef = useRef(false);
+
+  useEffect(() => {
+    if (!githubLogin || ranRef.current) return;
+    // A shared-conversation deep link takes precedence over auto-open.
+    if (
+      typeof window !== "undefined" &&
+      new URLSearchParams(window.location.search).has("chat")
+    ) {
+      return;
+    }
+    ranRef.current = true;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`/api/orgs/${githubLogin}/automations/inbox`);
+        if (!res.ok) return;
+        const data = await res.json();
+        if (cancelled || !data?.conversationId) return;
+        await openServerConversation(githubLogin, data.conversationId);
+      } catch {
+        /* best-effort; auto-open is non-critical */
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [githubLogin]);
+}

--- a/src/app/org/[githubLogin]/_state/useCanvasChatAutoSave.ts
+++ b/src/app/org/[githubLogin]/_state/useCanvasChatAutoSave.ts
@@ -75,6 +75,7 @@ function hydrateServerMessages(raw: unknown[]): CanvasChatMessage[] {
       approval: m.approval as CanvasChatMessage["approval"],
       rejection: m.rejection as CanvasChatMessage["rejection"],
       approvalResult: m.approvalResult as CanvasChatMessage["approvalResult"],
+      deferredCheck: m.deferredCheck as CanvasChatMessage["deferredCheck"],
       source: m.source as CanvasChatMessage["source"],
     }));
 }

--- a/src/app/org/[githubLogin]/_state/useSendCanvasChatMessage.ts
+++ b/src/app/org/[githubLogin]/_state/useSendCanvasChatMessage.ts
@@ -42,6 +42,36 @@ import {
   type ToolCall,
 } from "./canvasChatStore";
 
+/**
+ * Scan a rebuilt assistant-side timeline for a completed `schedule_check`
+ * tool call and return its parsed `deferredCheck` metadata, or `null`.
+ * Mirrors `extractDeferredCheckFromStep` in `canvas-turn-persistence.ts`.
+ */
+function extractDeferredCheck(
+  messages: CanvasChatMessage[],
+): CanvasChatMessage["deferredCheck"] | null {
+  for (const m of messages) {
+    const tc = m.toolCalls?.find(
+      (c) => c.toolName === "schedule_check" && c.output != null,
+    );
+    if (!tc) continue;
+    const out = tc.output as Record<string, unknown>;
+    if (
+      typeof out.deferredActionId === "string" &&
+      typeof out.fireAt === "string" &&
+      typeof out.description === "string"
+    ) {
+      return {
+        id: out.deferredActionId,
+        description: out.description,
+        fireAt: out.fireAt,
+        status: "PENDING",
+      };
+    }
+  }
+  return null;
+}
+
 interface SendArgs {
   conversationId: string;
   content: string;
@@ -340,6 +370,40 @@ export function useSendCanvasChatMessage() {
               if (m.role === "assistant" && !m.toolCalls?.length) {
                 timelineMessages[i] = { ...m, approvalResult };
                 break;
+              }
+            }
+          }
+
+          // Stamp deferred-check metadata onto the assistant message when a
+          // `schedule_check` tool call completed in this turn, so the
+          // `DeferredCheckCard` renders live. This mirrors the server-side
+          // `messagesFromSteps` extraction (anchoring to the text row when
+          // present, else the tool-call row); without it the card only
+          // surfaces after a reload / Pusher sync.
+          const deferredCheck = extractDeferredCheck(timelineMessages);
+          if (deferredCheck) {
+            const textIdx = (() => {
+              for (let i = timelineMessages.length - 1; i >= 0; i--) {
+                const m = timelineMessages[i];
+                if (m.role === "assistant" && !m.toolCalls?.length) return i;
+              }
+              return -1;
+            })();
+            if (textIdx >= 0) {
+              timelineMessages[textIdx] = {
+                ...timelineMessages[textIdx],
+                deferredCheck,
+              };
+            } else {
+              for (let i = timelineMessages.length - 1; i >= 0; i--) {
+                const m = timelineMessages[i];
+                if (
+                  m.role === "assistant" &&
+                  m.toolCalls?.some((c) => c.toolName === "schedule_check")
+                ) {
+                  timelineMessages[i] = { ...m, deferredCheck };
+                  break;
+                }
               }
             }
           }

--- a/src/lib/ai/askTools.ts
+++ b/src/lib/ai/askTools.ts
@@ -480,8 +480,8 @@ function buildWorkspaceTools(
     }),
     logs_agent: tool({
       description:
-        "Invoke the Logs Agent to perform deep, run-grounded analysis of agent execution logs for this workspace. " +
-        "Use this when the user asks about what happened during a run, on a swarm, debugging agent failures, or wants a synthesised explanation backed by real log data. " +
+        "Invoke the Logs Agent to perform deep, run-grounded analysis of infra, sandbox, and agent execution logs for this workspace. " +
+        "Use this when the user asks about what happened during a run, on a swarm, on a pod/sandbox, debugging agent failures, or wants a synthesised explanation backed by real log data. " +
         "Heavier than `search_logs` (which does a quick Lucene keyword search) — prefer `search_logs` for simple keyword lookups. " +
         "Optionally narrow the analysis to a specific feature or task by supplying featureId/taskId.",
       inputSchema: z.object({

--- a/src/lib/ai/askToolsMulti.ts
+++ b/src/lib/ai/askToolsMulti.ts
@@ -435,8 +435,8 @@ export function askToolsMulti(
     // search); prefer search_logs for simple lookups.
     allTools[`${prefix}__logs_agent`] = tool({
       description:
-        `[${ws.slug}] Invoke the Logs Agent for deep, run-grounded analysis of agent execution logs in ${ws.slug}. ` +
-        `Use when the user asks what happened during a run, on a swarm, to debug agent failures, or wants a synthesised explanation backed by real log data. ` +
+        `[${ws.slug}] Invoke the Logs Agent for deep, run-grounded analysis of infra, sandbox, and agent execution logs in ${ws.slug}. ` +
+        `Use when the user asks what happened during a run, on a swarm, on a pod/sandbox, to debug agent failures, or wants a synthesised explanation backed by real log data. ` +
         `Heavier than ${prefix}__search_logs — prefer that for simple keyword lookups. ` +
         `Optionally narrow to a specific feature or task via featureId/taskId.`,
       inputSchema: z.object({

--- a/src/lib/automations/schedule.ts
+++ b/src/lib/automations/schedule.ts
@@ -1,0 +1,141 @@
+/**
+ * Timezone-aware scheduling helpers for recurring Automations.
+ *
+ * An automation stores a wall-clock `timeOfDay` ("HH:MM") plus an IANA
+ * `timezone`. The cron needs the next UTC instant at which that local
+ * wall-clock time occurs. We compute it with `Intl.DateTimeFormat` (no
+ * external tz library is installed) so it stays DST-correct.
+ */
+
+/** Matches a 24-hour "HH:MM" wall-clock time. */
+const TIME_OF_DAY_RE = /^([01]\d|2[0-3]):([0-5]\d)$/;
+
+export function isValidTimeOfDay(value: string): boolean {
+  return TIME_OF_DAY_RE.test(value);
+}
+
+/** Validate an IANA timezone by asking `Intl` to format with it. */
+export function isValidTimezone(tz: string): boolean {
+  if (!tz) return false;
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Offset of a timezone from UTC, in milliseconds, at a given instant.
+ * Positive east of UTC. DST-aware because it asks `Intl` what the local
+ * wall-clock reads at that exact instant.
+ */
+function tzOffsetMs(utcMs: number, timezone: string): number {
+  const dtf = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    hourCycle: "h23",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+  const parts = dtf.formatToParts(new Date(utcMs));
+  const get = (type: string) =>
+    Number(parts.find((p) => p.type === type)?.value);
+  const asIfUtc = Date.UTC(
+    get("year"),
+    get("month") - 1,
+    get("day"),
+    get("hour"),
+    get("minute"),
+    get("second"),
+  );
+  return asIfUtc - utcMs;
+}
+
+/**
+ * The UTC `Date` corresponding to a wall-clock `Y-M-D HH:MM:00` in
+ * `timezone`. Resolves the offset twice to settle DST boundary jumps.
+ */
+function zonedWallTimeToUtc(
+  year: number,
+  month: number, // 1-12
+  day: number,
+  hour: number,
+  minute: number,
+  timezone: string,
+): Date {
+  const wallAsUtc = Date.UTC(year, month - 1, day, hour, minute, 0);
+  let utc = wallAsUtc - tzOffsetMs(wallAsUtc, timezone);
+  // Re-resolve against the candidate instant to correct DST transitions.
+  utc = wallAsUtc - tzOffsetMs(utc, timezone);
+  return new Date(utc);
+}
+
+/** Extract the calendar Y/M/D shown in `timezone` for a given instant. */
+function zonedYmd(
+  date: Date,
+  timezone: string,
+): { year: number; month: number; day: number } {
+  const dtf = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  const parts = dtf.formatToParts(date);
+  const get = (type: string) =>
+    Number(parts.find((p) => p.type === type)?.value);
+  return { year: get("year"), month: get("month"), day: get("day") };
+}
+
+/**
+ * Compute the next UTC instant at which `timeOfDay` ("HH:MM") occurs in
+ * `timezone`, strictly after `from`. If today's occurrence is still in the
+ * future it's used; otherwise the next day's.
+ */
+export function computeNextRunAt(
+  timeOfDay: string,
+  timezone: string,
+  from: Date = new Date(),
+): Date {
+  const m = TIME_OF_DAY_RE.exec(timeOfDay);
+  if (!m) {
+    throw new Error(`Invalid timeOfDay: ${timeOfDay}`);
+  }
+  const hour = Number(m[1]);
+  const minute = Number(m[2]);
+
+  const { year, month, day } = zonedYmd(from, timezone);
+  const todayRun = zonedWallTimeToUtc(year, month, day, hour, minute, timezone);
+  if (todayRun.getTime() > from.getTime()) {
+    return todayRun;
+  }
+  // Advance one calendar day in the target zone (handles month/year rollover
+  // because we re-derive the wall time through Date.UTC).
+  const tomorrow = zonedWallTimeToUtc(
+    year,
+    month,
+    day + 1,
+    hour,
+    minute,
+    timezone,
+  );
+  return tomorrow;
+}
+
+/**
+ * Human label for a schedule, e.g. "Daily at 4:00 AM". Rendered in the UI.
+ */
+export function describeSchedule(timeOfDay: string, timezone?: string): string {
+  const m = TIME_OF_DAY_RE.exec(timeOfDay);
+  if (!m) return timeOfDay;
+  let hour = Number(m[1]);
+  const minute = m[2];
+  const period = hour >= 12 ? "PM" : "AM";
+  hour = hour % 12 || 12;
+  const tzSuffix = timezone ? ` ${timezone}` : "";
+  return `Daily at ${hour}:${minute} ${period}${tzSuffix}`;
+}

--- a/src/lib/helpers/swarm-access.ts
+++ b/src/lib/helpers/swarm-access.ts
@@ -10,6 +10,7 @@ export interface WorkspaceSwarmAccess {
   swarmUrl: string;
   swarmApiKey: string; // Decrypted
   swarmStatus: string;
+  poolName: string;
 }
 
 /**
@@ -84,10 +85,12 @@ export async function getWorkspaceSwarmAccess(
   const swarm = await db.swarm.findUnique({
     where: { workspaceId: workspaceExists.id },
     select: {
+      id: true,
       name: true,
       status: true,
       swarmUrl: true,
       swarmApiKey: true,
+      poolName: true,
     },
   });
 
@@ -141,6 +144,7 @@ export async function getWorkspaceSwarmAccess(
       swarmUrl: swarm.swarmUrl,
       swarmApiKey: decryptedApiKey,
       swarmStatus: swarm.status,
+      poolName: swarm.poolName || swarm.id,
     },
   };
 }
@@ -158,10 +162,12 @@ export async function getSwarmAccessByWorkspaceId(
   const swarm = await db.swarm.findUnique({
     where: { workspaceId },
     select: {
+      id: true,
       name: true,
       status: true,
       swarmUrl: true,
       swarmApiKey: true,
+      poolName: true,
     },
   });
 
@@ -208,6 +214,7 @@ export async function getSwarmAccessByWorkspaceId(
       swarmUrl: baseSwarmUrl,
       swarmApiKey: decryptedApiKey,
       swarmStatus: swarm.status,
+      poolName: swarm.poolName || swarm.id,
     },
   };
 }

--- a/src/lib/pusher.ts
+++ b/src/lib/pusher.ts
@@ -130,7 +130,10 @@ export type CanvasConversationUpdateReason =
   | "deferred-check-cancelled"
   // A deferred check was fired by the cron dispatcher and the result
   // has been appended to the conversation.
-  | "deferred-check-fired";
+  | "deferred-check-fired"
+  // A recurring automation fired: the cron created a fresh org-canvas
+  // conversation and appended the agent's response to it.
+  | "automation";
 
 /**
  * Fire-and-forget broadcast that a canvas conversation's `messages` JSON

--- a/src/services/automation-dispatcher.ts
+++ b/src/services/automation-dispatcher.ts
@@ -57,22 +57,59 @@ async function resolveOrgWorkspaceSlugs(
 export async function dispatchDueAutomations(): Promise<AutomationDispatchResult> {
   const result: AutomationDispatchResult = { fired: 0, failed: 0, errors: [] };
 
-  console.log(`${LOG_PREFIX} Starting dispatch run`);
+  const sweepNow = new Date();
+  console.log(
+    `${LOG_PREFIX} Starting dispatch run at ${sweepNow.toISOString()}`,
+  );
 
   const due = await db.automation.findMany({
-    where: { enabled: true, nextRunAt: { lte: new Date() } },
+    where: { enabled: true, nextRunAt: { lte: sweepNow } },
     orderBy: { nextRunAt: "asc" },
     take: MAX_PER_RUN,
   });
 
   if (due.length === 0) {
+    // Surface upcoming automations so it's obvious WHY nothing fired (e.g.
+    // the scheduled time is still in the future, or everything is disabled).
+    const upcoming = await db.automation.findMany({
+      orderBy: { nextRunAt: "asc" },
+      take: 5,
+      select: {
+        id: true,
+        name: true,
+        enabled: true,
+        nextRunAt: true,
+        timeOfDay: true,
+        timezone: true,
+      },
+    });
+    if (upcoming.length === 0) {
+      console.log(`${LOG_PREFIX} No automations exist yet — nothing to do`);
+    } else {
+      console.log(
+        `${LOG_PREFIX} 0 due. Next ${upcoming.length} automation(s):`,
+      );
+      for (const u of upcoming) {
+        const mins = Math.round(
+          (new Date(u.nextRunAt).getTime() - sweepNow.getTime()) / 60000,
+        );
+        console.log(
+          `${LOG_PREFIX}   • "${u.name}" (${u.id}) enabled=${u.enabled} ` +
+            `at ${u.timeOfDay} ${u.timezone} → nextRunAt=${new Date(
+              u.nextRunAt,
+            ).toISOString()} (in ${mins} min)`,
+        );
+      }
+    }
     console.log(`${LOG_PREFIX} Dispatch complete — fired: 0, failed: 0`);
     return result;
   }
 
+  console.log(`${LOG_PREFIX} Found ${due.length} due automation(s)`);
+
   for (const automation of due) {
     console.log(
-      `${LOG_PREFIX} Dispatching automationId=${automation.id} org=${automation.sourceControlOrgId}`,
+      `${LOG_PREFIX} Dispatching automationId=${automation.id} name="${automation.name}" org=${automation.sourceControlOrgId} nextRunAt=${new Date(automation.nextRunAt).toISOString()}`,
     );
 
     try {
@@ -115,6 +152,9 @@ export async function dispatchDueAutomations(): Promise<AutomationDispatchResult
         );
         continue;
       }
+      console.log(
+        `${LOG_PREFIX} automationId=${automation.id} claimed; re-armed nextRunAt=${nextRunAt.toISOString()}`,
+      );
 
       // ── Resolve workspace scope ──────────────────────────────────────
       const workspaceSlugs = await resolveOrgWorkspaceSlugs(
@@ -125,6 +165,9 @@ export async function dispatchDueAutomations(): Promise<AutomationDispatchResult
           `No workspaces found for org ${automation.sourceControlOrgId}`,
         );
       }
+      console.log(
+        `${LOG_PREFIX} automationId=${automation.id} workspaceSlugs=[${workspaceSlugs.join(", ")}]`,
+      );
 
       // ── Create the fresh org-canvas conversation ─────────────────────
       const idPrefix = `automation-${automation.id}-${Date.now().toString(36)}-`;
@@ -154,6 +197,9 @@ export async function dispatchDueAutomations(): Promise<AutomationDispatchResult
         },
         select: { id: true },
       });
+      console.log(
+        `${LOG_PREFIX} automationId=${automation.id} created conversationId=${conversation.id}; running agent…`,
+      );
 
       // ── Run the agent ────────────────────────────────────────────────
       const messages: ModelMessage[] = [
@@ -172,6 +218,9 @@ export async function dispatchDueAutomations(): Promise<AutomationDispatchResult
 
       await agentResult.text;
       const steps = await agentResult.steps;
+      console.log(
+        `${LOG_PREFIX} automationId=${automation.id} agent finished — ${steps.length} step(s)`,
+      );
 
       const assistantPrefix = `${idPrefix}a`;
       const rows = messagesFromSteps(
@@ -194,6 +243,9 @@ export async function dispatchDueAutomations(): Promise<AutomationDispatchResult
         idPrefix: assistantPrefix,
         reason: "automation",
       });
+      console.log(
+        `${LOG_PREFIX} automationId=${automation.id} appended ${rows.length} message row(s) to conversationId=${conversation.id}`,
+      );
 
       // ── Mark the run available for auto-open ─────────────────────────
       await db.automation.update({

--- a/src/services/automation-dispatcher.ts
+++ b/src/services/automation-dispatcher.ts
@@ -1,0 +1,222 @@
+/**
+ * Dispatcher for due `Automation` records (recurring scheduled prompts).
+ *
+ * Called by the per-minute cron at `/api/cron/automations`. For each enabled
+ * automation whose `nextRunAt` has passed, the dispatcher:
+ *   1. Claims it via SELECT FOR UPDATE SKIP LOCKED and immediately advances
+ *      `nextRunAt` to the next occurrence (concurrent- + retry-safe; a daily
+ *      automation never double-fires within the same minute window).
+ *   2. Resolves the org's workspace slugs (org-canvas spans all workspaces).
+ *   3. Creates a brand-new org-canvas `SharedConversation` seeded with the
+ *      automation's prompt as the first user message.
+ *   4. Runs `runCanvasAgent` and appends the assistant turn.
+ *   5. Records the new conversation on `lastRunConversationId` with
+ *      `lastRunSeenAt = null` so the canvas page can auto-open it.
+ *
+ * Per-automation errors are caught and logged; remaining automations still
+ * run. Because `nextRunAt` is advanced at claim time, a failed run is simply
+ * skipped until the next day rather than hot-looping every minute.
+ */
+
+import { db } from "@/lib/db";
+import { type ModelMessage } from "ai";
+import { runCanvasAgent, type CachedConcepts } from "@/lib/ai/runCanvasAgent";
+import {
+  messagesFromSteps,
+  appendTurnMessages,
+  type StoredMessage,
+} from "@/services/canvas-turn-persistence";
+import { generateTitle } from "@/lib/ai/conversationHelpers";
+import { computeNextRunAt } from "@/lib/automations/schedule";
+
+const LOG_PREFIX = "[Automations]";
+const MAX_PER_RUN = 10;
+const MAX_WORKSPACE_SLUGS = 20;
+
+export interface AutomationDispatchResult {
+  fired: number;
+  failed: number;
+  errors: string[];
+}
+
+/**
+ * All non-deleted workspace slugs under an org, capped at MAX_WORKSPACE_SLUGS.
+ */
+async function resolveOrgWorkspaceSlugs(
+  sourceControlOrgId: string,
+): Promise<string[]> {
+  const workspaces = await db.workspace.findMany({
+    where: { sourceControlOrgId, deletedAt: null },
+    select: { slug: true },
+    orderBy: { createdAt: "asc" },
+    take: MAX_WORKSPACE_SLUGS,
+  });
+  return workspaces.map((w) => w.slug);
+}
+
+export async function dispatchDueAutomations(): Promise<AutomationDispatchResult> {
+  const result: AutomationDispatchResult = { fired: 0, failed: 0, errors: [] };
+
+  console.log(`${LOG_PREFIX} Starting dispatch run`);
+
+  const due = await db.automation.findMany({
+    where: { enabled: true, nextRunAt: { lte: new Date() } },
+    orderBy: { nextRunAt: "asc" },
+    take: MAX_PER_RUN,
+  });
+
+  if (due.length === 0) {
+    console.log(`${LOG_PREFIX} Dispatch complete — fired: 0, failed: 0`);
+    return result;
+  }
+
+  for (const automation of due) {
+    console.log(
+      `${LOG_PREFIX} Dispatching automationId=${automation.id} org=${automation.sourceControlOrgId}`,
+    );
+
+    try {
+      // ── Claim + advance the schedule atomically ──────────────────────
+      // Lock the row, re-check it's still due (another worker may have taken
+      // it), then push `nextRunAt` to the next occurrence so it can't refire.
+      const now = new Date();
+      const nextRunAt = computeNextRunAt(
+        automation.timeOfDay,
+        automation.timezone,
+        now,
+      );
+
+      let claimed = false;
+      await db.$transaction(async (tx) => {
+        const locked = await tx.$queryRaw<
+          { id: string; enabled: boolean; next_run_at: Date }[]
+        >`
+          SELECT id, enabled, next_run_at FROM automations
+          WHERE id = ${automation.id}
+          FOR UPDATE SKIP LOCKED
+        `;
+        if (
+          locked.length === 0 ||
+          !locked[0].enabled ||
+          new Date(locked[0].next_run_at).getTime() > now.getTime()
+        ) {
+          return;
+        }
+        await tx.automation.update({
+          where: { id: automation.id },
+          data: { nextRunAt, lastRunAt: now },
+        });
+        claimed = true;
+      });
+
+      if (!claimed) {
+        console.log(
+          `${LOG_PREFIX} automationId=${automation.id} already claimed/not-due — skipping`,
+        );
+        continue;
+      }
+
+      // ── Resolve workspace scope ──────────────────────────────────────
+      const workspaceSlugs = await resolveOrgWorkspaceSlugs(
+        automation.sourceControlOrgId,
+      );
+      if (workspaceSlugs.length === 0) {
+        throw new Error(
+          `No workspaces found for org ${automation.sourceControlOrgId}`,
+        );
+      }
+
+      // ── Create the fresh org-canvas conversation ─────────────────────
+      const idPrefix = `automation-${automation.id}-${Date.now().toString(36)}-`;
+      const userRow: StoredMessage = {
+        id: `${idPrefix}u`,
+        role: "user",
+        content: automation.prompt,
+        timestamp: now.toISOString(),
+      };
+
+      const conversation = await db.sharedConversation.create({
+        data: {
+          sourceControlOrgId: automation.sourceControlOrgId,
+          userId: automation.userId,
+          workspaceId: null,
+          messages: [userRow] as unknown as never,
+          title: automation.name || generateTitle([userRow]),
+          lastMessageAt: now,
+          source: "org-canvas",
+          settings: {
+            extraWorkspaceSlugs: workspaceSlugs,
+            automationId: automation.id,
+            automationName: automation.name,
+          } as unknown as never,
+          followUpQuestions: [],
+          isShared: false,
+        },
+        select: { id: true },
+      });
+
+      // ── Run the agent ────────────────────────────────────────────────
+      const messages: ModelMessage[] = [
+        { role: "user", content: automation.prompt },
+      ];
+
+      const { result: agentResult } = await runCanvasAgent({
+        userId: automation.userId,
+        orgId: automation.sourceControlOrgId,
+        workspaceSlugs,
+        messages,
+        cachedConcepts: null as CachedConcepts | null,
+        silentPusher: true,
+        currentCanvasConversationId: conversation.id,
+      });
+
+      await agentResult.text;
+      const steps = await agentResult.steps;
+
+      const assistantPrefix = `${idPrefix}a`;
+      const rows = messagesFromSteps(
+        steps as Parameters<typeof messagesFromSteps>[0],
+        assistantPrefix,
+      );
+
+      if (rows.length === 0) {
+        rows.push({
+          id: `${assistantPrefix}0`,
+          role: "assistant",
+          content: "(No response generated.)",
+          timestamp: new Date().toISOString(),
+        });
+      }
+
+      await appendTurnMessages({
+        conversationId: conversation.id,
+        rows,
+        idPrefix: assistantPrefix,
+        reason: "automation",
+      });
+
+      // ── Mark the run available for auto-open ─────────────────────────
+      await db.automation.update({
+        where: { id: automation.id },
+        data: { lastRunConversationId: conversation.id, lastRunSeenAt: null },
+      });
+
+      console.log(
+        `${LOG_PREFIX} Fired automationId=${automation.id} conversationId=${conversation.id}`,
+      );
+      result.fired++;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(
+        `${LOG_PREFIX} FAILED automationId=${automation.id} error=${message}`,
+      );
+      result.errors.push(`${automation.id}: ${message}`);
+      result.failed++;
+    }
+  }
+
+  console.log(
+    `${LOG_PREFIX} Dispatch complete — fired: ${result.fired}, failed: ${result.failed}`,
+  );
+  return result;
+}

--- a/src/services/logs-agent.ts
+++ b/src/services/logs-agent.ts
@@ -79,9 +79,10 @@ export async function runLogsAgent(
   let swarmUrl: string;
   let swarmApiKey: string;
   let swarmName: string;
+  let poolName: string;
 
   if (accessResult.success) {
-    ({ swarmUrl, swarmApiKey, swarmName } = accessResult.data);
+    ({ swarmUrl, swarmApiKey, swarmName, poolName } = accessResult.data);
   } else if (accessResult.error.type === "SWARM_API_KEY_MISSING") {
     const ws = await db.workspace.findFirst({
       where: { slug, deleted: false },
@@ -94,7 +95,7 @@ export async function runLogsAgent(
     if (!fallback.success) {
       return { success: false, error: { type: "SWARM_NOT_ACTIVE" } };
     }
-    ({ swarmUrl, swarmApiKey, swarmName } = fallback.data);
+    ({ swarmUrl, swarmApiKey, swarmName, poolName } = fallback.data);
   } else {
     const { error } = accessResult;
     type KnownType =
@@ -255,6 +256,7 @@ export async function runLogsAgent(
   const agentBody: Record<string, unknown> = {
     prompt: prompt.trim(),
     swarmName,
+    poolName,
     sessionId: sessionId || undefined,
     sessionConfig: {
       truncateToolResults: false,

--- a/src/types/automation.ts
+++ b/src/types/automation.ts
@@ -1,0 +1,30 @@
+/** Serialized Automation as returned by the org automations API. */
+export interface AutomationDTO {
+  id: string;
+  name: string;
+  prompt: string;
+  /** 24-hour "HH:MM" wall-clock time, interpreted in `timezone`. */
+  timeOfDay: string;
+  timezone: string;
+  enabled: boolean;
+  /** Human label, e.g. "Daily at 4:00 AM". */
+  schedule: string;
+  nextRunAt: string | null;
+  lastRunAt: string | null;
+  createdAt: string;
+}
+
+export interface CreateAutomationRequest {
+  name: string;
+  prompt: string;
+  timeOfDay: string;
+  timezone?: string;
+}
+
+export interface UpdateAutomationRequest {
+  name?: string;
+  prompt?: string;
+  timeOfDay?: string;
+  timezone?: string;
+  enabled?: boolean;
+}

--- a/vercel.json
+++ b/vercel.json
@@ -45,6 +45,10 @@
     {
       "path": "/api/cron/deferred-chat-actions",
       "schedule": "* * * * *"
+    },
+    {
+      "path": "/api/cron/automations",
+      "schedule": "* * * * *"
     }
   ]
 }


### PR DESCRIPTION
## 1. Fix DeferredCheckCard not rendering

The deferred-check (`schedule_check`) feature was fully wired on the backend, but the card never appeared in the UI:
- `hydrateServerMessages` dropped the `deferredCheck` field on load/Pusher sync (so even the PENDING→FIRED flip never showed).
- Nothing parsed the streamed `schedule_check` tool result into the live message during the creating turn.

Fixed both: map `deferredCheck` through hydration, and stamp it onto the assistant message live from the streamed tool result (mirrors server-side `messagesFromSteps` anchoring).

## 2. Recurring Automations for the org canvas chat

Schedule a prompt to run daily as a **fresh org-canvas conversation**, which **auto-opens** the next time you visit the canvas. Managed from the chat gear popover ("AUTOMATIONS +").

- **`Automation` Prisma model** (name, prompt, timeOfDay, timezone, enabled, nextRunAt, last-run tracking) + migration.
- **`computeNextRunAt`** schedule helper — DST-aware next-occurrence math via `Intl` (no tz lib needed).
- **`automation-dispatcher`** service + per-minute **`/api/cron/automations`** route (gated by `CRON_SECRET` + `AUTOMATIONS_ENABLED`). Claims due rows with `SELECT … FOR UPDATE SKIP LOCKED`, advances `nextRunAt` at claim time (no double-fire / hot-loop), creates a fresh org-canvas `SharedConversation`, runs the canvas agent, and records the run for auto-open.
- **CRUD API**: `GET/POST /api/orgs/[githubLogin]/automations`, `PATCH/DELETE …/[automationId]`, and `GET …/automations/inbox` (returns + marks-seen the most recent unseen run; 404-on-miss IDOR safety).
- **UI**: `AutomationsSection` in the gear popover (list, enable toggle, delete, inline create form with time + prompt); `useAutomationInbox` hook auto-opens the unseen run on canvas load (skips when a `?chat=` deep link is present).
- Added `"automation"` to the Pusher canvas-conversation reason union.

### Deploy notes
- Apply the new migration (`prisma migrate deploy`).
- Set `AUTOMATIONS_ENABLED=true` (and `DEFERRED_CHAT_ACTIONS_ENABLED=true`) in the environment.

### Testing
- Typecheck clean on all touched files (remaining errors are pre-existing `system-canvas`/`wouter` issues).
- Lint clean.
- 11 new schedule-helper tests (incl. DST + month rollover); existing deferred-check, canvas-turn-persistence, and SidebarChat suites all green.