### PR TITLE
Fix canvas chat live-sync: catch up on rejoin/reconnect

### DIFF
--- a/src/__tests__/unit/canvas/useCanvasChatAutoSave.test.ts
+++ b/src/__tests__/unit/canvas/useCanvasChatAutoSave.test.ts
@@ -77,17 +77,28 @@ function makeStore(initial?: Partial<ConvState>) {
 // simulate a server-side nudge.
 const { fakePusher } = vi.hoisted(() => {
   const handlers: Record<string, (...a: unknown[]) => void> = {};
+  const connHandlers: Record<string, ((...a: unknown[]) => void)[]> = {};
   const channel = {
     bind: (ev: string, h: (...a: unknown[]) => void) => {
       handlers[ev] = h;
     },
     unbind_all: () => {},
   };
-  const client = { subscribe: () => channel, unsubscribe: () => {} };
+  const connection = {
+    bind: (ev: string, h: (...a: unknown[]) => void) => {
+      (connHandlers[ev] ??= []).push(h);
+    },
+    unbind: (ev: string, h: (...a: unknown[]) => void) => {
+      connHandlers[ev] = (connHandlers[ev] ?? []).filter((x) => x !== h);
+    },
+  };
+  const client = { subscribe: () => channel, unsubscribe: () => {}, connection };
   return {
     fakePusher: {
       client,
       fire: (ev: string) => handlers[ev]?.(),
+      fireConnection: (ev: string) =>
+        (connHandlers[ev] ?? []).forEach((h) => h()),
     },
   };
 });
@@ -97,6 +108,13 @@ vi.mock("@/lib/pusher", () => ({
   getCanvasConversationChannelName: (id: string) => `canvas-conversation-${id}`,
   PUSHER_EVENTS: { CANVAS_CONVERSATION_UPDATED: "canvas-conversation-updated" },
 }));
+
+function setVisibility(state: "visible" | "hidden") {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+}
 
 // The hook imports `useCanvasChatStore` directly; we replace the module with
 // a factory that returns a fresh store per test.
@@ -365,5 +383,117 @@ describe("useCanvasChatAutoSave (live-sync)", () => {
     );
     const msgs = _store.getState().conversations["conv-1"].messages;
     expect(msgs.map((m) => m.id)).toContain("planner-y");
+  });
+
+  // ── Catch-up: Pusher has no replay ────────────────────────────────────
+  // Rows fanned out while we weren't subscribed / the socket was down /
+  // the tab was hidden must appear on return without waiting for the next
+  // live nudge. These cover the "rejoined the canvas chat and the planner
+  // sub-agent messages were missing" bug.
+
+  it("catches up on mount when a conversation is already active (remount)", async () => {
+    // Simulates a remount: the module-level store already holds an active
+    // conversation with a server id, so the change-driven `subscribe`
+    // callback never fires for it. The mount-seed must still subscribe AND
+    // refetch the rows that fanned out while we were gone.
+    _store.setState({
+      activeConversationId: "conv-1",
+      conversations: {
+        "conv-1": makeConv({
+          messages: [makeMsg("user", "m1")],
+          serverConversationId: "server-1",
+        }),
+      },
+    });
+
+    global.fetch = fetchReturning([
+      { id: "m1", role: "user", content: "Hello" },
+      { id: "planner-z", role: "assistant", content: "Plan ready" },
+    ]);
+
+    await act(async () => {
+      renderHook(() => useCanvasChatAutoSave({ githubLogin: "my-org" }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/orgs/my-org/chat/conversations/server-1",
+    );
+    const ids = _store.getState().conversations["conv-1"].messages.map(
+      (m) => m.id,
+    );
+    expect(ids).toContain("planner-z");
+  });
+
+  it("catches up when the tab becomes visible again", async () => {
+    setVisibility("hidden");
+    _store.setState({
+      activeConversationId: "conv-1",
+      conversations: {
+        "conv-1": makeConv({
+          messages: [makeMsg("user", "m1")],
+          serverConversationId: "server-1",
+        }),
+      },
+    });
+
+    // No rows yet at mount.
+    global.fetch = fetchReturning([{ id: "m1", role: "user", content: "Hello" }]);
+    await act(async () => {
+      renderHook(() => useCanvasChatAutoSave({ githubLogin: "my-org" }));
+      await Promise.resolve();
+    });
+
+    // Planner fanned out while hidden; tab returns → catch-up fetch merges it.
+    global.fetch = fetchReturning([
+      { id: "m1", role: "user", content: "Hello" },
+      { id: "planner-vis", role: "assistant", content: "Plan ready" },
+    ]);
+    await act(async () => {
+      setVisibility("visible");
+      document.dispatchEvent(new Event("visibilitychange"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const ids = _store.getState().conversations["conv-1"].messages.map(
+      (m) => m.id,
+    );
+    expect(ids).toContain("planner-vis");
+  });
+
+  it("catches up when the Pusher socket reconnects", async () => {
+    setVisibility("visible");
+    _store.setState({
+      activeConversationId: "conv-1",
+      conversations: {
+        "conv-1": makeConv({
+          messages: [makeMsg("user", "m1")],
+          serverConversationId: "server-1",
+        }),
+      },
+    });
+
+    global.fetch = fetchReturning([{ id: "m1", role: "user", content: "Hello" }]);
+    await act(async () => {
+      renderHook(() => useCanvasChatAutoSave({ githubLogin: "my-org" }));
+      await Promise.resolve();
+    });
+
+    global.fetch = fetchReturning([
+      { id: "m1", role: "user", content: "Hello" },
+      { id: "planner-recon", role: "assistant", content: "Plan ready" },
+    ]);
+    await act(async () => {
+      fakePusher.fireConnection("connected");
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const ids = _store.getState().conversations["conv-1"].messages.map(
+      (m) => m.id,
+    );
+    expect(ids).toContain("planner-recon");
   });
 });

--- a/src/app/org/[githubLogin]/_state/useCanvasChatAutoSave.ts
+++ b/src/app/org/[githubLogin]/_state/useCanvasChatAutoSave.ts
@@ -24,6 +24,20 @@
  * settles. Merging is identity-based (append-only), so a mid-turn nudge
  * can never drop a local message.
  *
+ * **Catch-up — Pusher has no replay.** Live nudges only cover the window
+ * we're actively subscribed AND the socket is up. To stay correct across
+ * the gaps we refetch-and-merge the active conversation: (a) immediately
+ * on every (re)subscribe, (b) once at mount seeded from current store
+ * state (a remount where the module-level store still holds the active
+ * convo never triggers the change-driven `subscribe` callback), (c) on
+ * `visibilitychange` → visible (backgrounded tabs suspend their socket),
+ * and (d) on Pusher `connected` (reconnect after a network blip). Without
+ * these, planner / sub-agent rows that fan out while you're away on
+ * another tab/chat stay invisible until the *next* live nudge happens to
+ * land — the "I rejoined the canvas chat and the sub-agent messages were
+ * missing until I left and came back" bug. Every catch-up routes through
+ * the same idempotent merge, so it can neither double-render nor drop.
+ *
  * Mounted once per page (in `OrgCanvasView`).
  */
 "use client";
@@ -210,6 +224,31 @@ export function useCanvasChatAutoSave({ githubLogin }: AutoSaveArgs) {
       }
     };
 
+    // ─── Catch-up sync ────────────────────────────────────────────────
+    // Resolve the local conversation for a server id (the active convo may
+    // have changed by call time) and merge whatever the server has now.
+    // The merge is idempotent (by id), so calling this defensively can
+    // never double-render or drop a message.
+    const syncByServerId = (serverId: string): void => {
+      const s = useCanvasChatStore.getState();
+      const cid = Object.keys(s.conversations).find(
+        (k) => s.conversations[k].serverConversationId === serverId,
+      );
+      if (cid) void syncFromServer(cid, serverId);
+    };
+
+    // Catch up the currently-active conversation. Used by the
+    // visibility/reconnect handlers below — Pusher delivers no replay, so
+    // any nudge fired while the tab was hidden or the socket was down is
+    // lost; an explicit refetch on return closes that gap.
+    const catchUpActive = (): void => {
+      const s = useCanvasChatStore.getState();
+      const activeId = s.activeConversationId;
+      if (!activeId) return;
+      const serverId = s.conversations[activeId]?.serverConversationId;
+      if (serverId) syncByServerId(serverId);
+    };
+
     // ─── Pusher subscription management ───────────────────────────────
     // Subscribe to the active conversation's channel; resubscribe when
     // the active conversation (or its server id) changes. Wrapped in
@@ -234,16 +273,15 @@ export function useCanvasChatAutoSave({ githubLogin }: AutoSaveArgs) {
         const channelName = getCanvasConversationChannelName(activeServerId);
         const channel = getPusherClient().subscribe(channelName);
         channel.bind(PUSHER_EVENTS.CANVAS_CONVERSATION_UPDATED, () => {
-          // Resolve the local conversation for this server id at call
-          // time (the active conversation may have changed).
-          const s = useCanvasChatStore.getState();
-          const cid = Object.keys(s.conversations).find(
-            (k) =>
-              s.conversations[k].serverConversationId === activeServerId,
-          );
-          if (cid) void syncFromServer(cid, activeServerId);
+          syncByServerId(activeServerId);
         });
         subRef.current = { serverId: activeServerId, channel };
+        // Catch up immediately on (re)subscribe: Pusher has no replay, so
+        // anything appended while we weren't subscribed to this channel
+        // (a reopened tab, a switch back to this conversation, the initial
+        // mount with the conversation already active) would otherwise stay
+        // invisible until the *next* live nudge. The fetch is idempotent.
+        syncByServerId(activeServerId);
       } catch {
         // Pusher unavailable — live-sync disabled.
       }
@@ -287,8 +325,54 @@ export function useCanvasChatAutoSave({ githubLogin }: AutoSaveArgs) {
       syncActiveSubscription(activeServerId);
     });
 
+    // Seed the subscription from current state at mount. `subscribe` only
+    // fires on *changes*, so a remount where the (module-level) store
+    // already holds an active conversation — e.g. navigating away from the
+    // canvas and back while the planner keeps fanning out — would never
+    // subscribe until some unrelated store mutation happened. This also
+    // performs the initial catch-up fetch (via `syncActiveSubscription`).
+    {
+      const s = useCanvasChatStore.getState();
+      const activeServerId = s.activeConversationId
+        ? s.conversations[s.activeConversationId]?.serverConversationId ?? null
+        : null;
+      syncActiveSubscription(activeServerId);
+    }
+
+    // ─── Visibility / reconnect catch-up ──────────────────────────────
+    // Browsers suspend backgrounded-tab websockets and Pusher drops on
+    // network blips; in both cases the nudges fired during the gap are
+    // never replayed. On return (tab visible again, socket reconnected)
+    // refetch the active conversation so missed planner / sub-agent rows
+    // appear. Mirrors the `visibilitychange` catch-up in the sibling
+    // `useSubAgentStatusRefresh`.
+    const handleVisibility = (): void => {
+      if (document.visibilityState === "visible") catchUpActive();
+    };
+    document.addEventListener("visibilitychange", handleVisibility);
+
+    const onReconnect = (): void => catchUpActive();
+    let pusherConnection: ReturnType<
+      typeof getPusherClient
+    >["connection"] | null = null;
+    try {
+      pusherConnection = getPusherClient().connection;
+      // `connected` fires on the initial connect AND on every reconnect.
+      pusherConnection.bind("connected", onReconnect);
+    } catch {
+      // Pusher unavailable — reconnect catch-up disabled.
+    }
+
     return () => {
       unsub();
+      document.removeEventListener("visibilitychange", handleVisibility);
+      if (pusherConnection) {
+        try {
+          pusherConnection.unbind("connected", onReconnect);
+        } catch {
+          /* ignore */
+        }
+      }
       // Tear down any live Pusher subscription on unmount.
       if (subRef.current.channel && subRef.current.serverId) {
         try {


### PR DESCRIPTION
## Problem

When you leave a canvas chat mid-conversation and come back, real-time updates don't arrive — most visibly, **Planner Sub-Agent messages don't show up** until you leave, load a different chat, and come back (which forces a re-subscribe + the next nudge to backfill).

## Root cause

The canvas chat's live-sync (`useCanvasChatAutoSave`) relied **solely** on live Pusher nudges, with no catch-up. Pusher has no event replay, so any `canvas-conversation-updated` nudge fired while you weren't actively subscribed was lost forever. The planner fans out its sub-agent messages over minutes — exactly when you're likely to have navigated away or backgrounded the tab.

Three compounding gaps:

1. **No catch-up on (re)subscribe** — `syncActiveSubscription` only *bound* the handler; it never fetched rows appended while unsubscribed.
2. **No initial call on mount** — the subscription was driven only by `useCanvasChatStore.subscribe(...)`, which fires on store *changes*. On a remount the module-level store already holds the active conversation, so nothing "changes" and no subscription was ever established.
3. **No visibility/reconnect handling** — backgrounded tabs suspend the websocket and network blips drop it; nudges during the gap vanish.

This is exactly why the workaround worked: switching chats and back forced `activeServerId` to change, re-subscribing, and the next nudge then triggered a full merge that pulled in everything missed.

## Fix

Bring `useCanvasChatAutoSave` to parity with its sibling `useSubAgentStatusRefresh` by catching up the active conversation via the existing **idempotent, merge-by-id** `syncFromServer`:

- **(a)** immediately on every (re)subscribe
- **(b)** once at mount, seeded from current store state
- **(c)** on `visibilitychange` -> visible
- **(d)** on Pusher `connected` (reconnect)

Because every catch-up routes through the same merge, it can never double-render or drop a message — the "never lose a message" invariant holds.

## Tests

Added 3 cases (remount catch-up, tab-visible catch-up, socket-reconnect catch-up). All 8 tests in the file and all 125 canvas tests pass.