### PR TITLE
Redesign workflow inspector page

### DIFF
--- a/src/__tests__/unit/components/workflow/WorkflowRunsTable.test.tsx
+++ b/src/__tests__/unit/components/workflow/WorkflowRunsTable.test.tsx
@@ -184,12 +184,12 @@ describe("WorkflowRunsTable", () => {
     expect(screen.getByText("No runs recorded yet.")).toBeInTheDocument();
   });
 
-  it("renders status badge text matching run status", () => {
+  it("renders status label text matching run status", () => {
     setupRuns(MOCK_RUNS);
     renderTable();
 
-    expect(screen.getByText("finished")).toBeInTheDocument();
-    expect(screen.getByText("error")).toBeInTheDocument();
+    expect(screen.getByText("Finished")).toBeInTheDocument();
+    expect(screen.getByText("Error")).toBeInTheDocument();
   });
 
   it("shows duration as Xm Ys for runs with both start and finish times", () => {
@@ -207,42 +207,40 @@ describe("WorkflowRunsTable", () => {
     expect(dashes.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("finished status badge does not have destructive variant class", () => {
+  it("finished status label uses the success (emerald) color, not the error color", () => {
     setupRuns([MOCK_RUNS[0]]);
     renderTable();
-    const badge = screen.getByText("finished");
-    expect(badge.className).not.toMatch(/bg-destructive/);
-    expect(badge.className).toMatch(/bg-primary/);
+    const label = screen.getByText("Finished");
+    expect(label.className).toContain("text-emerald-600");
+    expect(label.className).not.toContain("text-rose-600");
   });
 
-  it("error status badge has destructive variant class", () => {
+  it("error status label uses the error (rose) color", () => {
     setupRuns([MOCK_RUNS[1]]);
     renderTable();
-    const badge = screen.getByText("error");
-    expect(badge.className).toMatch(/destructive/);
+    const label = screen.getByText("Error");
+    expect(label.className).toContain("text-rose-600");
   });
 
-  describe("Run name truncation and tooltip", () => {
-    it("truncates names longer than 40 chars and shows tooltip with full name", () => {
+  describe("Run name + tooltip", () => {
+    it("renders the full run name (CSS-truncated) and a tooltip carrying the full name", () => {
       setupRuns([LONG_NAME_RUN]);
       renderTable();
 
-      const truncated = LONG_NAME.slice(0, 40) + "…";
-      const nameCell = screen.getByText(truncated);
-      expect(nameCell).toBeInTheDocument();
+      // The name is present in full in the DOM; visual truncation is CSS-only.
+      const truncatedEl = screen
+        .getAllByText(LONG_NAME)
+        .find((el) => el.className.includes("truncate"));
+      expect(truncatedEl).toBeTruthy();
 
       const tooltip = screen.getByTestId("tooltip-content");
       expect(tooltip).toHaveTextContent(LONG_NAME);
     });
 
-    it("does not render a tooltip for names 40 chars or shorter", () => {
-      setupRuns([MOCK_RUNS[0]]); // "Run #1001" — well under 40 chars
+    it("renders the run name for short names too", () => {
+      setupRuns([MOCK_RUNS[0]]); // "Run #1001"
       renderTable();
-
-      const nameCell = screen.getByText("Run #1001");
-      expect(nameCell).toBeInTheDocument();
-
-      expect(screen.queryByTestId("tooltip-content")).not.toBeInTheDocument();
+      expect(screen.getAllByText("Run #1001").length).toBeGreaterThanOrEqual(1);
     });
   });
 
@@ -251,7 +249,7 @@ describe("WorkflowRunsTable", () => {
       setupRuns(MOCK_RUNS);
       const onRunSelect = vi.fn();
       renderTable({ onRunSelect });
-      const rows = screen.getAllByRole("row").slice(1); // skip header
+      const rows = screen.getAllByTestId("run-row");
       fireEvent.click(rows[0]);
       expect(onRunSelect).toHaveBeenCalledWith(MOCK_RUNS[0].id);
     });
@@ -259,11 +257,10 @@ describe("WorkflowRunsTable", () => {
     it("applies bg-muted class only to the selected row", () => {
       setupRuns(MOCK_RUNS);
       renderTable({ onRunSelect: vi.fn(), selectedRunId: MOCK_RUNS[0].id });
-      const rows = screen.getAllByRole("row").slice(1);
-      const classesRow0 = rows[0].className.split(" ");
-      const classesRow1 = rows[1].className.split(" ");
-      expect(classesRow0).toContain("bg-muted");
-      expect(classesRow1).not.toContain("bg-muted");
+      const rows = screen.getAllByTestId("run-row");
+      // Token match so the unselected row's `hover:bg-muted/60` doesn't count
+      expect(rows[0].className.split(" ")).toContain("bg-muted");
+      expect(rows[1].className.split(" ")).not.toContain("bg-muted");
     });
   });
 
@@ -275,13 +272,15 @@ describe("WorkflowRunsTable", () => {
       expect(triggers).toHaveLength(MOCK_RUNS.length);
     });
 
-    it("renders an Actions column header (no View in Stak column)", () => {
+    it("exposes run actions via a kebab menu (one per row), not a table column", () => {
       setupRuns(MOCK_RUNS);
       renderTable();
-      expect(screen.getByRole("columnheader", { name: /actions/i })).toBeInTheDocument();
-      expect(
-        screen.queryByRole("columnheader", { name: /view in stak/i }),
-      ).not.toBeInTheDocument();
+      // List layout has no tabular column headers
+      expect(screen.queryByRole("columnheader")).not.toBeInTheDocument();
+      // One kebab trigger per run
+      expect(screen.getAllByRole("button", { name: /run actions/i })).toHaveLength(
+        MOCK_RUNS.length,
+      );
     });
 
     it("menu contains Open in Stak, Flag for eval, and Debug run items", () => {

--- a/src/__tests__/unit/components/workflow/WorkflowStatsPanel.test.tsx
+++ b/src/__tests__/unit/components/workflow/WorkflowStatsPanel.test.tsx
@@ -37,7 +37,7 @@ describe("WorkflowStatsPanel", () => {
   it("shows skeletons while loading", () => {
     setupStats(null, true);
     renderPanel();
-    expect(screen.getAllByTestId("skeleton")).toHaveLength(3);
+    expect(screen.getAllByTestId("skeleton").length).toBeGreaterThanOrEqual(3);
   });
 
   it("shows unavailable message when stats is null", () => {
@@ -120,14 +120,14 @@ describe("WorkflowStatsPanel", () => {
       setupStats({ available: true, total_runs: 3, error_rate: 0.15 });
       renderPanel();
       const errorEl = screen.getByText("15.0%");
-      expect(errorEl.className).toContain("text-red-500");
+      expect(errorEl.className).toContain("text-rose-600");
     });
 
-    it("does not highlight error rate when <= 10%", () => {
+    it("does not highlight error rate as an error when <= 10%", () => {
       setupStats({ available: true, total_runs: 3, error_rate: 0.05 });
       renderPanel();
       const errorEl = screen.getByText("5.0%");
-      expect(errorEl.className).not.toContain("text-red-500");
+      expect(errorEl.className).not.toContain("text-rose-600");
     });
   });
 });

--- a/src/app/api/mock/stakwork/workflows/[workflowId]/runs/route.ts
+++ b/src/app/api/mock/stakwork/workflows/[workflowId]/runs/route.ts
@@ -6,45 +6,31 @@ type RouteParams = {
   params: Promise<{ workflowId: string }>;
 };
 
+// Rich, status-varied run list for the workflows surfaced by
+// /api/workflow/recent (ids 1001-1005). Gives the inspector real data to
+// render — every status colour appears and the list is long enough to scroll.
+const populated = [
+  { id: 88012, name: "Generate Architecture — payments service", status: "active", started_at: "2026-06-17T14:32:00.000Z", finished_at: null },
+  { id: 88008, name: "User stories: onboarding revamp", status: "finished", started_at: "2026-06-17T13:58:00.000Z", finished_at: "2026-06-17T13:59:42.000Z" },
+  { id: 88004, name: "Pod repair — graphmindset-prod", status: "error", started_at: "2026-06-17T12:11:00.000Z", finished_at: "2026-06-17T12:11:09.000Z" },
+  { id: 87990, name: "Task generation: dependency coordinator", status: "completed", started_at: "2026-06-17T10:46:00.000Z", finished_at: "2026-06-17T10:49:28.000Z" },
+  { id: 87955, name: "Janitor analysis — coverage sweep", status: "halted", started_at: "2026-06-16T22:03:00.000Z", finished_at: "2026-06-16T22:08:51.000Z" },
+  { id: 87901, name: "Generate Architecture — auth refactor", status: "finished", started_at: "2026-06-16T19:20:00.000Z", finished_at: "2026-06-16T19:22:14.000Z" },
+  { id: 87870, name: "User stories: billing portal", status: "finished", started_at: "2026-06-16T15:42:00.000Z", finished_at: "2026-06-16T15:43:58.000Z" },
+  { id: 87844, name: "Task generation: notifications epic", status: "completed", started_at: "2026-06-16T11:08:00.000Z", finished_at: "2026-06-16T11:10:41.000Z" },
+  { id: 87810, name: "Janitor analysis — dead code sweep", status: "finished", started_at: "2026-06-15T20:55:00.000Z", finished_at: "2026-06-15T20:59:17.000Z" },
+  { id: 87777, name: "Pod repair — analytics-staging", status: "error", started_at: "2026-06-15T18:30:00.000Z", finished_at: "2026-06-15T18:30:12.000Z" },
+];
+
 const variants = [
   [
-    {
-      id: 1001,
-      name: "Run #1001",
-      status: "finished",
-      started_at: "2024-03-18T14:00:00.000Z",
-      finished_at: "2024-03-18T14:32:10.000Z",
-    },
-    {
-      id: 1002,
-      name: "Run #1002",
-      status: "error",
-      started_at: "2024-03-17T09:00:00.000Z",
-      finished_at: "2024-03-17T09:15:00.000Z",
-    },
-    {
-      id: 1003,
-      name: "Run #1003",
-      status: "completed",
-      started_at: "2024-03-16T08:00:00.000Z",
-      finished_at: "2024-03-16T08:45:00.000Z",
-    },
+    { id: 1001, name: "Run #1001", status: "finished", started_at: "2024-03-18T14:00:00.000Z", finished_at: "2024-03-18T14:32:10.000Z" },
+    { id: 1002, name: "Run #1002", status: "error", started_at: "2024-03-17T09:00:00.000Z", finished_at: "2024-03-17T09:15:00.000Z" },
+    { id: 1003, name: "Run #1003", status: "completed", started_at: "2024-03-16T08:00:00.000Z", finished_at: "2024-03-16T08:45:00.000Z" },
   ],
   [
-    {
-      id: 2001,
-      name: "Run #2001",
-      status: "halted",
-      started_at: "2024-04-01T10:00:00.000Z",
-      finished_at: "2024-04-01T10:05:00.000Z",
-    },
-    {
-      id: 2002,
-      name: "Run #2002",
-      status: "active",
-      started_at: "2024-04-02T09:00:00.000Z",
-      finished_at: null,
-    },
+    { id: 2001, name: "Run #2001", status: "halted", started_at: "2024-04-01T10:00:00.000Z", finished_at: "2024-04-01T10:05:00.000Z" },
+    { id: 2002, name: "Run #2002", status: "active", started_at: "2024-04-02T09:00:00.000Z", finished_at: null },
   ],
   [],
 ];
@@ -52,6 +38,9 @@ const variants = [
 export async function GET(_request: NextRequest, { params }: RouteParams) {
   const { workflowId } = await params;
   const id = parseInt(workflowId, 10);
+  if (!isNaN(id) && id >= 1001 && id <= 1005) {
+    return NextResponse.json({ success: true, data: { runs: populated } });
+  }
   const variant = variants[Math.abs(isNaN(id) ? 0 : id) % variants.length];
   return NextResponse.json({ success: true, data: { runs: variant } });
 }

--- a/src/app/api/mock/stakwork/workflows/[workflowId]/stats/route.ts
+++ b/src/app/api/mock/stakwork/workflows/[workflowId]/stats/route.ts
@@ -15,6 +15,12 @@ const variants = [
 export async function GET(_request: NextRequest, { params }: RouteParams) {
   const { workflowId } = await params;
   const id = parseInt(workflowId, 10);
+  if (!isNaN(id) && id >= 1001 && id <= 1005) {
+    return NextResponse.json({
+      success: true,
+      data: { available: true, last_run_at: "2026-06-17T14:32:00.000Z", total_runs: 1284, active_runs: 1, error_rate: 0.031 },
+    });
+  }
   const variant = variants[Math.abs(isNaN(id) ? 0 : id) % variants.length];
   return NextResponse.json({ success: true, data: { available: true, ...variant } });
 }

--- a/src/app/api/mock/stakwork/workflows/[workflowId]/versions/route.ts
+++ b/src/app/api/mock/stakwork/workflows/[workflowId]/versions/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+
+type RouteParams = {
+  params: Promise<{ workflowId: string }>;
+};
+
+// Build a small but valid workflow_json with positioned nodes + edges so the
+// React Flow diagram renders. `label` lets each version differ slightly, which
+// gives the History tab's diff something to show.
+function buildWorkflowJson(label: string): string {
+  const transitions = {
+    trigger: {
+      id: "step-trigger",
+      unique_id: "step-trigger",
+      name: "trigger",
+      display_name: "Trigger",
+      title: "Trigger",
+      skill: { type: "automated" },
+      position: { x: 0, y: 140 },
+      connections: { default: "step-plan" },
+      attributes: {},
+    },
+    plan: {
+      id: "step-plan",
+      unique_id: "step-plan",
+      name: "plan",
+      display_name: `Plan & decompose (${label})`,
+      title: "Plan & decompose",
+      skill: { type: "human" },
+      position: { x: 300, y: 140 },
+      connections: { success: "step-api", failure: "step-branch" },
+      attributes: { set_var: { model: "claude-opus-4-8", version: label } },
+    },
+    api: {
+      id: "step-api",
+      unique_id: "step-api",
+      name: "api",
+      display_name: "Stakwork API",
+      title: "Stakwork API",
+      skill: { type: "api" },
+      position: { x: 600, y: 50 },
+      attributes: {},
+    },
+    branch: {
+      id: "step-branch",
+      unique_id: "step-branch",
+      name: "branch",
+      display_name: "Branch: tests",
+      title: "Branch: tests",
+      skill: { type: "loop" },
+      position: { x: 600, y: 240 },
+      attributes: {},
+    },
+  };
+
+  return JSON.stringify({
+    transitions,
+    connections: [
+      { id: "e1", source: "step-trigger", target: "step-plan" },
+      { id: "e2", source: "step-plan", target: "step-api" },
+      { id: "e3", source: "step-plan", target: "step-branch" },
+    ],
+  });
+}
+
+const NAMES = ["A", "B", "C", "D", "E"];
+
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+  const { workflowId } = await params;
+  const id = parseInt(workflowId, 10);
+  const idNum = isNaN(id) ? 0 : id;
+  const letter = NAMES[(idNum - 1001 + NAMES.length) % NAMES.length] ?? String(idNum);
+  const name = `Mock Workflow ${letter}`;
+
+  const base = [
+    { workflow_version_id: "30251", published: false, published_at: null, date: "2026-06-16T10:00:00.000Z", label: "v3" },
+    { workflow_version_id: "20640", published: true, published_at: "2026-06-14T10:00:00.000Z", date: "2026-06-14T10:00:00.000Z", label: "v2" },
+    { workflow_version_id: "10112", published: true, published_at: "2026-06-09T10:00:00.000Z", date: "2026-06-09T10:00:00.000Z", label: "v1" },
+  ];
+
+  const versions = base.map((v) => ({
+    workflow_version_id: v.workflow_version_id,
+    workflow_id: idNum,
+    workflow_json: buildWorkflowJson(v.label),
+    workflow_name: name,
+    date_added_to_graph: v.date,
+    published: v.published,
+    published_at: v.published_at,
+    ref_id: `ref-${v.workflow_version_id}`,
+    node_type: "Workflow_version" as const,
+  }));
+
+  return NextResponse.json({ success: true, data: { versions } });
+}

--- a/src/app/api/workspaces/[slug]/workflows/[workflowId]/versions/route.ts
+++ b/src/app/api/workspaces/[slug]/workflows/[workflowId]/versions/route.ts
@@ -85,6 +85,23 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       return NextResponse.json({ success: false, error: "Invalid workflow ID" }, { status: 400 });
     }
 
+    // Dev mode: delegate to mock endpoint (mirrors the runs/stats routes).
+    // Lets the mock workflows from /api/workflow/recent open without a swarm.
+    if (isDevelopmentMode()) {
+      const origin = request.nextUrl.origin;
+      try {
+        const mockRes = await fetch(
+          `${origin}/api/mock/stakwork/workflows/${workflowIdNum}/versions`,
+        );
+        if (mockRes.ok) {
+          return NextResponse.json(await mockRes.json());
+        }
+      } catch {
+        // fall through to empty response
+      }
+      return NextResponse.json({ success: true, data: { versions: [] } }, { status: 200 });
+    }
+
     const swarm = await db.swarm.findUnique({
       where: { workspaceId: workspace.id },
     });

--- a/src/app/w/[slug]/workflows/[workflowId]/page.tsx
+++ b/src/app/w/[slug]/workflows/[workflowId]/page.tsx
@@ -5,7 +5,6 @@ import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { Workflow, Loader2, ArrowLeft, ExternalLink, X } from "lucide-react";
 import { toast } from "sonner";
-import { PageHeader } from "@/components/ui/page-header";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
@@ -201,45 +200,57 @@ export default function WorkflowInspectorPage() {
   }
 
   return (
-    <div className="space-y-4">
-      <PageHeader
-        title={workflowName}
-        icon={Workflow}
-        description={`ID: ${workflowIdNum}`}
-        actions={
-          <>
-            <Button asChild variant="ghost" size="sm" className="text-muted-foreground">
-              <Link href={slug ? `/w/${slug}/workflows` : "/workflows"}>
-                <ArrowLeft className="w-4 h-4 mr-1" />
-                Workflows
-              </Link>
-            </Button>
-            <Button asChild variant="ghost" size="sm" className="text-muted-foreground">
-              <a
-                href={`https://jobs.stakwork.com/admin/workflows/${workflowIdNum}/edit`}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <ExternalLink className="w-4 h-4 mr-1" />
-                View in Stakwork
-              </a>
-            </Button>
-            <Button onClick={handlePlanFromWorkflow} variant="outline" size="sm">
-              Plan from this Workflow
-            </Button>
-            <Button
-              onClick={handleOpenInEditor}
-              disabled={!selectedVersion || isCreatingTask}
-              size="sm"
-            >
-              {isCreatingTask && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
-              Open in Editor
-            </Button>
-          </>
-        }
-      />
+    <div className="flex min-h-0 flex-1 flex-col gap-4">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between" data-testid="page-header">
+        <div className="min-w-0">
+          <Link
+            href={slug ? `/w/${slug}/workflows` : "/workflows"}
+            className="mb-2 inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" />
+            Workflows
+          </Link>
+          <div className="flex min-w-0 items-center gap-3">
+            <span className="grid h-10 w-10 shrink-0 place-items-center rounded-xl bg-foreground text-background">
+              <Workflow className="h-5 w-5" />
+            </span>
+            <div className="min-w-0">
+              <h1 className="truncate text-xl font-semibold tracking-tight text-foreground" data-testid="page-title">
+                {workflowName}
+              </h1>
+              <p className="font-mono text-xs text-muted-foreground">workflow · {workflowIdNum}</p>
+            </div>
+          </div>
+        </div>
 
-      <ResizablePanelGroup direction="horizontal" className="h-[calc(100vh-12rem)] gap-2">
+        <div className="flex items-center gap-1">
+          <Button asChild variant="ghost" size="sm" className="gap-1.5 text-muted-foreground">
+            <a
+              href={`https://jobs.stakwork.com/admin/workflows/${workflowIdNum}/edit`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <ExternalLink className="h-4 w-4" />
+              View in Stakwork
+            </a>
+          </Button>
+          <span className="mx-1.5 h-5 w-px bg-border" aria-hidden="true" />
+          <Button onClick={handlePlanFromWorkflow} variant="outline" size="sm">
+            Plan from Workflow
+          </Button>
+          <Button
+            onClick={handleOpenInEditor}
+            disabled={!selectedVersion || isCreatingTask}
+            size="sm"
+            className="gap-1.5"
+          >
+            {isCreatingTask && <Loader2 className="h-4 w-4 animate-spin" />}
+            Open in Editor
+          </Button>
+        </div>
+      </div>
+
+      <ResizablePanelGroup direction="horizontal" className="min-h-0 flex-1 gap-2">
         {/* Left 60%: flow diagram */}
         <ResizablePanel defaultSize={60} minSize={25}>
         <div className="border rounded-lg overflow-hidden flex flex-col h-full">
@@ -251,21 +262,24 @@ export default function WorkflowInspectorPage() {
               onVersionSelect={setSelectedVersionId}
               isLoading={isLoadingVersions}
               workflowName={workflowName}
+              variant="compact"
             />
             {selectedRunId && (
-              <div className="flex items-center gap-2 mt-2">
-                <Badge variant="secondary">Run #{selectedRunId}</Badge>
-                <button
-                  onClick={() => { setSelectedRunId(null); setRunTransitions(null); }}
-                  className="p-0.5 hover:bg-muted rounded"
-                  aria-label="Exit run view"
-                >
-                  <X className="h-3.5 w-3.5" />
-                </button>
+              <div className="mt-2 flex items-center gap-2">
+                <span className="inline-flex items-center gap-1.5 rounded-lg border bg-card/70 px-2.5 py-1 text-xs font-medium backdrop-blur-md">
+                  <span className="font-mono">Run #{selectedRunId}</span>
+                  <button
+                    onClick={() => { setSelectedRunId(null); setRunTransitions(null); }}
+                    className="grid h-4 w-4 place-items-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+                    aria-label="Exit run view"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </span>
               </div>
             )}
           </div>
-          <div className="flex-1 overflow-hidden">
+          <div className="flex-1 min-h-0 overflow-hidden">
             {parsedWorkflowData ? (
               <>
               <WorkflowComponent
@@ -305,10 +319,10 @@ export default function WorkflowInspectorPage() {
 
         {/* Right 40%: tabbed detail */}
         <ResizablePanel defaultSize={40} minSize={20}>
-        <div className="border rounded-lg overflow-hidden flex flex-col h-full">
-          <Tabs defaultValue="stats" className="flex flex-col h-full">
+        <div className="border rounded-lg overflow-hidden flex flex-col h-full bg-card/40">
+          <Tabs defaultValue="stats" className="flex flex-col h-full min-h-0">
             <div className="border-b px-3 pt-3 shrink-0">
-              <TabsList className="flex w-full overflow-x-auto">
+              <TabsList className="max-w-full overflow-x-auto">
                 <TabsTrigger value="stats" className="shrink-0">Stats</TabsTrigger>
                 <TabsTrigger value="params" className="shrink-0">Params</TabsTrigger>
                 <TabsTrigger value="history" className="shrink-0">History</TabsTrigger>
@@ -317,15 +331,17 @@ export default function WorkflowInspectorPage() {
               </TabsList>
             </div>
 
-            <div className="flex-1 overflow-y-auto">
+            <div className="flex-1 min-h-0 overflow-y-auto">
               <TabsContent value="stats" className="mt-0">
                 {slug && (
                   <>
                     <WorkflowStatsPanel slug={slug} workflowId={workflowIdNum} />
-                    <div className="flex items-center gap-2 px-4 pt-2">
-                      <span className="text-sm font-medium">Runs</span>
+                    <div className="flex items-center justify-between px-4 py-2.5">
+                      <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                        Recent Runs
+                      </span>
                       {capturedEvalCount > 0 && (
-                        <Badge variant="secondary">
+                        <Badge variant="secondary" className="text-[10px]">
                           {capturedEvalCount} eval{capturedEvalCount !== 1 ? "s" : ""} captured
                         </Badge>
                       )}

--- a/src/components/workflow/WorkflowVersionSelector.tsx
+++ b/src/components/workflow/WorkflowVersionSelector.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import React, { useEffect } from "react";
-import { Loader2 } from "lucide-react";
+import { Loader2, GitBranch } from "lucide-react";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
 import type { WorkflowVersion } from "@/hooks/useWorkflowVersions";
 
 interface WorkflowVersionSelectorProps {
@@ -12,15 +12,52 @@ interface WorkflowVersionSelectorProps {
   selectedVersionId: string | null;
   onVersionSelect: (versionId: string) => void;
   isLoading: boolean;
+  /**
+   * "default" — labelled, full-width trigger (used in TaskStartInput).
+   * "compact" — label-less pill trigger with a branch icon (used in the
+   * workflow inspector header where space is tight).
+   */
+  variant?: "default" | "compact";
+}
+
+function VersionBadges({
+  isLatest,
+  isActive,
+  isPublished,
+}: {
+  isLatest: boolean;
+  isActive: boolean;
+  isPublished: boolean;
+}) {
+  return (
+    <>
+      {isLatest && (
+        <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+          Latest
+        </span>
+      )}
+      {isActive ? (
+        <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-1.5 py-0.5 text-[10px] font-medium text-emerald-600 ring-1 ring-inset ring-emerald-500/20 dark:text-emerald-400">
+          Active
+        </span>
+      ) : isPublished ? (
+        <span className="rounded-full border px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+          Published
+        </span>
+      ) : null}
+    </>
+  );
 }
 
 export function WorkflowVersionSelector({
-  workflowName,
   versions,
   selectedVersionId,
   onVersionSelect,
   isLoading,
+  variant = "default",
 }: WorkflowVersionSelectorProps) {
+  const isCompact = variant === "compact";
+
   // Auto-select first version if none selected and versions are available
   useEffect(() => {
     if (!selectedVersionId && versions.length > 0) {
@@ -30,7 +67,7 @@ export function WorkflowVersionSelector({
 
   if (isLoading) {
     return (
-      <div className="mt-4 flex items-center gap-2 text-muted-foreground">
+      <div className={cn("flex items-center gap-2 text-muted-foreground", !isCompact && "mt-4")}>
         <Loader2 className="h-4 w-4 animate-spin" />
         <span className="text-sm">Loading versions...</span>
       </div>
@@ -38,7 +75,11 @@ export function WorkflowVersionSelector({
   }
 
   if (versions.length === 0) {
-    return <div className="mt-4 text-sm text-muted-foreground">No versions found for this workflow</div>;
+    return (
+      <div className={cn("text-sm text-muted-foreground", !isCompact && "mt-4")}>
+        No versions found for this workflow
+      </div>
+    );
   }
 
   const formatDate = (dateString: string) => {
@@ -57,35 +98,40 @@ export function WorkflowVersionSelector({
     }
   };
 
-  const truncateId = (id: string) => {
-    return id.length > 8 ? id.substring(0, 8) : id;
-  };
+  const truncateId = (id: string) => (id.length > 8 ? id.substring(0, 8) : id);
 
-  const selectedVersion = versions.find((v) => v.workflow_version_id === selectedVersionId) || versions[0];
+  const selectedVersion =
+    versions.find((v) => v.workflow_version_id === selectedVersionId) || versions[0];
   const activeVersionId = versions.find((v) => v.published)?.workflow_version_id ?? null;
+  const latestVersionId = versions[0]?.workflow_version_id;
+
+  const renderMeta = (version: WorkflowVersion, isLatest: boolean) => (
+    <div className="flex items-center gap-2">
+      <span className="font-mono text-xs">{truncateId(version.workflow_version_id)}</span>
+      <span className="text-xs text-muted-foreground">{formatDate(version.date_added_to_graph)}</span>
+      <VersionBadges
+        isLatest={isLatest}
+        isActive={version.workflow_version_id === activeVersionId}
+        isPublished={version.published}
+      />
+    </div>
+  );
 
   return (
-    <div data-testid="version-selector" className="mt-4 space-y-2">
-      <label className="text-sm font-medium text-foreground">Select Version</label>
-      <Select value={selectedVersionId || versions[0]?.workflow_version_id} onValueChange={onVersionSelect}>
-        <SelectTrigger className="w-full h-10 text-sm">
+    <div data-testid="version-selector" className={cn(!isCompact && "mt-4 space-y-2")}>
+      {!isCompact && <label className="text-sm font-medium text-foreground">Select Version</label>}
+      <Select
+        value={selectedVersionId || latestVersionId}
+        onValueChange={onVersionSelect}
+      >
+        <SelectTrigger
+          className={cn(
+            isCompact ? "h-9 w-auto gap-2 rounded-lg px-2.5 text-xs" : "h-10 w-full text-sm",
+          )}
+        >
+          {isCompact && <GitBranch className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
           <SelectValue>
-            {selectedVersion && (
-              <div className="flex items-center gap-2">
-                <span className="font-mono text-xs">{truncateId(selectedVersion.workflow_version_id)}</span>
-                <span className="text-xs text-muted-foreground">{formatDate(selectedVersion.date_added_to_graph)}</span>
-                {selectedVersion.workflow_version_id === versions[0]?.workflow_version_id && (
-                  <Badge variant="secondary" className="text-xs">
-                    Latest
-                  </Badge>
-                )}
-                {selectedVersion.workflow_version_id === activeVersionId ? (
-                  <Badge variant="default" className="text-xs">Active</Badge>
-                ) : selectedVersion.published ? (
-                  <Badge variant="outline" className="text-xs text-muted-foreground">Published</Badge>
-                ) : null}
-              </div>
-            )}
+            {selectedVersion && renderMeta(selectedVersion, selectedVersion.workflow_version_id === latestVersionId)}
           </SelectValue>
         </SelectTrigger>
         <SelectContent>
@@ -95,20 +141,7 @@ export function WorkflowVersionSelector({
               value={version.workflow_version_id}
               className="cursor-pointer"
             >
-              <div className="flex items-center gap-2 py-1">
-                <span className="font-mono text-xs">{truncateId(version.workflow_version_id)}</span>
-                <span className="text-xs text-muted-foreground">{formatDate(version.date_added_to_graph)}</span>
-                {index === 0 && (
-                  <Badge variant="secondary" className="text-xs">
-                    Latest
-                  </Badge>
-                )}
-                {version.workflow_version_id === activeVersionId ? (
-                  <Badge variant="default" className="text-xs">Active</Badge>
-                ) : version.published ? (
-                  <Badge variant="outline" className="text-xs text-muted-foreground">Published</Badge>
-                ) : null}
-              </div>
+              <div className="py-1">{renderMeta(version, index === 0)}</div>
             </SelectItem>
           ))}
         </SelectContent>

--- a/src/components/workflow/inspector/WorkflowRunsTable.tsx
+++ b/src/components/workflow/inspector/WorkflowRunsTable.tsx
@@ -1,15 +1,6 @@
 "use client";
 
 import React, { useState } from "react";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
@@ -20,13 +11,12 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { ExternalLink, Flag, MoreVertical, Bug, Loader2 } from "lucide-react";
-import { useWorkflowRuns, type WorkflowRun } from "@/hooks/useWorkflowRuns";
+import { useWorkflowRuns } from "@/hooks/useWorkflowRuns";
 import { FlagRunEvalModal } from "@/components/evals/FlagRunEvalModal";
 import { startDebugRun } from "@/lib/workflow/debugRun";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
-
-const MAX_RUN_NAME_LEN = 40;
+import { RunStatusDot, runStatusMeta } from "./runStatus";
 
 interface WorkflowRunsTableProps {
   slug: string;
@@ -34,23 +24,6 @@ interface WorkflowRunsTableProps {
   onRunSelect?: (runId: number) => void;
   selectedRunId?: number;
   onEvalCaptured?: () => void;
-}
-
-function statusVariant(
-  status: WorkflowRun["status"],
-): "default" | "destructive" | "secondary" | "outline" {
-  switch (status) {
-    case "finished":
-      return "default";
-    case "error":
-      return "destructive";
-    case "halted":
-      return "secondary";
-    case "active":
-      return "outline";
-    case "completed":
-      return "default";
-  }
 }
 
 function formatDuration(startedAt: string | null, finishedAt: string | null): string {
@@ -61,6 +34,22 @@ function formatDuration(startedAt: string | null, finishedAt: string | null): st
   const mins = Math.floor(totalSecs / 60);
   const secs = totalSecs % 60;
   return mins > 0 ? `${mins}m ${secs}s` : `${secs}s`;
+}
+
+function formatRelative(iso: string | null): string {
+  if (!iso) return "—";
+  const then = new Date(iso).getTime();
+  if (isNaN(then)) return "—";
+  const diff = Date.now() - then;
+  if (diff < 0) return "just now";
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }
 
 export function WorkflowRunsTable({
@@ -77,195 +66,163 @@ export function WorkflowRunsTable({
 
   if (isLoading) {
     return (
-      <div className="p-4">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead className="w-48">Run Name</TableHead>
-              <TableHead>Status</TableHead>
-              <TableHead>Started At</TableHead>
-              <TableHead>Finished At</TableHead>
-              <TableHead>Duration</TableHead>
-              <TableHead className="w-16">Actions</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {[0, 1, 2].map((i) => (
-              <TableRow key={i}>
-                <TableCell>
-                  <Skeleton className="h-4 w-full" />
-                </TableCell>
-                <TableCell>
-                  <Skeleton className="h-4 w-full" />
-                </TableCell>
-                <TableCell>
-                  <Skeleton className="h-4 w-full" />
-                </TableCell>
-                <TableCell>
-                  <Skeleton className="h-4 w-full" />
-                </TableCell>
-                <TableCell>
-                  <Skeleton className="h-4 w-full" />
-                </TableCell>
-                <TableCell>
-                  <Skeleton className="h-4 w-8" />
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+      <div className="space-y-1 px-2 py-2">
+        {[0, 1, 2, 3].map((i) => (
+          <div key={i} className="flex items-center gap-3 px-2.5 py-2">
+            <Skeleton className="h-2 w-2 rounded-full" />
+            <div className="flex-1 space-y-1.5">
+              <Skeleton className="h-3.5 w-3/4" />
+              <Skeleton className="h-2.5 w-1/2" />
+            </div>
+          </div>
+        ))}
       </div>
     );
   }
 
   if (runs.length === 0) {
-    return <p className="text-sm text-muted-foreground p-4">No runs recorded yet.</p>;
+    return <p className="p-4 text-sm text-muted-foreground">No runs recorded yet.</p>;
   }
 
   return (
-    <div className="p-4">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead className="w-48">Run Name</TableHead>
-            <TableHead>Status</TableHead>
-            <TableHead>Started At</TableHead>
-            <TableHead>Finished At</TableHead>
-            <TableHead>Duration</TableHead>
-            <TableHead className="w-16">Actions</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {runs.map((run) => {
-            const runIdStr = String(run.id);
-            const isFlagged = flaggedRunIds.has(runIdStr);
-            const isDebugging = debuggingRunId === runIdStr;
+    <div className="px-2 pb-3">
+      {runs.map((run) => {
+        const runIdStr = String(run.id);
+        const isFlagged = flaggedRunIds.has(runIdStr);
+        const isDebugging = debuggingRunId === runIdStr;
+        const isSelected = run.id === selectedRunId;
+        const meta = runStatusMeta(run.status);
 
-            return (
-              <TableRow
-                key={run.id}
-                onClick={() => onRunSelect?.(run.id)}
-                className={`${run.id === selectedRunId ? "bg-muted" : ""} ${onRunSelect ? "cursor-pointer" : ""}`}
-              >
-                <TableCell>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span className="text-sm font-medium truncate block max-w-[180px]">
-                        {run.name.length > MAX_RUN_NAME_LEN
-                          ? run.name.slice(0, MAX_RUN_NAME_LEN) + "…"
-                          : run.name}
-                      </span>
-                    </TooltipTrigger>
-                    {run.name.length > MAX_RUN_NAME_LEN && (
-                      <TooltipContent>{run.name}</TooltipContent>
-                    )}
-                  </Tooltip>
-                </TableCell>
-                <TableCell>
-                  <Badge variant={statusVariant(run.status)}>{run.status}</Badge>
-                </TableCell>
-                <TableCell className="text-sm">
-                  {run.started_at ? new Date(run.started_at).toLocaleString() : "—"}
-                </TableCell>
-                <TableCell className="text-sm">
-                  {run.finished_at ? new Date(run.finished_at).toLocaleString() : "—"}
-                </TableCell>
-                <TableCell className="text-sm">
+        return (
+          <div
+            key={run.id}
+            data-testid="run-row"
+            role={onRunSelect ? "button" : undefined}
+            tabIndex={onRunSelect ? 0 : undefined}
+            onClick={() => onRunSelect?.(run.id)}
+            onKeyDown={(e) => {
+              if (onRunSelect && (e.key === "Enter" || e.key === " ")) {
+                e.preventDefault();
+                onRunSelect(run.id);
+              }
+            }}
+            className={cn(
+              "group/run relative flex items-center gap-3 rounded-lg px-2.5 py-2 text-left transition-colors",
+              onRunSelect && "cursor-pointer",
+              isSelected ? "bg-muted" : "hover:bg-muted/60",
+            )}
+          >
+            {isSelected && (
+              <span className={cn("absolute left-0 top-1/2 h-7 w-0.5 -translate-y-1/2 rounded-full", meta.bar)} />
+            )}
+
+            <RunStatusDot status={run.status} />
+
+            <div className="min-w-0 flex-1">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div className="truncate text-xs font-medium text-foreground">{run.name}</div>
+                </TooltipTrigger>
+                <TooltipContent>{run.name}</TooltipContent>
+              </Tooltip>
+              <div className="mt-0.5 flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                <span className="font-mono">#{run.id}</span>
+                <span>·</span>
+                <span className={meta.text}>{meta.label}</span>
+                <span>·</span>
+                <span>{formatRelative(run.started_at)}</span>
+                <span>·</span>
+                <span className="font-mono tabular-nums">
                   {formatDuration(run.started_at, run.finished_at)}
-                </TableCell>
-                <TableCell onClick={(e) => e.stopPropagation()}>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
-                      <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="Run actions">
-                        <MoreVertical className="h-4 w-4" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      {/* Open in Stak */}
-                      <DropdownMenuItem asChild>
-                        <a
-                          href={`https://jobs.stakwork.com/admin/projects/${run.id}`}
-                          target="_blank"
-                          rel="noreferrer"
-                          onClick={(e) => e.stopPropagation()}
-                        >
-                          <ExternalLink className="h-4 w-4 mr-2" />
-                          Open in Stak
-                        </a>
-                      </DropdownMenuItem>
+                </span>
+              </div>
+            </div>
 
-                      {/* Flag for eval */}
-                      <DropdownMenuItem
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          if (!isFlagged) setFlaggingRunId(runIdStr);
-                        }}
-                        disabled={isFlagged}
-                      >
-                        <Flag
-                          className={cn(
-                            "h-4 w-4 mr-2",
-                            isFlagged && "fill-orange-500 text-orange-500",
-                          )}
-                        />
-                        {isFlagged ? "Eval captured" : "Flag for eval"}
-                      </DropdownMenuItem>
+            <div
+              className={cn(
+                "shrink-0 transition-opacity",
+                isSelected ? "opacity-100" : "opacity-0 group-hover/run:opacity-100 focus-within:opacity-100",
+              )}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
+                  <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="Run actions">
+                    <MoreVertical className="h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem asChild>
+                    <a
+                      href={`https://jobs.stakwork.com/admin/projects/${run.id}`}
+                      target="_blank"
+                      rel="noreferrer"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <ExternalLink className="mr-2 h-4 w-4" />
+                      Open in Stak
+                    </a>
+                  </DropdownMenuItem>
 
-                      {/* Debug run */}
-                      <DropdownMenuItem
-                        onClick={async (e) => {
-                          e.stopPropagation();
-                          // Open blank tab synchronously to avoid popup blockers
-                          const tab = window.open("", "_blank");
-                          setDebuggingRunId(runIdStr);
-                          try {
-                            const taskId = await startDebugRun({
-                              slug,
-                              workflowId,
-                              runId: run.id,
-                            });
-                            if (tab) tab.location.href = `/w/${slug}/task/${taskId}`;
-                          } catch {
-                            tab?.close();
-                            toast.error("Failed to start debug session");
-                          } finally {
-                            setDebuggingRunId(null);
-                          }
-                        }}
-                        disabled={isDebugging}
-                      >
-                        {isDebugging ? (
-                          <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                        ) : (
-                          <Bug className="h-4 w-4 mr-2" />
-                        )}
-                        Debug run
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (!isFlagged) setFlaggingRunId(runIdStr);
+                    }}
+                    disabled={isFlagged}
+                  >
+                    <Flag className={cn("mr-2 h-4 w-4", isFlagged && "fill-orange-500 text-orange-500")} />
+                    {isFlagged ? "Eval captured" : "Flag for eval"}
+                  </DropdownMenuItem>
 
-                  {flaggingRunId === runIdStr && (
-                    <FlagRunEvalModal
-                      open={true}
-                      onOpenChange={(o) => {
-                        if (!o) setFlaggingRunId(null);
-                      }}
-                      slug={slug}
-                      workflowId={String(workflowId)}
-                      runId={runIdStr}
-                      onCaptured={() => {
-                        setFlaggedRunIds((prev) => new Set(prev).add(runIdStr));
-                        setFlaggingRunId(null);
-                        onEvalCaptured?.();
-                      }}
-                    />
-                  )}
-                </TableCell>
-              </TableRow>
-            );
-          })}
-        </TableBody>
-      </Table>
+                  <DropdownMenuItem
+                    onClick={async (e) => {
+                      e.stopPropagation();
+                      // Open blank tab synchronously to avoid popup blockers
+                      const tab = window.open("", "_blank");
+                      setDebuggingRunId(runIdStr);
+                      try {
+                        const taskId = await startDebugRun({ slug, workflowId, runId: run.id });
+                        if (tab) tab.location.href = `/w/${slug}/task/${taskId}`;
+                      } catch {
+                        tab?.close();
+                        toast.error("Failed to start debug session");
+                      } finally {
+                        setDebuggingRunId(null);
+                      }
+                    }}
+                    disabled={isDebugging}
+                  >
+                    {isDebugging ? (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                      <Bug className="mr-2 h-4 w-4" />
+                    )}
+                    Debug run
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+
+              {flaggingRunId === runIdStr && (
+                <FlagRunEvalModal
+                  open={true}
+                  onOpenChange={(o) => {
+                    if (!o) setFlaggingRunId(null);
+                  }}
+                  slug={slug}
+                  workflowId={String(workflowId)}
+                  runId={runIdStr}
+                  onCaptured={() => {
+                    setFlaggedRunIds((prev) => new Set(prev).add(runIdStr));
+                    setFlaggingRunId(null);
+                    onEvalCaptured?.();
+                  }}
+                />
+              )}
+            </div>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/workflow/inspector/WorkflowStatsPanel.tsx
+++ b/src/components/workflow/inspector/WorkflowStatsPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import { Activity, Zap, AlertTriangle } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useWorkflowRunStats } from "@/hooks/useWorkflowRunStats";
 
@@ -14,55 +15,81 @@ export function WorkflowStatsPanel({ slug, workflowId }: WorkflowStatsPanelProps
 
   if (isLoading) {
     return (
-      <div className="space-y-3 p-4">
-        <Skeleton className="h-16 w-full" />
-        <Skeleton className="h-16 w-full" />
-        <Skeleton className="h-16 w-full" />
+      <div className="grid grid-cols-3 divide-x border-b">
+        {[0, 1, 2].map((i) => (
+          <div key={i} className="px-4 py-3">
+            <Skeleton className="h-3 w-16" />
+            <Skeleton className="mt-2 h-6 w-12" />
+          </div>
+        ))}
       </div>
     );
   }
 
   if (!stats || stats.available === false) {
     return (
-      <p className="text-sm text-muted-foreground p-4">
+      <p className="border-b p-4 text-sm text-muted-foreground">
         Run statistics unavailable — the Stakwork stats service is not yet configured.
       </p>
     );
   }
 
-  if (stats.total_runs === 0 && (stats.active_runs ?? 0) === 0) {
+  const totalRuns = stats.total_runs ?? 0;
+  const activeRuns = stats.active_runs ?? 0;
+
+  if (totalRuns === 0 && activeRuns === 0) {
     return (
-      <p className="text-sm text-muted-foreground p-4">
+      <p className="border-b p-4 text-sm text-muted-foreground">
         No runs recorded yet for this workflow.
       </p>
     );
   }
 
+  const errorRate = typeof stats.error_rate === "number" ? stats.error_rate : null;
+  const errorRateValue = errorRate !== null ? `${(errorRate * 100).toFixed(1)}%` : "—";
+  const errorRateHigh = errorRate !== null && errorRate > 0.1;
+  const errorRateAccent =
+    errorRate === null
+      ? ""
+      : errorRateHigh
+        ? "text-rose-600 dark:text-rose-400"
+        : "text-emerald-600 dark:text-emerald-400";
+
   const lastRunFormatted = stats.last_run_at
-    ? `${new Date(stats.last_run_at).toLocaleDateString()} ${new Date(stats.last_run_at).toLocaleTimeString()}`
+    ? new Date(stats.last_run_at).toLocaleString(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      })
     : "—";
 
-  const errorRateValue = typeof stats.error_rate === "number"
-    ? `${(stats.error_rate * 100).toFixed(1)}%`
-    : "—";
-
-  const errorRateHigh = typeof stats.error_rate === "number" && stats.error_rate > 0.1;
+  const cells = [
+    { label: "Total Runs", icon: Activity, value: totalRuns.toLocaleString(), accent: "" },
+    {
+      label: "Active",
+      icon: Zap,
+      value: activeRuns.toLocaleString(),
+      accent: activeRuns > 0 ? "text-sky-600 dark:text-sky-400" : "",
+    },
+    { label: "Error Rate", icon: AlertTriangle, value: errorRateValue, accent: errorRateAccent },
+  ];
 
   return (
-    <div className="grid grid-cols-1 gap-3 p-4">
-      <div className="border rounded-lg p-3">
-        <p className="text-xs text-muted-foreground font-medium uppercase tracking-wide">Last Run</p>
-        <p className="text-sm font-semibold mt-1">{lastRunFormatted}</p>
+    <div className="border-b">
+      <div className="grid grid-cols-3 divide-x">
+        {cells.map((c) => (
+          <div key={c.label} className="px-4 py-3">
+            <div className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+              <c.icon className="h-3 w-3" />
+              {c.label}
+            </div>
+            <div className={`mt-1 text-xl font-semibold tabular-nums ${c.accent}`}>{c.value}</div>
+          </div>
+        ))}
       </div>
-      <div className="border rounded-lg p-3">
-        <p className="text-xs text-muted-foreground font-medium uppercase tracking-wide">Total Runs</p>
-        <p className="text-sm font-semibold mt-1">{stats.total_runs}</p>
-      </div>
-      <div className="border rounded-lg p-3">
-        <p className="text-xs text-muted-foreground font-medium uppercase tracking-wide">Error Rate</p>
-        <p className={`text-sm font-semibold mt-1 ${errorRateHigh ? "text-red-500" : ""}`}>
-          {errorRateValue}
-        </p>
+      <div className="px-4 py-2 text-xs text-muted-foreground">
+        Last run · <span className="text-foreground">{lastRunFormatted}</span>
       </div>
     </div>
   );

--- a/src/components/workflow/inspector/runStatus.tsx
+++ b/src/components/workflow/inspector/runStatus.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import React from "react";
+import type { WorkflowRun } from "@/hooks/useWorkflowRuns";
+
+export type RunStatus = WorkflowRun["status"];
+
+export interface RunStatusMeta {
+  label: string;
+  /** solid dot background */
+  dot: string;
+  /** foreground text accent */
+  text: string;
+  /** soft tinted pill (bg + text + ring) */
+  soft: string;
+  /** solid accent bar / fill */
+  bar: string;
+  /** whether the dot should pulse (in-flight states) */
+  pulse: boolean;
+}
+
+const META: Record<RunStatus, RunStatusMeta> = {
+  active: {
+    label: "Active",
+    dot: "bg-sky-500",
+    text: "text-sky-600 dark:text-sky-400",
+    soft: "bg-sky-500/10 text-sky-600 dark:text-sky-400 ring-sky-500/20",
+    bar: "bg-sky-500",
+    pulse: true,
+  },
+  finished: {
+    label: "Finished",
+    dot: "bg-emerald-500",
+    text: "text-emerald-600 dark:text-emerald-400",
+    soft: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 ring-emerald-500/20",
+    bar: "bg-emerald-500",
+    pulse: false,
+  },
+  completed: {
+    label: "Completed",
+    dot: "bg-emerald-500",
+    text: "text-emerald-600 dark:text-emerald-400",
+    soft: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 ring-emerald-500/20",
+    bar: "bg-emerald-500",
+    pulse: false,
+  },
+  error: {
+    label: "Error",
+    dot: "bg-rose-500",
+    text: "text-rose-600 dark:text-rose-400",
+    soft: "bg-rose-500/10 text-rose-600 dark:text-rose-400 ring-rose-500/20",
+    bar: "bg-rose-500",
+    pulse: false,
+  },
+  halted: {
+    label: "Halted",
+    dot: "bg-amber-500",
+    text: "text-amber-600 dark:text-amber-500",
+    soft: "bg-amber-500/10 text-amber-600 dark:text-amber-500 ring-amber-500/20",
+    bar: "bg-amber-500",
+    pulse: false,
+  },
+};
+
+export function runStatusMeta(status: RunStatus): RunStatusMeta {
+  return META[status] ?? META.finished;
+}
+
+export function RunStatusDot({
+  status,
+  withPulse = true,
+  className = "",
+}: {
+  status: RunStatus;
+  withPulse?: boolean;
+  className?: string;
+}) {
+  const m = runStatusMeta(status);
+  return (
+    <span className={`relative flex h-2 w-2 shrink-0 ${className}`}>
+      {withPulse && m.pulse && (
+        <span className={`absolute inline-flex h-full w-full animate-ping rounded-full ${m.dot} opacity-60`} />
+      )}
+      <span className={`relative inline-flex h-2 w-2 rounded-full ${m.dot}`} />
+    </span>
+  );
+}
+
+export function RunStatusPill({ status }: { status: RunStatus }) {
+  const m = runStatusMeta(status);
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${m.soft}`}
+    >
+      <RunStatusDot status={status} />
+      {m.label}
+    </span>
+  );
+}


### PR DESCRIPTION
- Replace stacked stat boxes with a compact metric ribbon and shared semantic run-status colors
- Rebuild runs table as a scrollable run list; compact version selector variant
- Refine header (breadcrumb back button, icon chip) and fix page to fill height with scrollable runs
- Add dev-mode mock data for workflow versions/runs/stats so mock workflows open locally