### PR TITLE
ask/sync: messages[] replay + side-effect-free dryRun + maxTurns (eval harness)

### DIFF
--- a/docs/plans/ask-sync-endpoint.md
+++ b/docs/plans/ask-sync-endpoint.md
@@ -33,6 +33,32 @@ Two deltas from the original plan:
   the trusted token skips them. `orgId` is derived from the primary
   workspace's `sourceControlOrgId` when not passed explicitly.
 
+### Replay input mode + `dryRun` (eval harness)
+
+Added for an automated eval harness that re-plays canvas-agent calls and
+scores the result without mutating anything:
+
+- **Replay input** — alongside the server-history shape (`{ message,
+  conversationId? }`), the endpoint accepts a full verbatim transcript:
+  `{ messages: ModelMessage[] }`, the same shape `/api/ask/quick` takes.
+  Replay is **stateless** (no conversation read/written) and **requires
+  `dryRun: true`** — a replayed transcript must never persist or mutate.
+
+- **`dryRun: true`** runs the agent as a pure function and writes nothing:
+  no row create/append, no prompt-cache write, no Pusher, no research
+  dispatch, no `schedule_check` injection. Crucially it is **selective,
+  not a blunt `readonly`**: the pure-output `propose_*` tools are KEPT
+  (they emit a proposal card with *no DB write* — the row is only created
+  later at approval time, see `initiativeTools.ts`), so an eval can read
+  exactly what `propose_feature` produced from the returned rows'
+  `toolCalls[].output`. Implemented as `readonly: true` +
+  `keepWriteToolNames: [propose_initiative, propose_feature,
+  propose_milestone]` + `capabilities: ["canvas"]` (drops the `planner`
+  capability so `send_to_feature_planner`, a real Stakwork dispatch, is
+  absent). Every genuinely-mutating tool (canvas/feature/research/
+  connection writes) is stripped. Response carries `dryRun: true` and
+  `conversationId: null`.
+
 > **Companion docs — read first.**
 > - `src/app/org/[githubLogin]/CANVAS_CHAT.md` — the chat subsystem; the org chat → toolset wiring (`runCanvasAgent`, `buildConnectionTools`/`buildCanvasTools`/`buildInitiativeTools`), the `<SubAgentRunCard>` async fan-out.
 > - `docs/plans/backend-driven-canvas-turns.md` — the server-as-single-writer turn model this endpoint inherits (`messagesFromSteps` → `appendTurnMessages`, the `${turnId}-` idempotency prefix, the `CANVAS_CONVERSATION_UPDATED` nudge). The sync endpoint is that exact persistence path with the streaming response swapped for an awaited JSON one.

--- a/docs/plans/ask-sync-endpoint.md
+++ b/docs/plans/ask-sync-endpoint.md
@@ -59,6 +59,14 @@ scores the result without mutating anything:
   connection writes) is stripped. Response carries `dryRun: true` and
   `conversationId: null`.
 
+- **`maxTurns`** (positive integer, optional) caps the agentic loop by
+  appending a `stepCountIs(maxTurns)` stop condition (ANY stop condition
+  ends the loop — so the run halts at the model's `[END_OF_ANSWER]` or the
+  cap, whichever is first). It counts the agent's **generated steps in
+  this call**, NOT the input transcript — so `maxTurns: 1` with a
+  100-message replay still returns exactly one step. Lets an evaluator
+  score just the next single response/tool-call.
+
 > **Companion docs — read first.**
 > - `src/app/org/[githubLogin]/CANVAS_CHAT.md` — the chat subsystem; the org chat → toolset wiring (`runCanvasAgent`, `buildConnectionTools`/`buildCanvasTools`/`buildInitiativeTools`), the `<SubAgentRunCard>` async fan-out.
 > - `docs/plans/backend-driven-canvas-turns.md` — the server-as-single-writer turn model this endpoint inherits (`messagesFromSteps` → `appendTurnMessages`, the `${turnId}-` idempotency prefix, the `CANVAS_CONVERSATION_UPDATED` nudge). The sync endpoint is that exact persistence path with the streaming response swapped for an awaited JSON one.

--- a/src/__tests__/integration/api/ask/sync.test.ts
+++ b/src/__tests__/integration/api/ask/sync.test.ts
@@ -424,4 +424,126 @@ describe('POST /api/ask/sync', () => {
       expect(response.status).toBe(401);
     });
   });
+
+  describe('dryRun (eval / replay)', () => {
+    it('rejects messages[] replay mode without dryRun (400)', async () => {
+      const { owner, workspace } = await setupOrgWorkspace();
+      const request = createAuthenticatedPostRequest(
+        '/api/ask/sync',
+        {
+          messages: [{ role: 'user', content: 'replayed prompt' }],
+          workspaceSlug: workspace.slug,
+        },
+        owner,
+      );
+      const response = await POST(request);
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error).toMatch(/dryRun/i);
+    });
+
+    it('dryRun + messages[] returns rows and persists NOTHING', async () => {
+      const { owner, org, workspace } = await setupOrgWorkspace();
+
+      vi.mocked(streamText).mockReturnValue(
+        mockFinishedStream([
+          { text: 'dry answer', toolCalls: [], toolResults: [] },
+        ]) as any,
+      );
+
+      const request = createAuthenticatedPostRequest(
+        '/api/ask/sync',
+        {
+          messages: [
+            { role: 'user', content: 'First' },
+            { role: 'assistant', content: 'Prior' },
+            { role: 'user', content: 'Replay me' },
+          ],
+          workspaceSlug: workspace.slug,
+          dryRun: true,
+        },
+        owner,
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.dryRun).toBe(true);
+      expect(data.conversationId).toBeNull();
+      expect(data.messages[0].content).toBe('dry answer');
+
+      // The transcript was passed verbatim to the agent.
+      const callArgs = vi.mocked(streamText).mock.calls.at(-1)![0];
+      const contents = (callArgs.messages ?? []).map((m: any) => m.content);
+      expect(contents).toEqual(
+        expect.arrayContaining(['First', 'Prior', 'Replay me']),
+      );
+
+      // No SharedConversation row was created for this org.
+      const count = await db.sharedConversation.count({
+        where: { sourceControlOrgId: org.id },
+      });
+      expect(count).toBe(0);
+    });
+
+    it('dryRun in server-history mode also persists nothing', async () => {
+      const { owner, org, workspace } = await setupOrgWorkspace();
+
+      vi.mocked(streamText).mockReturnValue(
+        mockFinishedStream([
+          { text: 'dry answer', toolCalls: [], toolResults: [] },
+        ]) as any,
+      );
+
+      const response = await POST(
+        createAuthenticatedPostRequest(
+          '/api/ask/sync',
+          { message: 'preview this', workspaceSlug: workspace.slug, dryRun: true },
+          owner,
+        ),
+      );
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.dryRun).toBe(true);
+      expect(data.conversationId).toBeNull();
+
+      const count = await db.sharedConversation.count({
+        where: { sourceControlOrgId: org.id },
+      });
+      expect(count).toBe(0);
+    });
+
+    it('dryRun composes a side-effect-free toolset: propose_* kept, mutators + planner stripped', async () => {
+      const { owner, workspace } = await setupOrgWorkspace();
+
+      vi.mocked(streamText).mockReturnValue(
+        mockFinishedStream([{ text: 'ok', toolCalls: [], toolResults: [] }]) as any,
+      );
+
+      await POST(
+        createAuthenticatedPostRequest(
+          '/api/ask/sync',
+          {
+            messages: [{ role: 'user', content: 'propose a feature' }],
+            workspaceSlug: workspace.slug,
+            dryRun: true,
+          },
+          owner,
+        ),
+      );
+
+      const callArgs = vi.mocked(streamText).mock.calls.at(-1)![0];
+      const toolNames = Object.keys(callArgs.tools ?? {});
+
+      // Pure-output proposal tools survive the readonly strip.
+      expect(toolNames).toContain('propose_feature');
+      // Genuinely-mutating tools are stripped...
+      expect(toolNames).not.toContain('update_canvas');
+      expect(toolNames).not.toContain('assign_feature_to_initiative');
+      // ...and the planner capability (real Stakwork dispatch) is absent.
+      expect(toolNames).not.toContain('send_to_feature_planner');
+      // No deferred-check write tool injected.
+      expect(toolNames).not.toContain('schedule_check');
+    });
+  });
 });

--- a/src/__tests__/integration/api/ask/sync.test.ts
+++ b/src/__tests__/integration/api/ask/sync.test.ts
@@ -546,4 +546,91 @@ describe('POST /api/ask/sync', () => {
       expect(toolNames).not.toContain('schedule_check');
     });
   });
+
+  describe('maxTurns', () => {
+    it('rejects a non-positive / non-integer maxTurns (400)', async () => {
+      const { owner, workspace } = await setupOrgWorkspace();
+      for (const bad of [0, -1, 2.5, 'three']) {
+        const response = await POST(
+          createAuthenticatedPostRequest(
+            '/api/ask/sync',
+            { message: 'hi', workspaceSlug: workspace.slug, maxTurns: bad },
+            owner,
+          ),
+        );
+        expect(response.status).toBe(400);
+        const data = await response.json();
+        expect(data.error).toMatch(/maxTurns/i);
+      }
+    });
+
+    it('appends a step-cap stop condition when maxTurns is set', async () => {
+      const { owner, workspace } = await setupOrgWorkspace();
+
+      vi.mocked(streamText).mockReturnValue(
+        mockFinishedStream([{ text: 'one step', toolCalls: [], toolResults: [] }]) as any,
+      );
+
+      // Without maxTurns: only the default end-marker stop condition.
+      await POST(
+        createAuthenticatedPostRequest(
+          '/api/ask/sync',
+          { message: 'no cap', workspaceSlug: workspace.slug },
+          owner,
+        ),
+      );
+      const noCap = vi.mocked(streamText).mock.calls.at(-1)![0];
+      expect(noCap.stopWhen).toHaveLength(1);
+
+      // With maxTurns: the cap is appended (end-marker + step cap).
+      await POST(
+        createAuthenticatedPostRequest(
+          '/api/ask/sync',
+          { message: 'capped', workspaceSlug: workspace.slug, maxTurns: 1 },
+          owner,
+        ),
+      );
+      const capped = vi.mocked(streamText).mock.calls.at(-1)![0];
+      expect(capped.stopWhen).toHaveLength(2);
+    });
+
+    it('counts generated steps, not input messages (100 in, 1 step out)', async () => {
+      const { owner, workspace } = await setupOrgWorkspace();
+
+      // A big replayed transcript — these are CONTEXT, not steps.
+      const transcript = Array.from({ length: 100 }, (_, i) => ({
+        role: i % 2 === 0 ? 'user' : 'assistant',
+        content: `msg ${i}`,
+      }));
+
+      // The agent generates exactly one step (what maxTurns:1 would yield).
+      vi.mocked(streamText).mockReturnValue(
+        mockFinishedStream([
+          { text: 'the single next step', toolCalls: [], toolResults: [] },
+        ]) as any,
+      );
+
+      const response = await POST(
+        createAuthenticatedPostRequest(
+          '/api/ask/sync',
+          {
+            messages: transcript,
+            workspaceSlug: workspace.slug,
+            dryRun: true,
+            maxTurns: 1,
+          },
+          owner,
+        ),
+      );
+      expect(response.status).toBe(200);
+      const data = await response.json();
+
+      // All 100 messages were fed to the model as context...
+      const callArgs = vi.mocked(streamText).mock.calls.at(-1)![0];
+      expect(callArgs.messages).toHaveLength(100);
+      // ...but the response carries only the generated step(s), never the input.
+      expect(data.messages).toHaveLength(1);
+      expect(data.messages[0].content).toBe('the single next step');
+    });
+  });
 });

--- a/src/app/api/ask/sync/route.ts
+++ b/src/app/api/ask/sync/route.ts
@@ -20,6 +20,7 @@ import {
   runCanvasAgent,
   extractConceptIdsFromStep,
 } from "@/lib/ai/runCanvasAgent";
+import type { OrgCapability } from "@/lib/ai/capabilities";
 import type { DispatchedResearchIntent } from "@/lib/ai/researchTools";
 import { toModelMessages } from "@/lib/ai/conversationHelpers";
 import {
@@ -36,6 +37,11 @@ import {
   hasConcepts,
   persistOrgCanvasPromptCache,
 } from "@/services/org-canvas-conversation";
+import {
+  PROPOSE_INITIATIVE_TOOL,
+  PROPOSE_FEATURE_TOOL,
+  PROPOSE_MILESTONE_TOOL,
+} from "@/lib/proposals/types";
 
 /**
  * Synchronous (non-streaming) canvas-agent turn. See
@@ -49,11 +55,61 @@ import {
  * agent-as-tool callers that want the canvas agent as a plain function,
  * and for external eval workflows (authenticated via `x-api-token`).
  *
+ * ## Input modes
+ *
+ * - **Server-history** (`{ message, conversationId? }`): the server
+ *   reconstructs prior turns from `conversationId` and appends the new
+ *   `message`. Persists the turn (unless `dryRun`). The mobile path.
+ * - **Replay** (`{ messages: ModelMessage[] }`): the caller supplies the
+ *   FULL transcript verbatim (same shape as `/api/ask/quick`'s normal
+ *   mode). Stateless: no conversation is read or written. Requires
+ *   `dryRun: true` — a replayed transcript must never mutate state. The
+ *   eval-harness path.
+ *
+ * ## dryRun (side-effect-free)
+ *
+ * `dryRun: true` runs the agent as a pure function and writes NOTHING:
+ *   - no conversation row create / append, no prompt-cache write;
+ *   - the agent runs `readonly` with the `propose_*` tools KEPT (those
+ *     emit proposal cards without DB writes — the row is only created
+ *     later at approval time — so an eval can inspect exactly what
+ *     `propose_feature` produced), while every genuinely-mutating tool
+ *     (canvas/feature/research/connection writes) is stripped;
+ *   - the `planner` capability is dropped, so `send_to_feature_planner`
+ *     (a real Stakwork dispatch) is absent;
+ *   - no `schedule_check` tool, no research-worker dispatch, no Pusher.
+ * The proposed content lands in the returned rows' `toolCalls[].output`.
+ *
  * Because the whole generation runs in-request, give the function the
  * same generous headroom as quick — a turn longer than this is the only
  * failure mode.
  */
 export const maxDuration = 800;
+
+/** Pure-output proposal tools — kept even under the dryRun readonly strip. */
+const PROPOSAL_TOOL_NAMES = [
+  PROPOSE_INITIATIVE_TOOL,
+  PROPOSE_FEATURE_TOOL,
+  PROPOSE_MILESTONE_TOOL,
+];
+
+/** Normalize a client-supplied messages[] array into ModelMessage[]. */
+function normalizeReplayMessages(messages: unknown[]): ModelMessage[] {
+  return messages
+    .map((m: any): ModelMessage | null => {
+      let role = m?.role;
+      if (!role || !["user", "assistant", "system", "tool"].includes(role)) {
+        role = "user";
+      }
+      let content = m?.content;
+      if (content === undefined || content === null) {
+        if (role === "tool") return null;
+        content = "";
+      }
+      return { role, content } as ModelMessage;
+    })
+    .filter((m: ModelMessage | null): m is ModelMessage => m !== null);
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -78,6 +134,7 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const {
       message,
+      messages: bodyMessages,
       conversationId,
       workspaceSlug,
       workspaceSlugs,
@@ -87,9 +144,28 @@ export async function POST(request: NextRequest) {
       selectedNodeId,
       selectedNodeIds,
       attachments,
+      dryRun: bodyDryRun,
     } = body;
 
-    if (typeof message !== "string" || message.trim().length === 0) {
+    const dryRun = bodyDryRun === true;
+
+    // Replay (eval) mode: a full verbatim transcript instead of a single
+    // `message` + server-side history.
+    const replayMessages =
+      Array.isArray(bodyMessages) && bodyMessages.length > 0
+        ? (bodyMessages as unknown[])
+        : null;
+    const isReplayMode = replayMessages !== null;
+
+    if (isReplayMode) {
+      // A replayed transcript is stateless (no conversation to persist to)
+      // and must never mutate org state or dispatch external runs.
+      if (!dryRun) {
+        throw validationError(
+          "messages[] replay mode requires dryRun: true (it is stateless and side-effect-free).",
+        );
+      }
+    } else if (typeof message !== "string" || message.trim().length === 0) {
       throw validationError("Missing required parameter: message");
     }
 
@@ -167,67 +243,75 @@ export async function POST(request: NextRequest) {
     const isMultiWorkspace = slugs.length > 1;
     const turnId = randomUUID();
 
-    // ── Build messages: server-history + the new user turn ───────────
+    // ── Build the ModelMessage[] for this turn ───────────────────────
+    let convertedMessages: ModelMessage[];
+    let userText = "";
+    let userAttachments: StoredAttachment[] = [];
+
+    if (isReplayMode) {
+      // Replay: use the supplied transcript verbatim.
+      convertedMessages = normalizeReplayMessages(replayMessages);
+    } else {
+      // Server-history: reconstruct prior turns + append the new message.
+      const history = conversationId
+        ? ((await fetchOrgCanvasConversationMessages({
+            conversationId,
+            userId,
+            orgId,
+          })) ?? [])
+        : [];
+
+      userText = message.trim();
+      userAttachments = normalizeStoredAttachments(attachments);
+
+      // Build the new user ModelMessage. With image attachments the content
+      // is a multi-part array (`{type:"text"} + {type:"image"}`) mirroring
+      // the web client's `toModelMessages`; `resolveMessageImageUrls`
+      // rewrites the relative presigned-url paths into absolute signed URLs.
+      const imageAttachments = userAttachments.filter((a) =>
+        a.mimeType.startsWith("image/"),
+      );
+      const newUserMessage: ModelMessage =
+        imageAttachments.length > 0
+          ? ({
+              role: "user",
+              content: [
+                ...(userText ? [{ type: "text", text: userText }] : []),
+                ...imageAttachments.map((a) => ({
+                  type: "image",
+                  image: `/api/upload/presigned-url?s3Key=${encodeURIComponent(a.path)}`,
+                })),
+              ],
+            } as ModelMessage)
+          : ({ role: "user", content: userText } as ModelMessage);
+
+      convertedMessages = [...toModelMessages(history), newUserMessage];
+    }
+
+    await resolveMessageImageUrls(convertedMessages);
+
+    // Org-canvas prompt cache (read-only; speeds up by skipping the swarm
+    // `listConcepts` call). No-ops without a conversationId (replay mode).
     const promptCache = await loadOrgCanvasPromptCache({
       conversationId,
       userId,
       orgId,
     });
 
-    const history = conversationId
-      ? ((await fetchOrgCanvasConversationMessages({
-          conversationId,
-          userId,
-          orgId,
-        })) ?? [])
-      : [];
-
-    const userText = message.trim();
-
-    // Normalize forwarded attachments into the stored shape. Persisted with
-    // the user row so they survive reload, and embedded as image parts below
-    // so the model sees them this turn.
-    const userAttachments: StoredAttachment[] =
-      normalizeStoredAttachments(attachments);
-
-    // Build the new user ModelMessage. With image attachments the content
-    // is a multi-part array (`{type:"text"} + {type:"image"}`) mirroring the
-    // web client's `toModelMessages`; `resolveMessageImageUrls` rewrites the
-    // relative presigned-url paths into absolute signed S3 URLs.
-    const imageAttachments = userAttachments.filter((a) =>
-      a.mimeType.startsWith("image/"),
-    );
-    const newUserMessage: ModelMessage =
-      imageAttachments.length > 0
-        ? ({
-            role: "user",
-            content: [
-              ...(userText ? [{ type: "text", text: userText }] : []),
-              ...imageAttachments.map((a) => ({
-                type: "image",
-                image: `/api/upload/presigned-url?s3Key=${encodeURIComponent(a.path)}`,
-              })),
-            ],
-          } as ModelMessage)
-        : ({ role: "user", content: userText } as ModelMessage);
-
-    const convertedMessages: ModelMessage[] = [
-      ...toModelMessages(history),
-      newUserMessage,
-    ];
-
-    await resolveMessageImageUrls(convertedMessages);
-
     // ── Persist the user message (creates the row on the first turn) ──
-    const rowId = await persistCanvasUserMessage({
-      orgId,
-      userId,
-      existingRowId: promptCache?.rowId ?? null,
-      turnId,
-      content: userText,
-      attachments: userAttachments,
-      workspaceSlugs: slugs,
-    });
+    // Skipped entirely in dryRun — a dry run writes nothing.
+    let rowId: string | null = null;
+    if (!dryRun) {
+      rowId = await persistCanvasUserMessage({
+        orgId,
+        userId,
+        existingRowId: promptCache?.rowId ?? null,
+        turnId,
+        content: userText,
+        attachments: userAttachments,
+        workspaceSlugs: slugs,
+      });
+    }
 
     // Per-user canvas-chat model preference (set from the Agent settings
     // gear). Null/absent → aieo default.
@@ -243,13 +327,33 @@ export async function POST(request: NextRequest) {
       const learnedConceptIds = new Set<string>();
       const dispatchedResearch: DispatchedResearchIntent[] = [];
 
+      // dryRun composes a side-effect-free toolset: the org canvas agent
+      // with write tools stripped, EXCEPT the pure-output `propose_*` tools
+      // (kept so evals can read the proposed feature/initiative), and with
+      // the `planner` capability dropped so `send_to_feature_planner` (a
+      // real Stakwork dispatch) is absent. A live turn runs the full agent.
+      const agentOptions = dryRun
+        ? {
+            // Always enable the org toolset in dryRun so `propose_*` exists,
+            // regardless of single- vs multi-workspace.
+            orgId,
+            capabilities: ["canvas"] as readonly OrgCapability[],
+            readonly: true,
+            keepWriteToolNames: PROPOSAL_TOOL_NAMES,
+            silentPusher: true,
+          }
+        : {
+            // Org tools merge only for the multi-workspace org canvas —
+            // matches `/api/ask/quick`. A single-workspace live turn runs
+            // the plain per-workspace agent.
+            orgId: isMultiWorkspace ? orgId : undefined,
+            silentPusher: false,
+          };
+
       const { result, assembledPrefix, cacheableConcepts, cacheHit } =
         await runCanvasAgent({
           userId,
-          // Org tools (canvas/initiative/connections) merge only for the
-          // multi-workspace org canvas — matches `/api/ask/quick`. A
-          // single-workspace turn runs the plain per-workspace agent.
-          orgId: isMultiWorkspace ? orgId : undefined,
+          ...agentOptions,
           workspaceSlugs: slugs,
           modelName: chatAgentModel,
           cachedConcepts: promptCache?.cachedConcepts ?? null,
@@ -271,18 +375,22 @@ export async function POST(request: NextRequest) {
               : undefined,
           },
           messages: convertedMessages,
-          // The server-owned org-canvas row — what `send_to_feature_planner`
-          // lazy-claims for fan-out and what `schedule_check` keys off.
-          currentCanvasConversationId: rowId,
-          // A sync turn should still animate any open web canvas tab
-          // (HIGHLIGHT_NODES etc.) — it's the same conversation.
-          silentPusher: false,
+          // The server-owned org-canvas row (live turns only) — what
+          // `send_to_feature_planner` lazy-claims for fan-out and what
+          // `schedule_check` keys off. Undefined in dryRun (no row).
+          ...(rowId ? { currentCanvasConversationId: rowId } : {}),
           dispatchedResearch,
-          additionalTools: buildDeferredCheckTools({
-            conversationId: rowId,
-            orgId,
-            userId,
-          }),
+          // schedule_check creates a DeferredAction row — a write. Inject it
+          // only on a live turn with a resolved conversation row.
+          ...(!dryRun && rowId
+            ? {
+                additionalTools: buildDeferredCheckTools({
+                  conversationId: rowId,
+                  orgId,
+                  userId,
+                }),
+              }
+            : {}),
           hooks: {
             onStepFinish: (sf) => {
               extractConceptIdsFromStep(sf.content).forEach((id) =>
@@ -305,57 +413,66 @@ export async function POST(request: NextRequest) {
         assistantPrefix,
       );
 
-      await appendTurnMessages({
-        conversationId: rowId,
-        rows,
-        idPrefix: assistantPrefix,
-        reason: "user-turn",
-      });
+      // ── Persistence + async tail — live turns only ───────────────────
+      let title: string | undefined;
+      if (!dryRun && rowId) {
+        await appendTurnMessages({
+          conversationId: rowId,
+          rows,
+          idPrefix: assistantPrefix,
+          reason: "user-turn",
+        });
 
-      // Persist the freshly-fetched concepts so the next turn can reuse them
-      // and skip the swarm `listConcepts` call. Only on a cache MISS with
-      // non-empty concepts (a swarm outage yields an empty list; caching
-      // that would poison the cache). Best-effort, off the response path.
-      if (!cacheHit && hasConcepts(cacheableConcepts)) {
-        after(async () => {
-          try {
-            await persistOrgCanvasPromptCache(
-              rowId,
-              cacheableConcepts,
-              assembledPrefix,
+        // Persist the freshly-fetched concepts so the next turn can reuse
+        // them and skip the swarm `listConcepts` call. Only on a cache MISS
+        // with non-empty concepts (a swarm outage yields an empty list;
+        // caching that would poison the cache). Best-effort, off-response.
+        if (!cacheHit && hasConcepts(cacheableConcepts)) {
+          const cacheRowId = rowId;
+          after(async () => {
+            try {
+              await persistOrgCanvasPromptCache(
+                cacheRowId,
+                cacheableConcepts,
+                assembledPrefix,
+              );
+            } catch (err) {
+              console.error(
+                "❌ [sync-ask] Failed to persist prompt cache:",
+                err,
+              );
+            }
+          });
+        }
+
+        // Schedule research sub-agent workers for each dispatched intent.
+        // Their replies land on the conversation later (the "async tail" —
+        // see the plan); the sync response only carries what finished now.
+        if (dispatchedResearch.length > 0) {
+          after(async () => {
+            const { runResearchSubAgent } = await import(
+              "@/services/canvas-research-worker"
             );
-          } catch (err) {
-            console.error("❌ [sync-ask] Failed to persist prompt cache:", err);
-          }
-        });
-      }
+            for (const intent of dispatchedResearch) {
+              await runResearchSubAgent({ ...intent, workspaceSlugs: slugs });
+            }
+          });
+        }
 
-      // Schedule research sub-agent workers for each dispatched intent.
-      // Their replies land on the conversation later (the "async tail" —
-      // see the plan); the sync response only carries what finished now.
-      if (dispatchedResearch.length > 0) {
-        after(async () => {
-          const { runResearchSubAgent } = await import(
-            "@/services/canvas-research-worker"
-          );
-          for (const intent of dispatchedResearch) {
-            await runResearchSubAgent({ ...intent, workspaceSlugs: slugs });
-          }
-        });
+        title =
+          (
+            await db.sharedConversation.findUnique({
+              where: { id: rowId },
+              select: { title: true },
+            })
+          )?.title ?? undefined;
       }
-
-      const title =
-        (
-          await db.sharedConversation.findUnique({
-            where: { id: rowId },
-            select: { title: true },
-          })
-        )?.title ?? undefined;
 
       return NextResponse.json({
         conversationId: rowId,
         messages: rows,
         ...(title ? { title } : {}),
+        ...(dryRun ? { dryRun: true } : {}),
       });
     } catch (agentError) {
       // Preserve typed ApiError statuses from the inner pipeline; only

--- a/src/app/api/ask/sync/route.ts
+++ b/src/app/api/ask/sync/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse, after } from "next/server";
 import { randomUUID } from "crypto";
-import { ModelMessage } from "ai";
+import { ModelMessage, stepCountIs } from "ai";
 import {
   validationError,
   serverError,
@@ -80,6 +80,15 @@ import {
  *   - no `schedule_check` tool, no research-worker dispatch, no Pusher.
  * The proposed content lands in the returned rows' `toolCalls[].output`.
  *
+ * ## maxTurns
+ *
+ * `maxTurns` (positive integer, optional) caps the agentic loop via an
+ * extra `stepCountIs(maxTurns)` stop condition — ANY stop condition ends
+ * the loop, so the run halts at whichever comes first (the model's
+ * `[END_OF_ANSWER]` marker or the step cap). `maxTurns: 1` returns just
+ * the next single step (the immediate text and/or tool call), which an
+ * evaluator can use to score one response/tool-call in isolation.
+ *
  * Because the whole generation runs in-request, give the function the
  * same generous headroom as quick — a turn longer than this is the only
  * failure mode.
@@ -145,9 +154,25 @@ export async function POST(request: NextRequest) {
       selectedNodeIds,
       attachments,
       dryRun: bodyDryRun,
+      maxTurns: bodyMaxTurns,
     } = body;
 
     const dryRun = bodyDryRun === true;
+
+    // Optional cap on the agentic loop. A positive integer; `1` returns
+    // just the next single step. Undefined → uncapped (the model's
+    // `[END_OF_ANSWER]` marker is the only stop, as before).
+    let maxTurns: number | undefined;
+    if (bodyMaxTurns !== undefined && bodyMaxTurns !== null) {
+      if (
+        typeof bodyMaxTurns !== "number" ||
+        !Number.isInteger(bodyMaxTurns) ||
+        bodyMaxTurns < 1
+      ) {
+        throw validationError("maxTurns must be a positive integer");
+      }
+      maxTurns = bodyMaxTurns;
+    }
 
     // Replay (eval) mode: a full verbatim transcript instead of a single
     // `message` + server-side history.
@@ -375,6 +400,9 @@ export async function POST(request: NextRequest) {
               : undefined,
           },
           messages: convertedMessages,
+          // Caller-imposed step cap. Appended to the default end-marker
+          // stop condition (ANY condition stopping ends the loop).
+          ...(maxTurns ? { extraStopConditions: stepCountIs(maxTurns) } : {}),
           // The server-owned org-canvas row (live turns only) — what
           // `send_to_feature_planner` lazy-claims for fan-out and what
           // `schedule_check` keys off. Undefined in dryRun (no row).


### PR DESCRIPTION
Follow-up to #4489. Adds the things an automated **eval harness** needs to re-play canvas-agent calls and score the result.

## 1. `messages[]` replay input

In addition to the existing server-history shape (`{ message, conversationId? }`), `/api/ask/sync` now accepts a full verbatim transcript:

```jsonc
{ "messages": [ /* ModelMessage[] */ ], "workspaceSlugs": [...], "dryRun": true }
```

Same shape `/api/ask/quick` takes. Replay is **stateless** (no conversation read/written) and **requires `dryRun: true`** — a replayed transcript must never persist or mutate.

## 2. `dryRun: true` — selective, side-effect-free

Runs the agent as a pure function and writes **nothing**: no row create/append, no prompt-cache, no Pusher, no research dispatch, no `schedule_check`.

Critically it is **selective, not a blunt `readonly`**:

> `propose_feature` has **no DB writes** — it only structures the suggestion. The row is created later, in a *separate* approval request (`initiativeTools.ts:843`).

So an eval **can** see what `propose_feature` output with zero side effects — but plain `readonly: true` would strip the propose tools (`capabilities.ts:76`). So dryRun is:

| Tool family | Side effect at call time | dryRun |
|---|---|---|
| `propose_feature/initiative/milestone` | none (emits a card; row at approval) | **kept** |
| read tools | none | kept |
| `update_canvas`, `patch_canvas`, `assign_*` | mutate | stripped |
| `save_/update_/dispatch_research`, `*_connection` | write/dispatch | stripped |
| `send_to_feature_planner` | real Stakwork dispatch | stripped (drop `planner` capability) |
| `schedule_check` | creates DeferredAction | not injected |

Mechanically: `readonly: true` + `keepWriteToolNames: [propose_*]` + `capabilities: ["canvas"]` + `silentPusher: true`. Proposed content lands in the returned rows' `toolCalls[].output`. Response carries `dryRun: true`, `conversationId: null`.

## 3. `maxTurns` — cap the agentic loop

`maxTurns` (positive integer, optional) appends a `stepCountIs(maxTurns)` stop condition. ANY stop condition ends the loop, so it halts at the model's `[END_OF_ANSWER]` or the cap, whichever first.

It counts the agent's **generated steps in this call, NOT the input transcript** — so `maxTurns: 1` with a 100-message replay still returns exactly one step. Lets an evaluator score just the next single response/tool-call.

### Eval usage
```jsonc
POST /api/ask/sync   (x-api-token)
{ "messages": [...transcript...], "workspaceSlugs": ["ws"], "dryRun": true, "maxTurns": 1 }
→ { "dryRun": true, "conversationId": null, "messages": [ /* one step, incl. propose_feature output */ ] }
```

## Tests (18 sync integration tests)
- replay mode without `dryRun` → 400
- `dryRun` persists nothing (replay **and** server-history; asserts zero `SharedConversation` rows)
- `dryRun` toolset keeps `propose_feature`, strips `update_canvas` / `assign_feature_to_initiative` / `send_to_feature_planner` / `schedule_check`
- `maxTurns` validation (rejects 0 / negative / non-integer / string)
- `maxTurns` appends the step-cap stop condition (1 → 2 conditions)
- context-vs-steps: 100 input messages + `maxTurns: 1` → 1 step out

Typecheck + eslint clean.