### PR TITLE
Polish workflow inspector: tab padding + run-row action chip

### DIFF
--- a/src/app/w/[slug]/workflows/[workflowId]/page.tsx
+++ b/src/app/w/[slug]/workflows/[workflowId]/page.tsx
@@ -324,7 +324,7 @@ export default function WorkflowInspectorPage() {
         <ResizablePanel defaultSize={40} minSize={20}>
         <div className="border rounded-lg overflow-hidden flex flex-col h-full bg-card/40">
           <Tabs defaultValue="stats" className="flex flex-col h-full min-h-0">
-            <div className="border-b px-3 pt-3 shrink-0">
+            <div className="border-b px-3 py-3 shrink-0">
               <TabsList className="max-w-full overflow-x-auto">
                 <TabsTrigger value="stats" className="shrink-0">Stats</TabsTrigger>
                 <TabsTrigger value="params" className="shrink-0">Params</TabsTrigger>

--- a/src/components/workflow/inspector/WorkflowRunsTable.tsx
+++ b/src/components/workflow/inspector/WorkflowRunsTable.tsx
@@ -135,7 +135,10 @@ export function WorkflowRunsTable({
 
             <div
               className={cn(
-                "flex shrink-0 items-center gap-0.5 transition-opacity",
+                // Float as a solid chip pinned to the right so the icons sit
+                // above the row text instead of colliding with it when the
+                // panel is narrow.
+                "absolute right-1.5 top-1/2 z-10 flex -translate-y-1/2 items-center gap-0.5 rounded-lg border bg-popover px-0.5 py-0.5 shadow-sm transition-opacity",
                 isSelected ? "opacity-100" : "opacity-0 group-hover/run:opacity-100 focus-within:opacity-100",
               )}
               onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
Two small inspector-panel polish fixes:

1. **Tab strip padding** — the Stats/Params/History/Prompts strip used `pt-3` only, so the segmented control touched the divider below it. Changed to `py-3`.
2. **Run-row actions when narrow** — when the right panel is collapsed, the inline Open/Flag/Debug icons collided with the timestamp text. They now float as a solid rounded chip pinned to the right (revealed on hover/selection), sitting above the row content cleanly at any width.

WorkflowRunsTable unit tests still pass (27).