### PR TITLE
Fix scorer metrics endpoint timeouts with query bounds and in-memory cache for 7d and 30d windows

### DIFF
--- a/src/__tests__/unit/lib/scorer/metrics.test.ts
+++ b/src/__tests__/unit/lib/scorer/metrics.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Unit tests for scorer metrics.ts
+ *
+ * Covers:
+ * - getCachedWindowedMetrics / setCachedWindowedMetrics: set/get, TTL expiry, LRU eviction
+ * - computeMetricsBulk (via computeAndCacheMetrics): createdAt bounds on artifact/agentLog queries,
+ *   take: 500 cap on feature fetch
+ */
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const { mockDb } = vi.hoisted(() => ({
+  mockDb: {
+    feature: { findMany: vi.fn(), findUniqueOrThrow: vi.fn() },
+    artifact: { findMany: vi.fn() },
+    agentLog: { groupBy: vi.fn() },
+    scorerDigest: { upsert: vi.fn() },
+    workspace: { update: vi.fn(), findUnique: vi.fn() },
+    $transaction: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/db", () => ({ db: mockDb }));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import {
+  getCachedWindowedMetrics,
+  setCachedWindowedMetrics,
+  computeAndCacheMetrics,
+} from "@/lib/scorer/metrics";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeFeature(id = "f1") {
+  return {
+    id,
+    title: "Feature " + id,
+    status: "IN_PROGRESS",
+    workspaceId: "ws1",
+    architecture: null,
+    tasks: [
+      {
+        id: "t1",
+        title: "Task 1",
+        description: null,
+        featureId: id,
+        workflowStartedAt: null,
+        workflowCompletedAt: null,
+        haltRetryAttempted: false,
+        chatMessages: [{ message: "do this please" }],
+      },
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Windowed cache tests
+// ---------------------------------------------------------------------------
+
+describe("getCachedWindowedMetrics / setCachedWindowedMetrics", () => {
+  const wsId = "ws-cache-test";
+  const win = "7d";
+  const data = {
+    aggregate: {
+      featureCount: 1,
+      avgMessagesPerTask: 1,
+      ciPassRate: 0,
+      avgPlanPrecision: 0,
+      avgPlanRecall: 0,
+      prMergeRate: 0,
+    },
+    features: [],
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("set and get returns the cached data", () => {
+    setCachedWindowedMetrics(wsId, win, data);
+    const result = getCachedWindowedMetrics(wsId, win);
+    expect(result).toEqual(data);
+  });
+
+  test("returns null when no entry exists", () => {
+    expect(getCachedWindowedMetrics("nonexistent", "7d")).toBeNull();
+  });
+
+  test("returns null after TTL expires (5 minutes)", () => {
+    setCachedWindowedMetrics(wsId, "30d", data);
+    // Advance past 5-minute TTL
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+    expect(getCachedWindowedMetrics(wsId, "30d")).toBeNull();
+  });
+
+  test("returns data before TTL expires", () => {
+    setCachedWindowedMetrics(wsId, "24h", data);
+    vi.advanceTimersByTime(4 * 60 * 1000); // 4 minutes — still valid
+    expect(getCachedWindowedMetrics(wsId, "24h")).toEqual(data);
+  });
+
+  test("LRU eviction: oldest entry dropped when at capacity (100)", () => {
+    vi.useRealTimers(); // use real timers for this test
+
+    // Pre-fill cache to exactly 100 entries
+    for (let i = 0; i < 100; i++) {
+      setCachedWindowedMetrics(`ws-lru-${i}`, "7d", data);
+    }
+
+    // The first key inserted should still exist at capacity
+    expect(getCachedWindowedMetrics("ws-lru-0", "7d")).toEqual(data);
+
+    // Adding one more should evict the oldest (ws-lru-0)
+    setCachedWindowedMetrics("ws-lru-overflow", "7d", data);
+    expect(getCachedWindowedMetrics("ws-lru-0", "7d")).toBeNull();
+
+    // The new entry should be present
+    expect(getCachedWindowedMetrics("ws-lru-overflow", "7d")).toEqual(data);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeMetricsBulk (via computeAndCacheMetrics) — query bounds
+// ---------------------------------------------------------------------------
+
+describe("computeAndCacheMetrics — DB query bounds", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default: feature.findMany returns one feature with a task
+    mockDb.feature.findMany.mockResolvedValue([makeFeature()]);
+    // No artifacts, no agent logs
+    mockDb.artifact.findMany.mockResolvedValue([]);
+    mockDb.agentLog.groupBy.mockResolvedValue([]);
+    // scorerDigest upsert and workspace update succeed
+    mockDb.$transaction.mockResolvedValue([]);
+    mockDb.workspace.update.mockResolvedValue({});
+  });
+
+  test("feature findMany uses take: 500", async () => {
+    await computeAndCacheMetrics("ws1");
+
+    expect(mockDb.feature.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 500 })
+    );
+  });
+
+  test("artifact findMany does NOT include createdAt when no since", async () => {
+    await computeAndCacheMetrics("ws1");
+
+    expect(mockDb.artifact.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.not.objectContaining({ createdAt: expect.anything() }),
+      })
+    );
+  });
+
+  test("artifact findMany includes createdAt: { gte: since } when since is provided", async () => {
+    const since = new Date("2024-01-01T00:00:00Z");
+    await computeAndCacheMetrics("ws1", since);
+
+    expect(mockDb.artifact.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          createdAt: { gte: since },
+        }),
+      })
+    );
+  });
+
+  test("agentLog groupBy does NOT include createdAt when no since", async () => {
+    await computeAndCacheMetrics("ws1");
+
+    expect(mockDb.agentLog.groupBy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.not.objectContaining({ createdAt: expect.anything() }),
+      })
+    );
+  });
+
+  test("agentLog groupBy includes createdAt: { gte: since } when since is provided", async () => {
+    const since = new Date("2024-01-01T00:00:00Z");
+    await computeAndCacheMetrics("ws1", since);
+
+    expect(mockDb.agentLog.groupBy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          createdAt: { gte: since },
+        }),
+      })
+    );
+  });
+
+  test("feature findMany includes createdAt: { gte: since } in where when since is provided", async () => {
+    const since = new Date("2024-06-01T00:00:00Z");
+    await computeAndCacheMetrics("ws1", since);
+
+    expect(mockDb.feature.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          createdAt: { gte: since },
+        }),
+      })
+    );
+  });
+});

--- a/src/app/api/admin/scorer/metrics/route.ts
+++ b/src/app/api/admin/scorer/metrics/route.ts
@@ -3,6 +3,8 @@ import { requireSuperAdmin } from "@/lib/auth/require-superadmin";
 import {
   loadCachedMetrics,
   computeAndCacheMetrics,
+  getCachedWindowedMetrics,
+  setCachedWindowedMetrics,
 } from "@/lib/scorer/metrics";
 
 const PAGE_SIZE = 20;
@@ -47,8 +49,31 @@ export async function GET(request: NextRequest) {
       }
     }
 
+    // Check short-TTL in-memory cache for windowed queries (7d/30d/24h)
+    if (!refresh && since) {
+      const cached = getCachedWindowedMetrics(workspaceId, window);
+      if (cached) {
+        const totalFeatures = cached.features.length;
+        const totalPages = Math.max(1, Math.ceil(totalFeatures / PAGE_SIZE));
+        const start = (page - 1) * PAGE_SIZE;
+        return NextResponse.json({
+          aggregate: cached.aggregate,
+          features: cached.features.slice(start, start + PAGE_SIZE),
+          pagination: { page, pageSize: PAGE_SIZE, totalFeatures, totalPages },
+        });
+      }
+      console.warn(
+        `[scorer/metrics] cache miss: ${workspaceId} window=${window}, computing...`
+      );
+    }
+
     // Cache miss or filtered: compute fresh and cache
     const result = await computeAndCacheMetrics(workspaceId, since);
+
+    // Store windowed result in short-TTL cache
+    if (since) {
+      setCachedWindowedMetrics(workspaceId, window, result);
+    }
 
     // Paginate the full result
     const totalFeatures = result.features.length;

--- a/src/lib/scorer/metrics.ts
+++ b/src/lib/scorer/metrics.ts
@@ -14,6 +14,49 @@
 import { db } from "@/lib/db";
 
 // ---------------------------------------------------------------------------
+// Windowed metrics in-memory cache (short-TTL, mirrors accessCache pattern)
+// ---------------------------------------------------------------------------
+
+const WINDOWED_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+const WINDOWED_CACHE_MAX = 100;
+
+interface WindowedCacheEntry {
+  data: { aggregate: AggregateMetrics; features: FeatureMetrics[] };
+  expiresAt: number;
+}
+const windowedMetricsCache = new Map<string, WindowedCacheEntry>();
+
+export function getCachedWindowedMetrics(
+  workspaceId: string,
+  window: string
+): WindowedCacheEntry["data"] | null {
+  const key = `${workspaceId}:${window}`;
+  const entry = windowedMetricsCache.get(key);
+  if (!entry) return null;
+  if (Date.now() > entry.expiresAt) {
+    windowedMetricsCache.delete(key);
+    return null;
+  }
+  return entry.data;
+}
+
+export function setCachedWindowedMetrics(
+  workspaceId: string,
+  window: string,
+  data: WindowedCacheEntry["data"]
+): void {
+  // Simple LRU eviction — drop oldest entry when at capacity
+  if (windowedMetricsCache.size >= WINDOWED_CACHE_MAX) {
+    const oldest = windowedMetricsCache.keys().next().value;
+    if (oldest) windowedMetricsCache.delete(oldest);
+  }
+  windowedMetricsCache.set(`${workspaceId}:${window}`, {
+    data,
+    expiresAt: Date.now() + WINDOWED_CACHE_TTL,
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Affirmation filter for correction counting
 // ---------------------------------------------------------------------------
 
@@ -299,6 +342,8 @@ export async function loadCachedMetrics(
 // Raw compute (no caching, used internally)
 // ---------------------------------------------------------------------------
 
+const FEATURE_FETCH_LIMIT = 500;
+
 function computeAggregateMetrics(
   workspaceId: string,
   since?: Date
@@ -316,6 +361,7 @@ async function computeMetricsBulk(
   const features = await db.feature.findMany({
     where: { workspaceId, deleted: false, ...dateFilter },
     orderBy: { createdAt: "desc" },
+    take: FEATURE_FETCH_LIMIT,
     select: {
       id: true,
       title: true,
@@ -353,6 +399,7 @@ async function computeMetricsBulk(
           where: {
             message: { taskId: { in: allTaskIds } },
             type: { in: ["DIFF", "PULL_REQUEST"] },
+            ...(since ? { createdAt: { gte: since } } : {}),
           },
           select: {
             type: true,
@@ -380,7 +427,10 @@ async function computeMetricsBulk(
     allTaskIds.length > 0
       ? await db.agentLog.groupBy({
           by: ["taskId", "agent"],
-          where: { taskId: { in: allTaskIds } },
+          where: {
+            taskId: { in: allTaskIds },
+            ...(since ? { createdAt: { gte: since } } : {}),
+          },
           _count: true,
         })
       : [];


### PR DESCRIPTION
Generated with Hive: Fix scorer metrics endpoint timeouts with query bounds and in-memory cache for 7d and 30d windows