### PR TITLE
Simplify evals requirement and trigger UI

### DIFF
--- a/src/__tests__/integration/api/workspaces/evals/evals.test.ts
+++ b/src/__tests__/integration/api/workspaces/evals/evals.test.ts
@@ -662,66 +662,38 @@ describe("Evals API — Integration Tests", () => {
         expect(nodesService.addNode).not.toHaveBeenCalled();
       });
 
-      test("rejects missing prompt_snippet", async () => {
+      test("creates requirement with only name and reason (no example cases)", async () => {
         const owner = await createTestUser();
         const workspace = await createTestWorkspace({ ownerId: owner.id });
         await createTestMembership({ workspaceId: workspace.id, userId: owner.id, role: "OWNER" });
         await createTestSwarm({ workspaceId: workspace.id, swarmApiKey: "test-key" });
 
-        const { prompt_snippet: _, ...bodyWithoutSnippet } = validBody;
+        vi.mocked(nodesService.addNode).mockResolvedValueOnce({ success: true, ref_id: "req-min" });
+        vi.mocked(nodesService.addEdge).mockResolvedValueOnce({ success: true });
 
         const request = createAuthenticatedPostRequest(
           `http://localhost:3000/api/workspaces/${workspace.slug}/evals/set-1/requirements`,
           owner,
-          bodyWithoutSnippet,
+          { name: "Minimal req", description: "because it matters" },
         );
 
         const response = await createRequirement(request, {
           params: Promise.resolve({ slug: workspace.slug, evalSetId: "set-1" }),
         });
 
-        await expectError(response, "prompt_snippet is required", 400);
-        expect(nodesService.addNode).not.toHaveBeenCalled();
-      });
-
-      test("rejects empty desirable_cases array", async () => {
-        const owner = await createTestUser();
-        const workspace = await createTestWorkspace({ ownerId: owner.id });
-        await createTestMembership({ workspaceId: workspace.id, userId: owner.id, role: "OWNER" });
-        await createTestSwarm({ workspaceId: workspace.id, swarmApiKey: "test-key" });
-
-        const request = createAuthenticatedPostRequest(
-          `http://localhost:3000/api/workspaces/${workspace.slug}/evals/set-1/requirements`,
-          owner,
-          { ...validBody, desirable_cases: [] },
+        expect(response.status).toBe(200);
+        expect(nodesService.addNode).toHaveBeenCalledWith(
+          expect.any(Object),
+          expect.objectContaining({
+            node_type: "EvalRequirement",
+            node_data: expect.objectContaining({
+              name: "Minimal req",
+              description: "because it matters",
+              desirable_cases: [],
+              undesirable_cases: [],
+            }),
+          }),
         );
-
-        const response = await createRequirement(request, {
-          params: Promise.resolve({ slug: workspace.slug, evalSetId: "set-1" }),
-        });
-
-        await expectError(response, "desirable_cases must be a non-empty array", 400);
-        expect(nodesService.addNode).not.toHaveBeenCalled();
-      });
-
-      test("rejects empty undesirable_cases array", async () => {
-        const owner = await createTestUser();
-        const workspace = await createTestWorkspace({ ownerId: owner.id });
-        await createTestMembership({ workspaceId: workspace.id, userId: owner.id, role: "OWNER" });
-        await createTestSwarm({ workspaceId: workspace.id, swarmApiKey: "test-key" });
-
-        const request = createAuthenticatedPostRequest(
-          `http://localhost:3000/api/workspaces/${workspace.slug}/evals/set-1/requirements`,
-          owner,
-          { ...validBody, undesirable_cases: [] },
-        );
-
-        const response = await createRequirement(request, {
-          params: Promise.resolve({ slug: workspace.slug, evalSetId: "set-1" }),
-        });
-
-        await expectError(response, "undesirable_cases must be a non-empty array", 400);
-        expect(nodesService.addNode).not.toHaveBeenCalled();
       });
     });
 
@@ -1339,6 +1311,39 @@ describe("Evals API — Integration Tests", () => {
           }),
         );
       });
+
+      test("updates requirement with only name and reason", async () => {
+        const owner = await createTestUser();
+        const workspace = await createTestWorkspace({ ownerId: owner.id });
+        await createTestMembership({ workspaceId: workspace.id, userId: owner.id, role: "OWNER" });
+        await createTestSwarm({ workspaceId: workspace.id, swarmApiKey: "test-key" });
+
+        vi.mocked(nodesService.updateNode).mockResolvedValueOnce({ success: true });
+
+        const request = createAuthenticatedPutRequest(
+          `http://localhost:3000/api/workspaces/${workspace.slug}/evals/set-1/requirements/req-1`,
+          owner,
+          { name: "Renamed req", description: "new reason" },
+        );
+
+        const response = await updateRequirement(request, {
+          params: Promise.resolve({ slug: workspace.slug, evalSetId: "set-1", reqId: "req-1" }),
+        });
+
+        expect(response.status).toBe(200);
+        expect(nodesService.updateNode).toHaveBeenCalledWith(
+          expect.any(Object),
+          expect.objectContaining({
+            ref_id: "req-1",
+            node_data: expect.objectContaining({
+              name: "Renamed req",
+              description: "new reason",
+              desirable_cases: [],
+              undesirable_cases: [],
+            }),
+          }),
+        );
+      });
     });
 
     describe("Validation", () => {
@@ -1359,63 +1364,6 @@ describe("Evals API — Integration Tests", () => {
         });
 
         await expectError(response, "name is required", 400);
-      });
-
-      test("returns 400 when prompt_snippet is missing", async () => {
-        const owner = await createTestUser();
-        const workspace = await createTestWorkspace({ ownerId: owner.id });
-        await createTestMembership({ workspaceId: workspace.id, userId: owner.id, role: "OWNER" });
-        await createTestSwarm({ workspaceId: workspace.id, swarmApiKey: "test-key" });
-
-        const request = createAuthenticatedPutRequest(
-          `http://localhost:3000/api/workspaces/${workspace.slug}/evals/set-1/requirements/req-1`,
-          owner,
-          { ...validReqBody, prompt_snippet: "" },
-        );
-
-        const response = await updateRequirement(request, {
-          params: Promise.resolve({ slug: workspace.slug, evalSetId: "set-1", reqId: "req-1" }),
-        });
-
-        await expectError(response, "prompt_snippet is required", 400);
-      });
-
-      test("returns 400 when desirable_cases is empty", async () => {
-        const owner = await createTestUser();
-        const workspace = await createTestWorkspace({ ownerId: owner.id });
-        await createTestMembership({ workspaceId: workspace.id, userId: owner.id, role: "OWNER" });
-        await createTestSwarm({ workspaceId: workspace.id, swarmApiKey: "test-key" });
-
-        const request = createAuthenticatedPutRequest(
-          `http://localhost:3000/api/workspaces/${workspace.slug}/evals/set-1/requirements/req-1`,
-          owner,
-          { ...validReqBody, desirable_cases: [] },
-        );
-
-        const response = await updateRequirement(request, {
-          params: Promise.resolve({ slug: workspace.slug, evalSetId: "set-1", reqId: "req-1" }),
-        });
-
-        await expectError(response, "desirable_cases must be a non-empty array", 400);
-      });
-
-      test("returns 400 when undesirable_cases is empty", async () => {
-        const owner = await createTestUser();
-        const workspace = await createTestWorkspace({ ownerId: owner.id });
-        await createTestMembership({ workspaceId: workspace.id, userId: owner.id, role: "OWNER" });
-        await createTestSwarm({ workspaceId: workspace.id, swarmApiKey: "test-key" });
-
-        const request = createAuthenticatedPutRequest(
-          `http://localhost:3000/api/workspaces/${workspace.slug}/evals/set-1/requirements/req-1`,
-          owner,
-          { ...validReqBody, undesirable_cases: [] },
-        );
-
-        const response = await updateRequirement(request, {
-          params: Promise.resolve({ slug: workspace.slug, evalSetId: "set-1", reqId: "req-1" }),
-        });
-
-        await expectError(response, "undesirable_cases must be a non-empty array", 400);
       });
     });
 

--- a/src/__tests__/unit/components/evals/CreateRequirementModal.test.tsx
+++ b/src/__tests__/unit/components/evals/CreateRequirementModal.test.tsx
@@ -47,29 +47,15 @@ vi.mock("@/components/ui/textarea", () => ({
   ),
 }));
 
-// Mock TagInput: renders a plain input; pressing Enter calls onChange([...items, value])
-vi.mock("@/components/ui/tag-input", () => ({
-  TagInput: ({ items, onChange, placeholder, error }: any) => (
-    <div>
-      <input
-        data-testid={`tag-input-${placeholder}`}
-        placeholder={placeholder}
-        onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
-          if (e.key === "Enter") {
-            e.preventDefault();
-            const val = (e.currentTarget as HTMLInputElement).value.trim();
-            if (val) onChange([...items, val]);
-            (e.currentTarget as HTMLInputElement).value = "";
-          }
-        }}
-      />
-      {error && <p>{error}</p>}
-    </div>
-  ),
+vi.mock("@/components/ui/label", () => ({
+  Label: ({ children, htmlFor }: any) => <label htmlFor={htmlFor}>{children}</label>,
 }));
 
 import { CreateRequirementModal } from "@/components/evals/CreateRequirementModal";
 import { toast } from "sonner";
+
+const NAME_PLACEHOLDER = "What should the agent always do?";
+const REASON_PLACEHOLDER = "Why does this matter?";
 
 const defaultProps = {
   open: true,
@@ -79,14 +65,7 @@ const defaultProps = {
   onCreated: vi.fn(),
 };
 
-/** Helper: type into a TagInput mock and press Enter to add a chip */
-async function addTagItem(placeholder: string, value: string) {
-  const input = screen.getByTestId(`tag-input-${placeholder}`);
-  await userEvent.type(input, value);
-  await userEvent.keyboard("{Enter}");
-}
-
-describe("CreateRequirementModal — validation", () => {
+describe("CreateRequirementModal — name + reason", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }) as any;
@@ -95,77 +74,22 @@ describe("CreateRequirementModal — validation", () => {
   it("renders the form when open", () => {
     render(<CreateRequirementModal {...defaultProps} />);
     expect(screen.getByTestId("dialog")).toBeTruthy();
-    expect(screen.getByPlaceholderText("e.g. Correct auth handling")).toBeTruthy();
+    expect(screen.getByPlaceholderText(NAME_PLACEHOLDER)).toBeTruthy();
+    expect(screen.getByPlaceholderText(REASON_PLACEHOLDER)).toBeTruthy();
   });
 
-  it("blocks submission when name is empty", async () => {
-    render(<CreateRequirementModal {...defaultProps} />);
-
-    await userEvent.type(
-      screen.getByPlaceholderText("The portion of the prompt being evaluated..."),
-      "Some prompt",
-    );
-    await addTagItem("The agent correctly...", "Good output");
-    await addTagItem("The agent fails to...", "Bad output");
-
-    await userEvent.click(screen.getByRole("button", { name: "Add Requirement" }));
-
-    await waitFor(() => {
-      expect(screen.getByText("Name is required")).toBeTruthy();
-    });
-    expect(global.fetch).not.toHaveBeenCalled();
-  });
-
-  it("blocks submission when desirable_cases is empty", async () => {
-    render(<CreateRequirementModal {...defaultProps} />);
-
-    await userEvent.type(screen.getByPlaceholderText("e.g. Correct auth handling"), "My req");
-    await userEvent.type(
-      screen.getByPlaceholderText("The portion of the prompt being evaluated..."),
-      "Some prompt",
-    );
-    await addTagItem("The agent fails to...", "Bad output");
-    // Leave desirable_cases blank
-
-    await userEvent.click(screen.getByRole("button", { name: "Add Requirement" }));
-
-    await waitFor(() => {
-      expect(screen.getByText("At least one desirable case is required")).toBeTruthy();
-    });
-    expect(global.fetch).not.toHaveBeenCalled();
-  });
-
-  it("blocks submission when undesirable_cases is empty", async () => {
-    render(<CreateRequirementModal {...defaultProps} />);
-
-    await userEvent.type(screen.getByPlaceholderText("e.g. Correct auth handling"), "My req");
-    await userEvent.type(
-      screen.getByPlaceholderText("The portion of the prompt being evaluated..."),
-      "Some prompt",
-    );
-    await addTagItem("The agent correctly...", "Good output");
-    // Leave undesirable_cases blank
-
-    await userEvent.click(screen.getByRole("button", { name: "Add Requirement" }));
-
-    await waitFor(() => {
-      expect(screen.getByText("At least one undesirable case is required")).toBeTruthy();
-    });
-    expect(global.fetch).not.toHaveBeenCalled();
-  });
-
-  it("blocks submission when all fields empty", async () => {
+  it("blocks submission when the requirement is empty", async () => {
     render(<CreateRequirementModal {...defaultProps} />);
 
     await userEvent.click(screen.getByRole("button", { name: "Add Requirement" }));
 
     await waitFor(() => {
-      expect(screen.getByText("Name is required")).toBeTruthy();
+      expect(screen.getByText("Requirement is required")).toBeTruthy();
     });
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
-  it("submits successfully when all required fields are filled", async () => {
+  it("submits with only a name (reason omitted)", async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ success: true, data: { ref_id: "new-req-1" } }),
@@ -173,14 +97,7 @@ describe("CreateRequirementModal — validation", () => {
 
     render(<CreateRequirementModal {...defaultProps} />);
 
-    await userEvent.type(screen.getByPlaceholderText("e.g. Correct auth handling"), "My req");
-    await userEvent.type(
-      screen.getByPlaceholderText("The portion of the prompt being evaluated..."),
-      "Some prompt",
-    );
-    await addTagItem("The agent correctly...", "Good output");
-    await addTagItem("The agent fails to...", "Bad output");
-
+    await userEvent.type(screen.getByPlaceholderText(NAME_PLACEHOLDER), "My req");
     await userEvent.click(screen.getByRole("button", { name: "Add Requirement" }));
 
     await waitFor(() => {
@@ -190,31 +107,16 @@ describe("CreateRequirementModal — validation", () => {
       );
     });
 
+    const callBody = JSON.parse((global.fetch as any).mock.calls[0][1].body);
+    expect(callBody.name).toBe("My req");
+    expect(callBody.description).toBeUndefined();
+    expect(callBody.order).toBe(0);
+
     expect(toast.success).toHaveBeenCalledWith("Requirement added");
     expect(defaultProps.onCreated).toHaveBeenCalled();
   });
 
-  it("shows error toast when request fails", async () => {
-    global.fetch = vi.fn().mockResolvedValue({ ok: false }) as any;
-
-    render(<CreateRequirementModal {...defaultProps} />);
-
-    await userEvent.type(screen.getByPlaceholderText("e.g. Correct auth handling"), "My req");
-    await userEvent.type(
-      screen.getByPlaceholderText("The portion of the prompt being evaluated..."),
-      "Prompt",
-    );
-    await addTagItem("The agent correctly...", "Good");
-    await addTagItem("The agent fails to...", "Bad");
-
-    await userEvent.click(screen.getByRole("button", { name: "Add Requirement" }));
-
-    await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith("Failed to add requirement");
-    });
-  });
-
-  it("sends multiple positive/negative cases correctly", async () => {
+  it("includes the reason as description when provided", async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ success: true }),
@@ -222,18 +124,8 @@ describe("CreateRequirementModal — validation", () => {
 
     render(<CreateRequirementModal {...defaultProps} />);
 
-    await userEvent.type(screen.getByPlaceholderText("e.g. Correct auth handling"), "My req");
-    await userEvent.type(
-      screen.getByPlaceholderText("The portion of the prompt being evaluated..."),
-      "Prompt",
-    );
-    // Add two positive cases via separate Enter presses
-    await addTagItem("The agent correctly...", "Case one");
-    await addTagItem("The agent correctly...", "Case two");
-    // Add two negative cases via separate Enter presses
-    await addTagItem("The agent fails to...", "Neg one");
-    await addTagItem("The agent fails to...", "Neg two");
-
+    await userEvent.type(screen.getByPlaceholderText(NAME_PLACEHOLDER), "My req");
+    await userEvent.type(screen.getByPlaceholderText(REASON_PLACEHOLDER), "It matters");
     await userEvent.click(screen.getByRole("button", { name: "Add Requirement" }));
 
     await waitFor(() => {
@@ -241,7 +133,19 @@ describe("CreateRequirementModal — validation", () => {
     });
 
     const callBody = JSON.parse((global.fetch as any).mock.calls[0][1].body);
-    expect(callBody.desirable_cases).toEqual(["Case one", "Case two"]);
-    expect(callBody.undesirable_cases).toEqual(["Neg one", "Neg two"]);
+    expect(callBody.description).toBe("It matters");
+  });
+
+  it("shows error toast when request fails", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false }) as any;
+
+    render(<CreateRequirementModal {...defaultProps} />);
+
+    await userEvent.type(screen.getByPlaceholderText(NAME_PLACEHOLDER), "My req");
+    await userEvent.click(screen.getByRole("button", { name: "Add Requirement" }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Failed to add requirement");
+    });
   });
 });

--- a/src/__tests__/unit/components/evals/EditRequirementModal.test.tsx
+++ b/src/__tests__/unit/components/evals/EditRequirementModal.test.tsx
@@ -47,8 +47,15 @@ vi.mock("@/components/ui/textarea", () => ({
   ),
 }));
 
+vi.mock("@/components/ui/label", () => ({
+  Label: ({ children, htmlFor }: any) => <label htmlFor={htmlFor}>{children}</label>,
+}));
+
 import { EditRequirementModal } from "@/components/evals/EditRequirementModal";
 import { toast } from "sonner";
+
+const NAME_PLACEHOLDER = "What should the agent always do?";
+const REASON_PLACEHOLDER = "Why does this matter?";
 
 const REQUIREMENT = {
   ref_id: "req-1",
@@ -82,25 +89,14 @@ describe("EditRequirementModal", () => {
     expect(screen.getByText("Edit Requirement")).toBeTruthy();
   });
 
-  it("pre-populates all fields from requirement.properties", () => {
+  it("pre-populates name and reason from requirement.properties", () => {
     render(<EditRequirementModal {...defaultProps} />);
 
-    const nameInput = screen.getByPlaceholderText("e.g. Correct auth handling") as HTMLInputElement;
+    const nameInput = screen.getByPlaceholderText(NAME_PLACEHOLDER) as HTMLTextAreaElement;
     expect(nameInput.value).toBe("Existing Req");
 
-    const descTextarea = screen.getByPlaceholderText("Optional description...") as HTMLTextAreaElement;
-    expect(descTextarea.value).toBe("Existing req desc");
-
-    const promptTextarea = screen.getByPlaceholderText(
-      "The portion of the prompt being evaluated...",
-    ) as HTMLTextAreaElement;
-    expect(promptTextarea.value).toBe("When asked to do X...");
-
-    const posTextarea = screen.getByPlaceholderText("The agent correctly...") as HTMLTextAreaElement;
-    expect(posTextarea.value).toBe("Does A\nDoes B");
-
-    const negTextarea = screen.getByPlaceholderText("The agent fails to...") as HTMLTextAreaElement;
-    expect(negTextarea.value).toBe("Fails to C");
+    const reasonInput = screen.getByPlaceholderText(REASON_PLACEHOLDER) as HTMLInputElement;
+    expect(reasonInput.value).toBe("Existing req desc");
   });
 
   it("does not render when open=false", () => {
@@ -108,46 +104,19 @@ describe("EditRequirementModal", () => {
     expect(screen.queryByTestId("dialog")).toBeNull();
   });
 
-  it("shows validation error when name is cleared", async () => {
+  it("shows validation error when the requirement is cleared", async () => {
     render(<EditRequirementModal {...defaultProps} />);
-    const nameInput = screen.getByPlaceholderText("e.g. Correct auth handling");
-    await userEvent.clear(nameInput);
+    await userEvent.clear(screen.getByPlaceholderText(NAME_PLACEHOLDER));
 
     await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => {
-      expect(screen.getByText("Name is required")).toBeTruthy();
+      expect(screen.getByText("Requirement is required")).toBeTruthy();
     });
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
-  it("shows validation error when desirable_cases is cleared", async () => {
-    render(<EditRequirementModal {...defaultProps} />);
-    const posTextarea = screen.getByPlaceholderText("The agent correctly...");
-    await userEvent.clear(posTextarea);
-
-    await userEvent.click(screen.getByRole("button", { name: "Save" }));
-
-    await waitFor(() => {
-      expect(screen.getByText("At least one desirable case is required")).toBeTruthy();
-    });
-    expect(global.fetch).not.toHaveBeenCalled();
-  });
-
-  it("shows validation error when undesirable_cases is cleared", async () => {
-    render(<EditRequirementModal {...defaultProps} />);
-    const negTextarea = screen.getByPlaceholderText("The agent fails to...");
-    await userEvent.clear(negTextarea);
-
-    await userEvent.click(screen.getByRole("button", { name: "Save" }));
-
-    await waitFor(() => {
-      expect(screen.getByText("At least one undesirable case is required")).toBeTruthy();
-    });
-    expect(global.fetch).not.toHaveBeenCalled();
-  });
-
-  it("calls PUT with correct URL and body on submit", async () => {
+  it("calls PUT and preserves legacy prompt_snippet/example cases in the body", async () => {
     global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) }) as any;
 
     render(<EditRequirementModal {...defaultProps} />);
@@ -163,9 +132,30 @@ describe("EditRequirementModal", () => {
 
     const body = JSON.parse((global.fetch as any).mock.calls[0][1].body);
     expect(body.name).toBe("Existing Req");
+    expect(body.description).toBe("Existing req desc");
     expect(body.prompt_snippet).toBe("When asked to do X...");
     expect(body.desirable_cases).toEqual(["Does A", "Does B"]);
     expect(body.undesirable_cases).toEqual(["Fails to C"]);
+  });
+
+  it("omits legacy fields when the requirement has none", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }) as any;
+
+    const minimalReq = {
+      ref_id: "req-2",
+      node_type: "EvalRequirement",
+      properties: { name: "Minimal", description: "why" },
+    };
+    render(<EditRequirementModal {...defaultProps} requirement={minimalReq} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    const body = JSON.parse((global.fetch as any).mock.calls[0][1].body);
+    expect(body.name).toBe("Minimal");
+    expect(body.prompt_snippet).toBeUndefined();
+    expect(body.desirable_cases).toBeUndefined();
+    expect(body.undesirable_cases).toBeUndefined();
   });
 
   it("calls onUpdated and closes modal on success", async () => {
@@ -193,25 +183,5 @@ describe("EditRequirementModal", () => {
       expect(toast.error).toHaveBeenCalledWith("Failed to update requirement");
     });
     expect(defaultProps.onUpdated).not.toHaveBeenCalled();
-  });
-
-  it("splits multi-line cases correctly in the request body", async () => {
-    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }) as any;
-
-    const reqWithMultiline = {
-      ...REQUIREMENT,
-      properties: {
-        ...REQUIREMENT.properties,
-        desirable_cases: ["Case one", "Case two"],
-        undesirable_cases: ["Neg one"],
-      },
-    };
-    render(<EditRequirementModal {...defaultProps} requirement={reqWithMultiline} />);
-
-    await userEvent.click(screen.getByRole("button", { name: "Save" }));
-
-    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
-    const body = JSON.parse((global.fetch as any).mock.calls[0][1].body);
-    expect(body.desirable_cases).toEqual(["Case one", "Case two"]);
   });
 });

--- a/src/__tests__/unit/components/evals/EvalSetDetail.test.tsx
+++ b/src/__tests__/unit/components/evals/EvalSetDetail.test.tsx
@@ -20,11 +20,6 @@ vi.mock("@/components/evals/CreateRequirementModal", () => ({
   CreateRequirementModal: () => null,
 }));
 
-vi.mock("@/components/evals/CaptureEvalTriggerModal", () => ({
-  CaptureEvalTriggerModal: ({ open }: { open: boolean }) =>
-    open ? <div data-testid="capture-trigger-modal" /> : null,
-}));
-
 vi.mock("@/components/evals/EvalTriggerList", () => ({
   EvalTriggerList: ({ reqId }: { reqId: string }) => (
     <div data-testid={`eval-trigger-list-${reqId}`} />
@@ -96,10 +91,14 @@ vi.mock("@/components/ui/skeleton", () => ({
 
 vi.mock("lucide-react", () => ({
   ArrowLeft: () => <span>←</span>,
-  Zap: () => <span>⚡</span>,
+  Check: () => <span>✓</span>,
+  ClipboardList: () => <span>📋</span>,
+  Link2: () => <span>🔗</span>,
   Pencil: () => <span>✏️</span>,
   Plus: () => <span>+</span>,
   Trash2: () => <span>🗑️</span>,
+  X: () => <span>✗</span>,
+  Zap: () => <span>⚡</span>,
 }));
 
 import { EvalSetDetail } from "@/components/evals/EvalSetDetail";
@@ -314,7 +313,7 @@ describe("EvalSetDetail", () => {
     });
   });
 
-  it("renders CaptureEvalTriggerModal (not LinkRunModal)", async () => {
+  it("shows the requirement name and reason", async () => {
     global.fetch = vi.fn().mockResolvedValue({
       json: async () => ({ data: { nodes: MOCK_REQUIREMENTS, total: 2 } }),
     });
@@ -322,14 +321,9 @@ describe("EvalSetDetail", () => {
     render(<EvalSetDetail evalSet={EVAL_SET} onBack={() => {}} />);
     await waitFor(() => expect(screen.getAllByTestId("requirement-row")).toHaveLength(2));
 
-    // Trigger the modal by clicking "Capture Trigger"
-    const captureBtns = screen.getAllByText(/Capture Trigger/i);
-    expect(captureBtns.length).toBeGreaterThan(0);
-    await userEvent.click(captureBtns[0]);
-
-    expect(screen.getByTestId("capture-trigger-modal")).toBeTruthy();
-    // LinkRunModal should NOT be present at all
-    expect(screen.queryByTestId("link-run-modal")).toBeNull();
+    const rows = screen.getAllByTestId("requirement-row");
+    expect(rows[0].textContent).toContain("Req Alpha");
+    expect(rows[0].textContent).toContain("First requirement");
   });
 
   it("does NOT render LinkRunModal anywhere", async () => {

--- a/src/__tests__/unit/components/evals/EvalTriggerList.test.tsx
+++ b/src/__tests__/unit/components/evals/EvalTriggerList.test.tsx
@@ -31,10 +31,13 @@ vi.mock("@/components/ui/skeleton", () => ({
 }));
 
 vi.mock("lucide-react", () => ({
+  ArrowRight: () => <span>→</span>,
+  Check: () => <span>✓</span>,
   ChevronDown: () => <span data-testid="chevron-down">▼</span>,
   ChevronRight: () => <span data-testid="chevron-right">▶</span>,
   Loader2: () => <span data-testid="loader-icon">⟳</span>,
   Play: () => <span>▷</span>,
+  X: () => <span>✗</span>,
 }));
 
 import { EvalTriggerList } from "@/components/evals/EvalTriggerList";
@@ -195,11 +198,13 @@ describe("EvalTriggerList", () => {
     await userEvent.click(screen.getByTestId("trigger-count-chip"));
 
     await waitFor(() => {
-      expect(screen.getByTestId("trigger-count-chip").textContent).toContain("2 triggers");
+      const chip = screen.getByTestId("trigger-count-chip").textContent ?? "";
+      expect(chip).toContain("Triggers");
+      expect(chip).toContain("2");
     });
   });
 
-  it("shows 'No triggers' chip after empty response", async () => {
+  it("shows empty 'none yet' chip after empty response", async () => {
     global.fetch = vi.fn().mockResolvedValue({
       json: async () => ({ data: { nodes: [] } }),
     });
@@ -208,8 +213,32 @@ describe("EvalTriggerList", () => {
     await userEvent.click(screen.getByTestId("trigger-count-chip"));
 
     await waitFor(() => {
-      expect(screen.getByTestId("trigger-count-chip").textContent).toContain("No triggers");
+      expect(screen.getByTestId("trigger-count-chip").textContent).toContain("none yet");
     });
+  });
+
+  it("hides triggers with no agent, start, or end (blank/legacy rows)", async () => {
+    const triggersWithBlank = [
+      MOCK_TRIGGERS[0],
+      {
+        ref_id: "trigger-blank",
+        node_type: "EvalTrigger",
+        properties: { run_count: 1 },
+        outputs: [],
+      },
+    ];
+    global.fetch = vi.fn().mockResolvedValue({
+      json: async () => ({ data: { nodes: triggersWithBlank } }),
+    });
+
+    render(<EvalTriggerList {...DEFAULT_PROPS} />);
+    await userEvent.click(screen.getByTestId("trigger-count-chip"));
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("trigger-row")).toHaveLength(1);
+    });
+    // Count chip reflects only the visible (identifiable) trigger
+    expect(screen.getByTestId("trigger-count-chip").textContent).toContain("1");
   });
 
   it("Run Eval button enters disabled state during execution", async () => {
@@ -277,7 +306,7 @@ describe("EvalTriggerList", () => {
     expect(rows[1].textContent).toContain("0.22");
   });
 
-  it("pass output uses default badge variant, fail uses destructive", async () => {
+  it("visually distinguishes pass and fail outputs", async () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce({ json: async () => ({ data: { nodes: [MOCK_TRIGGERS[0]] } }) })
       .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true }) })
@@ -291,12 +320,13 @@ describe("EvalTriggerList", () => {
     await userEvent.click(screen.getByTestId("run-eval-btn"));
     await waitFor(() => expect(screen.getAllByTestId("trigger-output-row")).toHaveLength(2));
 
-    const badges = screen
-      .getAllByTestId("trigger-output-row")
-      .flatMap((row) => Array.from(row.querySelectorAll("[data-variant]")));
-    const variants = badges.map((b) => b.getAttribute("data-variant"));
-    expect(variants).toContain("default");
-    expect(variants).toContain("destructive");
+    const rows = screen.getAllByTestId("trigger-output-row");
+    expect(rows[0].textContent?.toLowerCase()).toContain("pass");
+    expect(rows[1].textContent?.toLowerCase()).toContain("fail");
+
+    const html = screen.getByTestId("trigger-list").innerHTML;
+    expect(html).toContain("emerald");
+    expect(html).toContain("rose");
   });
 
   it("shows error toast when fetch fails", async () => {

--- a/src/app/api/workspaces/[slug]/evals/[evalSetId]/requirements/[reqId]/route.ts
+++ b/src/app/api/workspaces/[slug]/evals/[evalSetId]/requirements/[reqId]/route.ts
@@ -32,23 +32,10 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     const body = await request.json();
     const { name, description, prompt_snippet, desirable_cases, undesirable_cases } = body ?? {};
 
+    // A requirement only needs a name and an optional reason (description).
+    // prompt_snippet and example cases are optional and preserved if present.
     if (!name || typeof name !== "string" || !name.trim()) {
       return NextResponse.json({ error: "name is required" }, { status: 400 });
-    }
-    if (!prompt_snippet || typeof prompt_snippet !== "string" || !prompt_snippet.trim()) {
-      return NextResponse.json({ error: "prompt_snippet is required" }, { status: 400 });
-    }
-    if (!Array.isArray(desirable_cases) || desirable_cases.length === 0) {
-      return NextResponse.json(
-        { error: "desirable_cases must be a non-empty array" },
-        { status: 400 },
-      );
-    }
-    if (!Array.isArray(undesirable_cases) || undesirable_cases.length === 0) {
-      return NextResponse.json(
-        { error: "undesirable_cases must be a non-empty array" },
-        { status: 400 },
-      );
     }
 
     const swarmAccessResult = await getWorkspaceSwarmAccess(slug, userOrResponse.id);
@@ -79,9 +66,10 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
       node_data: {
         name: name.trim(),
         description,
-        prompt_snippet: prompt_snippet.trim(),
-        desirable_cases,
-        undesirable_cases,
+        prompt_snippet:
+          typeof prompt_snippet === "string" ? prompt_snippet.trim() : undefined,
+        desirable_cases: Array.isArray(desirable_cases) ? desirable_cases : [],
+        undesirable_cases: Array.isArray(undesirable_cases) ? undesirable_cases : [],
       },
     });
 

--- a/src/app/api/workspaces/[slug]/evals/[evalSetId]/requirements/route.ts
+++ b/src/app/api/workspaces/[slug]/evals/[evalSetId]/requirements/route.ts
@@ -103,26 +103,10 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     const { name, description, prompt_snippet, desirable_cases, undesirable_cases, order } =
       body ?? {};
 
+    // A requirement only needs a name and an optional reason (description).
+    // prompt_snippet and example cases are optional and may be added later.
     if (!name || typeof name !== "string" || !name.trim()) {
       return NextResponse.json({ error: "name is required" }, { status: 400 });
-    }
-    if (!prompt_snippet || typeof prompt_snippet !== "string" || !prompt_snippet.trim()) {
-      return NextResponse.json(
-        { error: "prompt_snippet is required" },
-        { status: 400 },
-      );
-    }
-    if (!Array.isArray(desirable_cases) || desirable_cases.length === 0) {
-      return NextResponse.json(
-        { error: "desirable_cases must be a non-empty array" },
-        { status: 400 },
-      );
-    }
-    if (!Array.isArray(undesirable_cases) || undesirable_cases.length === 0) {
-      return NextResponse.json(
-        { error: "undesirable_cases must be a non-empty array" },
-        { status: 400 },
-      );
     }
 
     const swarmAccessResult = await getWorkspaceSwarmAccess(slug, userOrResponse.id);
@@ -157,9 +141,10 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         id,
         name: name.trim(),
         description,
-        prompt_snippet: prompt_snippet.trim(),
-        desirable_cases,
-        undesirable_cases,
+        prompt_snippet:
+          typeof prompt_snippet === "string" ? prompt_snippet.trim() : undefined,
+        desirable_cases: Array.isArray(desirable_cases) ? desirable_cases : [],
+        undesirable_cases: Array.isArray(undesirable_cases) ? undesirable_cases : [],
       },
     });
     console.log(`[Evals Requirements POST] addNode result: success=${nodeResult.success}, ref_id=${nodeResult.ref_id ?? 'n/a'}, error=${nodeResult.error ?? 'none'}`);

--- a/src/components/evals/CreateRequirementModal.tsx
+++ b/src/components/evals/CreateRequirementModal.tsx
@@ -10,7 +10,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { TagInput } from "@/components/ui/tag-input";
+import { Label } from "@/components/ui/label";
 import { useWorkspace } from "@/hooks/useWorkspace";
 
 interface CreateRequirementModalProps {
@@ -30,40 +30,24 @@ export function CreateRequirementModal({
 }: CreateRequirementModalProps) {
   const { slug } = useWorkspace();
   const [name, setName] = useState("");
-  const [description, setDescription] = useState("");
-  const [promptSnippet, setPromptSnippet] = useState("");
-  const [desirableCases, setDesirableCases] = useState<string[]>([]);
-  const [undesirableCases, setUndesirableCases] = useState<string[]>([]);
+  const [reason, setReason] = useState("");
   const [submitting, setSubmitting] = useState(false);
-  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [error, setError] = useState("");
 
   function handleClose() {
     setName("");
-    setDescription("");
-    setPromptSnippet("");
-    setDesirableCases([]);
-    setUndesirableCases([]);
-    setErrors({});
+    setReason("");
+    setError("");
     onOpenChange(false);
-  }
-
-  function validate() {
-    const next: Record<string, string> = {};
-    if (!name.trim()) next.name = "Name is required";
-    if (!promptSnippet.trim()) next.promptSnippet = "Prompt snippet is required";
-    if (desirableCases.length === 0) next.desirableCases = "At least one desirable case is required";
-    if (undesirableCases.length === 0) next.undesirableCases = "At least one undesirable case is required";
-    return { next, posLines: desirableCases, negLines: undesirableCases };
   }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    const { next, posLines, negLines } = validate();
-    if (Object.keys(next).length > 0) {
-      setErrors(next);
+    if (!name.trim()) {
+      setError("Requirement is required");
       return;
     }
-    setErrors({});
+    setError("");
     setSubmitting(true);
     try {
       const res = await fetch(`/api/workspaces/${slug}/evals/${evalSetId}/requirements`, {
@@ -71,10 +55,7 @@ export function CreateRequirementModal({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           name: name.trim(),
-          description: description.trim() || undefined,
-          prompt_snippet: promptSnippet.trim(),
-          desirable_cases: posLines,
-          undesirable_cases: negLines,
+          description: reason.trim() || undefined,
           order,
         }),
       });
@@ -93,74 +74,36 @@ export function CreateRequirementModal({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-lg max-h-[90vh] overflow-y-auto">
+      <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>Add Requirement</DialogTitle>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-1">
-            <label className="text-sm font-medium" htmlFor="req-name">
-              Name <span className="text-destructive">*</span>
-            </label>
-            <Input
+          <div className="space-y-1.5">
+            <Label htmlFor="req-name">
+              Requirement <span className="text-destructive">*</span>
+            </Label>
+            <Textarea
               id="req-name"
               value={name}
-              onChange={(e) => { setName(e.target.value); setErrors((p) => ({ ...p, name: "" })); }}
-              placeholder="e.g. Correct auth handling"
-            />
-            {errors.name && <p className="text-xs text-destructive">{errors.name}</p>}
-          </div>
-
-          <div className="space-y-1">
-            <label className="text-sm font-medium" htmlFor="req-description">
-              Description
-            </label>
-            <Textarea
-              id="req-description"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="Optional description..."
+              onChange={(e) => {
+                setName(e.target.value);
+                if (error) setError("");
+              }}
+              placeholder="What should the agent always do?"
               rows={2}
+              autoFocus
             />
+            {error && <p className="text-xs text-destructive">{error}</p>}
           </div>
 
-          <div className="space-y-1">
-            <label className="text-sm font-medium" htmlFor="req-prompt">
-              Prompt Snippet <span className="text-destructive">*</span>
-            </label>
-            <Textarea
-              id="req-prompt"
-              value={promptSnippet}
-              onChange={(e) => { setPromptSnippet(e.target.value); setErrors((p) => ({ ...p, promptSnippet: "" })); }}
-              placeholder="The portion of the prompt being evaluated..."
-              rows={3}
-            />
-            {errors.promptSnippet && <p className="text-xs text-destructive">{errors.promptSnippet}</p>}
-          </div>
-
-          <div className="space-y-1">
-            <label className="text-sm font-medium" htmlFor="req-positive">
-              Desirable Cases <span className="text-destructive">*</span>
-            </label>
-            <TagInput
-              id="req-positive"
-              items={desirableCases}
-              onChange={(items) => { setDesirableCases(items); setErrors((p) => ({ ...p, desirableCases: "" })); }}
-              placeholder="The agent correctly..."
-              error={errors.desirableCases}
-            />
-          </div>
-
-          <div className="space-y-1">
-            <label className="text-sm font-medium" htmlFor="req-negative">
-              Undesirable Cases <span className="text-destructive">*</span>
-            </label>
-            <TagInput
-              id="req-negative"
-              items={undesirableCases}
-              onChange={(items) => { setUndesirableCases(items); setErrors((p) => ({ ...p, undesirableCases: "" })); }}
-              placeholder="The agent fails to..."
-              error={errors.undesirableCases}
+          <div className="space-y-1.5">
+            <Label htmlFor="req-reason">Reason</Label>
+            <Input
+              id="req-reason"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="Why does this matter?"
             />
           </div>
 

--- a/src/components/evals/EditRequirementModal.tsx
+++ b/src/components/evals/EditRequirementModal.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import type { JarvisNode } from "@/types/jarvis";
 
@@ -30,28 +31,16 @@ export function EditRequirementModal({
 }: EditRequirementModalProps) {
   const { slug } = useWorkspace();
   const [name, setName] = useState("");
-  const [description, setDescription] = useState("");
-  const [promptSnippet, setPromptSnippet] = useState("");
-  const [desirableCases, setDesirableCases] = useState("");
-  const [undesirableCases, setUndesirableCases] = useState("");
+  const [reason, setReason] = useState("");
   const [submitting, setSubmitting] = useState(false);
-  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [error, setError] = useState("");
 
   // Pre-populate when modal opens or requirement changes
   useEffect(() => {
     if (open) {
       setName(String(requirement.properties?.name ?? ""));
-      setDescription(String(requirement.properties?.description ?? ""));
-      setPromptSnippet(String(requirement.properties?.prompt_snippet ?? ""));
-      const pos = Array.isArray(requirement.properties?.desirable_cases)
-        ? (requirement.properties.desirable_cases as string[]).join("\n")
-        : "";
-      const neg = Array.isArray(requirement.properties?.undesirable_cases)
-        ? (requirement.properties.undesirable_cases as string[]).join("\n")
-        : "";
-      setDesirableCases(pos);
-      setUndesirableCases(neg);
-      setErrors({});
+      setReason(String(requirement.properties?.description ?? ""));
+      setError("");
     }
   }, [open, requirement]);
 
@@ -59,26 +48,27 @@ export function EditRequirementModal({
     onOpenChange(false);
   }
 
-  function validate() {
-    const next: Record<string, string> = {};
-    if (!name.trim()) next.name = "Name is required";
-    if (!promptSnippet.trim()) next.promptSnippet = "Prompt snippet is required";
-    const posLines = desirableCases.split("\n").map((l) => l.trim()).filter(Boolean);
-    const negLines = undesirableCases.split("\n").map((l) => l.trim()).filter(Boolean);
-    if (posLines.length === 0) next.desirableCases = "At least one desirable case is required";
-    if (negLines.length === 0) next.undesirableCases = "At least one undesirable case is required";
-    return { next, posLines, negLines };
-  }
-
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    const { next, posLines, negLines } = validate();
-    if (Object.keys(next).length > 0) {
-      setErrors(next);
+    if (!name.trim()) {
+      setError("Requirement is required");
       return;
     }
-    setErrors({});
+    setError("");
     setSubmitting(true);
+
+    // Preserve any legacy prompt_snippet / example cases on the node so editing
+    // name + reason doesn't wipe data created before the simplified form.
+    const props = requirement.properties ?? {};
+    const promptSnippet =
+      typeof props.prompt_snippet === "string" ? props.prompt_snippet : undefined;
+    const desirableCases = Array.isArray(props.desirable_cases)
+      ? props.desirable_cases
+      : undefined;
+    const undesirableCases = Array.isArray(props.undesirable_cases)
+      ? props.undesirable_cases
+      : undefined;
+
     try {
       const res = await fetch(
         `/api/workspaces/${slug}/evals/${evalSetId}/requirements/${requirement.ref_id}`,
@@ -87,10 +77,10 @@ export function EditRequirementModal({
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             name: name.trim(),
-            description: description.trim() || undefined,
-            prompt_snippet: promptSnippet.trim(),
-            desirable_cases: posLines,
-            undesirable_cases: negLines,
+            description: reason.trim() || undefined,
+            prompt_snippet: promptSnippet,
+            desirable_cases: desirableCases,
+            undesirable_cases: undesirableCases,
           }),
         },
       );
@@ -109,77 +99,37 @@ export function EditRequirementModal({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-lg max-h-[90vh] overflow-y-auto">
+      <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>Edit Requirement</DialogTitle>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-1">
-            <label className="text-sm font-medium" htmlFor="edit-req-name">
-              Name <span className="text-destructive">*</span>
-            </label>
-            <Input
+          <div className="space-y-1.5">
+            <Label htmlFor="edit-req-name">
+              Requirement <span className="text-destructive">*</span>
+            </Label>
+            <Textarea
               id="edit-req-name"
               value={name}
-              onChange={(e) => { setName(e.target.value); setErrors((p) => ({ ...p, name: "" })); }}
-              placeholder="e.g. Correct auth handling"
-            />
-            {errors.name && <p className="text-xs text-destructive">{errors.name}</p>}
-          </div>
-
-          <div className="space-y-1">
-            <label className="text-sm font-medium" htmlFor="edit-req-description">
-              Description
-            </label>
-            <Textarea
-              id="edit-req-description"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="Optional description..."
+              onChange={(e) => {
+                setName(e.target.value);
+                if (error) setError("");
+              }}
+              placeholder="What should the agent always do?"
               rows={2}
+              autoFocus
             />
+            {error && <p className="text-xs text-destructive">{error}</p>}
           </div>
 
-          <div className="space-y-1">
-            <label className="text-sm font-medium" htmlFor="edit-req-prompt">
-              Prompt Snippet <span className="text-destructive">*</span>
-            </label>
-            <Textarea
-              id="edit-req-prompt"
-              value={promptSnippet}
-              onChange={(e) => { setPromptSnippet(e.target.value); setErrors((p) => ({ ...p, promptSnippet: "" })); }}
-              placeholder="The portion of the prompt being evaluated..."
-              rows={3}
+          <div className="space-y-1.5">
+            <Label htmlFor="edit-req-reason">Reason</Label>
+            <Input
+              id="edit-req-reason"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="Why does this matter?"
             />
-            {errors.promptSnippet && <p className="text-xs text-destructive">{errors.promptSnippet}</p>}
-          </div>
-
-          <div className="space-y-1">
-            <label className="text-sm font-medium" htmlFor="edit-req-positive">
-              Desirable Cases (one per line) <span className="text-destructive">*</span>
-            </label>
-            <Textarea
-              id="edit-req-positive"
-              value={desirableCases}
-              onChange={(e) => { setDesirableCases(e.target.value); setErrors((p) => ({ ...p, desirableCases: "" })); }}
-              placeholder="The agent correctly..."
-              rows={3}
-            />
-            {errors.desirableCases && <p className="text-xs text-destructive">{errors.desirableCases}</p>}
-          </div>
-
-          <div className="space-y-1">
-            <label className="text-sm font-medium" htmlFor="edit-req-negative">
-              Undesirable Cases (one per line) <span className="text-destructive">*</span>
-            </label>
-            <Textarea
-              id="edit-req-negative"
-              value={undesirableCases}
-              onChange={(e) => { setUndesirableCases(e.target.value); setErrors((p) => ({ ...p, undesirableCases: "" })); }}
-              placeholder="The agent fails to..."
-              rows={3}
-            />
-            {errors.undesirableCases && <p className="text-xs text-destructive">{errors.undesirableCases}</p>}
           </div>
 
           <DialogFooter>

--- a/src/components/evals/EvalSetDetail.tsx
+++ b/src/components/evals/EvalSetDetail.tsx
@@ -4,11 +4,18 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ActionMenu } from "@/components/ui/action-menu";
-import { ArrowLeft, Pencil, Plus, Trash2, Zap } from "lucide-react";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import { ArrowLeft, ClipboardList, Link2, Pencil, Plus, Trash2 } from "lucide-react";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { CreateRequirementModal } from "./CreateRequirementModal";
 import { EditRequirementModal } from "./EditRequirementModal";
-import { CaptureEvalTriggerModal } from "./CaptureEvalTriggerModal";
 import { EvalTriggerList } from "./EvalTriggerList";
 import type { JarvisNode } from "@/types/jarvis";
 
@@ -35,7 +42,6 @@ export function EvalSetDetail({ evalSet, onBack }: EvalSetDetailProps) {
   const [requirements, setRequirements] = useState<RequirementNode[]>([]);
   const [loading, setLoading] = useState(true);
   const [createOpen, setCreateOpen] = useState(false);
-  const [linkTarget, setLinkTarget] = useState<{ reqId: string } | null>(null);
   const [editReqTarget, setEditReqTarget] = useState<RequirementNode | null>(null);
 
   async function fetchRequirements() {
@@ -87,7 +93,15 @@ export function EvalSetDetail({ evalSet, onBack }: EvalSetDetailProps) {
             <ArrowLeft className="h-4 w-4" />
           </Button>
           <div>
-            <h2 className="text-xl font-semibold">{evalSetName}</h2>
+            <div className="flex items-center gap-2">
+              <h2 className="text-xl font-semibold">{evalSetName}</h2>
+              {!loading && requirements.length > 0 && (
+                <Badge variant="secondary" className="text-xs">
+                  {requirements.length} requirement
+                  {requirements.length !== 1 ? "s" : ""}
+                </Badge>
+              )}
+            </div>
             {!!evalSet.properties?.description && (
               <p className="text-sm text-muted-foreground">
                 {String(evalSet.properties.description)}
@@ -109,9 +123,23 @@ export function EvalSetDetail({ evalSet, onBack }: EvalSetDetailProps) {
           ))}
         </div>
       ) : requirements.length === 0 ? (
-        <div className="rounded-lg border border-dashed p-10 text-center text-sm text-muted-foreground">
-          No requirements yet — add one to get started
-        </div>
+        <Empty className="border">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <ClipboardList />
+            </EmptyMedia>
+            <EmptyTitle>No requirements yet</EmptyTitle>
+            <EmptyDescription>
+              Add a requirement to define what good looks like for this eval set.
+            </EmptyDescription>
+          </EmptyHeader>
+          <EmptyContent>
+            <Button size="sm" onClick={() => setCreateOpen(true)}>
+              <Plus className="mr-1 h-4 w-4" />
+              Add Requirement
+            </Button>
+          </EmptyContent>
+        </Empty>
       ) : (
         <div className="space-y-3">
           {requirements.map((req) => {
@@ -122,12 +150,6 @@ export function EvalSetDetail({ evalSet, onBack }: EvalSetDetailProps) {
             const promptSnippet = req.properties?.prompt_snippet
               ? String(req.properties.prompt_snippet)
               : null;
-            const posCount = Array.isArray(req.properties?.desirable_cases)
-              ? req.properties.desirable_cases.length
-              : 0;
-            const negCount = Array.isArray(req.properties?.undesirable_cases)
-              ? req.properties.undesirable_cases.length
-              : 0;
             const sessionCount =
               typeof req.properties?.linked_session_count === "number"
                 ? req.properties.linked_session_count
@@ -140,14 +162,12 @@ export function EvalSetDetail({ evalSet, onBack }: EvalSetDetailProps) {
                 data-testid="requirement-row"
               >
                 <div className="flex items-start justify-between gap-4">
-                  <div className="min-w-0 flex-1 space-y-1">
+                  <div className="min-w-0 flex-1 space-y-1.5">
                     <div className="flex flex-wrap items-center gap-2">
                       <span className="font-medium">{name}</span>
-                      <Badge variant="outline" className="text-xs">
-                        +{posCount} / -{negCount}
-                      </Badge>
                       {sessionCount > 0 && (
-                        <Badge variant="secondary" className="text-xs">
+                        <Badge variant="secondary" className="gap-1 text-xs">
+                          <Link2 className="h-3 w-3" />
                           {sessionCount} session{sessionCount !== 1 ? "s" : ""}
                         </Badge>
                       )}
@@ -156,42 +176,32 @@ export function EvalSetDetail({ evalSet, onBack }: EvalSetDetailProps) {
                       <p className="text-sm text-muted-foreground">{description}</p>
                     )}
                     {promptSnippet && (
-                      <p className="truncate text-xs text-muted-foreground font-mono bg-muted rounded px-2 py-1">
+                      <p className="truncate rounded bg-muted px-2 py-1 font-mono text-xs text-muted-foreground">
                         {promptSnippet}
                       </p>
                     )}
                   </div>
-                  <div className="flex items-center gap-1 shrink-0">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => setLinkTarget({ reqId: req.ref_id })}
-                    >
-                      <Zap className="mr-1 h-3 w-3" />
-                      Capture Trigger
-                    </Button>
-                    <ActionMenu
-                      actions={[
-                        {
-                          label: "Edit",
-                          icon: Pencil,
-                          onClick: () => setEditReqTarget(req),
+                  <ActionMenu
+                    actions={[
+                      {
+                        label: "Edit",
+                        icon: Pencil,
+                        onClick: () => setEditReqTarget(req),
+                      },
+                      {
+                        label: "Delete",
+                        icon: Trash2,
+                        variant: "destructive",
+                        confirmation: {
+                          title: "Delete requirement?",
+                          description:
+                            "This will permanently remove this requirement from the eval set.",
+                          confirmText: "Delete",
+                          onConfirm: () => handleDeleteRequirement(req.ref_id),
                         },
-                        {
-                          label: "Delete",
-                          icon: Trash2,
-                          variant: "destructive",
-                          confirmation: {
-                            title: "Delete requirement?",
-                            description:
-                              "This will permanently remove this requirement from the eval set.",
-                            confirmText: "Delete",
-                            onConfirm: () => handleDeleteRequirement(req.ref_id),
-                          },
-                        },
-                      ]}
-                    />
-                  </div>
+                      },
+                    ]}
+                  />
                 </div>
                 <EvalTriggerList
                   evalSetId={evalSet.ref_id}
@@ -211,16 +221,6 @@ export function EvalSetDetail({ evalSet, onBack }: EvalSetDetailProps) {
         order={requirements.length}
         onCreated={fetchRequirements}
       />
-
-      {linkTarget && (
-        <CaptureEvalTriggerModal
-          open={!!linkTarget}
-          onOpenChange={(o) => { if (!o) setLinkTarget(null); }}
-          evalSetId={evalSet.ref_id}
-          reqId={linkTarget.reqId}
-          onCreated={fetchRequirements}
-        />
-      )}
 
       {editReqTarget !== null && (
         <EditRequirementModal

--- a/src/components/evals/EvalTriggerList.tsx
+++ b/src/components/evals/EvalTriggerList.tsx
@@ -2,8 +2,9 @@ import { useState, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ChevronDown, ChevronRight, Loader2, Play } from "lucide-react";
+import { ArrowRight, Check, ChevronRight, Loader2, Play, X } from "lucide-react";
 import { toast } from "sonner";
+import { cn } from "@/lib/utils";
 
 export interface EvalTriggerListProps {
   evalSetId: string;
@@ -46,6 +47,15 @@ function normalizeOutput(n: RawOutputNode): EvalTriggerOutput {
     score: Number(n.properties?.score ?? 0),
     judge_notes: n.properties?.judge_notes ? String(n.properties.judge_notes) : undefined,
   };
+}
+
+// Skip triggers with no identifiable source (legacy/empty data) — they have no
+// agent, start point, or end point and only add noise to the list.
+function triggerHasIdentity(t: EvalTrigger): boolean {
+  const agent = String(t.properties?.agent ?? "").trim();
+  const start = String(t.properties?.start_point ?? "").trim();
+  const end = String(t.properties?.end_point ?? "").trim();
+  return Boolean(agent || start || end);
 }
 
 export function EvalTriggerList({ evalSetId, reqId, slug }: EvalTriggerListProps) {
@@ -114,70 +124,101 @@ export function EvalTriggerList({ evalSetId, reqId, slug }: EvalTriggerListProps
     }
   }
 
-  const count = loaded ? triggers.length : null;
-  const chipLabel =
-    count === null ? "triggers" : count === 0 ? "No triggers" : `${count} trigger${count !== 1 ? "s" : ""}`;
+  const visibleTriggers = triggers.filter(triggerHasIdentity);
+  const count = loaded ? visibleTriggers.length : null;
 
   return (
-    <div className="mt-2">
+    <div className="mt-3 border-t pt-2.5">
       <button
         type="button"
         data-testid="trigger-count-chip"
         onClick={handleToggle}
-        className="inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted"
+        className="inline-flex items-center gap-1.5 rounded-md py-1 pr-2 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
       >
-        {expanded ? (
-          <ChevronDown className="h-3 w-3" />
-        ) : (
-          <ChevronRight className="h-3 w-3" />
+        <ChevronRight
+          className={cn(
+            "h-3.5 w-3.5 shrink-0 transition-transform duration-200",
+            expanded && "rotate-90",
+          )}
+        />
+        <span>Triggers</span>
+        {count !== null && count > 0 && (
+          <span className="rounded-full bg-muted px-1.5 py-0.5 text-[11px] leading-none text-foreground">
+            {count}
+          </span>
         )}
-        {chipLabel}
+        {count === 0 && <span className="text-muted-foreground/70">· none yet</span>}
+        {loading && <Loader2 className="h-3 w-3 animate-spin" />}
       </button>
 
       {expanded && (
-        <div className="mt-2 space-y-2 pl-2" data-testid="trigger-list">
+        <div className="mt-2 space-y-2" data-testid="trigger-list">
           {loading ? (
             <>
-              <Skeleton className="h-14 w-full" data-testid="trigger-skeleton" />
-              <Skeleton className="h-14 w-full" data-testid="trigger-skeleton" />
+              <Skeleton className="h-16 w-full" data-testid="trigger-skeleton" />
+              <Skeleton className="h-16 w-full" data-testid="trigger-skeleton" />
             </>
-          ) : triggers.length === 0 ? (
-            <p className="text-xs text-muted-foreground">No triggers captured yet</p>
+          ) : visibleTriggers.length === 0 ? (
+            <div className="rounded-md border border-dashed px-3 py-5 text-center text-xs text-muted-foreground">
+              No triggers yet for this requirement.
+            </div>
           ) : (
-            triggers.map((trigger) => {
+            visibleTriggers.map((trigger) => {
               const agent = String(trigger.properties?.agent ?? "");
               const env = String(trigger.properties?.environment ?? "");
               const runCount = Number(trigger.properties?.run_count ?? 1);
               const startPoint = String(trigger.properties?.start_point ?? "");
               const endPoint = String(trigger.properties?.end_point ?? "");
               const isRunning = runningIds.has(trigger.ref_id);
+              const outputs = trigger.outputs ?? [];
+              const passCount = outputs.filter((o) => o.result === "pass").length;
 
               return (
                 <div
                   key={trigger.ref_id}
-                  className="rounded-md border bg-muted/30 p-3"
+                  className="rounded-md border bg-card p-3"
                   data-testid="trigger-row"
                 >
                   <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0 flex-1 space-y-1">
+                    <div className="min-w-0 flex-1 space-y-1.5">
                       <div className="flex flex-wrap items-center gap-1.5">
-                        <span className="text-sm font-medium">{agent}</span>
+                        <span className="text-sm font-medium">{agent || "Agent"}</span>
                         {env && (
-                          <Badge variant="outline" className="text-xs">
+                          <Badge variant="secondary" className="text-[11px]">
                             {env}
                           </Badge>
                         )}
-                        <span className="text-xs text-muted-foreground">{runCount}× runs</span>
+                        <span className="text-xs text-muted-foreground">
+                          {runCount} attempt{runCount !== 1 ? "s" : ""} per run
+                        </span>
+                        {outputs.length > 0 && (
+                          <Badge
+                            variant="outline"
+                            className={cn(
+                              "text-[11px]",
+                              passCount === outputs.length
+                                ? "border-emerald-500/30 text-emerald-600 dark:text-emerald-400"
+                                : passCount === 0
+                                  ? "border-rose-500/30 text-rose-600 dark:text-rose-400"
+                                  : "text-foreground",
+                            )}
+                          >
+                            {passCount}/{outputs.length} passed
+                          </Badge>
+                        )}
                       </div>
                       {(startPoint || endPoint) && (
-                        <p className="text-xs text-muted-foreground">
-                          {startPoint} → {endPoint}
-                        </p>
+                        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                          <span className="truncate">{startPoint || "—"}</span>
+                          <ArrowRight className="h-3 w-3 shrink-0" />
+                          <span className="truncate">{endPoint || "—"}</span>
+                        </div>
                       )}
                     </div>
                     <Button
                       size="sm"
                       variant="outline"
+                      className="h-7 shrink-0 px-2 text-xs"
                       disabled={isRunning}
                       onClick={() => handleRunEval(trigger.ref_id)}
                       data-testid="run-eval-btn"
@@ -197,28 +238,37 @@ export function EvalTriggerList({ evalSetId, reqId, slug }: EvalTriggerListProps
                   </div>
 
                   {/* EvalTriggerOutput rows */}
-                  {trigger.outputs && trigger.outputs.length > 0 && (
-                    <div className="mt-2 space-y-1 border-t pt-2 pl-3">
-                      {trigger.outputs.map((output) => {
+                  {outputs.length > 0 && (
+                    <div className="mt-2.5 space-y-1.5 border-t pt-2.5">
+                      {outputs.map((output) => {
                         const isPass = output.result === "pass";
                         return (
                           <div
                             key={output.ref_id}
-                            className="flex flex-wrap items-center gap-2 text-xs"
+                            className="flex items-center gap-2 text-xs"
                             data-testid="trigger-output-row"
                           >
-                            <span className="font-mono text-muted-foreground">
+                            <span className="w-6 shrink-0 font-mono text-muted-foreground">
                               #{output.attempt_number}
                             </span>
-                            <Badge
-                              variant={isPass ? "default" : "destructive"}
-                              className={`text-xs ${isPass ? "bg-green-600 text-white" : ""}`}
+                            <span
+                              className={cn(
+                                "inline-flex items-center gap-1 rounded px-1.5 py-0.5 font-medium capitalize",
+                                isPass
+                                  ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+                                  : "bg-rose-500/10 text-rose-600 dark:text-rose-400",
+                              )}
                             >
+                              {isPass ? <Check className="h-3 w-3" /> : <X className="h-3 w-3" />}
                               {output.result}
-                            </Badge>
-                            <span className="font-medium">{(output.score ?? 0).toFixed(2)}</span>
+                            </span>
+                            <span className="font-medium tabular-nums">
+                              {(output.score ?? 0).toFixed(2)}
+                            </span>
                             {output.judge_notes && (
-                              <span className="text-muted-foreground">{output.judge_notes}</span>
+                              <span className="truncate text-muted-foreground">
+                                {output.judge_notes}
+                              </span>
                             )}
                           </div>
                         );


### PR DESCRIPTION
- Reduce requirement create/edit to name + reason
- Remove Capture Trigger action and the +0/-0 example-case indicator
- Hide blank/agent-less triggers; relabel run count to 'N attempts per run'
- Relax requirements POST/PUT validation to require only name