### PR TITLE
Fix overflowing eval-set picker in eval capture modals

### DIFF
--- a/src/components/evals/CaptureEvalForm.tsx
+++ b/src/components/evals/CaptureEvalForm.tsx
@@ -3,7 +3,6 @@
 import React from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { Loader2, Plus, CheckCircle2, Circle } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -55,7 +54,7 @@ export function CaptureEvalForm({
         ) : evalSetsError ? (
           <p className="text-sm text-destructive">Failed to load eval sets</p>
         ) : (
-          <ScrollArea className="max-h-40 rounded-md border p-2">
+          <div className="max-h-40 overflow-y-auto rounded-md border p-2">
             <div className="space-y-1">
               {evalSets.length === 0 && (
                 <p className="px-2 py-1 text-xs text-muted-foreground">
@@ -105,7 +104,7 @@ export function CaptureEvalForm({
                 Create new eval set
               </button>
             </div>
-          </ScrollArea>
+          </div>
         )}
         {selectedEvalSetId === CREATE_NEW_VALUE && (
           <Input

--- a/src/components/evals/FlagAsEvalModal.tsx
+++ b/src/components/evals/FlagAsEvalModal.tsx
@@ -14,7 +14,6 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { TagInput } from "@/components/ui/tag-input";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { Loader2, Plus, CheckCircle2, Circle } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -224,7 +223,7 @@ export function FlagAsEvalModal({
                   Loading eval sets…
                 </div>
               ) : (
-                <ScrollArea className="max-h-44 rounded-md border p-2">
+                <div className="max-h-44 overflow-y-auto rounded-md border p-2">
                   <div className="space-y-1">
                     {evalSets.map((es) => {
                       const selected = selectedEvalSetId === es.ref_id;
@@ -269,7 +268,7 @@ export function FlagAsEvalModal({
                       Create new EvalSet
                     </button>
                   </div>
-                </ScrollArea>
+                </div>
               )}
               {selectedEvalSetId === CREATE_NEW_VALUE && (
                 <div className="space-y-1">

--- a/src/components/evals/FlagRunEvalModal.tsx
+++ b/src/components/evals/FlagRunEvalModal.tsx
@@ -10,7 +10,6 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { Loader2, CheckCircle2, Circle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { CaptureEvalForm, CREATE_NEW_VALUE } from "@/components/evals/CaptureEvalForm";
@@ -257,7 +256,7 @@ export function FlagRunEvalModal({
                 No LLM request steps found in this run.
               </div>
             ) : (
-              <ScrollArea className="max-h-64 rounded-md border p-2">
+              <div className="max-h-64 overflow-y-auto rounded-md border p-2">
                 <div className="space-y-1">
                   {steps.map((s) => {
                     const isSelected = selectedStep?.stepId === s.stepId;
@@ -302,7 +301,7 @@ export function FlagRunEvalModal({
                     );
                   })}
                 </div>
-              </ScrollArea>
+              </div>
             )}
           </div>
         )}


### PR DESCRIPTION
Replace Radix ScrollArea (no overflow-hidden, no definite height) with a native max-h overflow-y-auto div so the picker list scrolls within its box instead of spilling over the field below.