### PR TITLE
Fix dispatch_research workers never scheduling

### DIFF
--- a/src/app/api/ask/quick/route.ts
+++ b/src/app/api/ask/quick/route.ts
@@ -643,17 +643,35 @@ export async function POST(request: NextRequest) {
       // Schedule research sub-agent workers for each dispatched intent.
       // Each worker runs off the stream's critical path via after() so
       // the HTTP response is already returned before any web searches run.
-      for (const intent of dispatchedResearch) {
-        after(async () => {
-          const { runResearchSubAgent } = await import(
-            "@/services/canvas-research-worker"
-          );
+      //
+      // CRITICAL: `dispatchedResearch` is populated by the
+      // `dispatch_research` tool, which only executes while the stream is
+      // CONSUMED — i.e. AFTER this synchronous handler returns. So we must
+      // NOT read the collector here (it's still empty at this point);
+      // instead, register a single `after()` that first drives the stream
+      // to completion (`consumeStream()` is idempotent and shared with the
+      // turn-persist block above), THEN iterates the now-populated array.
+      // Reading it synchronously here scheduled zero workers and left every
+      // dispatched research row stuck in the "researching" state forever.
+      after(async () => {
+        try {
+          await result.consumeStream();
+          await result.steps;
+        } catch {
+          // Stream errors are surfaced/logged elsewhere; we still want to
+          // schedule whatever intents were collected before the failure.
+        }
+        if (dispatchedResearch.length === 0) return;
+        const { runResearchSubAgent } = await import(
+          "@/services/canvas-research-worker"
+        );
+        for (const intent of dispatchedResearch) {
           await runResearchSubAgent({
             ...intent,
             workspaceSlugs: slugs,
           });
-        });
-      }
+        }
+      });
 
       return result.toUIMessageStreamResponse({
         // Hand the server-created/validated org-canvas row id back to the


### PR DESCRIPTION
## Problem

Background research (`dispatch_research`) never completes: the `Research` row is created and the card appears in the "researching" state, but it stays stuck there forever. No `web_search`, no `update_research`, and **zero `[canvas-research]` logs** — the sub-agent worker is never even started.

Observed in production logs:
```
TOOL CALL: dispatch_research : { slug: 'browser-use-vs-agent-router-sandbox', ... }
TOOL RESULT: dispatch_research
```
…and then silence.

## Root cause

`streamText`/`runCanvasAgent` returns lazily — the model call and tool executions only run while the response stream is **consumed**, which happens *after* the synchronous request handler returns.

The worker scheduling loop in `src/app/api/ask/quick/route.ts` read the collector **synchronously, before** the stream ran:

```js
for (const intent of dispatchedResearch) {
  after(async () => { await runResearchSubAgent({ ...intent, workspaceSlugs }); });
}
```

Every `await` between `await runCanvasAgent(...)` and this loop is nested inside an `after()` callback or the streaming `onFinish` hook — so the entire span is synchronous. Since JS is single-threaded, no background generation can advance during that span, so the `dispatch_research` tool's `execute` (which pushes into `dispatchedResearch`) cannot have run yet. The array is provably empty at iteration time → zero `after()` callbacks registered → no workers. The intent gets pushed later during stream consumption, but nothing is listening anymore.

This has been broken since `dispatch_research` was first added (#4259). The older **inline** research flow (`save_research` + `update_research`, called by the main agent in the same turn) is a separate, intact path and is unaffected.

## Fix

Move the iteration **inside** a single `after()` callback that first drives the stream to completion (`await result.consumeStream(); await result.steps;`), then reads the now-populated collector. This mirrors the adjacent turn-persistence `after()` block, which already consumes the stream before reading `result.steps`.

## Notes / follow-ups (not in this PR)

- `Research` rows created before this fix are still stuck at `content: null` — there is no recovery cron. A separate re-driver (re-dispatch or mark-failed for `content IS NULL` rows) is worth adding; the worker's advisory-lock + idempotency guards make that safe.
- No test covered the route's scheduling timing (worker and tool are unit-tested in isolation), which is why this slipped through. A regression test asserting `runResearchSubAgent` runs only after stream consumption would be valuable.