### PR TITLE
Prefer id over unique_id for stepId in extractStepFromTransition and add conflict-case test

### DIFF
--- a/src/__tests__/unit/api/workflow-request-steps.test.ts
+++ b/src/__tests__/unit/api/workflow-request-steps.test.ts
@@ -317,6 +317,15 @@ describe("extractStepFromTransition — correct paths", () => {
     expect(result.messages).toEqual([{ role: "system", content: "You are..." }]);
   });
 
+  test("prefers id (slug) over unique_id (UUID) when both are present", () => {
+    const transition = {
+      id: "llm_generate_feature_title", // human-readable slug — must win
+      unique_id: "a1b2c3d4-uuid-for-react-flow", // UUID — must lose
+      attributes: { url: "https://api.openai.com/v1/chat/completions" },
+    };
+    expect(extractStepFromTransition(transition).stepId).toBe("llm_generate_feature_title");
+  });
+
   test("does NOT include headers or Authorization in snapshot", () => {
     const transition = realRunFixture.workflowData.transitions.replay_openai;
     const result = extractStepFromTransition(transition);

--- a/src/lib/stakwork/transitions.ts
+++ b/src/lib/stakwork/transitions.ts
@@ -194,7 +194,7 @@ export function extractStepFromTransition(transition: TransitionStep): Extracted
   };
 
   return {
-    stepId: ((transition.unique_id ?? transition.id) as string | undefined) ?? "",
+    stepId: ((transition.id ?? transition.unique_id) as string | undefined) ?? "",
     name: ((transition.display_name ?? transition.name) as string | undefined) ?? "",
     model,
     provider: inferProvider(requestUrl),


### PR DESCRIPTION
Generated with Hive: Prefer id over unique_id for stepId in extractStepFromTransition and add conflict-case test