### PR TITLE
Scorer: edit proposals before accepting + weight operator guidance

### DIFF
--- a/src/app/admin/scorer/ScorerDashboard.tsx
+++ b/src/app/admin/scorer/ScorerDashboard.tsx
@@ -17,6 +17,7 @@ import {
   Link2,
   Sparkles,
   Check,
+  Pencil,
 } from "lucide-react";
 import { toast } from "sonner";
 import {
@@ -1290,6 +1291,9 @@ function InsightImprove({ insightId }: { insightId: string }) {
   const [running, setRunning] = useState(false);
   const [proposals, setProposals] = useState<DescriptionProposal[]>([]);
   const [actingId, setActingId] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editText, setEditText] = useState("");
+  const [savingEdit, setSavingEdit] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
   const [history, setHistory] = useState<DescriptionProposal[]>([]);
   const [historyLoading, setHistoryLoading] = useState(false);
@@ -1388,6 +1392,26 @@ function InsightImprove({ insightId }: { insightId: string }) {
     }
   };
 
+  const saveEdit = async (id: string) => {
+    setSavingEdit(true);
+    try {
+      const res = await fetch(`/api/admin/scorer/proposals/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "edit", text: editText }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed");
+      toast.success("Proposal updated");
+      setEditingId(null);
+      await loadProposals();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to update");
+    } finally {
+      setSavingEdit(false);
+    }
+  };
+
   return (
     <div className="mt-3 border-t border-border/50 pt-2">
       <div className="flex items-center gap-3">
@@ -1465,47 +1489,100 @@ function InsightImprove({ insightId }: { insightId: string }) {
                   {p.rationale}
                 </p>
               )}
-              <div className="flex flex-col gap-1.5">
-                {p.edits.map((e, i) => (
-                  <div
-                    key={i}
-                    className="text-[11px] font-mono rounded overflow-hidden border"
-                  >
-                    {e.oldStr ? (
-                      <div className="bg-red-500/10 text-red-400 px-2 py-1 whitespace-pre-wrap border-b border-border/50">
-                        {e.oldStr}
-                      </div>
-                    ) : null}
-                    <div className="bg-green-500/10 text-green-400 px-2 py-1 whitespace-pre-wrap">
-                      {e.newStr}
-                    </div>
+              {editingId === p.id ? (
+                <>
+                  <div className="text-[9px] text-muted-foreground mb-1">
+                    Edit the resulting workspace description, then save.
                   </div>
-                ))}
-              </div>
-              <div className="flex justify-end gap-2 mt-2">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="text-[10px] h-6 px-2"
-                  disabled={actingId === p.id}
-                  onClick={() => act(p.id, "reject")}
-                >
-                  Reject
-                </Button>
-                <Button
-                  size="sm"
-                  className="text-[10px] h-6 px-2"
-                  disabled={actingId === p.id}
-                  onClick={() => act(p.id, "accept")}
-                >
-                  {actingId === p.id ? (
-                    <Loader2 className="w-3 h-3 mr-1 animate-spin" />
-                  ) : (
-                    <Check className="w-3 h-3 mr-1" />
-                  )}
-                  Accept &amp; apply
-                </Button>
-              </div>
+                  <textarea
+                    value={editText}
+                    onChange={(e) => setEditText(e.target.value)}
+                    rows={8}
+                    className="w-full text-[11px] font-mono rounded border bg-background p-2 resize-y focus:outline-none focus:ring-1 focus:ring-purple-500"
+                  />
+                  <div className="flex justify-end gap-2 mt-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="text-[10px] h-6 px-2"
+                      disabled={savingEdit}
+                      onClick={() => setEditingId(null)}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      size="sm"
+                      className="text-[10px] h-6 px-2"
+                      disabled={savingEdit}
+                      onClick={() => saveEdit(p.id)}
+                    >
+                      {savingEdit ? (
+                        <Loader2 className="w-3 h-3 mr-1 animate-spin" />
+                      ) : (
+                        <Check className="w-3 h-3 mr-1" />
+                      )}
+                      Save
+                    </Button>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div className="flex flex-col gap-1.5">
+                    {p.edits.map((e, i) => (
+                      <div
+                        key={i}
+                        className="text-[11px] font-mono rounded overflow-hidden border"
+                      >
+                        {e.oldStr ? (
+                          <div className="bg-red-500/10 text-red-400 px-2 py-1 whitespace-pre-wrap border-b border-border/50">
+                            {e.oldStr}
+                          </div>
+                        ) : null}
+                        <div className="bg-green-500/10 text-green-400 px-2 py-1 whitespace-pre-wrap">
+                          {e.newStr}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                  <div className="flex justify-end gap-2 mt-2">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-[10px] h-6 px-2"
+                      disabled={actingId === p.id}
+                      onClick={() => {
+                        setEditText(p.afterPreview);
+                        setEditingId(p.id);
+                      }}
+                    >
+                      <Pencil className="w-3 h-3 mr-1" />
+                      Edit
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="text-[10px] h-6 px-2"
+                      disabled={actingId === p.id}
+                      onClick={() => act(p.id, "reject")}
+                    >
+                      Reject
+                    </Button>
+                    <Button
+                      size="sm"
+                      className="text-[10px] h-6 px-2"
+                      disabled={actingId === p.id}
+                      onClick={() => act(p.id, "accept")}
+                    >
+                      {actingId === p.id ? (
+                        <Loader2 className="w-3 h-3 mr-1 animate-spin" />
+                      ) : (
+                        <Check className="w-3 h-3 mr-1" />
+                      )}
+                      Accept &amp; apply
+                    </Button>
+                  </div>
+                </>
+              )}
             </div>
           ))}
         </div>

--- a/src/app/api/admin/scorer/proposals/[id]/route.ts
+++ b/src/app/api/admin/scorer/proposals/[id]/route.ts
@@ -1,13 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireSuperAdmin } from "@/lib/auth/require-superadmin";
-import { applyProposal, rejectProposal } from "@/lib/scorer/improve";
+import {
+  applyProposal,
+  rejectProposal,
+  editProposal,
+} from "@/lib/scorer/improve";
 
 /**
- * PATCH — accept or reject a description proposal.
- * Body: { action: "accept" | "reject" }
+ * PATCH — accept, reject, or edit a description proposal.
+ * Body: { action: "accept" | "reject" | "edit", text?: string }
  *
  * Accept applies the recorded edits to the live Workspace.description via
  * exact str_replace; if the value drifted, the proposal is marked CONFLICT.
+ * Edit replaces the proposed final text (recomputes the diff).
  */
 export async function PATCH(
   request: NextRequest,
@@ -27,6 +32,19 @@ export async function PATCH(
       return NextResponse.json({ status: "REJECTED", id });
     }
 
+    if (action === "edit") {
+      const text = body?.text;
+      if (typeof text !== "string") {
+        return NextResponse.json(
+          { error: "text is required for edit" },
+          { status: 400 }
+        );
+      }
+      const result = await editProposal(id, text);
+      const status = result.error ? 400 : 200;
+      return NextResponse.json({ id, ...result }, { status });
+    }
+
     if (action === "accept") {
       const result = await applyProposal(id);
       const status =
@@ -35,7 +53,7 @@ export async function PATCH(
     }
 
     return NextResponse.json(
-      { error: "action must be 'accept' or 'reject'" },
+      { error: "action must be 'accept', 'reject', or 'edit'" },
       { status: 400 }
     );
   } catch (error) {

--- a/src/lib/scorer/editor.ts
+++ b/src/lib/scorer/editor.ts
@@ -140,6 +140,62 @@ export function createInMemoryEditor(initialContent: string): InMemoryEditor {
 }
 
 /**
+ * Convert a human-edited full document into recorded edits, so an edited
+ * proposal applies through the same exact-match path as an agent proposal.
+ *
+ * Produces a single minimal `str_replace` (common prefix/suffix trimmed,
+ * expanded to whole lines if needed for a unique, non-empty anchor). Falls
+ * back to a whole-document `create` when no unique anchor exists — still
+ * applied with exact semantics (CONFLICT on drift, never a silent clobber).
+ */
+export function diffToEdits(before: string, after: string): ProposedEdit[] {
+  if (before === after) return [];
+  if (before.length === 0) {
+    return [{ command: "create", oldStr: "", newStr: after }];
+  }
+
+  const lenB = before.length;
+  const lenA = after.length;
+
+  let p = 0;
+  const maxP = Math.min(lenB, lenA);
+  while (p < maxP && before[p] === after[p]) p++;
+
+  let s = 0;
+  const maxS = Math.min(lenB - p, lenA - p);
+  while (s < maxS && before[lenB - 1 - s] === after[lenA - 1 - s]) s++;
+
+  const startB = p;
+  const endB = lenB - s;
+  const endA = lenA - s;
+
+  const unique = (o: string) =>
+    o.length > 0 && before.indexOf(o) === before.lastIndexOf(o);
+
+  let oldStr = before.slice(startB, endB);
+  let newStr = after.slice(startB, endA);
+
+  if (!unique(oldStr)) {
+    // Expand the changed region out to whole-line boundaries to get a
+    // non-empty, ideally-unique anchor. The expanded chars on the left lie
+    // in the common prefix and on the right in the common suffix, so they
+    // are identical in `before` and `after`.
+    let lo = startB;
+    while (lo > 0 && before[lo - 1] !== "\n") lo--;
+    let hi = endB;
+    while (hi < lenB && before[hi] !== "\n") hi++;
+    const k = hi - endB;
+    oldStr = before.slice(lo, hi);
+    newStr = after.slice(lo, endA + k);
+    if (!unique(oldStr)) {
+      return [{ command: "create", oldStr: before, newStr: after }];
+    }
+  }
+
+  return [{ command: "str_replace", oldStr, newStr }];
+}
+
+/**
  * Re-apply a recorded edit against a live value with exact `str_replace`
  * semantics. Returns the new value, or `null` if the edit no longer applies
  * cleanly (stale / conflicting — i.e. not exactly one match).

--- a/src/lib/scorer/improve.ts
+++ b/src/lib/scorer/improve.ts
@@ -20,6 +20,7 @@ import { getModel, getApiKeyForProvider } from "@/lib/ai/provider";
 import {
   createInMemoryEditor,
   applyEdit,
+  diffToEdits,
   type TextEditInput,
   type ProposedEdit,
 } from "./editor";
@@ -212,6 +213,37 @@ export async function applyProposal(
   ]);
 
   return { status: "APPLIED", description: live };
+}
+
+/**
+ * Replace a PENDING proposal's edits with the human-edited final text.
+ * Recomputes the minimal diff against the original (pre-edit) description so
+ * the proposal still applies via exact str_replace, and refreshes the
+ * afterPreview shown in the UI/history.
+ */
+export async function editProposal(
+  proposalId: string,
+  text: string
+): Promise<{ status: string; editCount?: number; error?: string }> {
+  const proposal = await db.scorerDescriptionProposal.findUniqueOrThrow({
+    where: { id: proposalId },
+  });
+
+  if (proposal.status !== "PENDING") {
+    return { status: proposal.status, error: "Proposal is not pending" };
+  }
+
+  const edits = diffToEdits(proposal.beforePreview, text);
+
+  await db.scorerDescriptionProposal.update({
+    where: { id: proposalId },
+    data: {
+      edits: edits as unknown as Prisma.InputJsonValue,
+      afterPreview: text,
+    },
+  });
+
+  return { status: "PENDING", editCount: edits.length };
 }
 
 export async function rejectProposal(proposalId: string): Promise<void> {

--- a/src/lib/scorer/improve.ts
+++ b/src/lib/scorer/improve.ts
@@ -29,14 +29,18 @@ const DOC_PATH = "workspace-description.md";
 
 const SYSTEM_PROMPT = `You maintain the "workspace description" — a short context document that is injected directly into the system prompt of AI coding agents working in this workspace. Improving it makes those agents smarter immediately, with no code change or deploy.
 
-You are given a scorer INSIGHT describing an observed problem with agent behavior, plus optional guidance from a human operator. Make the SMALLEST, most surgical edit to the workspace description that durably addresses the insight — e.g. clarifying which repository contains which backend/service, noting constraints the agent cannot verify, or recording domain facts the agent repeatedly gets wrong.
+You are given a scorer INSIGHT (an observed problem with agent behavior) and — when provided — OPERATOR GUIDANCE from a human.
+
+PRIORITY OF INSTRUCTIONS:
+1. When OPERATOR GUIDANCE is present it is your PRIMARY and OVERRIDING directive. Do exactly — and ONLY — what it asks. The insight is then BACKGROUND CONTEXT ONLY: if the operator addresses just one part of the insight (or something tangential to it), edit only that. Do NOT broaden the edit to cover the rest of the insight or the suggestion.
+2. When there is NO operator guidance, address the insight itself: make the smallest, most surgical edit that durably resolves it.
 
 Rules:
 - Use the str_replace_based_edit_tool to view and edit the document.
 - ALWAYS \`view\` the current document before editing it.
 - Prefer \`str_replace\` for targeted changes; include enough surrounding context that old_str matches exactly once. Use \`create\` only when the document is empty.
-- Keep edits concise and factual. Do NOT restructure or rewrite content unrelated to the insight.
-- Do NOT invent facts that aren't supported by the insight, the repositories list, or the operator's guidance.
+- Keep edits concise and factual. Do NOT restructure or rewrite unrelated content. Add nothing beyond what the ACTIVE directive (operator guidance if present, otherwise the insight) calls for.
+- Do NOT invent facts that aren't supported by the operator's guidance, the insight, or the repositories list.
 
 When finished, briefly explain in plain text what you changed and why. If no edit is warranted, make no tool calls and explain why.`;
 
@@ -94,8 +98,21 @@ export async function runImprovement({
         .join("\n")
     : "(no repositories linked)";
 
+  const directive = userPrompt
+    ? [
+        "OPERATOR GUIDANCE — PRIMARY DIRECTIVE. Do exactly and ONLY this:",
+        userPrompt,
+        "",
+        "Treat the INSIGHT below as background context only. Address only what the operator guidance above asks — do NOT expand the edit to cover the rest of the insight or its suggestion.",
+      ]
+    : [
+        "No operator guidance was provided — address the INSIGHT below directly.",
+      ];
+
   const prompt = [
-    "INSIGHT",
+    ...directive,
+    "",
+    userPrompt ? "INSIGHT (background context only)" : "INSIGHT",
     `Pattern: ${insight.pattern}`,
     `Description: ${insight.description}`,
     `Suggestion: ${insight.suggestion}`,
@@ -109,10 +126,6 @@ export async function runImprovement({
         ? "It currently has content — `view` it first, then make targeted `str_replace` edits."
         : "It is currently EMPTY — author it from scratch with the `create` command (do NOT use str_replace on an empty document)."
     }`,
-    "",
-    userPrompt
-      ? `OPERATOR GUIDANCE:\n${userPrompt}`
-      : "No additional operator guidance was provided.",
   ].join("\n");
 
   const apiKey = getApiKeyForProvider("anthropic");


### PR DESCRIPTION
## What

Two improvements to the scorer self-improvement proposal flow (builds on #4472):

### 1. Edit a proposal before accepting
- Each pending proposal has an **Edit** (✏️) button that opens a textarea pre-filled with the proposed final description.
- On **Save**, `PATCH /api/admin/scorer/proposals/[id] { action: "edit", text }` calls `editProposal()`, which recomputes the change with `diffToEdits(beforePreview, text)` and stores it as the proposal's `edits` + refreshed `afterPreview`. Status stays `PENDING`.
- **Accept** still applies through exact `applyEdit` (`str_replace`), preserving no-clobber / CONFLICT-on-drift.

### 2. Heavily weight OPERATOR GUIDANCE over the insight
Previously the insight was framed as the primary task and the operator prompt was appended last, so the agent anchored on the insight and addressed the whole thing even when the operator asked about only part of it.

Now, when operator guidance is present it leads the prompt as the **primary, overriding directive**, the insight is explicitly demoted to "background context only," and the system prompt instructs the agent to do exactly — and only — what the operator asks.

## Files
- `src/lib/scorer/editor.ts` — `diffToEdits()`
- `src/lib/scorer/improve.ts` — `editProposal()`, prompt re-weighting
- `src/app/api/admin/scorer/proposals/[id]/route.ts` — `"edit"` action
- `src/app/admin/scorer/ScorerDashboard.tsx` — edit UI

## Testing
- `diffToEdits` + `applyEdit` verified across 12 scenarios.
- `tsc --noEmit` clean; ESLint clean (one pre-existing unrelated warning).