### PR TITLE
Add time budget to research sub-agent to prevent timeouts

### DIFF
--- a/src/lib/ai/runCanvasAgent.ts
+++ b/src/lib/ai/runCanvasAgent.ts
@@ -38,7 +38,11 @@
  */
 
 import { streamText, ModelMessage, ToolSet } from "ai";
-import type { StreamTextResult } from "ai";
+import type {
+  StreamTextResult,
+  StopCondition,
+  PrepareStepFunction,
+} from "ai";
 import {
   getMultiWorkspacePrefixMessages,
   getQuickAskPrefixMessages,
@@ -270,6 +274,25 @@ export interface RunCanvasAgentOptions {
    * Sibling pattern to `capturedWebSearchResults`.
    */
   dispatchedResearch?: DispatchedResearchIntent[];
+  /**
+   * Per-step override hook, forwarded verbatim to `streamText`. Lets a
+   * caller change tools / tool-choice / messages between steps (e.g. the
+   * research sub-agent injecting an elapsed-time note and, past its hard
+   * budget, restricting `activeTools` to `update_research` to force a
+   * timely finalize). **Off by default** — the interactive canvas/dashboard
+   * chat and every other caller pass nothing here, so their loop is
+   * unchanged.
+   */
+  prepareStep?: PrepareStepFunction<ToolSet>;
+  /**
+   * Extra stop conditions appended to the default `[END_OF_ANSWER]`
+   * end-marker condition. ANY condition stopping ends the loop. **Off by
+   * default.** The research sub-agent passes `hasToolCall("update_research")`
+   * so its loop ends the moment it writes the doc.
+   */
+  extraStopConditions?:
+    | StopCondition<ToolSet>
+    | Array<StopCondition<ToolSet>>;
   /** Caller-owned side effects. */
   hooks?: CanvasAgentHooks;
 }
@@ -489,6 +512,8 @@ export async function runCanvasAgent(
     additionalTools,
     dispatchedResearch,
     cachedConcepts,
+    prepareStep,
+    extraStopConditions,
   } = opts;
 
   // When cached concepts are supplied we skip the slow per-workspace
@@ -837,7 +862,15 @@ export async function runCanvasAgent(
     tools,
     messages: modelMessages,
     providerOptions,
-    stopWhen: createHasEndMarkerCondition(),
+    stopWhen: [
+      createHasEndMarkerCondition(),
+      ...(extraStopConditions
+        ? Array.isArray(extraStopConditions)
+          ? extraStopConditions
+          : [extraStopConditions]
+        : []),
+    ],
+    ...(prepareStep ? { prepareStep } : {}),
     stopSequences: ["[END_OF_ANSWER]"],
     onStepFinish: async (sf) => {
       logStep(sf.content);

--- a/src/services/canvas-research-worker.ts
+++ b/src/services/canvas-research-worker.ts
@@ -21,10 +21,85 @@
  * one call per `dispatch_research` tool invocation in the stream.
  */
 
+import {
+  hasToolCall,
+  type ModelMessage,
+  type PrepareStepFunction,
+  type ToolSet,
+} from "ai";
 import { db } from "@/lib/db";
 import { runCanvasAgent } from "@/lib/ai/runCanvasAgent";
 import { fanOutResearchToCanvas } from "@/services/canvas-research-fanout";
 import { getCurrentDateSnippet } from "@/lib/constants/prompt";
+
+/**
+ * Time budget for a research sub-agent run. The worker executes inside
+ * the dispatching request's Vercel `after()` block, so the whole run
+ * shares that function's `maxDuration` (800s). We carve that into:
+ *
+ *   - SOFT_BUDGET_MS — what the agent is *told* it has. An elapsed-time
+ *     note is injected before every step so it paces itself and avoids
+ *     over-gathering (e.g. fanning the slow `repo_agent` across repos).
+ *   - HARD_BUDGET_MS — the enforced cutover. Once elapsed, `prepareStep`
+ *     restricts `activeTools` to `update_research` and forces the model
+ *     to call it, so a timely (possibly partial) writeup always lands
+ *     instead of the run dying empty at the 800s wall. Set below the
+ *     soft budget AND well under 800s to leave headroom for one
+ *     in-flight tool call (a `repo_agent` call can run minutes and
+ *     cannot be interrupted mid-flight) plus the finalize step.
+ */
+const SOFT_BUDGET_MS = 600_000; // 10 min — communicated to the agent
+const HARD_BUDGET_MS = 480_000; // 8 min — forced finalize cutover
+
+const FINALIZE_TOOL = "update_research";
+
+/**
+ * Build the per-step budget hook for a single run. Closes over the run's
+ * start time. Before every step it strips any stale budget note, appends
+ * a fresh elapsed-time note, and — once past the hard budget — narrows
+ * the toolset to `update_research` and forces the call.
+ */
+function buildBudgetPrepareStep(
+  startMs: number,
+): PrepareStepFunction<ToolSet> {
+  return ({ messages }) => {
+    const elapsedMs = Date.now() - startMs;
+    const elapsedS = Math.round(elapsedMs / 1000);
+    const overHard = elapsedMs >= HARD_BUDGET_MS;
+
+    // Drop any prior injected note so they don't accumulate across steps.
+    const base = (messages as ModelMessage[]).filter(
+      (m) =>
+        !(
+          m.role === "user" &&
+          typeof m.content === "string" &&
+          m.content.startsWith("[TIME BUDGET]")
+        ),
+    );
+
+    const note = overHard
+      ? `[TIME BUDGET] ${elapsedS}s elapsed — your hard deadline has passed. Stop all searching. Call ${FINALIZE_TOOL} NOW with the complete markdown writeup using whatever you have gathered so far.`
+      : `[TIME BUDGET] ${elapsedS}s elapsed of a ~${Math.round(
+          SOFT_BUDGET_MS / 1000,
+        )}s budget. Finish all gathering (web_search / repo_agent) before ${Math.round(
+          HARD_BUDGET_MS / 1000,
+        )}s, then call ${FINALIZE_TOOL} once. Be efficient — avoid redundant or overly deep tool calls.`;
+
+    const withNote: ModelMessage[] = [
+      ...base,
+      { role: "user", content: note },
+    ];
+
+    if (overHard) {
+      return {
+        messages: withNote,
+        activeTools: [FINALIZE_TOOL],
+        toolChoice: { type: "tool", toolName: FINALIZE_TOOL },
+      };
+    }
+    return { messages: withNote };
+  };
+}
 
 export interface ResearchSubAgentArgs {
   researchId: string;
@@ -142,23 +217,35 @@ export async function runResearchSubAgent(
     });
 
     // Run the research sub-agent with readonly: true but keep update_research.
+    // The budget hook + stop condition keep it from running past the
+    // dispatching function's wall: it paces against a soft budget, is
+    // forced to finalize once past the hard budget, and the loop ends the
+    // instant the doc is written (see buildBudgetPrepareStep).
     const { result } = await runCanvasAgent({
       userId,
       orgId,
       workspaceSlugs,
       readonly: true,
-      keepWriteToolNames: ["update_research"],
+      keepWriteToolNames: [FINALIZE_TOOL],
       silentPusher: true,
       currentCanvasConversationId: conversationId,
+      prepareStep: buildBudgetPrepareStep(Date.now()),
+      // End the loop as soon as the doc is written — the worker's sole
+      // job is one `update_research` call. Fires only AFTER the write, so
+      // it never truncates gathering or yields an empty result.
+      extraStopConditions: [hasToolCall(FINALIZE_TOOL)],
       messages: [
         {
           role: "user",
           content:
             `${getCurrentDateSnippet()}\n\n` +
-            `You are a research sub-agent. Your only job is to research the following topic and call update_research once with the full markdown writeup.\n\n` +
+            `You are a research sub-agent. Your only job is to research the following topic and call ${FINALIZE_TOOL} once with the full markdown writeup.\n\n` +
             `Research slug: ${slug}\nTopic: ${topic}\nTitle: ${title}\nSummary: ${summary}\n\n` +
             `Instructions: ${prompt}\n\n` +
-            `Call web_search as many times as needed, then call update_research ONCE with the complete markdown. Do not write chat messages. Do not call any other write tools.`,
+            `Gather efficiently, then call ${FINALIZE_TOOL} ONCE with the complete markdown. Keep the writeup focused and well-structured — cover the requested sections without padding. ` +
+            `Prefer broad, high-signal queries over many narrow sequential ones; a handful of strong sources beats exhaustive coverage. ` +
+            `Use web_search for anything external/third-party. repo_agent is for the user's OWN codebases ONLY and is SLOW (each call takes minutes) — use it sparingly, if at all. ` +
+            `You are on a strict time budget (see the [TIME BUDGET] notes); do not over-gather. Do not write chat messages. Do not call any other write tools.`,
         },
       ],
     });


### PR DESCRIPTION
## Problem

Follow-up to #4453. With background research now actually running, a codebase-heavy run hit the **800s Vercel function timeout with no document written** — the research row is stuck at `content: null` forever.

Cause: the research sub-agent ran the full readonly canvas toolset (90 tools, including the per-workspace `repo_agent`, ~2-3 min **per call**) with **no time awareness, no step cap, and no forced finalize**. On a topic about the user's own codebase it made 4 sequential `repo_agent` calls + `search_logs` and blew the budget:

```
TOOL CALL: hive__repo_agent ...   (×4, minutes each)
TOOL CALL: hive__search_logs ...
Vercel Runtime Timeout Error: Task timed out after 800 seconds
```

## Fix

Add an opt-in time budget, **scoped to the research worker only** — tools stay fully flexible (web *and* codebase research).

**`src/lib/ai/runCanvasAgent.ts` (generic, behavior-preserving):**
- Two new optional passthroughs to `streamText`: `prepareStep` and `extraStopConditions`. Both default `undefined`, so the interactive canvas/dashboard chat and every other caller are unchanged.

**`src/services/canvas-research-worker.ts` (research-only behavior):**
- **Soft budget (10 min):** a `prepareStep` hook injects a `[TIME BUDGET] Ns elapsed…` note before each step so the agent paces itself (stale notes are stripped so they don't accumulate).
- **Hard budget (8 min / 480s):** once elapsed, `prepareStep` restricts `activeTools` to `update_research` and forces `toolChoice` to it, so a timely (possibly partial) writeup **always lands** instead of the run dying empty.
- **`extraStopConditions: [hasToolCall("update_research")]`** ends the loop the instant the doc is written. This fires only *after* the write (the act that saves content), so it can never truncate gathering or yield an empty result; it also prevents the forced-tool-choice path from looping.
- **Prompt tweaks:** gather efficiently, prefer broad high-signal queries, `repo_agent` is slow/codebase-only so use sparingly, keep the writeup brief.

`HARD_BUDGET_MS` (480s) is a tunable constant — set below the soft budget and well under 800s to leave headroom for one in-flight tool call (a `repo_agent` call can't be interrupted mid-flight) plus the finalize step.

## Testing

- `npx tsc --noEmit` clean.
- Existing unit tests pass: `canvas-research-worker` (10), `dispatchResearch` (3), `filterReadonly` (9).