### PR TITLE
Fix StepDetailsModal tab clicks closing modal and missing IO fetch

### DIFF
--- a/src/__tests__/unit/components/workflow/StepDetailsModal.test.tsx
+++ b/src/__tests__/unit/components/workflow/StepDetailsModal.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 import React from "react";
-import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { StepDetailsModal } from "@/components/StepDetailsModal";
 import type { WorkflowTransition } from "@/types/stakwork/workflow";
 
@@ -79,5 +80,154 @@ describe("StepDetailsModal — overlay and sizing", () => {
       />,
     );
     expect(screen.getByText("Deploy Service")).toBeDefined();
+  });
+});
+
+// ── Tab switching does not close the modal ────────────────────────────────────
+
+describe("StepDetailsModal — tab clicks do not close the modal", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        json: () => Promise.resolve({ data: null }),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("does not call onClose when clicking the Inputs tab", async () => {
+    const onClose = vi.fn();
+    render(<StepDetailsModal step={makeStep()} isOpen={true} onClose={onClose} />);
+
+    await userEvent.click(screen.getByRole("tab", { name: "Inputs" }));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("does not call onClose when clicking the Outputs tab", async () => {
+    const onClose = vi.fn();
+    render(<StepDetailsModal step={makeStep()} isOpen={true} onClose={onClose} />);
+
+    await userEvent.click(screen.getByRole("tab", { name: "Outputs" }));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("does not call onClose when clicking the Logs tab", async () => {
+    const onClose = vi.fn();
+    render(<StepDetailsModal step={makeStep()} isOpen={true} onClose={onClose} />);
+
+    await userEvent.click(screen.getByRole("tab", { name: "Logs" }));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});
+
+// ── IO endpoint fetching ──────────────────────────────────────────────────────
+
+describe("StepDetailsModal — IO endpoint", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({
+      json: () =>
+        Promise.resolve({ data: { inputs: { foo: "bar" }, outputs: { baz: "qux" } } }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("fetches IO using step.name when run transitions have no project_step_id", async () => {
+    render(
+      <StepDetailsModal
+        step={makeStep({ id: "step-1", name: "my_step" })}
+        isOpen={true}
+        onClose={vi.fn()}
+        projectId="proj-1"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/v1/projects/proj-1/steps/my_step/io",
+      );
+    });
+  });
+
+  it("fetches IO using runStep.project_step_id when provided in run transitions", async () => {
+    const runTransitions: Record<string, WorkflowTransition> = {
+      "step-1": makeStep({ id: "step-1", name: "my_step", project_step_id: "psid-123" }),
+    };
+    render(
+      <StepDetailsModal
+        step={makeStep({ id: "step-1", name: "my_step" })}
+        isOpen={true}
+        onClose={vi.fn()}
+        projectId="proj-1"
+        runTransitions={runTransitions}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/v1/projects/proj-1/steps/psid-123/io",
+      );
+    });
+  });
+
+  it("does not fetch IO when projectId is undefined", async () => {
+    render(<StepDetailsModal step={makeStep()} isOpen={true} onClose={vi.fn()} />);
+
+    await Promise.resolve();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+// ── IO tab empty states ───────────────────────────────────────────────────────
+
+describe("StepDetailsModal — IO tab empty states", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("shows 'Select a run to view IO data.' in Inputs/Outputs when projectId is undefined", async () => {
+    render(<StepDetailsModal step={makeStep()} isOpen={true} onClose={vi.fn()} />);
+
+    await userEvent.click(screen.getByRole("tab", { name: "Inputs" }));
+    expect(screen.getByText("Select a run to view IO data.")).toBeDefined();
+
+    await userEvent.click(screen.getByRole("tab", { name: "Outputs" }));
+    expect(screen.getByText("Select a run to view IO data.")).toBeDefined();
+  });
+
+  it("shows 'No input data available.' when projectId is set but ioData is null", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ json: () => Promise.resolve({ data: null }) }),
+    );
+
+    render(
+      <StepDetailsModal
+        step={makeStep({ name: "my_step" })}
+        isOpen={true}
+        onClose={vi.fn()}
+        projectId="proj-1"
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("tab", { name: "Inputs" }));
+    await waitFor(() => {
+      expect(screen.getByText("No input data available.")).toBeDefined();
+    });
   });
 });

--- a/src/__tests__/unit/components/workflow/merge-workflow-run-status.test.ts
+++ b/src/__tests__/unit/components/workflow/merge-workflow-run-status.test.ts
@@ -21,11 +21,13 @@ function makeRunStep(
   id: string,
   name: string,
   stepState: string,
+  extra: Partial<WorkflowTransition> = {},
 ): WorkflowTransition {
   return {
     ...makeStep(id, name),
     status: { step_state: stepState, workflow_state: stepState, job_statuses: {} },
     last_transition_state: stepState,
+    ...extra,
   };
 }
 
@@ -110,6 +112,22 @@ describe("mergeWorkflowRunStatus — object-format base transitions", () => {
 
     const result = mergeWorkflowRunStatus(base, runTransitions);
     expect(result).toEqual(base);
+  });
+
+  it("copies project_step_id from the matched run step into the enriched base step", () => {
+    const base = {
+      transitions: {
+        step_one: makeStep("step-1", "step_one"),
+      },
+    };
+    const runTransitions = {
+      "step-1": makeRunStep("step-1", "step_one", "finished", { project_step_id: "psid-123" }),
+    };
+
+    const result = mergeWorkflowRunStatus(base, runTransitions);
+    const transitions = result.transitions as Record<string, WorkflowTransition>;
+
+    expect(transitions.step_one.project_step_id).toBe("psid-123");
   });
 });
 

--- a/src/components/StepDetailsModal/index.tsx
+++ b/src/components/StepDetailsModal/index.tsx
@@ -95,13 +95,21 @@ export function StepDetailsModal({ step, isOpen, onClose, onSelect, runTransitio
   const [isLoadingIO, setIsLoadingIO] = useState(false);
 
   useEffect(() => {
-    if (!isOpen || !projectId || !step?.project_step_id) {
+    if (!isOpen || !projectId) {
+      setIoData(null);
+      return;
+    }
+    const runStep = runTransitions
+      ? (runTransitions[step?.id ?? ''] ?? runTransitions[step?.name ?? ''] ?? null)
+      : null;
+    const effectiveStepId = runStep?.project_step_id ?? step?.name;
+    if (!effectiveStepId) {
       setIoData(null);
       return;
     }
     let cancelled = false;
     setIsLoadingIO(true);
-    fetch(`/api/v1/projects/${projectId}/steps/${step.project_step_id}/io`)
+    fetch(`/api/v1/projects/${projectId}/steps/${effectiveStepId}/io`)
       .then((r) => r.json())
       .then((result) => {
         if (!cancelled) {
@@ -111,7 +119,7 @@ export function StepDetailsModal({ step, isOpen, onClose, onSelect, runTransitio
       .catch(() => { if (!cancelled) setIoData(null); })
       .finally(() => { if (!cancelled) setIsLoadingIO(false); });
     return () => { cancelled = true; };
-  }, [isOpen, projectId, step?.project_step_id]);
+  }, [isOpen, projectId, step?.id, step?.name, step?.project_step_id, runTransitions]);
 
   if (!step || !isOpen) return null;
 
@@ -146,7 +154,10 @@ export function StepDetailsModal({ step, isOpen, onClose, onSelect, runTransitio
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <div className="bg-background rounded-lg shadow-lg border w-[75vw] max-h-[90vh] flex flex-col">
+      <div
+        className="bg-background rounded-lg shadow-lg border w-[75vw] max-h-[90vh] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b">
           <div className="flex items-center gap-3">
@@ -242,7 +253,9 @@ export function StepDetailsModal({ step, isOpen, onClose, onSelect, runTransitio
 
           {/* Inputs */}
           <TabsContent value="inputs" className="flex-1 overflow-y-auto p-4 mt-0">
-            {isLoadingIO ? (
+            {!projectId ? (
+              <p className="text-xs text-muted-foreground">Select a run to view IO data.</p>
+            ) : isLoadingIO ? (
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <Loader2 className="h-4 w-4 animate-spin" /> Loading...
               </div>
@@ -257,7 +270,9 @@ export function StepDetailsModal({ step, isOpen, onClose, onSelect, runTransitio
 
           {/* Outputs */}
           <TabsContent value="outputs" className="flex-1 overflow-y-auto p-4 mt-0">
-            {isLoadingIO ? (
+            {!projectId ? (
+              <p className="text-xs text-muted-foreground">Select a run to view IO data.</p>
+            ) : isLoadingIO ? (
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <Loader2 className="h-4 w-4 animate-spin" /> Loading...
               </div>

--- a/src/lib/utils/merge-workflow-run-status.ts
+++ b/src/lib/utils/merge-workflow-run-status.ts
@@ -31,7 +31,12 @@ export function mergeWorkflowRunStatus(
   const enrichStep = (key: string, step: WorkflowTransition): WorkflowTransition => {
     const rs = byId[step.id] ?? byName[step.name] ?? byId[key] ?? byName[key] ?? null;
     if (!rs) return step;
-    return { ...step, status: rs.status, last_transition_state: rs.last_transition_state };
+    return {
+      ...step,
+      status: rs.status,
+      last_transition_state: rs.last_transition_state,
+      project_step_id: rs.project_step_id,
+    };
   };
 
   if (Array.isArray(baseTransitions)) {


### PR DESCRIPTION
- stopPropagation on modal content so tab clicks don't trigger onClose
- derive IO step id from run transitions, falling back to step name
- forward project_step_id through merge-workflow-run-status enrichStep
- contextual empty states for Inputs/Outputs tabs