### PR TITLE
feat(agent-logs): store free-form _metadata from webhook body

### DIFF
--- a/prisma/migrations/20260619120000_add_agent_log_metadata/migration.sql
+++ b/prisma/migrations/20260619120000_add_agent_log_metadata/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "agent_logs"
+  ADD COLUMN "metadata" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1112,6 +1112,7 @@ model AgentLog {
   repos         String[]     @map("repos")
   config        Json? // full config blob: { model, provider, source, repos, tools, toolsConfig, temperature, schema, providerConfig } — provider/source/repos also promoted to columns
   stats         Json? // cached parsed blob stats: { totalMessages, estimatedTokens, durationSeconds, totalToolCalls, toolFrequency, bashFrequency, developerShellFrequency, conversationPreview }
+  metadata      Json? // free-form metadata passed in webhook body as `_metadata`; stored as-is, not interpreted
   feature       Feature?     @relation(fields: [featureId], references: [id])
   stakworkRun   StakworkRun? @relation(fields: [stakworkRunId], references: [id])
   task          Task?        @relation(fields: [taskId], references: [id])

--- a/src/app/api/webhook/agent-logs/route.ts
+++ b/src/app/api/webhook/agent-logs/route.ts
@@ -25,6 +25,7 @@ export const fetchCache = "force-no-store";
  *   task_id?:       string   — optional Task to associate with
  *   feature_id?:    string   — optional Feature to associate with
  *   logs:           unknown  — the actual log data (JSON array, JSONL string, etc.)
+ *   _metadata?:     object   — optional free-form metadata, stored as-is on the AgentLog record
  *
  * At least one of 'stakwork_run_id', 'task_id', or 'feature_id' is required.
  */
@@ -53,6 +54,11 @@ export async function POST(request: NextRequest) {
         : undefined;
     const provider: string | undefined = config?.provider ? String(config.provider) : undefined;
     const source: string | undefined = config?.source ? String(config.source) : undefined;
+    // Free-form metadata — stored as-is, not interpreted
+    const metadata: Record<string, unknown> | undefined =
+      body._metadata && typeof body._metadata === "object" && !Array.isArray(body._metadata)
+        ? (body._metadata as Record<string, unknown>)
+        : undefined;
     const repos: string[] = Array.isArray(config?.repos)
       ? (config.repos as unknown[]).filter((r): r is string => typeof r === "string")
       : [];
@@ -195,6 +201,7 @@ export async function POST(request: NextRequest) {
             provider: provider ?? null,
             source: source ?? null,
             repos,
+            metadata: metadata as Prisma.InputJsonValue | undefined,
           },
         })
       : await db.agentLog.create({
@@ -210,6 +217,7 @@ export async function POST(request: NextRequest) {
             provider: provider ?? null,
             source: source ?? null,
             repos,
+            metadata: metadata as Prisma.InputJsonValue | undefined,
           },
         });
 


### PR DESCRIPTION
## Summary
- Adds an optional `metadata` JSON column to the `AgentLog` model
- The `/api/webhook/agent-logs` endpoint now accepts a `_metadata` object in the request body and persists it as-is on the record (on both create and update)
- Metadata is **stored only** — it is not interpreted or used in any logic (e.g. not passed to the Jarvis graph write)

## Details
- `prisma/schema.prisma`: new `metadata Json?` column on `AgentLog`
- `route.ts`: parses `_metadata` from body (only when it's a plain object, not an array)
- New migration `20260619120000_add_agent_log_metadata` adds `metadata JSONB`

## Migration
Run `npx prisma migrate deploy` to apply the new column.