### PR TITLE
Polish workflow canvas: legible fit, row actions, recenter, header flag

### DIFF
--- a/src/__tests__/unit/components/workflow/WorkflowRunsTable.test.tsx
+++ b/src/__tests__/unit/components/workflow/WorkflowRunsTable.test.tsx
@@ -60,47 +60,6 @@ vi.mock("@/components/ui/tooltip", () => ({
   ),
 }));
 
-// ── mock DropdownMenu ─────────────────────────────────────────────────────────
-vi.mock("@/components/ui/dropdown-menu", () => ({
-  DropdownMenu: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="dropdown-menu">{children}</div>
-  ),
-  DropdownMenuTrigger: ({
-    children,
-    asChild,
-    onClick,
-  }: {
-    children: React.ReactNode;
-    asChild?: boolean;
-    onClick?: React.MouseEventHandler;
-  }) => (
-    <div data-testid="dropdown-trigger" onClick={onClick}>
-      {asChild ? children : <button>{children}</button>}
-    </div>
-  ),
-  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="dropdown-content">{children}</div>
-  ),
-  DropdownMenuItem: ({
-    children,
-    onClick,
-    disabled,
-    asChild,
-  }: {
-    children: React.ReactNode;
-    onClick?: React.MouseEventHandler;
-    disabled?: boolean;
-    asChild?: boolean;
-  }) =>
-    asChild ? (
-      <div data-testid="dropdown-item">{children}</div>
-    ) : (
-      <button data-testid="dropdown-item" onClick={onClick} disabled={disabled}>
-        {children}
-      </button>
-    ),
-}));
-
 // ── mock startDebugRun ────────────────────────────────────────────────────────
 const mockStartDebugRun = vi.fn();
 vi.mock("@/lib/workflow/debugRun", () => ({
@@ -233,8 +192,8 @@ describe("WorkflowRunsTable", () => {
         .find((el) => el.className.includes("truncate"));
       expect(truncatedEl).toBeTruthy();
 
-      const tooltip = screen.getByTestId("tooltip-content");
-      expect(tooltip).toHaveTextContent(LONG_NAME);
+      const tooltips = screen.getAllByTestId("tooltip-content");
+      expect(tooltips.some((t) => t.textContent === LONG_NAME)).toBe(true);
     });
 
     it("renders the run name for short names too", () => {
@@ -264,31 +223,19 @@ describe("WorkflowRunsTable", () => {
     });
   });
 
-  describe("three-dot kebab menu", () => {
-    it("renders a three-dot menu trigger per run row", () => {
+  describe("row action buttons", () => {
+    it("renders Open in Stak, Flag for eval, and Debug run actions per row", () => {
       setupRuns(MOCK_RUNS);
       renderTable();
-      const triggers = screen.getAllByRole("button", { name: /run actions/i });
-      expect(triggers).toHaveLength(MOCK_RUNS.length);
+      expect(screen.getAllByRole("link", { name: /open in stak/i })).toHaveLength(MOCK_RUNS.length);
+      expect(screen.getAllByRole("button", { name: /flag for eval/i })).toHaveLength(MOCK_RUNS.length);
+      expect(screen.getAllByRole("button", { name: /debug run/i })).toHaveLength(MOCK_RUNS.length);
     });
 
-    it("exposes run actions via a kebab menu (one per row), not a table column", () => {
+    it("uses a list layout with no tabular column headers", () => {
       setupRuns(MOCK_RUNS);
       renderTable();
-      // List layout has no tabular column headers
       expect(screen.queryByRole("columnheader")).not.toBeInTheDocument();
-      // One kebab trigger per run
-      expect(screen.getAllByRole("button", { name: /run actions/i })).toHaveLength(
-        MOCK_RUNS.length,
-      );
-    });
-
-    it("menu contains Open in Stak, Flag for eval, and Debug run items", () => {
-      setupRuns([MOCK_RUNS[0]]);
-      renderTable();
-      expect(screen.getByText("Open in Stak")).toBeInTheDocument();
-      expect(screen.getByText("Flag for eval")).toBeInTheDocument();
-      expect(screen.getByText("Debug run")).toBeInTheDocument();
     });
 
     it("Open in Stak link has correct href and target", () => {
@@ -313,12 +260,12 @@ describe("WorkflowRunsTable", () => {
       );
     });
 
-    it("menu trigger click does not propagate to row (onRunSelect not called)", () => {
+    it("clicking an action does not propagate to the row (onRunSelect not called)", () => {
       setupRuns(MOCK_RUNS);
       const onRunSelect = vi.fn();
       renderTable({ onRunSelect });
-      const trigger = screen.getAllByTestId("dropdown-trigger")[0];
-      fireEvent.click(trigger);
+      const row = screen.getAllByTestId("run-row")[0];
+      fireEvent.click(within(row).getByRole("button", { name: /flag for eval/i }));
       expect(onRunSelect).not.toHaveBeenCalled();
     });
 
@@ -326,9 +273,7 @@ describe("WorkflowRunsTable", () => {
       it("clicking Flag for eval opens FlagRunEvalModal for that run", () => {
         setupRuns(MOCK_RUNS);
         renderTable();
-        // Each run has a "Flag for eval" dropdown item
-        const flagItems = screen.getAllByText("Flag for eval");
-        fireEvent.click(flagItems[0]);
+        fireEvent.click(screen.getAllByRole("button", { name: /flag for eval/i })[0]);
         expect(
           screen.getByTestId(`flag-modal-${MOCK_RUNS[0].id}`),
         ).toBeInTheDocument();
@@ -337,7 +282,7 @@ describe("WorkflowRunsTable", () => {
       it("modal receives correct props (slug, workflowId, runId)", () => {
         setupRuns([MOCK_RUNS[0]]);
         renderTable();
-        fireEvent.click(screen.getByText("Flag for eval"));
+        fireEvent.click(screen.getByRole("button", { name: /flag for eval/i }));
         expect(mockFlagRunEvalModal).toHaveBeenCalledWith(
           expect.objectContaining({
             slug: "test-ws",
@@ -348,18 +293,17 @@ describe("WorkflowRunsTable", () => {
         );
       });
 
-      it("after capture, menu item shows 'Eval captured' and is disabled", () => {
+      it("after capture, the action shows 'Eval captured' and is disabled", () => {
         setupRuns([MOCK_RUNS[0]]);
         renderTable();
 
-        // open modal via menu item
-        fireEvent.click(screen.getByText("Flag for eval"));
-        // simulate capture
+        fireEvent.click(screen.getByRole("button", { name: /flag for eval/i }));
         fireEvent.click(screen.getByTestId(`flag-modal-capture-${MOCK_RUNS[0].id}`));
 
-        // menu item should now show "Eval captured" and be disabled
-        expect(screen.getByText("Eval captured")).toBeInTheDocument();
-        expect(screen.queryByText("Flag for eval")).not.toBeInTheDocument();
+        const captured = screen.getByRole("button", { name: /eval captured/i });
+        expect(captured).toBeInTheDocument();
+        expect(captured).toBeDisabled();
+        expect(screen.queryByRole("button", { name: /flag for eval/i })).not.toBeInTheDocument();
       });
 
       it("calls onEvalCaptured prop when a capture is confirmed", () => {
@@ -367,7 +311,7 @@ describe("WorkflowRunsTable", () => {
         const onEvalCaptured = vi.fn();
         renderTable({ onEvalCaptured });
 
-        fireEvent.click(screen.getByText("Flag for eval"));
+        fireEvent.click(screen.getByRole("button", { name: /flag for eval/i }));
         fireEvent.click(screen.getByTestId(`flag-modal-capture-${MOCK_RUNS[0].id}`));
 
         expect(onEvalCaptured).toHaveBeenCalledOnce();
@@ -378,7 +322,7 @@ describe("WorkflowRunsTable", () => {
         const onEvalCaptured = vi.fn();
         renderTable({ onEvalCaptured });
 
-        fireEvent.click(screen.getByText("Flag for eval"));
+        fireEvent.click(screen.getByRole("button", { name: /flag for eval/i }));
         expect(
           screen.getByTestId(`flag-modal-${MOCK_RUNS[0].id}`),
         ).toBeInTheDocument();
@@ -389,8 +333,8 @@ describe("WorkflowRunsTable", () => {
           screen.queryByTestId(`flag-modal-${MOCK_RUNS[0].id}`),
         ).not.toBeInTheDocument();
         expect(onEvalCaptured).not.toHaveBeenCalled();
-        // "Flag for eval" item should be restored
-        expect(screen.getByText("Flag for eval")).toBeInTheDocument();
+        // "Flag for eval" action should be restored
+        expect(screen.getByRole("button", { name: /flag for eval/i })).toBeInTheDocument();
       });
     });
 
@@ -407,7 +351,7 @@ describe("WorkflowRunsTable", () => {
         renderTable();
 
         await act(async () => {
-          fireEvent.click(screen.getByText("Debug run"));
+          fireEvent.click(screen.getByRole("button", { name: /debug run/i }));
         });
 
         expect(window.open).toHaveBeenCalledWith("", "_blank");
@@ -425,7 +369,7 @@ describe("WorkflowRunsTable", () => {
         renderTable();
 
         await act(async () => {
-          fireEvent.click(screen.getByText("Debug run"));
+          fireEvent.click(screen.getByRole("button", { name: /debug run/i }));
         });
 
         expect(mockTab.close).toHaveBeenCalled();
@@ -436,9 +380,10 @@ describe("WorkflowRunsTable", () => {
         setupRuns([MOCK_RUNS[0]]);
         const onRunSelect = vi.fn();
         renderTable({ onRunSelect });
+        const row = screen.getAllByTestId("run-row")[0];
 
         await act(async () => {
-          fireEvent.click(screen.getByText("Debug run"));
+          fireEvent.click(within(row).getByRole("button", { name: /debug run/i }));
         });
 
         expect(onRunSelect).not.toHaveBeenCalled();

--- a/src/app/api/mock/stakwork/workflows/[workflowId]/versions/route.ts
+++ b/src/app/api/mock/stakwork/workflows/[workflowId]/versions/route.ts
@@ -64,6 +64,7 @@ function buildWorkflowJson(label: string): string {
       name: "Prompt",
       display_name: "Prompt",
       skill: { type: "human" },
+      url: "https://api.anthropic.com/v1/messages",
       position: { x: 1260, y: ROW_Y },
       attributes: { vars: { prompt: "Confirm the generated feature title before continuing." } },
     },

--- a/src/components/StepDetailsModal/index.tsx
+++ b/src/components/StepDetailsModal/index.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useRef } from "react";
 import { Bot, Zap, Globe, RefreshCw, GitBranch, X, CheckCircle2, Loader2, Flag } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { toast } from "sonner";
 import { WorkflowTransition, StepType, getStepType } from "@/types/stakwork/workflow";
 import { isLlmStep } from "@/lib/stakwork/transitions";
@@ -268,8 +269,22 @@ export function StepDetailsModal({ step, isOpen, onClose, onSelect, runTransitio
               <div className="truncate font-mono text-xs text-muted-foreground">{step.name}</div>
             </div>
           </div>
-          <div className="flex shrink-0 items-center gap-3">
+          <div className="flex shrink-0 items-center gap-2">
             {runState && <StatusPill state={runState} />}
+            {showFlagForEval && !flagOpen && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={() => setFlagOpen(true)}
+                    aria-label="Flag for eval"
+                    className="grid h-7 w-7 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  >
+                    <Flag className="h-4 w-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Flag for eval</TooltipContent>
+              </Tooltip>
+            )}
             <button
               onClick={onClose}
               className="grid h-7 w-7 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
@@ -418,28 +433,15 @@ export function StepDetailsModal({ step, isOpen, onClose, onSelect, runTransitio
         )}
 
         {/* Footer */}
-        {(showFlagForEval || onSelect) && (
+        {onSelect && (
           <div className="flex justify-end gap-2 border-t px-5 py-3">
-            {showFlagForEval && !flagOpen && (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setFlagOpen(true)}
-                className="mr-auto"
-              >
-                <Flag className="mr-2 h-4 w-4" />
-                Flag for eval
-              </Button>
-            )}
             <Button variant="outline" size="sm" onClick={onClose}>
               Cancel
             </Button>
-            {onSelect && (
-              <Button size="sm" onClick={onSelect}>
-                <CheckCircle2 className="mr-2 h-4 w-4" />
-                Select Step
-              </Button>
-            )}
+            <Button size="sm" onClick={onSelect}>
+              <CheckCircle2 className="mr-2 h-4 w-4" />
+              Select Step
+            </Button>
           </div>
         )}
       </div>

--- a/src/components/workflow/index.tsx
+++ b/src/components/workflow/index.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useCallback, useEffect, useState, useRef } from "react";
 import axios from "axios";
+import { Maximize2 } from "lucide-react";
 import ImportNodeModal from "./ImportNodeModal";
 import RequestQueue from "./RequestQueue";
 import { toast } from "sonner";
@@ -395,6 +396,38 @@ function WorkflowApp(workflowApp: WorkflowAppProps) {
     }
   }, [useAssistantDimensions]);
 
+  // Card mode (inspector / run view) controls the viewport via targetPosition,
+  // so imperative fitView() is a no-op — compute the framing and set it directly.
+  // Small graphs are centred; large ones (real workflows) stay legible by
+  // anchoring to the Start node at a readable zoom instead of shrinking to fit.
+  const recenterCardView = useCallback(() => {
+    if (!nodes.length) return;
+    const container = ref.current as HTMLElement | null;
+    const width = container?.clientWidth || windowWidth;
+    const height = container?.clientHeight || windowHeight;
+    const bounds = getNodesBounds(nodes);
+    const READABLE = 0.6;
+    const fitVp = getViewportForBounds(bounds, width, height, 0.05, 1.2, 0.2);
+    autoCenteringRef.current = true;
+    if (fitVp.zoom >= READABLE) {
+      setTargetPosition({ x: fitVp.x, y: fitVp.y, zoom: fitVp.zoom });
+    } else {
+      const startNode =
+        nodes.find((n: any) => n.id === "start") ??
+        nodes.reduce((a: any, b: any) => (a.position.x <= b.position.x ? a : b));
+      const nodeH = Number(startNode?.data?.height) || 60;
+      const cy = startNode.position.y + nodeH / 2;
+      setTargetPosition({
+        zoom: READABLE,
+        x: 120 - startNode.position.x * READABLE,
+        y: height / 2 - cy * READABLE,
+      });
+    }
+    setTimeout(() => {
+      autoCenteringRef.current = false;
+    }, 150);
+  }, [nodes]);
+
   // Auto-fit view for project workflows on initial load
   useEffect(() => {
     if (!reactFlowInstance || nodes.length === 0 || hasInitialFitViewRef.current) return;
@@ -402,22 +435,9 @@ function WorkflowApp(workflowApp: WorkflowAppProps) {
     const isEditorMode = !!workflowData && !projectId;
     const hasSavedPosition = isEditorMode && !!localStorage.getItem(`position_${workflowId}`);
 
-    // Card mode (inspector / run view) controls the viewport via targetPosition,
-    // so imperative fitView() is a no-op. Compute the fit and set it directly.
     if (nodeStyle === "card") {
       hasInitialFitViewRef.current = true;
-      setTimeout(() => {
-        const container = ref.current as HTMLElement | null;
-        const width = container?.clientWidth || windowWidth;
-        const height = container?.clientHeight || windowHeight;
-        const bounds = getNodesBounds(nodes);
-        const vp = getViewportForBounds(bounds, width, height, 0.1, 1.2, 0.18);
-        autoCenteringRef.current = true;
-        setTargetPosition({ x: vp.x, y: vp.y, zoom: vp.zoom });
-        setTimeout(() => {
-          autoCenteringRef.current = false;
-        }, 150);
-      }, 120);
+      setTimeout(() => recenterCardView(), 120);
       return;
     }
 
@@ -1365,7 +1385,18 @@ function WorkflowApp(workflowApp: WorkflowAppProps) {
               <SearchButton workflowId={workflowId} />
             </Controls> */}
             {/* <MiniMap position={'bottom-left'} pannable zoomable/> */}
-            {!projectId && <SmartLayoutButton onNodesChange={onCustomNodesChanged} />}
+            {nodeStyle === "card" ? (
+              <button
+                onClick={recenterCardView}
+                title="Recenter"
+                aria-label="Recenter"
+                className="absolute right-2.5 top-2.5 z-10 grid h-8 w-8 place-items-center rounded-lg border bg-card/90 text-muted-foreground shadow-sm backdrop-blur transition-colors hover:bg-muted hover:text-foreground"
+              >
+                <Maximize2 className="h-4 w-4" />
+              </button>
+            ) : (
+              !projectId && <SmartLayoutButton onNodesChange={onCustomNodesChanged} />
+            )}
           </div>
         )}
 

--- a/src/components/workflow/inspector/WorkflowRunsTable.tsx
+++ b/src/components/workflow/inspector/WorkflowRunsTable.tsx
@@ -4,13 +4,7 @@ import React, { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { ExternalLink, Flag, MoreVertical, Bug, Loader2 } from "lucide-react";
+import { ExternalLink, Flag, Bug, Loader2 } from "lucide-react";
 import { useWorkflowRuns } from "@/hooks/useWorkflowRuns";
 import { FlagRunEvalModal } from "@/components/evals/FlagRunEvalModal";
 import { startDebugRun } from "@/lib/workflow/debugRun";
@@ -141,42 +135,60 @@ export function WorkflowRunsTable({
 
             <div
               className={cn(
-                "shrink-0 transition-opacity",
+                "flex shrink-0 items-center gap-0.5 transition-opacity",
                 isSelected ? "opacity-100" : "opacity-0 group-hover/run:opacity-100 focus-within:opacity-100",
               )}
               onClick={(e) => e.stopPropagation()}
             >
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
-                  <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="Run actions">
-                    <MoreVertical className="h-4 w-4" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem asChild>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    asChild
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 text-muted-foreground"
+                    aria-label="Open in Stak"
+                  >
                     <a
                       href={`https://jobs.stakwork.com/admin/projects/${run.id}`}
                       target="_blank"
                       rel="noreferrer"
                       onClick={(e) => e.stopPropagation()}
                     >
-                      <ExternalLink className="mr-2 h-4 w-4" />
-                      Open in Stak
+                      <ExternalLink className="h-4 w-4" />
                     </a>
-                  </DropdownMenuItem>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Open in Stak</TooltipContent>
+              </Tooltip>
 
-                  <DropdownMenuItem
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 text-muted-foreground"
+                    aria-label={isFlagged ? "Eval captured" : "Flag for eval"}
+                    disabled={isFlagged}
                     onClick={(e) => {
                       e.stopPropagation();
                       if (!isFlagged) setFlaggingRunId(runIdStr);
                     }}
-                    disabled={isFlagged}
                   >
-                    <Flag className={cn("mr-2 h-4 w-4", isFlagged && "fill-orange-500 text-orange-500")} />
-                    {isFlagged ? "Eval captured" : "Flag for eval"}
-                  </DropdownMenuItem>
+                    <Flag className={cn("h-4 w-4", isFlagged && "fill-orange-500 text-orange-500")} />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>{isFlagged ? "Eval captured" : "Flag for eval"}</TooltipContent>
+              </Tooltip>
 
-                  <DropdownMenuItem
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 text-muted-foreground"
+                    aria-label="Debug run"
+                    disabled={isDebugging}
                     onClick={async (e) => {
                       e.stopPropagation();
                       // Open blank tab synchronously to avoid popup blockers
@@ -192,17 +204,16 @@ export function WorkflowRunsTable({
                         setDebuggingRunId(null);
                       }
                     }}
-                    disabled={isDebugging}
                   >
                     {isDebugging ? (
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      <Loader2 className="h-4 w-4 animate-spin" />
                     ) : (
-                      <Bug className="mr-2 h-4 w-4" />
+                      <Bug className="h-4 w-4" />
                     )}
-                    Debug run
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Debug run</TooltipContent>
+              </Tooltip>
 
               {flaggingRunId === runIdStr && (
                 <FlagRunEvalModal


### PR DESCRIPTION
Follow-up polish on the workflow inspector / run view (PR #4419 follow-up).

### Changes
1. **Legible large workflows** — real workflows were shrunk to fit and became illegible dots. The card view now anchors to the **Start** node at a readable zoom when the graph is too large to fit legibly; small graphs still center as before.
2. **Recenter control** — the read-only inspector showed the editor's *Smart Layout* button (which mutates + persists node positions). Replaced it in card mode with a lightweight **Recenter** icon button.
3. **Run-row actions** — replaced the kebab menu with inline **Open in Stak / Flag / Debug** icon buttons (with tooltips) revealed on row hover.
4. **Modal header flag** — moved the step modal's *Flag for eval* action from a bottom-left button to a flag icon in the header (with tooltip).

Also restored the richer multi-skill mock workflow for local testing.

### Testing
- `StepDetailsModal` (24) and `WorkflowRunsTable` (27) unit tests updated and passing
- Typecheck + lint clean
- Verified all four in the running app (inspector + run view)