### PR TITLE
Route Lambda/CloudWatch log questions to logs_agent

### DIFF
--- a/src/lib/ai/askTools.ts
+++ b/src/lib/ai/askTools.ts
@@ -295,7 +295,7 @@ export function askTools(swarmUrl: string, swarmApiKey: string, repoUrls: string
       },
     }),
     search_logs: tool({
-      description: `Search the deployed application's live production logs (indexed in Quickwit). These ARE the runtime logs emitted by the user's running app, no matter where it's hosted (Vercel, AWS, Fly, etc.) — so use this for "prod"/"production"/"Vercel"/"the deployed app" log questions and any errors users are hitting. Supports Lucene query syntax. Does not support wildcards.
+      description: `Search the deployed application's live production logs (indexed in Quickwit). These ARE the runtime logs emitted by the user's running app — so use this for "prod"/"production"/"Vercel"/"the deployed app" log questions and any errors users are hitting. NOTE: this only covers the Quickwit-indexed app logs; it does NOT cover AWS Lambda / CloudWatch system logs — for those (or any question mentioning a Lambda function or CloudWatch) use the \`logs_agent\` tool instead. Supports Lucene query syntax. Does not support wildcards.
 IMPORTANT: every term MUST include a field prefix (e.g. "message:", "level:", "path:"). There is no default search field, so a bare query like "CLN" will fail with a 400 error ("query requires a default search field"). To search for a keyword, use "message:CLN".
 Example queries:
 - "path:pool AND path:status" (for searching endpoint like /api/pool/[slug]/status)
@@ -480,9 +480,11 @@ function buildWorkspaceTools(
     }),
     logs_agent: tool({
       description:
-        "Invoke the Logs Agent to perform deep, run-grounded analysis of infra, sandbox, and agent execution logs for this workspace. " +
-        "Use this when the user asks about what happened during a run, on a swarm, on a pod/sandbox, debugging agent failures, or wants a synthesised explanation backed by real log data. " +
-        "Heavier than `search_logs` (which does a quick Lucene keyword search) — prefer `search_logs` for simple keyword lookups. " +
+        "Invoke the Logs Agent to perform deep, run-grounded analysis of infra, sandbox, agent execution, AND AWS CloudWatch logs for this workspace. " +
+        "It has direct access to CloudWatch and all of the workspace's log groups (including AWS Lambda functions), and can do complex investigations — e.g. downloading thousands of log lines into local files and grepping through them. " +
+        "Use this when the user asks about what happened during a run, on a swarm, on a pod/sandbox, debugging agent failures, ANY question about a Lambda/CloudWatch/AWS log group, or wants a synthesised explanation backed by real log data. " +
+        "If the user mentions a Lambda function or CloudWatch, invoke this immediately — do NOT ask for permission first, and do NOT use `search_logs` (which only covers Quickwit-indexed app logs, not CloudWatch/Lambda system logs). " +
+        "Heavier than `search_logs` — prefer `search_logs` only for simple Lucene keyword lookups against the indexed app logs. " +
         "Optionally narrow the analysis to a specific feature or task by supplying featureId/taskId.",
       inputSchema: z.object({
         prompt: z.string().describe("The question or debugging query to send to the Logs Agent"),

--- a/src/lib/ai/askToolsMulti.ts
+++ b/src/lib/ai/askToolsMulti.ts
@@ -265,7 +265,7 @@ export function askToolsMulti(
 
     // search_logs (via MCP)
     allTools[`${prefix}__search_logs`] = tool({
-      description: `[${ws.slug}] Search ${ws.slug}'s live production application logs (indexed in Quickwit). These ARE the runtime logs emitted by the deployed app, regardless of host (Vercel, AWS, Fly, etc.) — use this for "prod"/"production"/"Vercel"/"deployed app" questions and errors users are hitting. Supports Lucene query syntax. Does not support wildcards. IMPORTANT: every term MUST include a field prefix (e.g. "message:", "level:", "path:") — there is no default search field, so a bare query like "CLN" fails with a 400 error. To search a keyword use "message:CLN".`,
+      description: `[${ws.slug}] Search ${ws.slug}'s live production application logs (indexed in Quickwit). These ARE the runtime logs emitted by the deployed app — use this for "prod"/"production"/"Vercel"/"deployed app" questions and errors users are hitting. NOTE: this only covers the Quickwit-indexed app logs; it does NOT cover AWS Lambda / CloudWatch system logs — for those (or any question mentioning a Lambda function or CloudWatch) use ${prefix}__logs_agent instead. Supports Lucene query syntax. Does not support wildcards. IMPORTANT: every term MUST include a field prefix (e.g. "message:", "level:", "path:") — there is no default search field, so a bare query like "CLN" fails with a 400 error. To search a keyword use "message:CLN".`,
       inputSchema: z.object({
         query: z.string().describe("Lucene query string"),
         max_hits: z
@@ -435,9 +435,11 @@ export function askToolsMulti(
     // search); prefer search_logs for simple lookups.
     allTools[`${prefix}__logs_agent`] = tool({
       description:
-        `[${ws.slug}] Invoke the Logs Agent for deep, run-grounded analysis of infra, sandbox, and agent execution logs in ${ws.slug}. ` +
-        `Use when the user asks what happened during a run, on a swarm, on a pod/sandbox, to debug agent failures, or wants a synthesised explanation backed by real log data. ` +
-        `Heavier than ${prefix}__search_logs — prefer that for simple keyword lookups. ` +
+        `[${ws.slug}] Invoke the Logs Agent for deep, run-grounded analysis of infra, sandbox, agent execution, AND AWS CloudWatch logs in ${ws.slug}. ` +
+        `It has direct access to CloudWatch and all of ${ws.slug}'s log groups (including AWS Lambda functions), and can do complex investigations — e.g. downloading thousands of log lines into local files and grepping through them. ` +
+        `Use when the user asks what happened during a run, on a swarm, on a pod/sandbox, to debug agent failures, ANY question about a Lambda/CloudWatch/AWS log group, or wants a synthesised explanation backed by real log data. ` +
+        `If the user mentions a Lambda function or CloudWatch, invoke this immediately — do NOT ask for permission first, and do NOT use ${prefix}__search_logs (which only covers Quickwit-indexed app logs, not CloudWatch/Lambda system logs). ` +
+        `Heavier than ${prefix}__search_logs — prefer that only for simple keyword lookups against the indexed app logs. ` +
         `Optionally narrow to a specific feature or task via featureId/taskId.`,
       inputSchema: z.object({
         prompt: z.string().describe("The question or debugging query to send to the Logs Agent"),


### PR DESCRIPTION
## Problem

When a dev asked to access logs from the `unstructured_pdf_parser` Lambda function, the dashboard chat tried `search_logs` (which only searches Quickwit-indexed app logs), found nothing, and then *asked permission* before offering to invoke `logs_agent` instead of just doing it.

Root cause is a tool-description gap:
- `logs_agent` actually has **direct CloudWatch access to all of the workspace's log groups (including Lambda functions)** and can run complex investigations, but its description only mentioned "infra, sandbox, and agent execution logs."
- `search_logs` over-claimed AWS coverage ("no matter where it's hosted (Vercel, AWS, Fly, etc.)"), steering the model toward it for AWS/Lambda questions.

## Changes

- **`logs_agent`** (`askTools.ts`, `askToolsMulti.ts`): describe its direct CloudWatch/Lambda log-group access and heavy investigation ability; instruct the model to invoke it immediately (no permission prompt) whenever a Lambda function or CloudWatch is mentioned.
- **`search_logs`** (both files): drop the misleading AWS coverage claim; clarify it only covers Quickwit-indexed app logs and redirect Lambda/CloudWatch questions to `logs_agent`.

Description-only change; no runtime behavior of the tools themselves is modified.