### PR TITLE
Add unread (amber dot) indicator for canvas chats

### DIFF
--- a/prisma/migrations/20260617120000_add_conversation_owner_seen_at/migration.sql
+++ b/prisma/migrations/20260617120000_add_conversation_owner_seen_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "shared_conversations" ADD COLUMN "owner_seen_at" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -591,6 +591,13 @@ model SharedConversation {
   updatedAt          DateTime          @updatedAt @map("updated_at")
   isShared           Boolean           @default(false) @map("is_shared")
   lastMessageAt      DateTime?         @map("last_message_at")
+  // When the owner last viewed this conversation. The history list marks a
+  // chat "unread" (amber dot) when `lastMessageAt > ownerSeenAt` — i.e. a
+  // backgrounded chat the agent advanced (planner / sub-agent / auto-turn /
+  // deferred-check) since the owner last opened it. Set on open and on each
+  // live-sync of the active chat. Org-canvas chats are single-owner, so a
+  // per-row timestamp is sufficient (no per-viewer read table needed).
+  ownerSeenAt        DateTime?         @map("owner_seen_at")
   source             String?
   settings           Json?             @default("{}")
   user               User?             @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/src/__tests__/unit/canvas/CanvasHistoryPopover.test.tsx
+++ b/src/__tests__/unit/canvas/CanvasHistoryPopover.test.tsx
@@ -72,6 +72,7 @@ const mockItems = [
     isShared: false,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
+    unread: true,
   },
   {
     id: "conv-b",
@@ -82,6 +83,7 @@ const mockItems = [
     isShared: false,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
+    unread: false,
   },
 ];
 
@@ -251,6 +253,41 @@ describe("CanvasHistoryPopover", () => {
       0,
     );
     expect(mockClearActiveConversation).not.toHaveBeenCalled();
+  });
+
+  it("renders an amber unread dot only on unread conversations", async () => {
+    global.fetch = buildFetch(mockItems, {});
+
+    render(<CanvasHistoryPopover githubLogin="my-org" />);
+    fireEvent.click(screen.getByTestId("popover-trigger"));
+
+    await waitFor(() => screen.getByText("Planning session"));
+
+    // conv-a is unread, conv-b is not → exactly one dot.
+    const dots = screen.getAllByLabelText("Unread");
+    expect(dots).toHaveLength(1);
+  });
+
+  it("marks a conversation seen (POST .../seen) and clears its dot on open", async () => {
+    const fetchMock = buildFetch(mockItems, { "conv-a": mockConversationDetail });
+    global.fetch = fetchMock;
+
+    render(<CanvasHistoryPopover githubLogin="my-org" />);
+    fireEvent.click(screen.getByTestId("popover-trigger"));
+
+    await waitFor(() => screen.getByText("Planning session"));
+    expect(screen.getAllByLabelText("Unread")).toHaveLength(1);
+
+    fireEvent.click(screen.getByText("Planning session"));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/orgs/my-org/chat/conversations/conv-a/seen",
+        { method: "POST" },
+      );
+    });
+    // Optimistically cleared locally.
+    expect(screen.queryByLabelText("Unread")).toBeNull();
   });
 
   it("closes popover after loading a conversation", async () => {

--- a/src/app/api/orgs/[githubLogin]/chat/conversations/[conversationId]/seen/route.ts
+++ b/src/app/api/orgs/[githubLogin]/chat/conversations/[conversationId]/seen/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getMiddlewareContext, requireAuth } from "@/lib/middleware/utils";
+import { validateUserBelongsToOrg } from "@/services/workspace";
+import { db } from "@/lib/db";
+
+async function resolveOrg(githubLogin: string) {
+  return db.sourceControlOrg.findUnique({
+    where: { githubLogin },
+    select: { id: true },
+  });
+}
+
+/**
+ * POST /api/orgs/[githubLogin]/chat/conversations/[conversationId]/seen
+ *
+ * Stamp `ownerSeenAt = now()` so the history list stops flagging this
+ * conversation as unread. Owner-only: scoped by `userId`, so a non-owner
+ * (shared-room viewer) silently no-ops rather than clobbering the owner's
+ * read state — and a missing/foreign row returns 404 for IDOR safety.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ githubLogin: string; conversationId: string }> },
+) {
+  const context = getMiddlewareContext(request);
+  const userOrResponse = requireAuth(context);
+  if (userOrResponse instanceof NextResponse) return userOrResponse;
+
+  const { githubLogin, conversationId } = await params;
+
+  const isMember = await validateUserBelongsToOrg(githubLogin, userOrResponse.id);
+  if (!isMember) {
+    return NextResponse.json({ error: "Organization not found" }, { status: 404 });
+  }
+
+  try {
+    const org = await resolveOrg(githubLogin);
+    if (!org) {
+      return NextResponse.json({ error: "Organization not found" }, { status: 404 });
+    }
+
+    // updateMany so a non-owner / wrong-org id matches zero rows instead of
+    // throwing — we report 404 when nothing was stamped.
+    const { count } = await db.sharedConversation.updateMany({
+      where: {
+        id: conversationId,
+        sourceControlOrgId: org.id,
+        userId: userOrResponse.id,
+      },
+      data: { ownerSeenAt: new Date() },
+    });
+
+    if (count === 0) {
+      return NextResponse.json({ error: "Conversation not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error(
+      "[POST /api/orgs/[githubLogin]/chat/conversations/[id]/seen] Error:",
+      error,
+    );
+    return NextResponse.json({ error: "Failed to mark seen" }, { status: 500 });
+  }
+}

--- a/src/app/api/orgs/[githubLogin]/chat/conversations/route.ts
+++ b/src/app/api/orgs/[githubLogin]/chat/conversations/route.ts
@@ -59,6 +59,7 @@ export async function GET(
         id: true,
         title: true,
         lastMessageAt: true,
+        ownerSeenAt: true,
         messages: true,
         source: true,
         isShared: true,
@@ -76,6 +77,12 @@ export async function GET(
       isShared: conv.isShared,
       createdAt: conv.createdAt.toISOString(),
       updatedAt: conv.updatedAt.toISOString(),
+      // Unread = content arrived since the owner last viewed this chat
+      // (a backgrounded chat the agent advanced). Never seen yet but has
+      // content → unread; otherwise compare timestamps.
+      unread: conv.lastMessageAt
+        ? !conv.ownerSeenAt || conv.lastMessageAt > conv.ownerSeenAt
+        : false,
     }));
 
     return NextResponse.json({ items });

--- a/src/app/org/[githubLogin]/_components/CanvasHistoryPopover.tsx
+++ b/src/app/org/[githubLogin]/_components/CanvasHistoryPopover.tsx
@@ -119,6 +119,16 @@ export function CanvasHistoryPopover({ githubLogin }: CanvasHistoryPopoverProps)
       );
       store.setServerConversationId(newId, item.id);
 
+      // Opening the chat clears its unread flag — optimistically locally,
+      // and persisted so the next list load agrees. Fire-and-forget.
+      setItems((prev) =>
+        prev.map((it) => (it.id === item.id ? { ...it, unread: false } : it)),
+      );
+      void fetch(
+        `/api/orgs/${githubLogin}/chat/conversations/${item.id}/seen`,
+        { method: "POST" },
+      ).catch(() => {});
+
       setOpen(false);
     } catch {
       // silently fail
@@ -223,8 +233,17 @@ export function CanvasHistoryPopover({ githubLogin }: CanvasHistoryPopoverProps)
                     disabled={isLoadingThis}
                     className="w-full px-3 py-2 text-left hover:bg-muted/50 transition-colors flex flex-col gap-0.5 disabled:opacity-60"
                   >
-                    <span className="text-xs font-medium text-foreground truncate block">
-                      {label}
+                    <span className="flex items-center gap-1.5 min-w-0">
+                      {item.unread && (
+                        <span
+                          aria-label="Unread"
+                          title="New activity since you last viewed"
+                          className="shrink-0 w-1.5 h-1.5 rounded-full bg-amber-500"
+                        />
+                      )}
+                      <span className="text-xs font-medium text-foreground truncate block">
+                        {label}
+                      </span>
                     </span>
                     <span className="text-[10px] text-muted-foreground">
                       {formatRelativeTime(item.lastMessageAt)}

--- a/src/app/org/[githubLogin]/_state/useCanvasChatAutoSave.ts
+++ b/src/app/org/[githubLogin]/_state/useCanvasChatAutoSave.ts
@@ -103,6 +103,19 @@ export function useCanvasChatAutoSave({ githubLogin }: AutoSaveArgs) {
     const isIdle = (conv: { isStreaming: boolean }): boolean =>
       !conv.isStreaming;
 
+    // Clear a conversation's unread flag server-side. Called for the chat
+    // the user is actively viewing (the active conversation): when its own
+    // turn settles, and when a live-sync lands new server rows into it —
+    // so watching a planner/sub-agent fan out keeps it "seen". A
+    // backgrounded chat is never marked here, so it stays unread until the
+    // user opens it. Fire-and-forget; owner-only on the server.
+    const markSeen = (serverId: string): void => {
+      void fetch(
+        `/api/orgs/${githubLogin}/chat/conversations/${serverId}/seen`,
+        { method: "POST" },
+      ).catch(() => {});
+    };
+
     // Prefixes for turns this tab authored — their server rows are
     // filtered out of the merge (we already show them optimistically).
     const authoredPrefixes = (): string[] =>
@@ -171,9 +184,13 @@ export function useCanvasChatAutoSave({ githubLogin }: AutoSaveArgs) {
         const reconciled = reconcilePlannerSources(merged.messages, mapped);
 
         if (merged.added.length === 0 && !reconciled.changed) return; // in sync
-        useCanvasChatStore
-          .getState()
-          .setConversationMessages(conversationId, reconciled.messages);
+        const store = useCanvasChatStore.getState();
+        store.setConversationMessages(conversationId, reconciled.messages);
+
+        // The user is looking at this chat (only the active conv is
+        // subscribed/synced live), and we just merged new server content
+        // into it — so it's been seen. Clear its unread flag.
+        if (store.activeConversationId === conversationId) markSeen(serverId);
       } catch {
         // Network hiccup — a later nudge (or the next server append) will
         // resync.
@@ -252,10 +269,14 @@ export function useCanvasChatAutoSave({ githubLogin }: AutoSaveArgs) {
           before?.isStreaming &&
           after &&
           !after.isStreaming &&
-          after.serverConversationId &&
-          pendingSyncRef.current.has(activeId)
+          after.serverConversationId
         ) {
-          void syncFromServer(activeId, after.serverConversationId);
+          // The active chat's own turn just finished and the user is
+          // looking at it — mark it seen so it doesn't flag itself unread.
+          markSeen(after.serverConversationId);
+          if (pendingSyncRef.current.has(activeId)) {
+            void syncFromServer(activeId, after.serverConversationId);
+          }
         }
       }
 

--- a/src/types/shared-conversation.ts
+++ b/src/types/shared-conversation.ts
@@ -69,6 +69,9 @@ export interface ConversationListItem {
   creatorName?: string | null;
   creatorId?: string;
   creatorImage?: string | null;
+  // True when content arrived since the owner last viewed this chat —
+  // drives the amber "unread" dot in the history list.
+  unread?: boolean;
 }
 
 // Full conversation detail for GET /conversations/[id]


### PR DESCRIPTION
## Problem

After kicking off multiple canvas chats and switching away, there was no way to tell which backgrounded chats had **new content to review** — the agent advances them in the background (planner / sub-agent / auto-turn / deferred-check), but the history list gave no signal.

## Approach

Track per-conversation read state with a new `ownerSeenAt` column on `SharedConversation`. Org-canvas chats are single-owner, so a per-row timestamp is sufficient (no per-viewer read table). The "content changed" signal already exists: `lastMessageAt` is bumped on every server append, including all background fan-out (`appendTurnMessages`).

A chat is **unread** when `lastMessageAt > ownerSeenAt` (or it has content and was never seen).

## Changes

**Data**
- `SharedConversation.ownerSeenAt DateTime?` + migration `20260617120000_add_conversation_owner_seen_at`.

**API**
- `POST /api/orgs/[githubLogin]/chat/conversations/[id]/seen` — stamps `ownerSeenAt = now()`. Owner-only via `updateMany` scoped to `userId` + org; returns 404 when nothing matched (IDOR-safe). Falls under the default `protected` middleware policy, so no `middleware.ts` change.
- List `GET` now returns `unread` per item; `ConversationListItem` gains `unread?: boolean`.

**Client**
- `CanvasHistoryPopover` renders a small amber dot (`aria-label="Unread"`) on unread chats; opening one optimistically clears the dot and fires the `seen` POST.
- `useCanvasChatAutoSave` marks the **active** chat seen when (a) its own turn settles and (b) a live-sync merges new server rows into it. Backgrounded chats are never marked here, so a chat the agent advances while you're away stays unread until you open it — and the chat you're actively watching never falsely flags itself.

## Behavior

- Kick off N chats → switch away → agent advances them → each shows an amber dot in the history list.
- Open one → dot clears (persisted). Active chat you're watching is never falsely flagged.

## Testing

- `CanvasHistoryPopover.test.tsx` — added: dot renders only on unread items; clicking fires `POST .../seen` and clears the dot.
- `npx vitest run src/__tests__/unit/canvas` — 94 passed.
- Existing list integration test asserts only length/id, so the added field is safe.