### PR TITLE
feat(canvas-agent): load system prompt from Prompt Manager

### DIFF
--- a/src/lib/ai/canvas-system-prompt.ts
+++ b/src/lib/ai/canvas-system-prompt.ts
@@ -1,0 +1,116 @@
+import { config } from "@/config/env";
+import { isDevelopmentMode } from "@/lib/runtime";
+import { DEFAULT_CANVAS_SYSTEM_PROMPT } from "@/lib/constants/prompt";
+
+/**
+ * Resolve the canvas agent's persona/reply-style preamble from the
+ * Stakwork Prompt Manager.
+ *
+ * The prompt is looked up by **name** (`CANVAS_AGENT_SYSTEM_PROMPT`) so
+ * the same code works across environments without hardcoding an
+ * environment-specific prompt id. We use the **published** version's
+ * value (what an editor explicitly promoted), falling back to the
+ * prompt's current `value` if nothing is published.
+ *
+ * There is no caching: the whole lookup is bounded by a single 10s
+ * deadline and ALWAYS falls back to the in-repo
+ * `DEFAULT_CANVAS_SYSTEM_PROMPT` on timeout, error, missing config, or
+ * dev/mock mode. The agent therefore never blocks on — or breaks
+ * because of — the Prompt Manager.
+ */
+
+const PROMPT_NAME = "CANVAS_AGENT_SYSTEM_PROMPT";
+const TIMEOUT_MS = 10_000;
+
+interface StakworkPromptListItem {
+  id: number;
+  name: string;
+}
+
+interface StakworkPromptDetail {
+  id: number;
+  name: string;
+  value: string;
+  published_version_id: number | null;
+}
+
+interface StakworkPromptVersionDetail {
+  value: string;
+}
+
+export async function getCanvasSystemPrompt(): Promise<string> {
+  // Dev/mock mode: the in-memory mock store has no CANVAS_AGENT_SYSTEM_PROMPT
+  // and we can't reach the real Stakwork API, so use the in-repo copy.
+  if (isDevelopmentMode()) {
+    return DEFAULT_CANVAS_SYSTEM_PROMPT;
+  }
+
+  if (!config.STAKWORK_API_KEY || !config.STAKWORK_BASE_URL) {
+    return DEFAULT_CANVAS_SYSTEM_PROMPT;
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  try {
+    return await resolvePublishedPrompt(controller.signal);
+  } catch (error) {
+    // Timeout (AbortError), network failure, bad JSON, missing prompt —
+    // all collapse to the in-repo default.
+    console.error("getCanvasSystemPrompt: falling back to default:", error);
+    return DEFAULT_CANVAS_SYSTEM_PROMPT;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function resolvePublishedPrompt(signal: AbortSignal): Promise<string> {
+  const headers = {
+    Authorization: `Token token=${config.STAKWORK_API_KEY}`,
+    "Content-Type": "application/json",
+  };
+
+  // 1. Find the prompt id by name.
+  const searchUrl = `${config.STAKWORK_BASE_URL}/prompts?search=${encodeURIComponent(PROMPT_NAME)}`;
+  const searchRes = await fetch(searchUrl, { method: "GET", headers, signal });
+  if (!searchRes.ok) {
+    throw new Error(`prompt search failed: ${searchRes.status}`);
+  }
+  const searchJson = await searchRes.json();
+  const prompts: StakworkPromptListItem[] = searchJson?.data?.prompts ?? [];
+  const match = prompts.find((p) => p.name === PROMPT_NAME);
+  if (!match) {
+    throw new Error(`prompt "${PROMPT_NAME}" not found`);
+  }
+
+  // 2. Fetch the prompt detail to learn the published version id.
+  const detailUrl = `${config.STAKWORK_BASE_URL}/prompts/${match.id}`;
+  const detailRes = await fetch(detailUrl, { method: "GET", headers, signal });
+  if (!detailRes.ok) {
+    throw new Error(`prompt detail failed: ${detailRes.status}`);
+  }
+  const detailJson = await detailRes.json();
+  const detail: StakworkPromptDetail | undefined = detailJson?.data;
+  if (!detail) {
+    throw new Error("prompt detail missing data");
+  }
+
+  // 3. Prefer the published version's value; fall back to the current value.
+  if (detail.published_version_id != null) {
+    const versionUrl = `${config.STAKWORK_BASE_URL}/prompts/${match.id}/versions/${detail.published_version_id}`;
+    const versionRes = await fetch(versionUrl, { method: "GET", headers, signal });
+    if (versionRes.ok) {
+      const versionJson = await versionRes.json();
+      const version: StakworkPromptVersionDetail | undefined = versionJson?.data;
+      if (version?.value) {
+        return version.value;
+      }
+    }
+  }
+
+  if (detail.value) {
+    return detail.value;
+  }
+
+  throw new Error("prompt has no usable value");
+}

--- a/src/lib/ai/canvas-system-prompt.ts
+++ b/src/lib/ai/canvas-system-prompt.ts
@@ -12,15 +12,34 @@ import { DEFAULT_CANVAS_SYSTEM_PROMPT } from "@/lib/constants/prompt";
  * value (what an editor explicitly promoted), falling back to the
  * prompt's current `value` if nothing is published.
  *
- * There is no caching: the whole lookup is bounded by a single 10s
- * deadline and ALWAYS falls back to the in-repo
- * `DEFAULT_CANVAS_SYSTEM_PROMPT` on timeout, error, missing config, or
- * dev/mock mode. The agent therefore never blocks on — or breaks
- * because of — the Prompt Manager.
+ * The whole lookup is bounded by a single 10s deadline and ALWAYS falls
+ * back to the in-repo `DEFAULT_CANVAS_SYSTEM_PROMPT` on timeout, error,
+ * missing config, or dev/mock mode. The agent therefore never blocks on
+ * — or breaks because of — the Prompt Manager.
+ *
+ * ## Caching (Vercel-aware)
+ *
+ * Resolved prompts are cached in-memory with a TTL so we don't make
+ * 3 sequential Stakwork calls on every agent turn.
+ *
+ * On Vercel each serverless instance has its OWN memory, so this is a
+ * best-effort per-instance cache (warm instances reuse it; cold starts
+ * refetch) — exactly what we want for a value that changes rarely. The
+ * cache is anchored on `globalThis` rather than a plain module-level
+ * `let` because Next.js can re-evaluate a module (route recompiles in
+ * dev, multiple bundles in prod) and reset module scope; `globalThis`
+ * survives that within the same process. A single in-flight promise is
+ * also memoized to dedupe concurrent turns (no thundering herd).
  */
 
 const PROMPT_NAME = "CANVAS_AGENT_SYSTEM_PROMPT";
 const TIMEOUT_MS = 10_000;
+// Cache a successful resolution for 5 min. Cache a fallback (Stakwork
+// down / not found) for only 30s so a freshly-published prompt — or
+// recovery from an outage — shows up quickly instead of being pinned to
+// the default for the full TTL.
+const SUCCESS_TTL_MS = 5 * 60_000;
+const FALLBACK_TTL_MS = 30_000;
 
 interface StakworkPromptListItem {
   id: number;
@@ -38,9 +57,29 @@ interface StakworkPromptVersionDetail {
   value: string;
 }
 
+interface CanvasPromptCacheEntry {
+  value: string;
+  expiresAt: number;
+}
+
+interface CanvasPromptCacheStore {
+  entry?: CanvasPromptCacheEntry;
+  inFlight?: Promise<string>;
+}
+
+// Anchor the cache on globalThis so it survives module re-evaluation
+// within a single (warm) serverless instance / dev process.
+const globalForCanvasPrompt = globalThis as typeof globalThis & {
+  __canvasSystemPromptCache?: CanvasPromptCacheStore;
+};
+const cacheStore: CanvasPromptCacheStore =
+  globalForCanvasPrompt.__canvasSystemPromptCache ??
+  (globalForCanvasPrompt.__canvasSystemPromptCache = {});
+
 export async function getCanvasSystemPrompt(): Promise<string> {
   // Dev/mock mode: the in-memory mock store has no CANVAS_AGENT_SYSTEM_PROMPT
   // and we can't reach the real Stakwork API, so use the in-repo copy.
+  // (Not cached — it's a constant.)
   if (isDevelopmentMode()) {
     return DEFAULT_CANVAS_SYSTEM_PROMPT;
   }
@@ -49,15 +88,45 @@ export async function getCanvasSystemPrompt(): Promise<string> {
     return DEFAULT_CANVAS_SYSTEM_PROMPT;
   }
 
+  // Fresh cache hit.
+  const cached = cacheStore.entry;
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.value;
+  }
+
+  // Dedupe concurrent refreshes: the first caller starts the fetch and
+  // everyone else awaits the same promise.
+  if (cacheStore.inFlight) {
+    return cacheStore.inFlight;
+  }
+
+  const fetchPromise = fetchAndCache();
+  cacheStore.inFlight = fetchPromise;
+  try {
+    return await fetchPromise;
+  } finally {
+    cacheStore.inFlight = undefined;
+  }
+}
+
+async function fetchAndCache(): Promise<string> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
 
   try {
-    return await resolvePublishedPrompt(controller.signal);
+    const value = await resolvePublishedPrompt(controller.signal);
+    cacheStore.entry = { value, expiresAt: Date.now() + SUCCESS_TTL_MS };
+    return value;
   } catch (error) {
     // Timeout (AbortError), network failure, bad JSON, missing prompt —
-    // all collapse to the in-repo default.
+    // all collapse to the in-repo default, cached briefly to avoid
+    // hammering Stakwork (with 10s timeouts) on every turn during an
+    // outage.
     console.error("getCanvasSystemPrompt: falling back to default:", error);
+    cacheStore.entry = {
+      value: DEFAULT_CANVAS_SYSTEM_PROMPT,
+      expiresAt: Date.now() + FALLBACK_TTL_MS,
+    };
     return DEFAULT_CANVAS_SYSTEM_PROMPT;
   } finally {
     clearTimeout(timer);

--- a/src/lib/ai/canvas-system-prompt.ts
+++ b/src/lib/ai/canvas-system-prompt.ts
@@ -12,7 +12,7 @@ import { DEFAULT_CANVAS_SYSTEM_PROMPT } from "@/lib/constants/prompt";
  * value (what an editor explicitly promoted), falling back to the
  * prompt's current `value` if nothing is published.
  *
- * The whole lookup is bounded by a single 10s deadline and ALWAYS falls
+ * The whole lookup is bounded by a single 15s deadline and ALWAYS falls
  * back to the in-repo `DEFAULT_CANVAS_SYSTEM_PROMPT` on timeout, error,
  * missing config, or dev/mock mode. The agent therefore never blocks on
  * — or breaks because of — the Prompt Manager.
@@ -33,7 +33,8 @@ import { DEFAULT_CANVAS_SYSTEM_PROMPT } from "@/lib/constants/prompt";
  */
 
 const PROMPT_NAME = "CANVAS_AGENT_SYSTEM_PROMPT";
-const TIMEOUT_MS = 10_000;
+// Covers all 3 sequential Stakwork calls (search → detail → version).
+const TIMEOUT_MS = 15_000;
 // Cache a successful resolution for 5 min. Cache a fallback (Stakwork
 // down / not found) for only 30s so a freshly-published prompt — or
 // recovery from an outage — shows up quickly instead of being pinned to
@@ -120,7 +121,7 @@ async function fetchAndCache(): Promise<string> {
   } catch (error) {
     // Timeout (AbortError), network failure, bad JSON, missing prompt —
     // all collapse to the in-repo default, cached briefly to avoid
-    // hammering Stakwork (with 10s timeouts) on every turn during an
+    // hammering Stakwork (with 15s timeouts) on every turn during an
     // outage.
     console.error("getCanvasSystemPrompt: falling back to default:", error);
     cacheStore.entry = {

--- a/src/lib/ai/runCanvasAgent.ts
+++ b/src/lib/ai/runCanvasAgent.ts
@@ -48,6 +48,7 @@ import {
   getQuickAskPrefixMessages,
 } from "@/lib/constants/prompt";
 import type { CanvasScopeHint } from "@/lib/constants/prompt";
+import { getCanvasSystemPrompt } from "@/lib/ai/canvas-system-prompt";
 import { askTools, listConcepts, createHasEndMarkerCondition } from "@/lib/ai/askTools";
 import { askToolsMulti } from "@/lib/ai/askToolsMulti";
 import {
@@ -645,6 +646,11 @@ export async function runCanvasAgent(
       }
     }
 
+    // Persona/reply-style preamble, pulled from the Stakwork Prompt
+    // Manager (published CANVAS_AGENT_SYSTEM_PROMPT). Bounded by a 10s
+    // deadline and always falls back to the in-repo default.
+    const canvasSystemPrompt = await getCanvasSystemPrompt();
+
     // Always rebuilt fresh (cheap string work) so the scope hint reflects
     // the user's CURRENT canvas/selection, even on a concept-cache hit.
     prefixMessages = getMultiWorkspacePrefixMessages(
@@ -654,6 +660,7 @@ export async function runCanvasAgent(
       orgId,
       buildScopeHint(scope, linkedWorkspaces),
       orgPromptSuffix,
+      canvasSystemPrompt,
     );
     cacheHit = multiCacheHit;
     cacheableConcepts = { conceptsByWorkspace };

--- a/src/lib/constants/prompt.ts
+++ b/src/lib/constants/prompt.ts
@@ -176,8 +176,37 @@ function buildMemberRoster(workspaces: WorkspaceConfig[]): string {
   return `\n## Team Members\n${lines.join("\n")}\n`;
 }
 
+export const DEFAULT_CANVAS_SYSTEM_PROMPT = `You are a source code learning assistant with access to multiple codebases. Your job is to provide a quick, clear, and actionable answer to the user's question, in a conversational tone.
+
+## Reply style — read this first
+
+**Be brief.** One short paragraph or a tight bullet list. Don't explain what you're about to do; just do it and report the result.
+
+**Don't narrate tool calls.** Skip phrases like "Let me check…", "Let me first look at…", "Now I'll…", "Let me gather information about…". The user doesn't see your tool calls and doesn't need a play-by-play. Just call the tools silently and answer.
+
+**No filler openers.** Don't start replies with "Perfect!", "Great question!", "Sure!", "Of course!", or similar. Get straight to the answer.
+
+**Never echo internal ids to the user.** Cuids (e.g. \`cmh4vrcj70001id04idolu9br\`) are an implementation detail. Refer to workspaces, initiatives, features, and milestones by their **name** in your replies — never their id, slug, or ref. The user sees names, not ids; ids in your reply look like noise.
+
+**Match the user's tone.** Highly technical question → technical answer (with function/endpoint names where useful). Casual question → plain language. Don't over-explain.
+
+**No deep dives unless asked.** Lengthy explanations are a failure mode, not a feature.
+
+**Don't review-and-critique by default.** When the user asks you to read something ("read the feature", "look at this plan", "what do you think"), your job is to **keep things moving**, not to produce a bulleted list of edits you'd make. If the thing you read ends with a question (e.g. *"Ready for architecture?"*, *"Does this look right?"*), answer that question — don't pivot to your own review. If you genuinely spot a blocker or clarifying question, raise the **single** most important thing in one sentence and ask the user how to proceed. Verbose "here are 4 things I'd add" responses are a failure mode.`
+
 // Multi-workspace system prompt
-export function getMultiWorkspaceSystemPrompt(workspaces: WorkspaceConfig[], currentUserGithubUsername?: string): string {
+//
+// `canvasSystemPrompt` is the agent's persona/reply-style preamble. It
+// defaults to `DEFAULT_CANVAS_SYSTEM_PROMPT` (the in-repo copy) but can
+// be overridden with a value fetched from the Stakwork Prompt Manager
+// (see `getCanvasSystemPrompt` in `@/lib/ai/canvas-system-prompt`). The
+// builder stays pure so it remains trivially testable; callers that want
+// the managed prompt fetch it first and pass it in.
+export function getMultiWorkspaceSystemPrompt(
+  workspaces: WorkspaceConfig[],
+  currentUserGithubUsername?: string,
+  canvasSystemPrompt: string = DEFAULT_CANVAS_SYSTEM_PROMPT,
+): string {
   // Surface only the identifiers the agent needs to *speak* about and
   // *call tools* with:
   //   - `name`: how the user refers to it in chat ("Graph & Swarm")
@@ -219,23 +248,7 @@ export function getMultiWorkspaceSystemPrompt(workspaces: WorkspaceConfig[], cur
   return `
 ${getCurrentDateSnippet()}
 
-You are a source code learning assistant with access to multiple codebases. Your job is to provide a quick, clear, and actionable answer to the user's question, in a conversational tone.
-
-## Reply style — read this first
-
-**Be brief.** One short paragraph or a tight bullet list. Don't explain what you're about to do; just do it and report the result.
-
-**Don't narrate tool calls.** Skip phrases like "Let me check…", "Let me first look at…", "Now I'll…", "Let me gather information about…". The user doesn't see your tool calls and doesn't need a play-by-play. Just call the tools silently and answer.
-
-**No filler openers.** Don't start replies with "Perfect!", "Great question!", "Sure!", "Of course!", or similar. Get straight to the answer.
-
-**Never echo internal ids to the user.** Cuids (e.g. \`cmh4vrcj70001id04idolu9br\`) are an implementation detail. Refer to workspaces, initiatives, features, and milestones by their **name** in your replies — never their id, slug, or ref. The user sees names, not ids; ids in your reply look like noise.
-
-**Match the user's tone.** Highly technical question → technical answer (with function/endpoint names where useful). Casual question → plain language. Don't over-explain.
-
-**No deep dives unless asked.** Lengthy explanations are a failure mode, not a feature.
-
-**Don't review-and-critique by default.** When the user asks you to read something ("read the feature", "look at this plan", "what do you think"), your job is to **keep things moving**, not to produce a bulleted list of edits you'd make. If the thing you read ends with a question (e.g. *"Ready for architecture?"*, *"Does this look right?"*), answer that question — don't pivot to your own review. If you genuinely spot a blocker or clarifying question, raise the **single** most important thing in one sentence and ask the user how to proceed. Verbose "here are 4 things I'd add" responses are a failure mode.
+${canvasSystemPrompt}
 
 ## Available Workspaces & Repositories
 ${workspaceList}
@@ -706,6 +719,12 @@ export function getMultiWorkspacePrefixMessages(
    * `getCanvasPromptSuffix()` composition (back-compat).
    */
   orgPromptSuffix?: string,
+  /**
+   * Agent persona/reply-style preamble. Defaults to the in-repo
+   * `DEFAULT_CANVAS_SYSTEM_PROMPT`; pass a value fetched from the
+   * Stakwork Prompt Manager (`getCanvasSystemPrompt`) to override it.
+   */
+  canvasSystemPrompt: string = DEFAULT_CANVAS_SYSTEM_PROMPT,
 ): ModelMessage[] {
   // Build pre-filled tool calls for each workspace's concepts
   const toolCalls: ModelMessage[] = [];
@@ -754,10 +773,10 @@ export function getMultiWorkspacePrefixMessages(
   // The two suffixes have disjoint vocabulary so they don't fight.
   const currentUserGithubUsername = workspaces[0]?.currentUserGithubUsername;
   const systemPrompt = orgId
-    ? getMultiWorkspaceSystemPrompt(workspaces, currentUserGithubUsername) +
+    ? getMultiWorkspaceSystemPrompt(workspaces, currentUserGithubUsername, canvasSystemPrompt) +
       (orgPromptSuffix ?? getCanvasPromptSuffix()) +
       getCanvasScopeHint(scope)
-    : getMultiWorkspaceSystemPrompt(workspaces, currentUserGithubUsername);
+    : getMultiWorkspaceSystemPrompt(workspaces, currentUserGithubUsername, canvasSystemPrompt);
 
   return [
     { role: "system", content: systemPrompt },


### PR DESCRIPTION
## What

The multi-workspace canvas agent now pulls its persona/reply-style preamble from the Stakwork **Prompt Manager** (the published `CANVAS_AGENT_SYSTEM_PROMPT`) instead of the hardcoded in-repo string. This lets us iterate on the agent's voice without a deploy.

## How

- **`src/lib/ai/canvas-system-prompt.ts`** (new) — `getCanvasSystemPrompt()`:
  - Looks up the prompt **by name** (`CANVAS_AGENT_SYSTEM_PROMPT`) via Stakwork search, so it's portable across environments (no hardcoded prod prompt id).
  - Uses the **published version's** value, falling back to the prompt's current `value` if nothing is published.
  - Bounded by a single **10s `AbortController` deadline**.
  - **Always falls back** to `DEFAULT_CANVAS_SYSTEM_PROMPT` on timeout, network/JSON error, missing config, not-found, or dev/mock mode — the agent never blocks on or breaks because of the Prompt Manager.
- **`src/lib/constants/prompt.ts`** — exported `DEFAULT_CANVAS_SYSTEM_PROMPT`; `getMultiWorkspaceSystemPrompt` / `getMultiWorkspacePrefixMessages` take an optional `canvasSystemPrompt` param (defaults to the in-repo copy) so the builders stay pure and testable.
- **`src/lib/ai/runCanvasAgent.ts`** — fetches the managed prompt and threads it through.

## Notes / tradeoffs

- **No caching (yet)** — every canvas-agent turn makes up to 3 sequential Stakwork calls (search → detail → version) before the LLM call. A short TTL cache is a follow-up.

## Testing

- Typecheck clean for changed files.
- Existing prompt unit tests pass (34 tests across `prompt-date`, `prompt-user-identity`, `canvas-scope-hint`).