### PR TITLE
Pass tagged workspace description to subAgents options

### DIFF
--- a/src/__tests__/unit/services/roadmap/resolve-extra-swarms.test.ts
+++ b/src/__tests__/unit/services/roadmap/resolve-extra-swarms.test.ts
@@ -32,6 +32,7 @@ function makeWorkspace(overrides: Record<string, unknown> = {}) {
   return {
     id: "ws-1",
     slug: "my-workspace",
+    description: "My workspace description",
     deleted: false,
     ownerId: "user-1",
     swarm: {
@@ -64,6 +65,7 @@ describe("resolveExtraSwarms", () => {
     expect(result).toHaveLength(1);
     expect(result[0]).toEqual({
       name: "my-workspace",
+      description: "My workspace description",
       url: "https://swarm.example.com:3355",
       apiKey: "decrypted:encrypted-key",
       repoUrls: "https://github.com/org/repo1,https://github.com/org/repo2",
@@ -71,6 +73,15 @@ describe("resolveExtraSwarms", () => {
         learn_concepts: true,
       },
     });
+  });
+
+  it("omits description when the workspace has none", async () => {
+    mockFindFirst.mockResolvedValueOnce(makeWorkspace({ description: null }));
+
+    const result = await resolveExtraSwarms("hello @my-workspace", "user-1");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].description).toBeUndefined();
   });
 
   it("skips a slug the user is not a member of (workspace not found)", async () => {

--- a/src/app/api/learnings/diagrams/create/route.ts
+++ b/src/app/api/learnings/diagrams/create/route.ts
@@ -48,6 +48,7 @@ export async function POST(request: NextRequest) {
     const subAgents = resolved.length
       ? resolved.map((s) => ({
           name: s.name,
+          description: s.description,
           url: s.url,
           apiToken: s.apiKey,
           repoUrl: s.repoUrls,

--- a/src/app/api/learnings/diagrams/edit/route.ts
+++ b/src/app/api/learnings/diagrams/edit/route.ts
@@ -53,6 +53,7 @@ export async function POST(request: NextRequest) {
     const subAgents = resolved.length
       ? resolved.map((s) => ({
           name: s.name,
+          description: s.description,
           url: s.url,
           apiToken: s.apiKey,
           repoUrl: s.repoUrls,

--- a/src/services/roadmap/feature-chat.ts
+++ b/src/services/roadmap/feature-chat.ts
@@ -170,6 +170,7 @@ const FEATURE_SELECT_FOR_CHAT = {
  */
 interface SubAgent {
   name: string,
+  description?: string;
   url: string;
   apiKey: string;
   repoUrls: string;
@@ -214,7 +215,14 @@ export async function resolveExtraSwarms(
         .map((r) => r.repositoryUrl)
         .join(",");
 
-      results.push({ name: slug, url, apiKey, repoUrls, toolsConfig: { learn_concepts: true } });
+      results.push({
+        name: slug,
+        description: workspace.description ?? undefined,
+        url,
+        apiKey,
+        repoUrls,
+        toolsConfig: { learn_concepts: true },
+      });
     } catch {
       // Silently skip any workspace that fails to resolve
     }

--- a/src/services/task-workflow.ts
+++ b/src/services/task-workflow.ts
@@ -643,7 +643,7 @@ export async function callStakworkAPI(params: {
   featureId?: string | null;
   planEdited?: boolean;
   isPrototype?: boolean;
-  subAgents?: { name: string, url: string; apiKey: string; repoUrls: string }[];
+  subAgents?: { name: string, description?: string; url: string; apiKey: string; repoUrls: string }[];
   taskModel?: string;
   /**
    * MCP servers to expose to the swarm-side `repo/agent`. The agent


### PR DESCRIPTION
## What

When another workspace is tagged via `@workspace-slug`, `resolveExtraSwarms` now forwards that workspace's **description** into the `subAgents` options.

Previously each subAgent only carried `{ name, url, apiKey, repoUrls, toolsConfig }` — the workspace description was never passed, even though the canonical `SubAgent` type in `src/lib/ai/askTools.ts` already supports an optional `description` field.

## Changes

- **`src/services/roadmap/feature-chat.ts`** — added `description?` to the local `SubAgent` interface and populated it from `workspace.description` in `resolveExtraSwarms` (the existing `include` query already returns the field).
- **`src/services/task-workflow.ts`** — added `description?` to the `subAgents` param type on `callStakworkAPI` so it forwards into `vars.subAgents`.
- **`src/app/api/learnings/diagrams/create/route.ts`** & **`edit/route.ts`** — added `description: s.description` to the `.map()` projection passed into `repoAgent`.
- **`src/__tests__/unit/services/roadmap/resolve-extra-swarms.test.ts`** — fixture now includes a description (asserted in the happy path) plus a new test verifying `description` is omitted when the workspace has none.

## Testing

- `resolve-extra-swarms` unit tests pass (9/9).
- Touched source files typecheck clean.