### PR TITLE
feat(canvas-agent): per-user chat model picker + scorer multi-agent transcripts

### DIFF
--- a/prisma/migrations/20260621171759_add_user_chat_agent_model/migration.sql
+++ b/prisma/migrations/20260621171759_add_user_chat_agent_model/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "chat_agent_model" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,6 +58,12 @@ model User {
   // `CANVAS_AUTONOMOUS_TURNS_ENABLED` env var is a master kill-switch
   // layered above this flag.
   canvasAutonomousTurns    Boolean                  @default(false) @map("canvas_autonomous_turns")
+  // Per-user default model for the canvas Agent chat, stored in
+  // `getModelValue()` "provider/name" form (e.g. "anthropic/claude-sonnet-4").
+  // Null = fall back to the admin-configured default. Set from the gear
+  // menu on the canvas Agent chat panel. Named `chatAgentModel` (not just
+  // `agentModel`) to leave room for per-agent defaults later.
+  chatAgentModel           String?                  @map("chat_agent_model")
   createdAt                DateTime                 @default(now()) @map("created_at")
   updatedAt                DateTime                 @updatedAt @map("updated_at")
   deleted                  Boolean                  @default(false)

--- a/src/app/api/ask/quick/route.ts
+++ b/src/app/api/ask/quick/route.ts
@@ -352,6 +352,19 @@ export async function POST(request: NextRequest) {
         ? await loadOrgCanvasPromptCache({ conversationId, userId, orgId })
         : null;
 
+    // Per-user canvas-chat model preference (set from the Agent settings
+    // gear). Threaded into `runCanvasAgent`, which only honors Anthropic
+    // selections today. Null/absent → aieo default. Public viewers have
+    // no user row, so they always get the default.
+    const chatAgentModel = userId
+      ? (
+          await db.user.findUnique({
+            where: { id: userId },
+            select: { chatAgentModel: true },
+          })
+        )?.chatAgentModel ?? undefined
+      : undefined;
+
     // ============================================================
     // Backend-driven canvas turn — server-side persistence (Tier 1).
     //
@@ -461,6 +474,7 @@ export async function POST(request: NextRequest) {
           userId,
           orgId: orgId && isMultiWorkspace ? orgId : undefined,
           workspaceSlugs: slugs,
+          modelName: chatAgentModel,
           // Reuse cached concepts (skips the swarm `listConcepts` call)
           // when we have them for this org-canvas conversation. The prefix
           // is still rebuilt fresh each turn for an accurate scope hint.

--- a/src/app/api/user/preferences/route.ts
+++ b/src/app/api/user/preferences/route.ts
@@ -5,10 +5,13 @@ import { db } from "@/lib/db";
 import { logger } from "@/lib/logger";
 
 /**
- * Authenticated user's UI preferences. Currently a single flag:
- * `canvasAutonomousTurns` — the per-user opt-in for the autonomous
- * canvas-agent turns (see `src/services/canvas-agent-autoturn.ts`).
- * Toggled from the gear menu on the canvas Agent chat panel.
+ * Authenticated user's UI preferences. Currently:
+ * - `canvasAutonomousTurns` — the per-user opt-in for the autonomous
+ *   canvas-agent turns (see `src/services/canvas-agent-autoturn.ts`).
+ * - `chatAgentModel` — the per-user default model for the canvas Agent
+ *   chat, in `getModelValue()` "provider/name" form. Null = inherit the
+ *   admin-configured default.
+ * Both are edited from the gear menu on the canvas Agent chat panel.
  */
 
 /** GET /api/user/preferences — read the current user's preferences. */
@@ -20,13 +23,16 @@ export async function GET() {
 
   const user = await db.user.findUnique({
     where: { id: session.user.id },
-    select: { canvasAutonomousTurns: true },
+    select: { canvasAutonomousTurns: true, chatAgentModel: true },
   });
   if (!user) {
     return NextResponse.json({ error: "User not found" }, { status: 404 });
   }
 
-  return NextResponse.json({ canvasAutonomousTurns: user.canvasAutonomousTurns });
+  return NextResponse.json({
+    canvasAutonomousTurns: user.canvasAutonomousTurns,
+    chatAgentModel: user.chatAgentModel,
+  });
 }
 
 /** PATCH /api/user/preferences — update one or more preference flags. */
@@ -38,7 +44,7 @@ export async function PATCH(request: NextRequest) {
     }
 
     const body = await request.json();
-    const { canvasAutonomousTurns } = body;
+    const { canvasAutonomousTurns, chatAgentModel } = body;
 
     if (
       canvasAutonomousTurns !== undefined &&
@@ -50,21 +56,35 @@ export async function PATCH(request: NextRequest) {
       );
     }
 
+    if (
+      chatAgentModel !== undefined &&
+      chatAgentModel !== null &&
+      typeof chatAgentModel !== "string"
+    ) {
+      return NextResponse.json(
+        { error: "chatAgentModel must be a string or null" },
+        { status: 400 },
+      );
+    }
+
     const updated = await db.user.update({
       where: { id: session.user.id },
       data: {
         ...(canvasAutonomousTurns !== undefined && { canvasAutonomousTurns }),
+        ...(chatAgentModel !== undefined && { chatAgentModel }),
       },
-      select: { canvasAutonomousTurns: true },
+      select: { canvasAutonomousTurns: true, chatAgentModel: true },
     });
 
     logger.info("User preferences updated", "USER_PREFERENCES_UPDATE", {
       userId: session.user.id,
       canvasAutonomousTurns: updated.canvasAutonomousTurns,
+      chatAgentModel: updated.chatAgentModel,
     });
 
     return NextResponse.json({
       canvasAutonomousTurns: updated.canvasAutonomousTurns,
+      chatAgentModel: updated.chatAgentModel,
     });
   } catch (error) {
     logger.error(

--- a/src/app/org/[githubLogin]/_components/CanvasAgentSettingsPopover.tsx
+++ b/src/app/org/[githubLogin]/_components/CanvasAgentSettingsPopover.tsx
@@ -9,6 +9,14 @@ import {
   PopoverContent,
 } from "@/components/ui/popover";
 import { Switch } from "@/components/ui/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { getModelValue, type LlmModelOption } from "@/lib/ai/models";
 import { AutomationsSection } from "./AutomationsSection";
 
 /**
@@ -22,8 +30,12 @@ import { AutomationsSection } from "./AutomationsSection";
  *     `CANVAS_AUTONOMOUS_TURNS_ENABLED=false` env var can still
  *     master-kill the feature regardless of this flag.
  *
- * The value is a user-level preference (not per-conversation), persisted
- * via `/api/user/preferences`. Fetched once on mount; toggled
+ *   - **Model** (`chatAgentModel`) — the per-user default model the
+ *     canvas agent chats with, stored in `getModelValue()` "provider/name"
+ *     form. Empty = inherit the admin-configured default.
+ *
+ * The values are user-level preferences (not per-conversation), persisted
+ * via `/api/user/preferences`. Fetched once on mount; changes are saved
  * optimistically with a rollback on failure.
  */
 export function CanvasAgentSettingsPopover({
@@ -34,6 +46,9 @@ export function CanvasAgentSettingsPopover({
   const [open, setOpen] = useState(false);
   const [enabled, setEnabled] = useState<boolean | null>(null);
   const [saving, setSaving] = useState(false);
+  const [models, setModels] = useState<LlmModelOption[]>([]);
+  const [selectedModel, setSelectedModel] = useState<string | null>(null);
+  const [savingModel, setSavingModel] = useState(false);
 
   // Load the current preference once. Null until loaded so the Switch
   // renders disabled (no flicker between default-off and the real value).
@@ -42,10 +57,29 @@ export function CanvasAgentSettingsPopover({
     fetch("/api/user/preferences")
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
-        if (!cancelled && data) setEnabled(!!data.canvasAutonomousTurns);
+        if (!cancelled && data) {
+          setEnabled(!!data.canvasAutonomousTurns);
+          setSelectedModel(data.chatAgentModel ?? "");
+        }
       })
       .catch(() => {
         /* leave null; toggle stays disabled until a retry */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Load the available models for the picker.
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/llm-models")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (!cancelled && data?.models) setModels(data.models);
+      })
+      .catch(() => {
+        /* leave empty; picker stays hidden until a retry */
       });
     return () => {
       cancelled = true;
@@ -70,6 +104,27 @@ export function CanvasAgentSettingsPopover({
       });
     } finally {
       setSaving(false);
+    }
+  };
+
+  const handleModelChange = async (next: string) => {
+    const prev = selectedModel;
+    setSelectedModel(next); // optimistic
+    setSavingModel(true);
+    try {
+      const res = await fetch("/api/user/preferences", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ chatAgentModel: next }),
+      });
+      if (!res.ok) throw new Error("Request failed");
+    } catch {
+      setSelectedModel(prev ?? ""); // rollback
+      toast.error("Couldn't save that setting", {
+        description: "Please try again.",
+      });
+    } finally {
+      setSavingModel(false);
     }
   };
 
@@ -102,6 +157,34 @@ export function CanvasAgentSettingsPopover({
             aria-label="Auto-respond to planners"
           />
         </div>
+
+        {models.length > 0 && (
+          <div className="border-t pt-3 space-y-1.5">
+            <p className="text-sm font-medium leading-none">Model</p>
+            <p className="text-xs text-muted-foreground">
+              The default model the canvas agent chats with.
+            </p>
+            <Select
+              value={selectedModel ?? ""}
+              onValueChange={handleModelChange}
+              disabled={selectedModel === null || savingModel}
+            >
+              <SelectTrigger
+                className="h-8 text-xs"
+                data-testid="chat-agent-model-selector"
+              >
+                <SelectValue placeholder="Default" />
+              </SelectTrigger>
+              <SelectContent>
+                {models.map((m) => (
+                  <SelectItem key={m.id} value={getModelValue(m)}>
+                    {m.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
 
         <div className="border-t pt-3">
           <AutomationsSection githubLogin={githubLogin} />

--- a/src/lib/ai/runCanvasAgent.ts
+++ b/src/lib/ai/runCanvasAgent.ts
@@ -198,6 +198,16 @@ export interface RunCanvasAgentOptions {
   /** User-visible chat messages, in AI SDK ModelMessage[] form. */
   messages: ModelMessage[];
   /**
+   * Optional model override in `getModelValue()` "provider/name" form
+   * (e.g. "anthropic/claude-opus-4-6"), sourced from the caller's
+   * `User.chatAgentModel` preference. Only Anthropic models are honored
+   * — the canvas agent is Anthropic-only today (provider tools, prompt
+   * caching, etc. are wired to Anthropic), so a non-Anthropic selection
+   * is ignored and the aieo default is used. When omitted/ignored, the
+   * model resolves to aieo's default (sonnet).
+   */
+  modelName?: string;
+  /**
    * Cached concepts from a previous turn of the SAME conversation. When
    * provided, we SKIP the slow per-workspace `listConcepts` swarm
    * round-trip (a swarm can be slow or offline, and re-fetching the
@@ -515,6 +525,7 @@ export async function runCanvasAgent(
     cachedConcepts,
     prepareStep,
     extraStopConditions,
+    modelName,
   } = opts;
 
   // When cached concepts are supplied we skip the slow per-workspace
@@ -819,11 +830,20 @@ export async function runCanvasAgent(
         )
       : undefined;
 
+  // Honor the caller's model preference only when it targets the
+  // Anthropic provider (the canvas agent's only supported provider
+  // today). `modelName` is in "provider/name" form; aieo strips the
+  // prefix and uses the remainder as the model id. A non-Anthropic
+  // selection is ignored so we never pair an OpenAI/Google id with the
+  // hardcoded Anthropic provider/key/tools.
+  const modelOverride =
+    modelName && modelName.startsWith("anthropic/") ? modelName : undefined;
+
   const model = getModel(
     provider,
     bifrost?.apiKey ?? apiKey,
     primarySlug,
-    undefined,
+    modelOverride,
     bifrost
       ? { baseUrl: bifrost.baseUrl, headers: bifrost.headers }
       : undefined,

--- a/src/lib/auth/nextauth.ts
+++ b/src/lib/auth/nextauth.ts
@@ -1,7 +1,7 @@
 import { db } from "@/lib/db";
 import { EncryptionService } from "@/lib/encryption";
 import { logger } from "@/lib/logger";
-import { ensureMockWorkspaceForUser, ensureStakworkMockWorkspace, ensureMockOrgData } from "@/utils/mockSetup";
+import { ensureMockWorkspaceForUser, ensureStakworkMockWorkspace, ensureMockOrgData, ensureMockLlmModels } from "@/utils/mockSetup";
 import { isSuperAdminUserId } from "@/config/env";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import axios from "axios";
@@ -268,6 +268,17 @@ export const authOptions: NextAuthOptions = {
             logger.authError(
               "Failed to create mock org data - continuing authentication",
               "SIGNIN_MOCK_ORG_FAILED",
+              error
+            );
+          }
+
+          // Seed baseline public LLM models so model pickers have options — non-fatal
+          try {
+            await ensureMockLlmModels();
+          } catch (error) {
+            logger.authError(
+              "Failed to seed mock LLM models - continuing authentication",
+              "SIGNIN_MOCK_LLM_MODELS_FAILED",
               error
             );
           }

--- a/src/lib/scorer/prompts.ts
+++ b/src/lib/scorer/prompts.ts
@@ -9,31 +9,43 @@ coding, building, testing, and PR creation.
 
 ## Agent types in the transcript
 
-Our system uses multiple specialized agents, each labeled in the transcript:
+Our system uses multiple specialized agents, each labeled in the transcript. The transcript
+marks every agent with a "NEW AGENT CONTEXT" banner. Common agents include:
 
 - **plan-agent-{featureId}** — Explores the codebase and produces the implementation plan
-  (brief, architecture, user stories), then generates actionable dev tickets from that plan.
-  May re-explore the codebase to verify claims and get exact signatures/interfaces.
-  Runs first. Has access to search and read tools.
+  (brief, architecture, user stories). May re-explore to verify claims and get exact
+  signatures/interfaces. Runs first. Has access to search and read tools.
+- **TASK_GENERATION-agent-{featureId}** — Turns the plan into actionable dev tickets. May run
+  as its own separate context, distinct from plan-agent.
 - **coding-agent-{taskId}** — Implements the code changes for a single task. Has shell, edit,
   and file tools. Produces a PR.
 - **build-agent-{taskId}** — Runs the project build and fixes any build errors.
 - **test-agent-{taskId}** — Determines which tests to run, runs them, and fixes failures.
 - **browser-agent-{taskId}** — Takes screenshots and validates UI changes in the browser.
+- **wfe-agent-{taskId}** — Workflow-engine agent for Stakwork workflow tasks (editing workflow
+  JSON, skills, child workflows). Runs per-task in the execution phase instead of the
+  coding/build/test agents.
 
-Each agent runs as a separate LLM session with its own conversation history. The plan-agent
-handles the entire planning phase (plan + task generation). The coding/build/test/browser
-agents are part of the execution phase and run per-task.
+The planning phase may involve one or more agents; the execution phase spins up one or more
+fresh agents per task.
 
-IMPORTANT: Each agent session accumulates tokens cumulatively — every tool call iteration
-sends the full conversation history so far. When two agents explore the same files, the
-token cost of that exploration is paid twice. This is a key cost consideration.
+CRITICAL — how token costs actually work across agents:
+- Each agent runs as a SEPARATE LLM session with its OWN fresh context window. It has zero
+  memory of any other agent's messages, tool calls, or fetched files.
+- WITHIN a single agent's context, tokens accumulate: every tool-call iteration resends that
+  agent's full conversation history so far. So redundant re-reads INSIDE ONE agent's context
+  are a real, quantifiable waste — flag those.
+- ACROSS different agents, re-fetching the same file or workflow is NOT double-paid in a shared
+  window and is NOT waste. A later agent (e.g. a per-task wfe-agent) MUST re-gather context from
+  scratch because it cannot see what an earlier agent (e.g. the plan-agent) already fetched.
+  Do NOT report cross-agent re-fetching as a cost problem — that is expected, correct behavior.
 
 ## What to look for
 
 - Where did a specific agent (name it) waste time or go in the wrong direction?
-- Did the plan-agent spend excessive tokens re-exploring files during task generation that
-  it already read during planning? If so, quantify the overlap (how many identical tool calls).
+- Within a SINGLE agent's context, did it redundantly re-read or re-fetch the same file it
+  already had in that same context? If so, quantify the overlap (how many identical tool calls).
+  (Only count repeats inside one agent's context — never across the "NEW AGENT CONTEXT" boundary.)
 - Did the coding-agent misunderstand the task? What in the task description caused confusion?
 - Were there files or modules a specific agent should have found faster?
 - Did the build/test agents have to fix issues the coding-agent should have caught?

--- a/src/lib/scorer/session.ts
+++ b/src/lib/scorer/session.ts
@@ -29,7 +29,7 @@ export interface FullSession {
 
   planning: {
     humanMessages: string[];
-    agentTranscript: TranscriptEntry[];
+    agentTranscripts: AgentTranscript[];
     planOutput: {
       brief: string | null;
       requirements: string | null;
@@ -222,11 +222,24 @@ export async function assembleFullSession(
     select: { message: true },
   });
 
-  // Build plan agent transcript
-  const planTranscript: TranscriptEntry[] = [];
+  // Build plan agent transcripts, grouped by agent so each agent's
+  // independent context stays a distinct block. The planning phase can
+  // involve more than one agent (e.g. plan-agent then TASK_GENERATION-agent),
+  // each with its own fresh context window.
+  const planLogsByAgent = new Map<string, string[]>();
   for (const log of featureLogs) {
-    const entries = await fetchAgentTranscript(log.blobUrl);
-    planTranscript.push(...entries);
+    const existing = planLogsByAgent.get(log.agent) || [];
+    existing.push(log.blobUrl);
+    planLogsByAgent.set(log.agent, existing);
+  }
+  const planAgentTranscripts: AgentTranscript[] = [];
+  for (const [agentName, blobUrls] of planLogsByAgent) {
+    const allEntries: TranscriptEntry[] = [];
+    for (const blobUrl of blobUrls) {
+      const entries = await fetchAgentTranscript(blobUrl);
+      allEntries.push(...entries);
+    }
+    planAgentTranscripts.push({ agentName, entries: allEntries });
   }
 
   // Compute metrics
@@ -269,7 +282,7 @@ export async function assembleFullSession(
 
     planning: {
       humanMessages: featureChatMessages.map((m) => m.message),
-      agentTranscript: planTranscript,
+      agentTranscripts: planAgentTranscripts,
       planOutput: {
         brief: feature.brief,
         requirements: feature.requirements,
@@ -486,6 +499,42 @@ export function sessionToText(session: FullSession): string {
   );
   lines.push("");
 
+  // Count distinct agent contexts across planning + execution. The session is
+  // the concatenation of these INDEPENDENT agents, each running in its OWN fresh
+  // context window with NO shared memory. The "HOW TO READ" note and the per-agent
+  // banners only make sense when more than one agent is present — a single-agent
+  // session is one continuous context and gets no banner.
+  const agentContextCount =
+    session.planning.agentTranscripts.length +
+    session.execution.reduce(
+      (sum, phase) =>
+        sum +
+        phase.tasks.reduce((t, task) => t + task.agentTranscripts.length, 0),
+      0
+    );
+  const multiAgent = agentContextCount > 1;
+
+  if (multiAgent) {
+    lines.push("--- HOW TO READ THIS TRANSCRIPT ---");
+    lines.push(
+      `This session spans ${agentContextCount} independent agents. Each agent (marked by a`
+    );
+    lines.push(
+      '"NEW AGENT CONTEXT" banner) runs in its own fresh context window with NO'
+    );
+    lines.push(
+      "memory of any other agent above or below it. Re-fetching or re-reading data"
+    );
+    lines.push(
+      "that a different agent already retrieved is expected — each agent must"
+    );
+    lines.push(
+      "gather its own context from scratch. Token costs do NOT accumulate across"
+    );
+    lines.push("these separate context windows.");
+    lines.push("");
+  }
+
   // Planning
   lines.push("--- PLANNING PHASE ---");
   lines.push("");
@@ -498,11 +547,8 @@ export function sessionToText(session: FullSession): string {
     lines.push("");
   }
 
-  if (session.planning.agentTranscript.length > 0) {
-    lines.push("Plan agent transcript:");
-    for (const entry of session.planning.agentTranscript) {
-      lines.push(formatTranscriptEntry(entry, "  "));
-    }
+  for (const agent of session.planning.agentTranscripts) {
+    lines.push(...formatAgentContextBlock(agent, "", multiAgent));
     lines.push("");
   }
 
@@ -538,10 +584,7 @@ export function sessionToText(session: FullSession): string {
       lines.push("");
 
       for (const agent of task.agentTranscripts) {
-        lines.push(`  ${agent.agentName} agent transcript:`);
-        for (const entry of agent.entries) {
-          lines.push(formatTranscriptEntry(entry, "    "));
-        }
+        lines.push(...formatAgentContextBlock(agent, "  ", multiAgent));
         lines.push("");
       }
 
@@ -570,6 +613,39 @@ export function sessionToText(session: FullSession): string {
   lines.push(`Total corrections: ${session.metrics.totalCorrections}`);
 
   return lines.join("\n");
+}
+
+/**
+ * Render one agent's transcript. When the session has multiple agents, wrap it
+ * in an explicit "fresh context" banner so readers (human or LLM) don't mistake
+ * cross-agent re-fetching for redundant work within one context. A single-agent
+ * session is one continuous context, so it gets a plain header instead.
+ */
+function formatAgentContextBlock(
+  agent: AgentTranscript,
+  indent: string,
+  multiAgent: boolean
+): string[] {
+  const lines: string[] = [];
+  if (multiAgent) {
+    const bar = `${indent}${"=".repeat(72)}`;
+    lines.push(bar);
+    lines.push(`${indent}NEW AGENT CONTEXT — "${agent.agentName}"`);
+    lines.push(
+      `${indent}Fresh context window. No memory of other agents' messages, tool calls,`
+    );
+    lines.push(
+      `${indent}or fetched files. Re-fetching data another agent already retrieved is`
+    );
+    lines.push(`${indent}expected, not redundant.`);
+    lines.push(bar);
+  } else {
+    lines.push(`${indent}${agent.agentName} agent transcript:`);
+  }
+  for (const entry of agent.entries) {
+    lines.push(formatTranscriptEntry(entry, `${indent}  `));
+  }
+  return lines;
 }
 
 function formatTranscriptEntry(entry: TranscriptEntry, indent: string): string {

--- a/src/utils/mockSetup.ts
+++ b/src/utils/mockSetup.ts
@@ -2,6 +2,7 @@ import { db } from "@/lib/db";
 import { EncryptionService } from "@/lib/encryption";
 import {
   InitiativeStatus,
+  LlmProvider,
   MilestoneStatus,
   PodState,
   PoolState,
@@ -968,4 +969,67 @@ async function ensureMockOrgInitiatives(
   console.log(
     `[MockSetup] Seeded ${platformMilestones.length + trustMilestones.length} milestones across 2 initiatives for mock-org`,
   );
+}
+
+/**
+ * Ensures a baseline set of public LLM models exists so model pickers
+ * (plan/task inputs, the canvas Agent settings model selector, etc.) have
+ * options in local dev. Models are global rows (not per-user/workspace),
+ * so this is keyed on the unique `name` and is cheap to re-run on every
+ * mock login. Existing rows are left untouched aside from re-asserting
+ * `isPublic` so they show up in `/api/llm-models`.
+ */
+export async function ensureMockLlmModels(): Promise<void> {
+  const models: Array<{
+    name: string;
+    provider: LlmProvider;
+    inputPricePer1M: number;
+    outputPricePer1M: number;
+    isPlanDefault?: boolean;
+    isTaskDefault?: boolean;
+  }> = [
+    // Names must be real model ids aieo recognizes — the model picker
+    // stores them as `getModelValue()` "provider/name" (e.g.
+    // "anthropic/claude-opus-4-6"), which is threaded straight into
+    // aieo as the model id. Bogus names would 404 against the provider.
+    {
+      name: "claude-sonnet-4-6",
+      provider: LlmProvider.ANTHROPIC,
+      inputPricePer1M: 3,
+      outputPricePer1M: 15,
+      isPlanDefault: true,
+      isTaskDefault: true,
+    },
+    {
+      name: "claude-opus-4-6",
+      provider: LlmProvider.ANTHROPIC,
+      inputPricePer1M: 15,
+      outputPricePer1M: 75,
+    },
+    {
+      name: "claude-haiku-4-5",
+      provider: LlmProvider.ANTHROPIC,
+      inputPricePer1M: 1,
+      outputPricePer1M: 5,
+    },
+  ];
+
+  for (const m of models) {
+    await db.llmModel.upsert({
+      where: { name: m.name },
+      create: {
+        name: m.name,
+        provider: m.provider,
+        inputPricePer1M: m.inputPricePer1M,
+        outputPricePer1M: m.outputPricePer1M,
+        isPublic: true,
+        isPlanDefault: m.isPlanDefault ?? false,
+        isTaskDefault: m.isTaskDefault ?? false,
+      },
+      // Only re-assert visibility; don't clobber admin-tuned pricing/defaults.
+      update: { isPublic: true },
+    });
+  }
+
+  console.log(`[MockSetup] Ensured ${models.length} public LLM models`);
 }


### PR DESCRIPTION
## Summary

Two related changes bundled together:

### 1. Canvas Agent model picker (per-user)
Adds a model selector to the **Agent settings** gear menu on the canvas chat panel so users can choose which model the canvas agent chats with.

- **Schema**: new `User.chatAgentModel` column (`chat_agent_model`), storing the choice in `getModelValue()` `provider/name` form (e.g. `anthropic/claude-opus-4-6`). Named `chatAgentModel` (not just `agentModel`) to leave room for other per-agent defaults later. Migration included.
- **API**: `/api/user/preferences` GET + PATCH extended to read/write `chatAgentModel` alongside the existing `canvasAutonomousTurns` flag, with the same validation/logging pattern.
- **UI**: `CanvasAgentSettingsPopover` gains a shadcn `Select` populated from `/api/llm-models`, loaded on mount and saved optimistically with rollback + toast on failure (mirrors the existing toggle).
- **Agent wiring**: `runCanvasAgent` takes a new `modelName` option, threaded into `getModel`. The canvas chat route (`/api/ask/quick`) loads the caller's `chatAgentModel` and passes it. Only **Anthropic** selections are honored — the canvas agent is Anthropic-only today (provider tools, prompt caching), so a non-Anthropic pick falls back to the default rather than breaking.
- **Local seeding**: `ensureMockLlmModels()` seeds baseline public Anthropic models (`claude-sonnet-4-6`, `claude-opus-4-6`, `claude-haiku-4-5`) on mock dev login, so model pickers actually have options in local dev (the DB previously had zero `llm_models`).

### 2. Scorer multi-agent transcripts
Improves how the scorer presents and reasons about agent transcripts:

- Planning-phase logs are now **grouped by agent** (`agentTranscripts`), so each agent's independent context window is a distinct block instead of one flattened list.
- Multi-agent sessions render a **"NEW AGENT CONTEXT"** banner per agent plus a "how to read" preamble.
- Prompt guidance updated to make the key distinction explicit: re-fetching data **across** separate agent contexts is expected (each agent starts fresh and cannot see prior agents), and should NOT be flagged as waste — only redundant re-reads **within a single agent's context** count as a real cost problem.

## Testing
- `vitest run` for scorer, `lib/ai/models`, and `PlanStartInput` suites: **78 passed**.
- Typecheck + eslint clean on all touched source files.
- Manually verified the picker renders and the canvas agent log reflects the chosen model.

## Notes
- Other `runCanvasAgent` callers (autoturn, research worker, scout, MCP tools, dispatchers) intentionally do not pass `modelName` — they keep the default since they're programmatic, not interactive chat.
- In full mock mode (`USE_MOCKS=true` without `USE_REAL_LLM`), model choice isn't visibly reflected since the mock provider returns a fixed model.