### PR TITLE
Generated with Hive: Add Lingo API proxy routes, patchEdge service, and mock data for Jargon nodes

### DIFF
--- a/src/__tests__/unit/api/workspaces/lingo-routes.test.ts
+++ b/src/__tests__/unit/api/workspaces/lingo-routes.test.ts
@@ -1,0 +1,613 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+import { MIDDLEWARE_HEADERS } from "@/config/middleware";
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/helpers/swarm-access", () => ({
+  getWorkspaceSwarmAccess: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/swarm", () => ({
+  getJarvisUrl: vi.fn((name: string) => `https://${name}.sphinx.chat:8444`),
+}));
+
+vi.mock("@/services/swarm/api/nodes", () => ({
+  addEdge: vi.fn(),
+  patchEdge: vi.fn(),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+// ─── Imports after mocks ──────────────────────────────────────────────────────
+
+import { getWorkspaceSwarmAccess } from "@/lib/helpers/swarm-access";
+import { addEdge, patchEdge } from "@/services/swarm/api/nodes";
+
+const mockGetWorkspaceSwarmAccess = vi.mocked(getWorkspaceSwarmAccess);
+const mockAddEdge = vi.mocked(addEdge);
+const mockPatchEdge = vi.mocked(patchEdge);
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const SLUG = "test-workspace";
+const USER = { id: "user-1", email: "user@test.com", name: "Test User" };
+const SWARM_DATA = {
+  workspaceId: "ws-1",
+  swarmName: "testswarm",
+  swarmUrl: "https://testswarm.sphinx.chat",
+  swarmApiKey: "api-key-123",
+  swarmStatus: "ACTIVE",
+  poolName: "pool-1",
+  swarmSecretAlias: null,
+};
+
+function makeAuthenticatedRequest(
+  url: string,
+  options: { method?: string; body?: object } = {},
+) {
+  const req = new NextRequest(url, {
+    method: options.method ?? "GET",
+    ...(options.body
+      ? {
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(options.body),
+        }
+      : {}),
+  });
+  const headers = new Headers(req.headers);
+  headers.set(MIDDLEWARE_HEADERS.USER_ID, USER.id);
+  headers.set(MIDDLEWARE_HEADERS.USER_EMAIL, USER.email);
+  headers.set(MIDDLEWARE_HEADERS.USER_NAME, USER.name);
+  headers.set(MIDDLEWARE_HEADERS.AUTH_STATUS, "authenticated");
+  headers.set(MIDDLEWARE_HEADERS.REQUEST_ID, "req-1");
+  return new NextRequest(url, {
+    method: options.method ?? "GET",
+    headers,
+    ...(options.body ? { body: JSON.stringify(options.body) } : {}),
+  });
+}
+
+function unauthenticatedRequest(url: string) {
+  return new NextRequest(url, { method: "GET" });
+}
+
+// ─── GET /lingo/nodes ─────────────────────────────────────────────────────────
+
+describe("GET /api/workspaces/[slug]/lingo/nodes", () => {
+  let GET: typeof import("@/app/api/workspaces/[slug]/lingo/nodes/route").GET;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    delete process.env.USE_MOCKS;
+    ({ GET } = await import("@/app/api/workspaces/[slug]/lingo/nodes/route"));
+  });
+
+  afterEach(() => {
+    delete process.env.USE_MOCKS;
+  });
+
+  test("returns 401 for unauthenticated request", async () => {
+    const req = unauthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/nodes`,
+    );
+    const res = await GET(req, { params: Promise.resolve({ slug: SLUG }) });
+    expect(res.status).toBe(401);
+  });
+
+  test("returns 403 when ACCESS_DENIED", async () => {
+    mockGetWorkspaceSwarmAccess.mockResolvedValueOnce({
+      success: false,
+      error: { type: "ACCESS_DENIED" },
+    });
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/nodes`,
+    );
+    const res = await GET(req, { params: Promise.resolve({ slug: SLUG }) });
+    expect(res.status).toBe(403);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test("returns 404 when WORKSPACE_NOT_FOUND", async () => {
+    mockGetWorkspaceSwarmAccess.mockResolvedValueOnce({
+      success: false,
+      error: { type: "WORKSPACE_NOT_FOUND" },
+    });
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/nodes`,
+    );
+    const res = await GET(req, { params: Promise.resolve({ slug: SLUG }) });
+    expect(res.status).toBe(404);
+  });
+
+  test("falls back to mock data when swarm not configured", async () => {
+    mockGetWorkspaceSwarmAccess.mockResolvedValueOnce({
+      success: false,
+      error: { type: "SWARM_NOT_CONFIGURED" },
+    });
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/nodes`,
+    );
+    const res = await GET(req, { params: Promise.resolve({ slug: SLUG }) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(Array.isArray(body.data.nodes)).toBe(true);
+    expect(body.data.nodes.length).toBeGreaterThan(0);
+    expect(typeof body.data.hasMore).toBe("boolean");
+  });
+
+  test("returns mock data when USE_MOCKS=true without calling jarvis", async () => {
+    process.env.USE_MOCKS = "true";
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/nodes`,
+    );
+    const res = await GET(req, { params: Promise.resolve({ slug: SLUG }) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(Array.isArray(body.data.nodes)).toBe(true);
+    expect(mockGetWorkspaceSwarmAccess).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test("forwards offset and limit to jarvis", async () => {
+    mockGetWorkspaceSwarmAccess.mockResolvedValueOnce({
+      success: true,
+      data: SWARM_DATA,
+    });
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ nodes: [] }), { status: 200 }),
+    );
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/nodes?limit=10&offset=20`,
+    );
+    await GET(req, { params: Promise.resolve({ slug: SLUG }) });
+
+    const [calledUrl] = mockFetch.mock.calls[0] as [string];
+    expect(calledUrl).toContain("limit=10");
+    expect(calledUrl).toContain("offset=20");
+    expect(calledUrl).toContain("type=Jargon");
+    expect(calledUrl).toContain("namespace=testswarm");
+  });
+
+  test("sets hasMore=true when response length equals limit", async () => {
+    mockGetWorkspaceSwarmAccess.mockResolvedValueOnce({
+      success: true,
+      data: SWARM_DATA,
+    });
+    const fakeNodes = Array.from({ length: 50 }, (_, i) => ({
+      ref_id: `node-${i}`,
+      name: `Node ${i}`,
+    }));
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ nodes: fakeNodes }), { status: 200 }),
+    );
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/nodes`,
+    );
+    const res = await GET(req, { params: Promise.resolve({ slug: SLUG }) });
+    const body = await res.json();
+    expect(body.data.hasMore).toBe(true);
+  });
+
+  test("sets hasMore=false when response length < limit", async () => {
+    mockGetWorkspaceSwarmAccess.mockResolvedValueOnce({
+      success: true,
+      data: SWARM_DATA,
+    });
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ nodes: [{ ref_id: "n1" }] }), { status: 200 }),
+    );
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/nodes`,
+    );
+    const res = await GET(req, { params: Promise.resolve({ slug: SLUG }) });
+    const body = await res.json();
+    expect(body.data.hasMore).toBe(false);
+  });
+});
+
+// ─── GET /lingo/nodes/[ref_id] ────────────────────────────────────────────────
+
+describe("GET /api/workspaces/[slug]/lingo/nodes/[ref_id]", () => {
+  let GET: typeof import("@/app/api/workspaces/[slug]/lingo/nodes/[ref_id]/route").GET;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    delete process.env.USE_MOCKS;
+    ({ GET } = await import(
+      "@/app/api/workspaces/[slug]/lingo/nodes/[ref_id]/route"
+    ));
+  });
+
+  afterEach(() => {
+    delete process.env.USE_MOCKS;
+  });
+
+  test("returns 401 for unauthenticated request", async () => {
+    const req = unauthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/nodes/jargon-001`,
+    );
+    const res = await GET(req, {
+      params: Promise.resolve({ slug: SLUG, ref_id: "jargon-001" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("returns 403 when ACCESS_DENIED", async () => {
+    mockGetWorkspaceSwarmAccess.mockResolvedValueOnce({
+      success: false,
+      error: { type: "ACCESS_DENIED" },
+    });
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/nodes/jargon-001`,
+    );
+    const res = await GET(req, {
+      params: Promise.resolve({ slug: SLUG, ref_id: "jargon-001" }),
+    });
+    expect(res.status).toBe(403);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test("returns mock data for known ref_id when USE_MOCKS=true", async () => {
+    process.env.USE_MOCKS = "true";
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/nodes/jargon-001`,
+    );
+    const res = await GET(req, {
+      params: Promise.resolve({ slug: SLUG, ref_id: "jargon-001" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.node.ref_id).toBe("jargon-001");
+    expect(Array.isArray(body.data.edges)).toBe(true);
+  });
+
+  test("returns 404 for unknown ref_id in mock mode", async () => {
+    process.env.USE_MOCKS = "true";
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/nodes/unknown-node`,
+    );
+    const res = await GET(req, {
+      params: Promise.resolve({ slug: SLUG, ref_id: "unknown-node" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  test("URL-encodes ref_id in jarvis call", async () => {
+    mockGetWorkspaceSwarmAccess.mockResolvedValueOnce({
+      success: true,
+      data: SWARM_DATA,
+    });
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ ref_id: "node ref/1" }), { status: 200 }),
+    );
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/nodes/node%20ref%2F1`,
+    );
+    await GET(req, {
+      params: Promise.resolve({ slug: SLUG, ref_id: "node ref/1" }),
+    });
+    const [calledUrl] = mockFetch.mock.calls[0] as [string];
+    expect(calledUrl).toContain("node%20ref%2F1");
+    expect(calledUrl).toContain("expand=true");
+  });
+});
+
+// ─── GET /lingo/nodes/search ──────────────────────────────────────────────────
+
+describe("GET /api/workspaces/[slug]/lingo/nodes/search", () => {
+  let GET: typeof import("@/app/api/workspaces/[slug]/lingo/nodes/search/route").GET;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    delete process.env.USE_MOCKS;
+    ({ GET } = await import(
+      "@/app/api/workspaces/[slug]/lingo/nodes/search/route"
+    ));
+  });
+
+  afterEach(() => {
+    delete process.env.USE_MOCKS;
+  });
+
+  test("returns 400 when q param is missing", async () => {
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/nodes/search`,
+    );
+    const res = await GET(req, { params: Promise.resolve({ slug: SLUG }) });
+    expect(res.status).toBe(400);
+  });
+
+  test("returns filtered mock data when USE_MOCKS=true", async () => {
+    process.env.USE_MOCKS = "true";
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/nodes/search?q=Swarm`,
+    );
+    const res = await GET(req, { params: Promise.resolve({ slug: SLUG }) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    // Should match nodes whose name includes "Swarm"
+    expect(body.data.every((n: { name: string }) =>
+      n.name.toLowerCase().includes("swarm"),
+    )).toBe(true);
+  });
+
+  test("forwards q and type params to jarvis", async () => {
+    mockGetWorkspaceSwarmAccess.mockResolvedValueOnce({
+      success: true,
+      data: SWARM_DATA,
+    });
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify([]), { status: 200 }),
+    );
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/nodes/search?q=pod&type=Jargon`,
+    );
+    await GET(req, { params: Promise.resolve({ slug: SLUG }) });
+    const [calledUrl] = mockFetch.mock.calls[0] as [string];
+    expect(calledUrl).toContain("q=pod");
+    expect(calledUrl).toContain("type=Jargon");
+  });
+
+  test("returns 403 on ACCESS_DENIED", async () => {
+    mockGetWorkspaceSwarmAccess.mockResolvedValueOnce({
+      success: false,
+      error: { type: "ACCESS_DENIED" },
+    });
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/nodes/search?q=test`,
+    );
+    const res = await GET(req, { params: Promise.resolve({ slug: SLUG }) });
+    expect(res.status).toBe(403);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+// ─── POST /lingo/edges ────────────────────────────────────────────────────────
+
+describe("POST /api/workspaces/[slug]/lingo/edges", () => {
+  let POST: typeof import("@/app/api/workspaces/[slug]/lingo/edges/route").POST;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    delete process.env.USE_MOCKS;
+    ({ POST } = await import("@/app/api/workspaces/[slug]/lingo/edges/route"));
+  });
+
+  afterEach(() => {
+    delete process.env.USE_MOCKS;
+  });
+
+  test("returns 401 for unauthenticated request", async () => {
+    const req = unauthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/edges`,
+    );
+    const res = await POST(req, { params: Promise.resolve({ slug: SLUG }) });
+    expect(res.status).toBe(401);
+  });
+
+  test("returns 400 when source_ref_id or target_ref_id missing", async () => {
+    mockGetWorkspaceSwarmAccess.mockResolvedValueOnce({
+      success: true,
+      data: SWARM_DATA,
+    });
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/edges`,
+      { method: "POST", body: { source_ref_id: "src-1" } },
+    );
+    const res = await POST(req, { params: Promise.resolve({ slug: SLUG }) });
+    expect(res.status).toBe(400);
+  });
+
+  test("returns mock success when USE_MOCKS=true", async () => {
+    process.env.USE_MOCKS = "true";
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/edges`,
+      { method: "POST", body: { source_ref_id: "src-1", target_ref_id: "tgt-1" } },
+    );
+    const res = await POST(req, { params: Promise.resolve({ slug: SLUG }) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(mockAddEdge).not.toHaveBeenCalled();
+  });
+
+  test("defaults edge_type to RELATED_TO when not provided", async () => {
+    mockGetWorkspaceSwarmAccess.mockResolvedValueOnce({
+      success: true,
+      data: SWARM_DATA,
+    });
+    mockAddEdge.mockResolvedValueOnce({ success: true });
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/edges`,
+      { method: "POST", body: { source_ref_id: "src-1", target_ref_id: "tgt-1" } },
+    );
+    await POST(req, { params: Promise.resolve({ slug: SLUG }) });
+    expect(mockAddEdge).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ edge: { edge_type: "RELATED_TO" } }),
+    );
+  });
+
+  test("passes provided edge_type to addEdge", async () => {
+    mockGetWorkspaceSwarmAccess.mockResolvedValueOnce({
+      success: true,
+      data: SWARM_DATA,
+    });
+    mockAddEdge.mockResolvedValueOnce({ success: true });
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/edges`,
+      {
+        method: "POST",
+        body: { source_ref_id: "s1", target_ref_id: "t1", edge_type: "USES" },
+      },
+    );
+    await POST(req, { params: Promise.resolve({ slug: SLUG }) });
+    expect(mockAddEdge).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ edge: { edge_type: "USES" } }),
+    );
+  });
+
+  test("returns 403 on ACCESS_DENIED (IDOR guard)", async () => {
+    mockGetWorkspaceSwarmAccess.mockResolvedValueOnce({
+      success: false,
+      error: { type: "ACCESS_DENIED" },
+    });
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/edges`,
+      { method: "POST", body: { source_ref_id: "s1", target_ref_id: "t1" } },
+    );
+    const res = await POST(req, { params: Promise.resolve({ slug: SLUG }) });
+    expect(res.status).toBe(403);
+    expect(mockAddEdge).not.toHaveBeenCalled();
+  });
+
+  test("returns 500 when addEdge fails", async () => {
+    mockGetWorkspaceSwarmAccess.mockResolvedValueOnce({
+      success: true,
+      data: SWARM_DATA,
+    });
+    mockAddEdge.mockResolvedValueOnce({ success: false, error: "Jarvis error" });
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/edges`,
+      { method: "POST", body: { source_ref_id: "s1", target_ref_id: "t1" } },
+    );
+    const res = await POST(req, { params: Promise.resolve({ slug: SLUG }) });
+    expect(res.status).toBe(500);
+  });
+});
+
+// ─── PATCH /lingo/edges/[ref_id] ──────────────────────────────────────────────
+
+describe("PATCH /api/workspaces/[slug]/lingo/edges/[ref_id]", () => {
+  let PATCH: typeof import("@/app/api/workspaces/[slug]/lingo/edges/[ref_id]/route").PATCH;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    delete process.env.USE_MOCKS;
+    ({ PATCH } = await import(
+      "@/app/api/workspaces/[slug]/lingo/edges/[ref_id]/route"
+    ));
+  });
+
+  afterEach(() => {
+    delete process.env.USE_MOCKS;
+  });
+
+  test("returns 401 for unauthenticated request", async () => {
+    const req = unauthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/edges/edge-001`,
+    );
+    const res = await PATCH(req, {
+      params: Promise.resolve({ slug: SLUG, ref_id: "edge-001" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("returns 403 on ACCESS_DENIED (IDOR guard)", async () => {
+    mockGetWorkspaceSwarmAccess.mockResolvedValueOnce({
+      success: false,
+      error: { type: "ACCESS_DENIED" },
+    });
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/edges/edge-001`,
+      { method: "PATCH" },
+    );
+    const res = await PATCH(req, {
+      params: Promise.resolve({ slug: SLUG, ref_id: "edge-001" }),
+    });
+    expect(res.status).toBe(403);
+    expect(mockPatchEdge).not.toHaveBeenCalled();
+  });
+
+  test("returns mock success when USE_MOCKS=true without calling patchEdge", async () => {
+    process.env.USE_MOCKS = "true";
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/edges/edge-001`,
+      { method: "PATCH" },
+    );
+    const res = await PATCH(req, {
+      params: Promise.resolve({ slug: SLUG, ref_id: "edge-001" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(mockPatchEdge).not.toHaveBeenCalled();
+  });
+
+  test("always sends { is_deleted: true } to patchEdge", async () => {
+    mockGetWorkspaceSwarmAccess.mockResolvedValueOnce({
+      success: true,
+      data: SWARM_DATA,
+    });
+    mockPatchEdge.mockResolvedValueOnce({ success: true });
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/edges/edge-abc`,
+      { method: "PATCH" },
+    );
+    await PATCH(req, {
+      params: Promise.resolve({ slug: SLUG, ref_id: "edge-abc" }),
+    });
+    expect(mockPatchEdge).toHaveBeenCalledWith(
+      expect.anything(),
+      "edge-abc",
+      { is_deleted: true },
+    );
+  });
+
+  test("returns { success: true } on successful soft-delete", async () => {
+    mockGetWorkspaceSwarmAccess.mockResolvedValueOnce({
+      success: true,
+      data: SWARM_DATA,
+    });
+    mockPatchEdge.mockResolvedValueOnce({ success: true });
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/edges/edge-abc`,
+      { method: "PATCH" },
+    );
+    const res = await PATCH(req, {
+      params: Promise.resolve({ slug: SLUG, ref_id: "edge-abc" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+
+  test("returns 500 when patchEdge fails", async () => {
+    mockGetWorkspaceSwarmAccess.mockResolvedValueOnce({
+      success: true,
+      data: SWARM_DATA,
+    });
+    mockPatchEdge.mockResolvedValueOnce({ success: false, error: "Jarvis error" });
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/edges/edge-fail`,
+      { method: "PATCH" },
+    );
+    const res = await PATCH(req, {
+      params: Promise.resolve({ slug: SLUG, ref_id: "edge-fail" }),
+    });
+    expect(res.status).toBe(500);
+  });
+
+  test("returns 404 on WORKSPACE_NOT_FOUND", async () => {
+    mockGetWorkspaceSwarmAccess.mockResolvedValueOnce({
+      success: false,
+      error: { type: "WORKSPACE_NOT_FOUND" },
+    });
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/bad-slug/lingo/edges/edge-001`,
+      { method: "PATCH" },
+    );
+    const res = await PATCH(req, {
+      params: Promise.resolve({ slug: "bad-slug", ref_id: "edge-001" }),
+    });
+    expect(res.status).toBe(404);
+    expect(mockPatchEdge).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/unit/services/patch-edge.test.ts
+++ b/src/__tests__/unit/services/patch-edge.test.ts
@@ -1,0 +1,105 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+// Import the real implementation (no mock for nodes.ts in this file)
+import { patchEdge } from "@/services/swarm/api/nodes";
+import type { JarvisConnectionConfig } from "@/types/jarvis";
+
+const CONFIG: JarvisConnectionConfig = {
+  jarvisUrl: "https://swarm.sphinx.chat:8444",
+  apiKey: "key-abc",
+};
+
+describe("patchEdge", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test("calls PATCH /v2/edges/:ref_id with correct URL, method, and body", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ status: "success" }), { status: 200 }),
+    );
+
+    const result = await patchEdge(CONFIG, "edge-ref-123", { is_deleted: true });
+
+    expect(result.success).toBe(true);
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://swarm.sphinx.chat:8444/v2/edges/edge-ref-123");
+    expect(init.method).toBe("PATCH");
+    expect(JSON.parse(init.body as string)).toEqual({ is_deleted: true });
+    expect((init.headers as Record<string, string>)["x-api-token"]).toBe("key-abc");
+  });
+
+  test("strips trailing slash from jarvisUrl before building path", async () => {
+    mockFetch.mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    const configWithSlash: JarvisConnectionConfig = {
+      ...CONFIG,
+      jarvisUrl: "https://swarm.sphinx.chat:8444/",
+    };
+    await patchEdge(configWithSlash, "edge-1", { is_deleted: true });
+
+    const [url] = mockFetch.mock.calls[0] as [string];
+    expect(url).toBe("https://swarm.sphinx.chat:8444/v2/edges/edge-1");
+  });
+
+  test("URL-encodes special characters in edgeRefId", async () => {
+    mockFetch.mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    await patchEdge(CONFIG, "edge ref/123", { is_deleted: true });
+
+    const [url] = mockFetch.mock.calls[0] as [string];
+    expect(url).toBe("https://swarm.sphinx.chat:8444/v2/edges/edge%20ref%2F123");
+  });
+
+  test("returns { success: true } on 2xx response", async () => {
+    mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    const result = await patchEdge(CONFIG, "edge-ok", { is_deleted: true });
+    expect(result.success).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  test("returns { success: false, error } on non-2xx response", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response("Not found", { status: 404 }),
+    );
+
+    const result = await patchEdge(CONFIG, "edge-999", { is_deleted: true });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("404");
+  });
+
+  test("returns { success: false, error } on 500 response", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response("Server error", { status: 500 }),
+    );
+
+    const result = await patchEdge(CONFIG, "edge-err", { is_deleted: true });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("500");
+  });
+
+  test("returns { success: false, error } on fetch exception", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("Network failure"));
+
+    const result = await patchEdge(CONFIG, "edge-throw", { is_deleted: true });
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Network failure");
+  });
+
+  test("sends arbitrary data payload as JSON body", async () => {
+    mockFetch.mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    await patchEdge(CONFIG, "edge-x", { is_deleted: true, custom_field: "hello" });
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({
+      is_deleted: true,
+      custom_field: "hello",
+    });
+  });
+});

--- a/src/app/api/mock/lingo/neighbors.ts
+++ b/src/app/api/mock/lingo/neighbors.ts
@@ -1,0 +1,156 @@
+import type { JargonNode } from "./nodes";
+
+export interface NeighborNode {
+  ref_id: string;
+  name: string;
+  node_type: string;
+}
+
+export interface NeighborEdge {
+  edge_ref_id: string;
+  edge_type: string;
+  neighbor_node: NeighborNode;
+}
+
+export interface NodeNeighborData {
+  node: JargonNode;
+  edges: NeighborEdge[];
+}
+
+export const mockLingoNeighbors: Record<string, NodeNeighborData> = {
+  "jargon-001": {
+    node: {
+      ref_id: "jargon-001",
+      name: "Pod Orchestration",
+      jargon_context: "The automated process of creating, scaling, and managing compute pods for AI workloads within a workspace swarm.",
+      jargon_candidates: ["pod management", "container orchestration", "swarm pods"],
+      created_at: "2026-06-20T18:00:00Z",
+    },
+    edges: [
+      {
+        edge_ref_id: "edge-001-003",
+        edge_type: "BELONGS_TO",
+        neighbor_node: { ref_id: "jargon-003", name: "Swarm", node_type: "Jargon" },
+      },
+      {
+        edge_ref_id: "edge-001-016",
+        edge_type: "RELATED_TO",
+        neighbor_node: { ref_id: "jargon-016", name: "WorkflowStatus", node_type: "Jargon" },
+      },
+      {
+        edge_ref_id: "edge-001-015",
+        edge_type: "USES",
+        neighbor_node: { ref_id: "jargon-015", name: "Service Factory", node_type: "Jargon" },
+      },
+    ],
+  },
+  "jargon-002": {
+    node: {
+      ref_id: "jargon-002",
+      name: "Janitor Workflow",
+      jargon_context: "An automated code quality sweep that analyses a repository for test coverage gaps, security vulnerabilities, and refactoring opportunities.",
+      jargon_candidates: ["janitor", "code sweep", "automated review"],
+      created_at: "2026-06-20T17:30:00Z",
+    },
+    edges: [
+      {
+        edge_ref_id: "edge-002-004",
+        edge_type: "TRIGGERS",
+        neighbor_node: { ref_id: "jargon-004", name: "StakworkRun", node_type: "Jargon" },
+      },
+      {
+        edge_ref_id: "edge-002-016",
+        edge_type: "UPDATES",
+        neighbor_node: { ref_id: "jargon-016", name: "WorkflowStatus", node_type: "Jargon" },
+      },
+      {
+        edge_ref_id: "edge-002-003",
+        edge_type: "RUNS_IN",
+        neighbor_node: { ref_id: "jargon-003", name: "Swarm", node_type: "Jargon" },
+      },
+    ],
+  },
+  "jargon-003": {
+    node: {
+      ref_id: "jargon-003",
+      name: "Swarm",
+      jargon_context: "A managed cluster of AI agents and supporting infrastructure assigned to a workspace, identified by a unique swarm name.",
+      jargon_candidates: ["agent cluster", "AI swarm", "workspace swarm"],
+      created_at: "2026-06-20T17:00:00Z",
+    },
+    edges: [
+      {
+        edge_ref_id: "edge-003-009",
+        edge_type: "CONTAINS",
+        neighbor_node: { ref_id: "jargon-009", name: "Jarvis", node_type: "Jargon" },
+      },
+      {
+        edge_ref_id: "edge-003-001",
+        edge_type: "MANAGES",
+        neighbor_node: { ref_id: "jargon-001", name: "Pod Orchestration", node_type: "Jargon" },
+      },
+      {
+        edge_ref_id: "edge-003-021",
+        edge_type: "ENABLES",
+        neighbor_node: { ref_id: "jargon-021", name: "Auto-Learn", node_type: "Jargon" },
+      },
+    ],
+  },
+  "jargon-004": {
+    node: {
+      ref_id: "jargon-004",
+      name: "StakworkRun",
+      jargon_context: "A tracked execution of a Stakwork AI workflow, recording inputs, outputs, and status transitions for audit and debugging.",
+      jargon_candidates: ["workflow run", "stakwork execution", "AI run"],
+      created_at: "2026-06-20T16:30:00Z",
+    },
+    edges: [
+      {
+        edge_ref_id: "edge-004-018",
+        edge_type: "PRODUCES",
+        neighbor_node: { ref_id: "jargon-018", name: "Streaming Response", node_type: "Jargon" },
+      },
+      {
+        edge_ref_id: "edge-004-016",
+        edge_type: "TRACKS",
+        neighbor_node: { ref_id: "jargon-016", name: "WorkflowStatus", node_type: "Jargon" },
+      },
+      {
+        edge_ref_id: "edge-004-002",
+        edge_type: "TRIGGERED_BY",
+        neighbor_node: { ref_id: "jargon-002", name: "Janitor Workflow", node_type: "Jargon" },
+      },
+    ],
+  },
+  "jargon-005": {
+    node: {
+      ref_id: "jargon-005",
+      name: "Feature Brief",
+      jargon_context: "A structured description of a product feature including requirements, architecture notes, and linked user stories.",
+      jargon_candidates: ["feature spec", "brief", "product brief"],
+      created_at: "2026-06-20T16:00:00Z",
+    },
+    edges: [
+      {
+        edge_ref_id: "edge-005-019",
+        edge_type: "CONTAINS",
+        neighbor_node: { ref_id: "jargon-019", name: "Phase", node_type: "Jargon" },
+      },
+      {
+        edge_ref_id: "edge-005-022",
+        edge_type: "LINKED_TO",
+        neighbor_node: { ref_id: "jargon-022", name: "User Journey Task", node_type: "Jargon" },
+      },
+      {
+        edge_ref_id: "edge-005-007",
+        edge_type: "USES",
+        neighbor_node: { ref_id: "jargon-007", name: "Dual Status System", node_type: "Jargon" },
+      },
+    ],
+  },
+};
+
+// For nodes that don't have explicit neighbor data, generate a default empty record
+export function getNeighborData(refId: string): NodeNeighborData | null {
+  return mockLingoNeighbors[refId] ?? null;
+}

--- a/src/app/api/mock/lingo/nodes.ts
+++ b/src/app/api/mock/lingo/nodes.ts
@@ -1,0 +1,164 @@
+export interface JargonNode {
+  ref_id: string;
+  name: string;
+  jargon_context: string;
+  jargon_candidates: string[];
+  created_at: string;
+}
+
+export const mockLingoNodes: JargonNode[] = [
+  {
+    ref_id: "jargon-001",
+    name: "Pod Orchestration",
+    jargon_context: "The automated process of creating, scaling, and managing compute pods for AI workloads within a workspace swarm.",
+    jargon_candidates: ["pod management", "container orchestration", "swarm pods"],
+    created_at: "2026-06-20T18:00:00Z",
+  },
+  {
+    ref_id: "jargon-002",
+    name: "Janitor Workflow",
+    jargon_context: "An automated code quality sweep that analyses a repository for test coverage gaps, security vulnerabilities, and refactoring opportunities.",
+    jargon_candidates: ["janitor", "code sweep", "automated review"],
+    created_at: "2026-06-20T17:30:00Z",
+  },
+  {
+    ref_id: "jargon-003",
+    name: "Swarm",
+    jargon_context: "A managed cluster of AI agents and supporting infrastructure assigned to a workspace, identified by a unique swarm name.",
+    jargon_candidates: ["agent cluster", "AI swarm", "workspace swarm"],
+    created_at: "2026-06-20T17:00:00Z",
+  },
+  {
+    ref_id: "jargon-004",
+    name: "StakworkRun",
+    jargon_context: "A tracked execution of a Stakwork AI workflow, recording inputs, outputs, and status transitions for audit and debugging.",
+    jargon_candidates: ["workflow run", "stakwork execution", "AI run"],
+    created_at: "2026-06-20T16:30:00Z",
+  },
+  {
+    ref_id: "jargon-005",
+    name: "Feature Brief",
+    jargon_context: "A structured description of a product feature including requirements, architecture notes, and linked user stories.",
+    jargon_candidates: ["feature spec", "brief", "product brief"],
+    created_at: "2026-06-20T16:00:00Z",
+  },
+  {
+    ref_id: "jargon-006",
+    name: "Workspace Slug",
+    jargon_context: "A URL-safe, lowercase identifier for a workspace used in routing (e.g., /w/my-workspace). Must not contain capitals, spaces, or leading/trailing hyphens.",
+    jargon_candidates: ["slug", "workspace identifier", "url slug"],
+    created_at: "2026-06-20T15:30:00Z",
+  },
+  {
+    ref_id: "jargon-007",
+    name: "Dual Status System",
+    jargon_context: "Tasks carry two independent status fields: `status` for user/PM work tracking and `workflowStatus` for system automation state.",
+    jargon_candidates: ["task status", "workflow status", "dual status"],
+    created_at: "2026-06-20T15:00:00Z",
+  },
+  {
+    ref_id: "jargon-008",
+    name: "Field-Level Encryption",
+    jargon_context: "AES-256-GCM encryption applied to individual sensitive database fields (e.g., API keys, tokens) using the EncryptionService.",
+    jargon_candidates: ["field encryption", "AES-256", "data encryption"],
+    created_at: "2026-06-20T14:30:00Z",
+  },
+  {
+    ref_id: "jargon-009",
+    name: "Jarvis",
+    jargon_context: "The graph database backend (ArcadeDB) that stores knowledge nodes and edges for a workspace swarm.",
+    jargon_candidates: ["jarvis backend", "graph DB", "knowledge graph"],
+    created_at: "2026-06-20T14:00:00Z",
+  },
+  {
+    ref_id: "jargon-010",
+    name: "IDOR Guard",
+    jargon_context: "Insecure Direct Object Reference protection ensuring that authenticated users can only access resources belonging to their authorised workspace.",
+    jargon_candidates: ["IDOR", "access guard", "authorization check"],
+    created_at: "2026-06-20T13:30:00Z",
+  },
+  {
+    ref_id: "jargon-011",
+    name: "IntersectionObserver Sentinel",
+    jargon_context: "A zero-height div placed at the bottom of a scrollable list that, when it enters the viewport, triggers the next page fetch for infinite scroll.",
+    jargon_candidates: ["sentinel element", "scroll trigger", "infinite scroll"],
+    created_at: "2026-06-20T13:00:00Z",
+  },
+  {
+    ref_id: "jargon-012",
+    name: "Optimistic Update",
+    jargon_context: "A UI pattern where the interface reflects the expected result of an action immediately, before the server confirms success, improving perceived responsiveness.",
+    jargon_candidates: ["optimistic UI", "optimistic state", "immediate feedback"],
+    created_at: "2026-06-20T12:30:00Z",
+  },
+  {
+    ref_id: "jargon-013",
+    name: "Breadcrumb Trail",
+    jargon_context: "A navigation aid displaying the sequence of nodes a user has traversed in the graph explorer, allowing step-back navigation.",
+    jargon_candidates: ["breadcrumb", "navigation trail", "graph path"],
+    created_at: "2026-06-20T12:00:00Z",
+  },
+  {
+    ref_id: "jargon-014",
+    name: "Pusher Channel",
+    jargon_context: "A real-time event channel provided by Pusher used to broadcast live updates (e.g., task status, workflow progress) to connected clients.",
+    jargon_candidates: ["pusher", "real-time channel", "websocket channel"],
+    created_at: "2026-06-20T11:30:00Z",
+  },
+  {
+    ref_id: "jargon-015",
+    name: "Service Factory",
+    jargon_context: "A singleton pattern used in Hive to instantiate and cache external API service clients (e.g., StakworkService, PoolManagerService).",
+    jargon_candidates: ["service factory", "singleton service", "factory pattern"],
+    created_at: "2026-06-20T11:00:00Z",
+  },
+  {
+    ref_id: "jargon-016",
+    name: "WorkflowStatus",
+    jargon_context: "System-controlled automation state for tasks: PENDING, IN_PROGRESS, COMPLETED, ERROR, HALTED, or FAILED.",
+    jargon_candidates: ["workflow status", "automation state", "system status"],
+    created_at: "2026-06-20T10:30:00Z",
+  },
+  {
+    ref_id: "jargon-017",
+    name: "Mock Fallback",
+    jargon_context: "When USE_MOCKS=true or a real external service is unreachable, API routes return pre-seeded in-memory data instead of calling the live service.",
+    jargon_candidates: ["mock mode", "mock fallback", "development mock"],
+    created_at: "2026-06-20T10:00:00Z",
+  },
+  {
+    ref_id: "jargon-018",
+    name: "Streaming Response",
+    jargon_context: "AI assistant replies that are delivered token-by-token to the client over a Server-Sent Events or ReadableStream connection.",
+    jargon_candidates: ["AI streaming", "SSE stream", "token stream"],
+    created_at: "2026-06-20T09:30:00Z",
+  },
+  {
+    ref_id: "jargon-019",
+    name: "Phase",
+    jargon_context: "An ordered stage within a product Feature that groups related tasks and tracks progress toward a milestone.",
+    jargon_candidates: ["feature phase", "sprint phase", "milestone phase"],
+    created_at: "2026-06-20T09:00:00Z",
+  },
+  {
+    ref_id: "jargon-020",
+    name: "Source Control Token",
+    jargon_context: "An encrypted GitHub App installation token stored per user/workspace, used to authenticate repository operations.",
+    jargon_candidates: ["GitHub token", "install token", "source control credential"],
+    created_at: "2026-06-20T08:30:00Z",
+  },
+  {
+    ref_id: "jargon-021",
+    name: "Auto-Learn",
+    jargon_context: "A swarm setting that enables the AI to continuously ingest new code changes into the knowledge graph without manual triggers.",
+    jargon_candidates: ["auto learn", "continuous ingestion", "auto ingest"],
+    created_at: "2026-06-20T08:00:00Z",
+  },
+  {
+    ref_id: "jargon-022",
+    name: "User Journey Task",
+    jargon_context: "An E2E test scenario tracked as a task with sourceType USER_JOURNEY; test code lives in the swarm graph while metadata is stored in the DB.",
+    jargon_candidates: ["user journey", "E2E task", "journey test"],
+    created_at: "2026-06-20T07:30:00Z",
+  },
+];

--- a/src/app/api/workspaces/[slug]/lingo/edges/[ref_id]/route.ts
+++ b/src/app/api/workspaces/[slug]/lingo/edges/[ref_id]/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getMiddlewareContext, requireAuth } from "@/lib/middleware/utils";
+import { getWorkspaceSwarmAccess } from "@/lib/helpers/swarm-access";
+import { getJarvisUrl } from "@/lib/utils/swarm";
+import { patchEdge } from "@/services/swarm/api/nodes";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string; ref_id: string }> },
+) {
+  const { slug, ref_id } = await params;
+  const ctx = getMiddlewareContext(request);
+  const user = requireAuth(ctx);
+  if (user instanceof NextResponse) return user;
+
+  // Mock fallback
+  if (process.env.USE_MOCKS === "true") {
+    return NextResponse.json({ success: true });
+  }
+
+  const swarmResult = await getWorkspaceSwarmAccess(slug, user.id);
+  if (!swarmResult.success) {
+    const { type } = swarmResult.error;
+    if (type === "WORKSPACE_NOT_FOUND") {
+      return NextResponse.json({ success: false, error: "Workspace not found" }, { status: 404 });
+    }
+    if (type === "ACCESS_DENIED") {
+      return NextResponse.json({ success: false, error: "Access denied" }, { status: 403 });
+    }
+    return NextResponse.json({ success: false, error: "Swarm unavailable" }, { status: 503 });
+  }
+
+  const { swarmName, swarmApiKey } = swarmResult.data;
+  const jarvisUrl = getJarvisUrl(swarmName);
+
+  const result = await patchEdge(
+    { jarvisUrl, apiKey: swarmApiKey },
+    ref_id,
+    { is_deleted: true },
+  );
+
+  if (!result.success) {
+    return NextResponse.json({ success: false, error: result.error }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/workspaces/[slug]/lingo/edges/route.ts
+++ b/src/app/api/workspaces/[slug]/lingo/edges/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getMiddlewareContext, requireAuth } from "@/lib/middleware/utils";
+import { getWorkspaceSwarmAccess } from "@/lib/helpers/swarm-access";
+import { getJarvisUrl } from "@/lib/utils/swarm";
+import { addEdge } from "@/services/swarm/api/nodes";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await params;
+  const ctx = getMiddlewareContext(request);
+  const user = requireAuth(ctx);
+  if (user instanceof NextResponse) return user;
+
+  let body: { source_ref_id: string; target_ref_id: string; edge_type?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ success: false, error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { source_ref_id, target_ref_id, edge_type = "RELATED_TO" } = body;
+  if (!source_ref_id || !target_ref_id) {
+    return NextResponse.json(
+      { success: false, error: "source_ref_id and target_ref_id are required" },
+      { status: 400 },
+    );
+  }
+
+  // Mock fallback
+  if (process.env.USE_MOCKS === "true") {
+    return NextResponse.json({ success: true, data: { edge_type, source_ref_id, target_ref_id } });
+  }
+
+  const swarmResult = await getWorkspaceSwarmAccess(slug, user.id);
+  if (!swarmResult.success) {
+    const { type } = swarmResult.error;
+    if (type === "WORKSPACE_NOT_FOUND") {
+      return NextResponse.json({ success: false, error: "Workspace not found" }, { status: 404 });
+    }
+    if (type === "ACCESS_DENIED") {
+      return NextResponse.json({ success: false, error: "Access denied" }, { status: 403 });
+    }
+    return NextResponse.json({ success: false, error: "Swarm unavailable" }, { status: 503 });
+  }
+
+  const { swarmName, swarmApiKey } = swarmResult.data;
+  const jarvisUrl = getJarvisUrl(swarmName);
+
+  const result = await addEdge(
+    { jarvisUrl, apiKey: swarmApiKey },
+    {
+      edge: { edge_type },
+      source: { ref_id: source_ref_id },
+      target: { ref_id: target_ref_id },
+    },
+  );
+
+  if (!result.success) {
+    return NextResponse.json({ success: false, error: result.error }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/workspaces/[slug]/lingo/nodes/[ref_id]/route.ts
+++ b/src/app/api/workspaces/[slug]/lingo/nodes/[ref_id]/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getMiddlewareContext, requireAuth } from "@/lib/middleware/utils";
+import { getWorkspaceSwarmAccess } from "@/lib/helpers/swarm-access";
+import { getJarvisUrl } from "@/lib/utils/swarm";
+import { getNeighborData } from "@/app/api/mock/lingo/neighbors";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string; ref_id: string }> },
+) {
+  const { slug, ref_id } = await params;
+  const ctx = getMiddlewareContext(request);
+  const user = requireAuth(ctx);
+  if (user instanceof NextResponse) return user;
+
+  // Mock fallback
+  if (process.env.USE_MOCKS === "true") {
+    const data = getNeighborData(ref_id);
+    if (!data) {
+      return NextResponse.json({ success: false, error: "Node not found" }, { status: 404 });
+    }
+    return NextResponse.json({ success: true, data });
+  }
+
+  const swarmResult = await getWorkspaceSwarmAccess(slug, user.id);
+  if (!swarmResult.success) {
+    const { type } = swarmResult.error;
+    if (type === "WORKSPACE_NOT_FOUND") {
+      return NextResponse.json({ success: false, error: "Workspace not found" }, { status: 404 });
+    }
+    if (type === "ACCESS_DENIED") {
+      return NextResponse.json({ success: false, error: "Access denied" }, { status: 403 });
+    }
+    if (type === "SWARM_NOT_CONFIGURED" || type === "SWARM_NAME_MISSING" || type === "SWARM_API_KEY_MISSING") {
+      const data = getNeighborData(ref_id);
+      if (!data) {
+        return NextResponse.json({ success: false, error: "Node not found" }, { status: 404 });
+      }
+      return NextResponse.json({ success: true, data });
+    }
+    return NextResponse.json({ success: false, error: "Swarm unavailable" }, { status: 503 });
+  }
+
+  const { swarmName, swarmApiKey } = swarmResult.data;
+  const jarvisUrl = getJarvisUrl(swarmName);
+
+  try {
+    const response = await fetch(
+      `${jarvisUrl}/v2/nodes/${encodeURIComponent(ref_id)}?expand=true`,
+      {
+        method: "GET",
+        headers: {
+          "x-api-token": swarmApiKey,
+          "Content-Type": "application/json",
+        },
+      },
+    );
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { success: false, error: `Jarvis returned ${response.status}` },
+        { status: response.status },
+      );
+    }
+
+    const data = await response.json();
+    return NextResponse.json({ success: true, data });
+  } catch (err) {
+    console.error("[Lingo nodes/[ref_id]] Jarvis fetch failed, falling back to mock", err);
+    const data = getNeighborData(ref_id);
+    if (!data) {
+      return NextResponse.json({ success: false, error: "Node not found" }, { status: 404 });
+    }
+    return NextResponse.json({ success: true, data });
+  }
+}

--- a/src/app/api/workspaces/[slug]/lingo/nodes/route.ts
+++ b/src/app/api/workspaces/[slug]/lingo/nodes/route.ts
@@ -1,0 +1,102 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getMiddlewareContext, requireAuth } from "@/lib/middleware/utils";
+import { getWorkspaceSwarmAccess } from "@/lib/helpers/swarm-access";
+import { getJarvisUrl } from "@/lib/utils/swarm";
+import { mockLingoNodes } from "@/app/api/mock/lingo/nodes";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await params;
+  const ctx = getMiddlewareContext(request);
+  const user = requireAuth(ctx);
+  if (user instanceof NextResponse) return user;
+
+  const { searchParams } = new URL(request.url);
+  const limit = Math.min(parseInt(searchParams.get("limit") ?? "50", 10), 100);
+  const offset = Math.max(parseInt(searchParams.get("offset") ?? "0", 10), 0);
+
+  // Mock fallback
+  if (process.env.USE_MOCKS === "true") {
+    const sorted = [...mockLingoNodes].sort(
+      (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+    );
+    const page = sorted.slice(offset, offset + limit);
+    return NextResponse.json({
+      success: true,
+      data: { nodes: page, hasMore: page.length === limit },
+    });
+  }
+
+  const swarmResult = await getWorkspaceSwarmAccess(slug, user.id);
+  if (!swarmResult.success) {
+    const { type } = swarmResult.error;
+    if (type === "WORKSPACE_NOT_FOUND") {
+      return NextResponse.json({ success: false, error: "Workspace not found" }, { status: 404 });
+    }
+    if (type === "ACCESS_DENIED") {
+      return NextResponse.json({ success: false, error: "Access denied" }, { status: 403 });
+    }
+    if (type === "SWARM_NOT_CONFIGURED" || type === "SWARM_NAME_MISSING" || type === "SWARM_API_KEY_MISSING") {
+      // Fall back to mock data when swarm is not configured
+      const sorted = [...mockLingoNodes].sort(
+        (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+      );
+      const page = sorted.slice(offset, offset + limit);
+      return NextResponse.json({
+        success: true,
+        data: { nodes: page, hasMore: page.length === limit },
+      });
+    }
+    return NextResponse.json({ success: false, error: "Swarm unavailable" }, { status: 503 });
+  }
+
+  const { swarmName, swarmApiKey } = swarmResult.data;
+  const jarvisUrl = getJarvisUrl(swarmName);
+
+  const queryParams = new URLSearchParams({
+    type: "Jargon",
+    namespace: swarmName,
+    limit: String(limit),
+    offset: String(offset),
+    sort: "created_at:desc",
+  });
+
+  try {
+    const response = await fetch(`${jarvisUrl}/v2/nodes?${queryParams}`, {
+      method: "GET",
+      headers: {
+        "x-api-token": swarmApiKey,
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { success: false, error: `Jarvis returned ${response.status}` },
+        { status: response.status },
+      );
+    }
+
+    const data = await response.json();
+    const nodes = Array.isArray(data) ? data : (data?.nodes ?? []);
+    return NextResponse.json({
+      success: true,
+      data: { nodes, hasMore: nodes.length === limit },
+    });
+  } catch (err) {
+    console.error("[Lingo nodes] Jarvis fetch failed, falling back to mock", err);
+    const sorted = [...mockLingoNodes].sort(
+      (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+    );
+    const page = sorted.slice(offset, offset + limit);
+    return NextResponse.json({
+      success: true,
+      data: { nodes: page, hasMore: page.length === limit },
+    });
+  }
+}

--- a/src/app/api/workspaces/[slug]/lingo/nodes/search/route.ts
+++ b/src/app/api/workspaces/[slug]/lingo/nodes/search/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getMiddlewareContext, requireAuth } from "@/lib/middleware/utils";
+import { getWorkspaceSwarmAccess } from "@/lib/helpers/swarm-access";
+import { getJarvisUrl } from "@/lib/utils/swarm";
+import { mockLingoNodes } from "@/app/api/mock/lingo/nodes";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await params;
+  const ctx = getMiddlewareContext(request);
+  const user = requireAuth(ctx);
+  if (user instanceof NextResponse) return user;
+
+  const { searchParams } = new URL(request.url);
+  const q = searchParams.get("q");
+  const type = searchParams.get("type");
+
+  if (!q) {
+    return NextResponse.json({ success: false, error: "Query parameter 'q' is required" }, { status: 400 });
+  }
+
+  // Mock fallback
+  if (process.env.USE_MOCKS === "true") {
+    const results = mockLingoNodes.filter((n) =>
+      n.name.toLowerCase().includes(q.toLowerCase()),
+    );
+    return NextResponse.json({ success: true, data: results });
+  }
+
+  const swarmResult = await getWorkspaceSwarmAccess(slug, user.id);
+  if (!swarmResult.success) {
+    const { type: errorType } = swarmResult.error;
+    if (errorType === "WORKSPACE_NOT_FOUND") {
+      return NextResponse.json({ success: false, error: "Workspace not found" }, { status: 404 });
+    }
+    if (errorType === "ACCESS_DENIED") {
+      return NextResponse.json({ success: false, error: "Access denied" }, { status: 403 });
+    }
+    if (
+      errorType === "SWARM_NOT_CONFIGURED" ||
+      errorType === "SWARM_NAME_MISSING" ||
+      errorType === "SWARM_API_KEY_MISSING"
+    ) {
+      const results = mockLingoNodes.filter((n) =>
+        n.name.toLowerCase().includes(q.toLowerCase()),
+      );
+      return NextResponse.json({ success: true, data: results });
+    }
+    return NextResponse.json({ success: false, error: "Swarm unavailable" }, { status: 503 });
+  }
+
+  const { swarmName, swarmApiKey } = swarmResult.data;
+  const jarvisUrl = getJarvisUrl(swarmName);
+
+  const queryParams = new URLSearchParams({ q });
+  if (type) queryParams.set("type", type);
+
+  try {
+    const response = await fetch(`${jarvisUrl}/nodes/search?${queryParams}`, {
+      method: "GET",
+      headers: {
+        "x-api-token": swarmApiKey,
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { success: false, error: `Jarvis returned ${response.status}` },
+        { status: response.status },
+      );
+    }
+
+    const data = await response.json();
+    return NextResponse.json({ success: true, data: Array.isArray(data) ? data : (data?.nodes ?? []) });
+  } catch (err) {
+    console.error("[Lingo nodes/search] Jarvis fetch failed, falling back to mock", err);
+    const results = mockLingoNodes.filter((n) =>
+      n.name.toLowerCase().includes(q.toLowerCase()),
+    );
+    return NextResponse.json({ success: true, data: results });
+  }
+}

--- a/src/services/swarm/api/nodes.ts
+++ b/src/services/swarm/api/nodes.ts
@@ -254,6 +254,41 @@ export async function deleteNode(
   }
 }
 
+export async function patchEdge(
+  config: JarvisConnectionConfig,
+  edgeRefId: string,
+  data: Record<string, unknown>,
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const url = `${config.jarvisUrl.replace(/\/$/, "")}/v2/edges/${encodeURIComponent(edgeRefId)}`;
+    const response = await fetch(url, {
+      method: "PATCH",
+      headers: {
+        "x-api-token": config.apiKey,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      const responseText = await response.text();
+      console.error("[Jarvis Nodes] patchEdge failed:", response.status, responseText);
+      return {
+        success: false,
+        error: `Request failed with status ${response.status}`,
+      };
+    }
+
+    return { success: true };
+  } catch (error) {
+    console.error("[Jarvis Nodes] patchEdge error:", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Request failed",
+    };
+  }
+}
+
 export async function deleteEdge(
   config: JarvisConnectionConfig,
   edgeRefId: string,


### PR DESCRIPTION
Add Lingo API proxy routes, patchEdge service, and mock data for Jargon nodes