### PR TITLE
Expand graph_search pg realm: tasks, workspaces, repos, research, connections, conversations

### DIFF
--- a/docs/plans/neo4j-graph-mirror.md
+++ b/docs/plans/neo4j-graph-mirror.md
@@ -1,0 +1,473 @@
+# Mirroring Postgres → Neo4j (graph mirror)
+
+Mirror a **chosen subset** of the Neon Postgres tables into a Neo4j graph on a
+separate server, so the data can be traversed as nodes + edges (workspaces →
+features → phases → tasks → messages → artifacts, people, repos, initiatives,
+…) without bolting graph queries onto the relational app.
+
+Status: **proposed.**
+
+## The one-line answer to "do all 1000 routes need to change?"
+
+**No.** Not one route changes. Every write in the app already funnels through a
+single Prisma client instance (`src/lib/db.ts:7`). We intercept **there**, once,
+with a Prisma Client extension. The 1000 route handlers are oblivious; they keep
+calling `db.task.update(...)` exactly as today.
+
+The FK→edge translation is **derived from the schema**, not hand-written per
+route: Prisma already declares every relationship (`@relation(fields:…,
+references:…)`), so the node/edge mapping is generated from the schema's DMMF
+plus a small per-model override table for the handful of awkward cases (chats,
+polymorphic parents, JSON blobs).
+
+## Why an extension, not the obvious alternatives
+
+| Approach | Verdict | Why |
+| --- | --- | --- |
+| **Dual-write in each route** | ✗ Rejected | 1000 places to forget; couples every handler to Neo4j uptime; misses migrations/backfills. This is the thing the question was worried about — we explicitly do not do it. |
+| **CDC / logical replication (Debezium → Neo4j sink)** | ◐ Viable, heavier | Truly automatic, catches *every* write including raw SQL & migrations. But it streams the whole DB (filtering lives in infra config), needs a Kafka/Redpanda + connector stack, and ships raw row shapes that still need the same mapping layer. Overkill unless we later need 100% fidelity. Kept as the documented upgrade path (see "When to graduate to CDC"). |
+| **Prisma Client extension → Redis Stream → consumer** | ✓ **Chosen** | One interception point covers all routes; per-model allowlist + field selection is plain TypeScript next to the schema; reuses the `ioredis` client we already run (`src/lib/redis.ts`). Its one gap (writes that bypass Prisma) is closeable and, for our curated business tables, negligible. |
+
+## The animating principle
+
+**Intercept at the data layer, project at the edge, write from afar.**
+
+1. **Data layer (in-app, cheap):** a Prisma extension observes writes and emits
+   a tiny, self-describing *change event* to a Redis Stream. It does **no**
+   Neo4j I/O — Vercel functions stay short and never block on the graph DB.
+2. **Projection (pure):** a mapping module turns a change event into graph
+   operations (`MERGE` node, `MERGE`/`DELETE` edges) using a schema-derived map
+   plus per-model overrides. Pure function, unit-testable, no I/O.
+3. **Write (out-of-app):** a long-running **consumer on the Neo4j server** (not
+   on Vercel) drains the stream and applies Cypher idempotently.
+
+Each stage is independently testable and independently fails safe: if Neo4j is
+down, events pile up in Redis and drain later; the app never notices.
+
+## Hard constraint: we are serverless
+
+`vercel.json` shows the app is Vercel serverless + cron. There is **no
+persistent worker process inside the app** to drain a queue. This is the single
+most load-bearing fact in the design and it dictates the topology:
+
+- The **producer** (Prisma extension) runs inside request/cron invocations and
+  must be fire-and-forget — enqueue to Redis via `after()`/`waitUntil` so it
+  never adds latency or fails a user request.
+- The **consumer** runs as an ordinary Node process **on the separate Neo4j
+  server** (the same box that runs Neo4j, or one next to it), holding a
+  `XREADGROUP` loop. It is the only thing that talks to Neo4j. This keeps the
+  Bolt connection off Vercel entirely and gives us a real, restartable worker
+  with backpressure.
+
+```
+            Vercel (serverless)                    │   Neon          │   Neo4j server (long-running)
+ ┌──────────────────────────────────────────┐     │                 │
+ │ 1000 routes ─► db (Prisma client) ─writes─┼─────┼──► Postgres      │
+ │                   │                        │     │                 │
+ │            $extends query hook             │     │                 │
+ │                   │ (after(): enqueue)     │     │                 │
+ │                   ▼                        │     │                 │
+ │            Redis Stream  "graphsync"  ◄────┼─────┼─────────────────┼──┐
+ └──────────────────────────────────────────┘     │                 │  │ XREADGROUP
+                                                    │                 │  ▼
+                                                    │           ┌─────────────────┐
+                                                    │           │ consumer worker │──MERGE──► Neo4j
+                                                    │           │ (mapping + Bolt)│
+                                                    │           └─────────────────┘
+```
+
+Redis Streams (not a plain list/pubsub) because they give us **consumer groups,
+acks, replay, and a pending-entries list** — i.e. at-least-once delivery with a
+dead-letter path, for free, on infra we already run.
+
+## Change-event contract
+
+The extension emits one self-describing event per mutating operation. It carries
+*data*, never Cypher — projection happens consumer-side so the mapping can
+evolve without redeploying the app.
+
+```ts
+interface GraphChangeEvent {
+  v: 1;                       // schema version of THIS envelope
+  model: string;              // Prisma model name, e.g. "Task"
+  op: "upsert" | "delete";    // create/update/upsert collapse to "upsert"
+  id: string;                 // primary key of the affected row
+  // Full post-write row for upserts (selected fields only — see field policy).
+  // For deletes, just enough to locate the node + its edges (the id + any FK
+  // columns needed to drop edges, captured pre-delete).
+  data: Record<string, unknown> | null;
+  ts: string;                 // ISO; for ordering/observability
+  txId?: string;              // optional: group multi-row tx (see ordering)
+}
+```
+
+`create | update | upsert` all collapse to `op: "upsert"` because the consumer
+always `MERGE`s — there is no separate "insert" path in an idempotent graph
+sync. `delete` / `deleteMany` produce `op: "delete"`.
+
+## The producer: one Prisma extension
+
+A single `$extends` on the client in `src/lib/db.ts`. Sketch:
+
+```ts
+// src/lib/graphsync/extension.ts
+const SYNCED = new Set(["Workspace","User","WorkspaceMember","Repository",
+  "Feature","Phase","Task","ChatMessage","Artifact","Attachment",
+  "SharedConversation","Initiative","Milestone", /* …chosen subset… */]);
+
+const MUTATIONS = new Set(["create","update","upsert","delete",
+  "createMany","updateMany","deleteMany"]);
+
+export const graphSync = Prisma.defineExtension({
+  name: "graphSync",
+  query: {
+    $allModels: {
+      async $allOperations({ model, operation, args, query }) {
+        const watched = SYNCED.has(model) && MUTATIONS.has(operation);
+        // For deletes we must read the row(s) BEFORE the write to capture
+        // FK columns needed to drop edges (the row is gone afterward).
+        const preDelete = watched && operation.startsWith("delete")
+          ? await capturePreDelete(model, args)   // SELECT by where
+          : null;
+
+        const result = await query(args);         // the real write
+
+        if (watched) {
+          // never block the request; never throw into the caller
+          after(() => enqueueGraphEvents({ model, operation, args, result, preDelete })
+            .catch((e) => logger.warn("graphsync enqueue failed", e)));
+        }
+        return result;
+      },
+    },
+  },
+});
+```
+
+Wired in `src/lib/db.ts`:
+
+```ts
+export const db = (globalForPrisma.prisma ?? new PrismaClient({ … }))
+  .$extends(graphSync);
+```
+
+Producer rules (these are the "no loose ends" details):
+
+- **Fire-and-forget, always.** Enqueue inside `after()` (Next) /
+  `ctx.waitUntil`. A graphsync failure must never fail or slow a user write.
+  Wrap in try/catch; on enqueue failure, log + drop (the periodic backfill, see
+  below, is the safety net).
+- **`createMany`/`updateMany`/`deleteMany` are the sharp edge.** They don't
+  return the affected rows. Options, in order of preference:
+  - For `updateMany`/`deleteMany`: run a `findMany({ where, select: { id, …fks } })`
+    around the op to enumerate affected ids (the `capturePreDelete` helper
+    generalizes to this). Cost is one extra indexed query on the bulk paths,
+    which are rare.
+  - For `createMany`: re-query by a discriminator if needed, or require callers
+    of bulk-create on synced models to also emit (rare; document the exceptions).
+  - If a bulk op can't be cheaply enumerated, **skip it and rely on backfill** —
+    the daily reconciler converges it. Mark such models explicitly.
+- **`$executeRaw` / `$queryRaw` are invisible** to the extension. Enumerate every
+  raw write to a synced table (grep `\$executeRaw|\$queryRaw`) and either route
+  it through the ORM or have it emit an event manually. This is the only place
+  "you touch code" beyond the extension — and it's a finite, auditable list, not
+  1000 routes.
+
+## The consumer: one worker on the Neo4j box
+
+A standalone Node process (lives in this repo under `scripts/graphsync-consumer.ts`
+or a tiny sibling package, deployed to the Neo4j server). Loop:
+
+```
+XREADGROUP GROUP g1 c1 COUNT 200 BLOCK 5000 STREAMS graphsync >
+  → for each event: project() → Cypher → run in a tx
+  → XACK on success
+  → on failure: leave unacked; after N delivery attempts (XPENDING idle),
+    move to graphsync:dead + alert
+```
+
+- **Idempotent by construction.** Every node write is `MERGE (n:Label {id})
+  SET n += $props`. Every edge is `MERGE (a)-[r:TYPE]->(b)`. Re-delivering an
+  event is a no-op. This is why at-least-once delivery is fine.
+- **Batched.** Drain up to N events, group by label, apply with `UNWIND
+  $rows AS row MERGE …` for throughput.
+- **Ordering** (see below) handled by per-key collapse, not global order.
+
+## Projection: schema-derived map + per-model overrides
+
+`src/lib/graphsync/map.ts` exports a `GRAPH_MAP`. The **bulk** of it is
+generated from Prisma's DMMF (`getDMMF()` over `schema.prisma`) at build time:
+every model → a node label, every `@relation` scalar FK → an edge. We commit the
+generated file and hand-edit only the override entries.
+
+```ts
+type ModelMap = {
+  label: string;
+  props: string[];                                  // field allowlist (privacy!)
+  edges: EdgeMap[];
+  expand?: (row: any) => ExpandedNode[];            // JSON-blob explosion
+};
+type EdgeMap = {
+  fk: string; to: string; type: string;
+  when?: (row: any) => unknown;                     // conditional / polymorphic
+};
+```
+
+### Field policy (privacy + noise)
+
+`props` is an **allowlist**, never "all columns." This is deliberate: many
+synced tables carry secrets or bulky blobs we must not copy into a second store.
+Hard exclusions, enforced by a test that fails if a sensitive column sneaks into
+any `props`:
+
+- Tokens/secrets: `Account.*_token`, `SourceControlToken`, `WorkspaceApiKey`,
+  `WorkspaceSecret`, `EnvironmentVariable.value`, `Swarm` keys, `Pod` creds.
+- Bulk JSON we don't want in the graph: `Whiteboard.elements/appState/files`,
+  raw `provenanceData`, etc.
+
+Default stance: sync **structure and identifiers**, not payloads. A `Task` node
+gets `id, title, status, priority, createdAt`; not its full chat history.
+
+### Polymorphic / nullable FKs
+
+The schema has several "belongs to A **or** B" columns. The `when` predicate
+emits only the live edge:
+
+```ts
+ChatMessage: {
+  label: "Message",
+  props: ["id","role","timestamp","status"],        // NOT `message` body by default
+  edges: [
+    { fk:"taskId",    to:"Task",    type:"IN_CHAT",  when: r => r.taskId },
+    { fk:"featureId", to:"Feature", type:"IN_CHAT",  when: r => r.featureId },
+    { fk:"userId",    to:"User",    type:"SENT_BY",  when: r => r.userId },
+  ],
+},
+Artifact:   { label:"Artifact",   props:["id","type","icon"],
+              edges:[{ fk:"messageId", to:"Message", type:"ATTACHED_TO" }] },
+Attachment: { label:"Attachment", props:["id","filename","mimeType","size"],
+              edges:[{ fk:"messageId", to:"Message", type:"ATTACHED_TO" }] },
+```
+
+Grounded in the real columns: `ChatMessage.taskId?`, `.featureId?`, `.userId?`
+(`prisma/schema.prisma:635-653`); `Artifact.messageId`, `Attachment.messageId`
+(`:664`, `:679`).
+
+## The genuinely hard model: `SharedConversation`
+
+This is the one place the schema-derived generator cannot help, and it needs the
+only bespoke code in the whole system. Two distinct problems:
+
+### Problem 1 — the messages are a JSON blob, not rows
+
+`SharedConversation.messages` is a single `Json` column
+(`prisma/schema.prisma:593`) holding `StoredMessage[]` (the shape in
+`src/services/canvas-turn-persistence.ts:92` — `{ id, role, content, timestamp,
+toolCalls?, attachments?, source?, … }`). There are **no per-message FKs to
+follow**, so generic FK→edge logic sees one opaque node. To get message-level
+nodes we must parse the blob ourselves via `expand()`:
+
+```ts
+SharedConversation: {
+  label: "Conversation",
+  props: ["id","title","source","inputTokens","outputTokens","lastMessageAt","createdAt"],
+  edges: [
+    { fk:"workspaceId",        to:"Workspace",        type:"IN_WORKSPACE", when:r=>r.workspaceId },
+    { fk:"sourceControlOrgId", to:"SourceControlOrg", type:"IN_ORG",       when:r=>r.sourceControlOrgId },
+    { fk:"userId",             to:"User",             type:"OWNED_BY",     when:r=>r.userId },
+  ],
+  expand: (row) => {
+    const msgs: StoredMessage[] = Array.isArray(row.messages) ? row.messages : [];
+    return msgs.map((m, i) => ({
+      // StoredMessage HAS a stable `id` (messagesFromSteps assigns
+      // `${idPrefix}${n}`), so prefer it; fall back to a synthetic id.
+      node: { label:"Message", id: m.id ?? `${row.id}:${i}`,
+              props: { role:m.role, idx:i, hasTools: !!m.toolCalls?.length } },
+      edges: [
+        { to:"Conversation", toId: row.id, type:"IN_CHAT" },
+        ...(i>0 ? [{ to:"Message", toId: msgs[i-1].id ?? `${row.id}:${i-1}`, type:"NEXT" }] : []),
+      ],
+    }));
+  },
+},
+```
+
+Note: `StoredMessage` already carries a stable `id`, so we are *not* forced into
+fragile positional synthetic ids — we only fall back to `${row.id}:${i}` if an
+older row predates ided messages.
+
+### Problem 2 — it's blob-per-conversation, so every turn is a full-row UPDATE
+
+`ChatMessage` is row-per-message: appending a turn is one `create` → one clean
+event. `SharedConversation` is the opposite — the whole `messages` array is
+rewritten in place each turn (e.g. `/api/ask/quick`'s `onFinish`, and the
+append path in `canvas-turn-persistence.ts`). So a single conversation emits a
+fresh `upsert` of the **entire history** on every turn. Consequences the
+consumer must handle:
+
+- **Idempotent re-projection is mandatory, not optional.** Each turn re-`expand()`s
+  the full blob; `MERGE` on message id makes re-seen messages no-ops and only the
+  new tail creates nodes. Without `MERGE` we'd duplicate the whole conversation
+  every turn.
+- **Stale-edge pruning.** If messages are ever removed/edited, `MERGE`-only
+  leaves orphan `Message` nodes. For the conversation case we accept append-only
+  semantics (messages aren't deleted mid-thread in practice); the daily backfill
+  reconciles any drift. Documented as a known, bounded limitation.
+- **Cost guard.** Re-exploding a 500-message conversation on every turn is
+  wasteful. Optimization (phase 2): the extension diffs `args.data.messages`
+  length vs prior and emits only the tail, or the consumer caches last-seen
+  length per conversation in Redis and skips unchanged prefixes. Not needed for
+  correctness; needed for scale.
+
+### Tiering knob
+
+How deep `SharedConversation` goes is a dial, pick per need:
+
+1. **Conversation-as-node only** — drop `expand`, keep the row as one node. Use
+   when you only need "workspace/user ↔ conversation" topology. Trivial, cheap.
+2. **Explode into Message nodes** (the `expand` above) — when you need to
+   traverse/query individual turns, link messages↔artifacts, etc. Moderate.
+3. **Explode + tail-diff optimization** — same graph, scalable writes. Phase 2.
+
+**Default recommendation: Tier 1 for `SharedConversation`** at launch (it's the
+canvas/quick-chat blob and message-level graph queries aren't the first use
+case), Tier 2 only when a concrete traversal needs it. `ChatMessage` (task &
+feature-plan chats) goes to message-level nodes from day one since it's already
+relational and free.
+
+## Ordering & consistency
+
+- **Per-key collapse, not global ordering.** Two events for the same `Task` id
+  must apply in order; unrelated rows may interleave freely. A single Redis
+  Stream consumed by one worker preserves enqueue order globally, which is
+  sufficient. If we later shard consumers for throughput, shard by `id` hash so
+  same-key events stay on one consumer.
+- **Out-of-order FKs (the child-before-parent case).** A `Task` event may arrive
+  before its `Workspace` exists in Neo4j. `MERGE` on the target by id *creates a
+  stub node* if absent (`MERGE (w:Workspace {id})`), which the later Workspace
+  event fills in with `SET w += $props`. So edges never fail for missing
+  endpoints; nodes converge. This is the key reason MERGE-everything is correct.
+- **Deletes & cascades.** Postgres `onDelete: Cascade` (e.g. deleting a `Task`
+  cascades its `ChatMessage`s) fires per-row Prisma events only if done through
+  the ORM cascade; DB-level cascades are invisible. Mitigation: on a `delete`
+  event, `DETACH DELETE` the node (drops it and all its relationships), and let
+  the backfill clean any orphaned children. Document which cascades are
+  DB-enforced vs ORM-enforced.
+
+## Initial backfill & ongoing reconciliation
+
+The extension only captures *future* writes. Two more pieces close the loop:
+
+1. **One-time backfill.** A script (`scripts/graphsync-backfill.ts`) pages every
+   synced table (`findMany` by cursor) and emits `upsert` events into the same
+   stream — so backfill and live writes share one idempotent code path. Run it
+   once at launch; safe to re-run anytime (it's all `MERGE`).
+2. **Daily reconciler (the safety net).** A Vercel cron (add to `vercel.json`,
+   alongside the existing crons) that re-emits recently-`updatedAt` rows, or does
+   a count/checksum compare per label and re-emits drift. This is what makes the
+   "fire-and-forget producer can drop an event" and "bulk ops skipped" and
+   "raw SQL missed" gaps *eventually consistent* rather than permanent. Most
+   synced models have `updatedAt`, making incremental reconcile cheap.
+
+With backfill + daily reconcile, the system self-heals: the worst case for any
+missed write is staleness until the next reconcile, never permanent divergence.
+
+## Failure modes (and why each is safe)
+
+| Failure | Effect | Recovery |
+| --- | --- | --- |
+| Neo4j down | Events accumulate in Redis Stream | Consumer resumes on reconnect; nothing lost |
+| Consumer crashes mid-batch | Unacked events stay in PEL | Re-delivered on restart; idempotent `MERGE` makes redelivery safe |
+| Redis enqueue fails in-app | That one event dropped | Daily reconciler re-emits; user write unaffected |
+| Bad event poisons consumer | Stuck on one entry | After N attempts → `graphsync:dead` + alert; skip and continue |
+| Mapping bug ships | Wrong edges written | Fix map, re-run backfill (idempotent) to overwrite |
+| Raw SQL write to synced table | Missed live | Daily reconciler converges; also flagged by the raw-write audit |
+| Schema migration adds/renames column | Map drift | Regenerate `GRAPH_MAP` from DMMF in CI; test fails if a model lacks a map entry |
+
+## Scope
+
+**In scope (v1):** the Prisma extension producer, the Redis Stream contract, the
+consumer worker on the Neo4j box, the DMMF-generated map + overrides for a chosen
+subset, the one-time backfill, the daily reconciler cron, and the chat-model
+handling (`ChatMessage` → message nodes; `SharedConversation` → Tier 1).
+
+**Chosen subset for v1** (the graph people actually want to traverse): `User`,
+`Workspace`, `WorkspaceMember`, `Repository`, `Feature`, `Phase`, `Task`,
+`ChatMessage`, `Artifact`, `Attachment`, `Initiative`, `Milestone`. Everything
+else (auth/session, infra: `Swarm`/`Pod`/`Ec2Alert`, billing:
+`FiatPayment`/`LightningPayment`, config tables) is **excluded** until a use case
+appears — adding a model later is one `SYNCED.add` + one map entry + a backfill
+run.
+
+**Out of scope (v1):** `SharedConversation` message-level explosion (Tier 2),
+tail-diff optimization, sharded consumers, real-time guarantees tighter than
+"seconds," and bidirectional sync (graph is strictly read-derived; never writes
+back to Postgres).
+
+## When to graduate to CDC
+
+If we ever need **100% fidelity including raw SQL/migrations/manual edits**, or
+the missed-write gap becomes unacceptable, swap the *producer* for Debezium on
+Neon's logical replication (`wal_level=logical`, which Neon supports) feeding the
+**same** Redis Stream / event contract. The consumer, mapping, backfill, and
+Neo4j side are unchanged — only the source of events changes. The architecture is
+deliberately producer-agnostic so this is a swap, not a rewrite.
+
+## Resolved design decisions
+
+1. **Extension over CDC for v1.** Filtering and mapping live in TypeScript next
+   to the schema; reuses existing Redis; no new streaming infra. CDC is the
+   documented upgrade path, not the starting point.
+2. **Consumer runs on the Neo4j server, not Vercel.** Serverless can't host a
+   long-running drain loop, and we don't want Bolt connections from ephemeral
+   functions. Redis Stream is the seam between the two worlds.
+3. **Events carry data, Cypher is built consumer-side.** Lets the mapping evolve
+   without redeploying the app; backfill and live writes share one path.
+4. **`MERGE` everything; never `CREATE`.** Makes at-least-once delivery, backfill
+   re-runs, out-of-order arrival, and blob re-projection all safe by construction.
+5. **`props` is an allowlist.** Privacy-first: secrets/blobs never leave Postgres;
+   a test enforces it.
+6. **`SharedConversation` = Tier 1 at launch; `ChatMessage` = message nodes.**
+   Matches effort to value: the relational chat is free, the blob chat is not.
+7. **Daily reconciler is mandatory, not optional.** It is what downgrades every
+   gap (dropped enqueue, bulk op, raw SQL) from "permanent divergence" to
+   "bounded staleness."
+8. **Graph is read-derived only.** No write-back to Postgres, ever. One direction.
+
+## Implementation order
+
+1. **Contract + map scaffolding.** Define `GraphChangeEvent`; write the DMMF
+   generator (`scripts/gen-graph-map.ts`) → commit generated `GRAPH_MAP`; add
+   override entries for the chat models and polymorphic FKs. Unit-test
+   `project(event) → Cypher ops` as a pure function (no I/O).
+2. **Producer.** `src/lib/graphsync/extension.ts` + wire into `src/lib/db.ts`.
+   Implement `capturePreDelete` and bulk-op enumeration. `after()` enqueue to a
+   `graphsync` Redis Stream. Unit-test that mutating ops on synced models enqueue
+   the right envelope and that user writes never throw/slow on enqueue failure.
+3. **Consumer.** `scripts/graphsync-consumer.ts`: `XREADGROUP` loop, batched
+   `UNWIND … MERGE`, `XACK`, PEL/dead-letter handling. Integration-test against a
+   throwaway Neo4j (docker) with replayed events (assert idempotency on double
+   delivery).
+4. **Backfill.** `scripts/graphsync-backfill.ts` paging every synced table into
+   the stream. Run against a copy; verify node/edge counts vs Postgres row/FK
+   counts.
+5. **Reconciler cron.** Add `/api/cron/graphsync-reconcile` to `vercel.json`;
+   re-emit recent `updatedAt` rows; alert on drift.
+6. **Chat deep-dive.** Land `ChatMessage`/`Artifact`/`Attachment` message-node
+   mapping; land `SharedConversation` Tier 1. Integration-test a real
+   feature-plan chat and a task chat end-to-end into the graph.
+7. **Ops.** Dashboards on stream depth, consumer lag, dead-letter count;
+   runbook for "Neo4j was down, drain the backlog."
+
+## Open questions for the human
+
+- **Where does Neo4j run** and does the consumer co-locate on it, or on a
+  sidecar box with network access to both Redis and Neo4j? (Affects deploy +
+  secrets, not the design.)
+- **Is "seconds of lag" acceptable** for the graph, or is there a use case
+  needing tighter real-time (which would push toward CDC sooner)?
+- **Confirm the v1 subset.** Is the 12-model list above the right set, or are
+  there others (e.g. `Connection`, `Diagram`, `JanitorRecommendation`) wanted in
+  the first graph?
+- **`SharedConversation` tier:** ship Tier 1 first as proposed, or is
+  message-level traversal of canvas/quick chats a day-one requirement (→ Tier 2)?

--- a/src/__tests__/unit/lib/ai/graphWalkerTools.test.ts
+++ b/src/__tests__/unit/lib/ai/graphWalkerTools.test.ts
@@ -24,6 +24,12 @@ vi.mock("@/lib/db", () => ({
     feature: { findMany: vi.fn() },
     initiative: { findMany: vi.fn() },
     milestone: { findMany: vi.fn() },
+    task: { findMany: vi.fn() },
+    workspace: { findMany: vi.fn() },
+    repository: { findMany: vi.fn() },
+    research: { findMany: vi.fn() },
+    connection: { findMany: vi.fn() },
+    $queryRaw: vi.fn(),
   },
 }));
 
@@ -108,6 +114,13 @@ const dbCanvas = db.canvas as {
 const dbFeature = db.feature as { findMany: ReturnType<typeof vi.fn> };
 const dbInitiative = db.initiative as { findMany: ReturnType<typeof vi.fn> };
 const dbMilestone = db.milestone as { findMany: ReturnType<typeof vi.fn> };
+const dbTask = db.task as { findMany: ReturnType<typeof vi.fn> };
+const dbWorkspace = db.workspace as { findMany: ReturnType<typeof vi.fn> };
+const dbRepository = db.repository as { findMany: ReturnType<typeof vi.fn> };
+const dbResearch = db.research as { findMany: ReturnType<typeof vi.fn> };
+const dbConnection = db.connection as { findMany: ReturnType<typeof vi.fn> };
+const dbQueryRaw = (db as unknown as { $queryRaw: ReturnType<typeof vi.fn> })
+  .$queryRaw;
 
 // ---------------------------------------------------------------------------
 // Test constants
@@ -380,11 +393,19 @@ describe("buildGraphWalkerTools", () => {
 
   describe("graph_search", () => {
     beforeEach(() => {
-      // Default: pg returns nothing, canvas returns nothing
+      // graph_search resolves the org's githubLogin once for URN construction.
+      dbSourceControlOrg.findUnique.mockResolvedValue({ githubLogin: "myorg" });
+      // Default: every arm returns nothing
       dbFeature.findMany.mockResolvedValue([]);
       dbInitiative.findMany.mockResolvedValue([]);
       dbMilestone.findMany.mockResolvedValue([]);
+      dbTask.findMany.mockResolvedValue([]);
+      dbWorkspace.findMany.mockResolvedValue([]);
+      dbRepository.findMany.mockResolvedValue([]);
+      dbResearch.findMany.mockResolvedValue([]);
+      dbConnection.findMany.mockResolvedValue([]);
       dbCanvas.findMany.mockResolvedValue([]);
+      dbQueryRaw.mockResolvedValue([]);
     });
 
     it("searches pg + canvas when no realm specified", async () => {
@@ -495,6 +516,305 @@ describe("buildGraphWalkerTools", () => {
         title: "Feature Alpha",
         realm: "pg",
       });
+    });
+
+    it("pg URNs embed the org githubLogin, not the cuid", async () => {
+      dbFeature.findMany.mockResolvedValue([{ id: "feat-9", title: "X" }]);
+
+      const tools = getTools();
+      await tools.graph_search.execute({ query: "X", realm: "pg" }, {} as never);
+
+      // org segment must be the githubLogin so URNs round-trip through graph_get
+      expect(mockFormatUrn).toHaveBeenCalledWith(
+        expect.objectContaining({ org: "myorg", type: "feature", id: "feat-9" }),
+      );
+      expect(dbSourceControlOrg.findUnique).toHaveBeenCalledWith({
+        where: { id: ORG_ID },
+        select: { githubLogin: true },
+      });
+    });
+
+    it("returns { results: [] } when the org cannot be resolved", async () => {
+      dbSourceControlOrg.findUnique.mockResolvedValue(null);
+      dbFeature.findMany.mockResolvedValue([{ id: "feat-1", title: "Auth" }]);
+
+      const tools = getTools();
+      const result = await tools.graph_search.execute(
+        { query: "Auth" },
+        {} as never,
+      );
+
+      expect(result).toEqual({ results: [] });
+      // Arms must not run without a valid org
+      expect(dbFeature.findMany).not.toHaveBeenCalled();
+    });
+
+    it("matches features on title and plan columns (brief/requirements/architecture)", async () => {
+      dbFeature.findMany.mockResolvedValue([{ id: "feat-7", title: "Billing" }]);
+
+      const tools = getTools();
+      await tools.graph_search.execute(
+        { query: "webhook", realm: "pg", type: "feature" },
+        {} as never,
+      );
+
+      expect(dbFeature.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            deleted: false,
+            workspace: { sourceControlOrgId: ORG_ID },
+            OR: [
+              { title: { contains: "webhook", mode: "insensitive" } },
+              { brief: { contains: "webhook", mode: "insensitive" } },
+              { requirements: { contains: "webhook", mode: "insensitive" } },
+              { architecture: { contains: "webhook", mode: "insensitive" } },
+            ],
+          }),
+        }),
+      );
+    });
+
+    it("searches tasks in the pg arm", async () => {
+      dbTask.findMany.mockResolvedValue([
+        { id: "task-1", title: "Fix login bug" },
+      ]);
+
+      const tools = getTools();
+      const result = await tools.graph_search.execute(
+        { query: "login", realm: "pg" },
+        {} as never,
+      );
+
+      // Tasks scoped to the org via workspace, excluding deleted/archived
+      expect(dbTask.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            deleted: false,
+            archived: false,
+            workspace: { sourceControlOrgId: ORG_ID, deleted: false },
+            OR: [
+              { title: { contains: "login", mode: "insensitive" } },
+              { description: { contains: "login", mode: "insensitive" } },
+            ],
+          }),
+        }),
+      );
+      expect(mockFormatUrn).toHaveBeenCalledWith(
+        expect.objectContaining({ realm: "pg", type: "task", id: "task-1" }),
+      );
+      const results = (
+        result as { results: Array<{ type: string; title: string }> }
+      ).results;
+      expect(results).toContainEqual(
+        expect.objectContaining({ type: "task", title: "Fix login bug", realm: "pg" }),
+      );
+    });
+
+    it("searches workspaces in the pg arm (name/description/mission)", async () => {
+      dbWorkspace.findMany.mockResolvedValue([
+        { id: "ws-1", name: "Core Platform" },
+      ]);
+
+      const tools = getTools();
+      const result = await tools.graph_search.execute(
+        { query: "platform", realm: "pg", type: "workspace" },
+        {} as never,
+      );
+
+      expect(dbWorkspace.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            sourceControlOrgId: ORG_ID,
+            deleted: false,
+            OR: [
+              { name: { contains: "platform", mode: "insensitive" } },
+              { description: { contains: "platform", mode: "insensitive" } },
+              { mission: { contains: "platform", mode: "insensitive" } },
+            ],
+          }),
+        }),
+      );
+      expect(mockFormatUrn).toHaveBeenCalledWith(
+        expect.objectContaining({ realm: "pg", type: "workspace", id: "ws-1" }),
+      );
+      const results = (
+        result as { results: Array<{ type: string; title: string }> }
+      ).results;
+      expect(results).toContainEqual(
+        expect.objectContaining({ type: "workspace", title: "Core Platform", realm: "pg" }),
+      );
+    });
+
+    it("searches repositories in the pg arm (name/description/URL)", async () => {
+      dbRepository.findMany.mockResolvedValue([
+        { id: "repo-1", name: "hive" },
+      ]);
+
+      const tools = getTools();
+      const result = await tools.graph_search.execute(
+        { query: "hive", realm: "pg", type: "repository" },
+        {} as never,
+      );
+
+      expect(dbRepository.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            workspace: { sourceControlOrgId: ORG_ID, deleted: false },
+            OR: [
+              { name: { contains: "hive", mode: "insensitive" } },
+              { description: { contains: "hive", mode: "insensitive" } },
+              { repositoryUrl: { contains: "hive", mode: "insensitive" } },
+            ],
+          }),
+        }),
+      );
+      expect(mockFormatUrn).toHaveBeenCalledWith(
+        expect.objectContaining({ realm: "pg", type: "repository", id: "repo-1" }),
+      );
+      const results = (
+        result as { results: Array<{ type: string; title: string }> }
+      ).results;
+      expect(results).toContainEqual(
+        expect.objectContaining({ type: "repository", title: "hive", realm: "pg" }),
+      );
+    });
+
+    it("searches research docs in the pg arm (title/topic/summary/content)", async () => {
+      dbResearch.findMany.mockResolvedValue([
+        { id: "res-1", title: "OAuth deep-dive", topic: "oauth" },
+      ]);
+
+      const tools = getTools();
+      const result = await tools.graph_search.execute(
+        { query: "oauth", realm: "pg", type: "research" },
+        {} as never,
+      );
+
+      expect(dbResearch.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            orgId: ORG_ID,
+            OR: [
+              { title: { contains: "oauth", mode: "insensitive" } },
+              { topic: { contains: "oauth", mode: "insensitive" } },
+              { summary: { contains: "oauth", mode: "insensitive" } },
+              { content: { contains: "oauth", mode: "insensitive" } },
+            ],
+          }),
+        }),
+      );
+      expect(mockFormatUrn).toHaveBeenCalledWith(
+        expect.objectContaining({ realm: "pg", type: "research", id: "res-1" }),
+      );
+      const results = (
+        result as { results: Array<{ type: string; title: string }> }
+      ).results;
+      expect(results).toContainEqual(
+        expect.objectContaining({ type: "research", title: "OAuth deep-dive", realm: "pg" }),
+      );
+    });
+
+    it("falls back to topic when a research title is empty", async () => {
+      dbResearch.findMany.mockResolvedValue([
+        { id: "res-2", title: "", topic: "rate limiting" },
+      ]);
+
+      const tools = getTools();
+      const result = await tools.graph_search.execute(
+        { query: "rate", realm: "pg", type: "research" },
+        {} as never,
+      );
+
+      const results = (
+        result as { results: Array<{ title: string }> }
+      ).results;
+      expect(results).toContainEqual(
+        expect.objectContaining({ title: "rate limiting" }),
+      );
+    });
+
+    it("searches connection docs in the pg arm (name/summary/architecture)", async () => {
+      dbConnection.findMany.mockResolvedValue([
+        { id: "conn-1", name: "Sphinx ↔ Hive" },
+      ]);
+
+      const tools = getTools();
+      const result = await tools.graph_search.execute(
+        { query: "sphinx", realm: "pg", type: "connection" },
+        {} as never,
+      );
+
+      expect(dbConnection.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            orgId: ORG_ID,
+            OR: [
+              { name: { contains: "sphinx", mode: "insensitive" } },
+              { summary: { contains: "sphinx", mode: "insensitive" } },
+              { architecture: { contains: "sphinx", mode: "insensitive" } },
+            ],
+          }),
+        }),
+      );
+      expect(mockFormatUrn).toHaveBeenCalledWith(
+        expect.objectContaining({ realm: "pg", type: "connection", id: "conn-1" }),
+      );
+      const results = (
+        result as { results: Array<{ type: string; title: string }> }
+      ).results;
+      expect(results).toContainEqual(
+        expect.objectContaining({ type: "connection", title: "Sphinx ↔ Hive", realm: "pg" }),
+      );
+    });
+
+    it("searches conversations in the pg arm via raw query", async () => {
+      dbQueryRaw.mockResolvedValue([
+        { id: "convo-1", title: "Roadmap chat" },
+        { id: "convo-2", title: null },
+      ]);
+
+      const tools = getTools();
+      const result = await tools.graph_search.execute(
+        { query: "roadmap", realm: "pg" },
+        {} as never,
+      );
+
+      expect(dbQueryRaw).toHaveBeenCalled();
+      expect(mockFormatUrn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          realm: "pg",
+          type: "conversation",
+          id: "convo-1",
+        }),
+      );
+      const results = (
+        result as { results: Array<{ type: string; title: string }> }
+      ).results;
+      expect(results).toContainEqual(
+        expect.objectContaining({ type: "conversation", title: "Roadmap chat" }),
+      );
+      // Null titles fall back to a placeholder
+      expect(results).toContainEqual(
+        expect.objectContaining({
+          type: "conversation",
+          title: "(untitled conversation)",
+        }),
+      );
+    });
+
+    it("does not search conversations or tasks when type filters them out", async () => {
+      const tools = getTools();
+      await tools.graph_search.execute(
+        { query: "x", realm: "pg", type: "feature" },
+        {} as never,
+      );
+
+      expect(dbTask.findMany).not.toHaveBeenCalled();
+      expect(dbWorkspace.findMany).not.toHaveBeenCalled();
+      expect(dbRepository.findMany).not.toHaveBeenCalled();
+      expect(dbResearch.findMany).not.toHaveBeenCalled();
+      expect(dbConnection.findMany).not.toHaveBeenCalled();
+      expect(dbQueryRaw).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/lib/ai/graphWalkerTools.ts
+++ b/src/lib/ai/graphWalkerTools.ts
@@ -129,34 +129,46 @@ function deduplicateByUrn(
 }
 
 /**
- * Keyword search over pg-realm entities: features, initiatives, milestones.
- * Scoped to the org via workspace.sourceControlOrgId for features,
- * and initiative.orgId for initiatives/milestones.
+ * Keyword search over pg-realm entities: features, initiatives, milestones,
+ * and tasks. Scoped to the org via workspace.sourceControlOrgId for features
+ * and tasks, and initiative.orgId for initiatives/milestones.
+ *
+ * `urnOrg` is the org's githubLogin — the {org} segment must be the githubLogin
+ * (NOT the DB cuid) so the emitted URNs round-trip back through graph_get /
+ * graph_neighbors, which key off githubLogin.
  */
 async function searchPg(
   query: string,
   {
     orgId,
+    urnOrg,
     type,
     limit,
-  }: { orgId: string; userId: string; type?: string; limit: number },
+  }: { orgId: string; urnOrg: string; type?: string; limit: number },
 ): Promise<SearchResult[]> {
   const results: SearchResult[] = [];
-  const lowerQuery = query.toLowerCase();
 
-  // Features — linked to org via workspace.sourceControlOrgId
+  // Features — linked to org via workspace.sourceControlOrgId. Match the
+  // title plus the rich plan columns (brief / requirements / architecture)
+  // so plan content is discoverable, not just the title.
   if (!type || type === "feature") {
     const features = await db.feature.findMany({
       where: {
         workspace: { sourceControlOrgId: orgId },
-        title: { contains: query, mode: "insensitive" },
+        deleted: false,
+        OR: [
+          { title: { contains: query, mode: "insensitive" } },
+          { brief: { contains: query, mode: "insensitive" } },
+          { requirements: { contains: query, mode: "insensitive" } },
+          { architecture: { contains: query, mode: "insensitive" } },
+        ],
       },
       select: { id: true, title: true },
       take: limit,
     });
     for (const f of features) {
       results.push({
-        urn: formatUrn({ realm: "pg", org: orgId, type: "feature", id: f.id }),
+        urn: formatUrn({ realm: "pg", org: urnOrg, type: "feature", id: f.id }),
         type: "feature",
         title: f.title,
         realm: "pg",
@@ -178,7 +190,7 @@ async function searchPg(
       results.push({
         urn: formatUrn({
           realm: "pg",
-          org: orgId,
+          org: urnOrg,
           type: "initiative",
           id: i.id,
         }),
@@ -203,12 +215,161 @@ async function searchPg(
       results.push({
         urn: formatUrn({
           realm: "pg",
-          org: orgId,
+          org: urnOrg,
           type: "milestone",
           id: m.id,
         }),
         type: "milestone",
         title: m.name,
+        realm: "pg",
+      });
+    }
+  }
+
+  // Research — direct orgId column. Match title OR topic OR summary OR the
+  // markdown content body. Projected onto canvas as `research:<id>` cards,
+  // but searched here against the DB row (the canvas arm only sees authored
+  // nodes, never projected ones).
+  if (!type || type === "research") {
+    const researches = await db.research.findMany({
+      where: {
+        orgId,
+        OR: [
+          { title: { contains: query, mode: "insensitive" } },
+          { topic: { contains: query, mode: "insensitive" } },
+          { summary: { contains: query, mode: "insensitive" } },
+          { content: { contains: query, mode: "insensitive" } },
+        ],
+      },
+      select: { id: true, title: true, topic: true },
+      take: limit,
+    });
+    for (const r of researches) {
+      results.push({
+        urn: formatUrn({
+          realm: "pg",
+          org: urnOrg,
+          type: "research",
+          id: r.id,
+        }),
+        type: "research",
+        title: r.title || r.topic,
+        realm: "pg",
+      });
+    }
+  }
+
+  // Connections — direct orgId column. Match name OR summary OR architecture.
+  if (!type || type === "connection") {
+    const connections = await db.connection.findMany({
+      where: {
+        orgId,
+        OR: [
+          { name: { contains: query, mode: "insensitive" } },
+          { summary: { contains: query, mode: "insensitive" } },
+          { architecture: { contains: query, mode: "insensitive" } },
+        ],
+      },
+      select: { id: true, name: true },
+      take: limit,
+    });
+    for (const c of connections) {
+      results.push({
+        urn: formatUrn({
+          realm: "pg",
+          org: urnOrg,
+          type: "connection",
+          id: c.id,
+        }),
+        type: "connection",
+        title: c.name,
+        realm: "pg",
+      });
+    }
+  }
+
+  // Workspaces — direct sourceControlOrgId column. Match name OR description
+  // OR mission; exclude soft-deleted rows.
+  if (!type || type === "workspace") {
+    const workspaces = await db.workspace.findMany({
+      where: {
+        sourceControlOrgId: orgId,
+        deleted: false,
+        OR: [
+          { name: { contains: query, mode: "insensitive" } },
+          { description: { contains: query, mode: "insensitive" } },
+          { mission: { contains: query, mode: "insensitive" } },
+        ],
+      },
+      select: { id: true, name: true },
+      take: limit,
+    });
+    for (const w of workspaces) {
+      results.push({
+        urn: formatUrn({
+          realm: "pg",
+          org: urnOrg,
+          type: "workspace",
+          id: w.id,
+        }),
+        type: "workspace",
+        title: w.name,
+        realm: "pg",
+      });
+    }
+  }
+
+  // Repositories — linked to org via workspace.sourceControlOrgId. Match
+  // name OR description OR repositoryUrl.
+  if (!type || type === "repository") {
+    const repositories = await db.repository.findMany({
+      where: {
+        workspace: { sourceControlOrgId: orgId, deleted: false },
+        OR: [
+          { name: { contains: query, mode: "insensitive" } },
+          { description: { contains: query, mode: "insensitive" } },
+          { repositoryUrl: { contains: query, mode: "insensitive" } },
+        ],
+      },
+      select: { id: true, name: true },
+      take: limit,
+    });
+    for (const r of repositories) {
+      results.push({
+        urn: formatUrn({
+          realm: "pg",
+          org: urnOrg,
+          type: "repository",
+          id: r.id,
+        }),
+        type: "repository",
+        title: r.name,
+        realm: "pg",
+      });
+    }
+  }
+
+  // Tasks — linked to org via workspace.sourceControlOrgId. Match title OR
+  // description; exclude soft-deleted and archived rows.
+  if (!type || type === "task") {
+    const tasks = await db.task.findMany({
+      where: {
+        workspace: { sourceControlOrgId: orgId, deleted: false },
+        deleted: false,
+        archived: false,
+        OR: [
+          { title: { contains: query, mode: "insensitive" } },
+          { description: { contains: query, mode: "insensitive" } },
+        ],
+      },
+      select: { id: true, title: true },
+      take: limit,
+    });
+    for (const t of tasks) {
+      results.push({
+        urn: formatUrn({ realm: "pg", org: urnOrg, type: "task", id: t.id }),
+        type: "task",
+        title: t.title,
         realm: "pg",
       });
     }
@@ -236,16 +397,17 @@ async function searchCanvas(
   query: string,
   {
     orgId,
+    urnOrg,
     type,
     limit,
-  }: { orgId: string; type?: string; limit: number },
+  }: { orgId: string; urnOrg: string; type?: string; limit: number },
 ): Promise<SearchResult[]> {
   // Only canvas nodes have a meaningful node type — skip if caller filters by non-canvas type
   if (type && type !== "node" && type !== "text") return [];
 
   const canvases = await db.canvas.findMany({
     where: { orgId },
-    select: { ref: true, data: true, org: { select: { githubLogin: true } } },
+    select: { ref: true, data: true },
   });
 
   const results: SearchResult[] = [];
@@ -260,7 +422,7 @@ async function searchCanvas(
         results.push({
           urn: formatUrn({
             realm: "canvas",
-            org: canvas.org.githubLogin,
+            org: urnOrg,
             type: node.type ?? "node",
             id: `${encodedRef}.${node.id}`,
           }),
@@ -274,6 +436,53 @@ async function searchCanvas(
   }
 
   return results;
+}
+
+/**
+ * Keyword search over org-canvas chat conversations (SharedConversation rows),
+ * scoped to the org via the direct `sourceControlOrgId` column.
+ *
+ * Matches the conversation `title` OR any content inside the `messages` JSON
+ * blob. JSON content matching requires a raw `messages::text ILIKE` predicate —
+ * Prisma's typed filters can't do substring search across an arbitrary JSON
+ * column. Results are pg-realm with type "conversation".
+ */
+async function searchConversations(
+  query: string,
+  {
+    orgId,
+    urnOrg,
+    type,
+    limit,
+  }: { orgId: string; urnOrg: string; type?: string; limit: number },
+): Promise<SearchResult[]> {
+  // Only emit conversations when the caller hasn't filtered to a different type.
+  if (type && type !== "conversation") return [];
+
+  const like = `%${query}%`;
+  const rows = await db.$queryRaw<Array<{ id: string; title: string | null }>>`
+    SELECT id, title
+    FROM shared_conversations
+    WHERE source_control_org_id = ${orgId}
+      AND (
+        title ILIKE ${like}
+        OR messages::text ILIKE ${like}
+      )
+    ORDER BY last_message_at DESC NULLS LAST
+    LIMIT ${limit}
+  `;
+
+  return rows.map((r) => ({
+    urn: formatUrn({
+      realm: "pg",
+      org: urnOrg,
+      type: "conversation",
+      id: r.id,
+    }),
+    type: "conversation",
+    title: r.title ?? "(untitled conversation)",
+    realm: "pg" as const,
+  }));
 }
 
 // ---------------------------------------------------------------------------
@@ -376,6 +585,8 @@ export function buildGraphWalkerTools(
       description:
         "Search for nodes by keyword across pg and canvas realms, " +
         "returning ranked results with URN, type, title, and realm. " +
+        "The pg realm covers features, initiatives, milestones, tasks, and " +
+        "org-canvas chat conversations; the canvas realm covers canvas nodes. " +
         "Scope with `realm`, `type`, or `workspace` to narrow results. " +
         "Default (no realm) searches pg + canvas. " +
         "`kg` realm is not yet enabled — specifying `realm: 'kg'` returns a stub error.",
@@ -395,7 +606,7 @@ export function buildGraphWalkerTools(
           .string()
           .optional()
           .describe(
-            "Filter by node type (e.g. 'feature', 'initiative', 'milestone', 'node').",
+            "Filter by node type (e.g. 'feature', 'initiative', 'milestone', 'task', 'conversation', 'node').",
           ),
         limit: z
           .number()
@@ -419,11 +630,28 @@ export function buildGraphWalkerTools(
       }) => {
         const arms: Promise<SearchResult[]>[] = [];
 
+        // Resolve the org's githubLogin once — the {org} segment of every
+        // emitted URN must be the githubLogin (not the DB cuid) so results
+        // round-trip through graph_get / graph_neighbors.
+        const orgRow =
+          !realm || realm === "pg" || realm === "canvas"
+            ? await db.sourceControlOrg.findUnique({
+                where: { id: orgId },
+                select: { githubLogin: true },
+              })
+            : null;
+
+        if ((!realm || realm === "pg" || realm === "canvas") && !orgRow) {
+          return { results: [] };
+        }
+        const urnOrg = orgRow?.githubLogin ?? "";
+
         if (!realm || realm === "pg") {
-          arms.push(searchPg(query, { orgId, userId, type, limit }));
+          arms.push(searchPg(query, { orgId, urnOrg, type, limit }));
+          arms.push(searchConversations(query, { orgId, urnOrg, type, limit }));
         }
         if (!realm || realm === "canvas") {
-          arms.push(searchCanvas(query, { orgId, type, limit }));
+          arms.push(searchCanvas(query, { orgId, urnOrg, type, limit }));
         }
         if (realm === "kg") {
           // TODO(kg-enable): resolve workspace slug(s) → getJarvisConfigForWorkspace →

--- a/src/lib/constants/prompt.ts
+++ b/src/lib/constants/prompt.ts
@@ -682,9 +682,11 @@ Realms: \`pg\` (Postgres roadmap entities), \`canvas\` (canvas nodes), \`kg\` (w
 - **\`graph_neighbors({ urn, depth? })\`** — Return all adjacent URNs reachable in one hop, with \`edgeType\` and \`direction\`. Use this to explore what a node is connected to without fetching the full content of each neighbor.
 
 - **\`graph_search({ query, realm?, type?, workspace?, limit? })\`** — Discover nodes by keyword. Returns \`{ urn, type, title, realm }[]\` ranked results. Scope with \`realm\` and/or \`type\` to narrow results:
-  - \`realm: "pg"\` — searches features, initiatives, milestones by name
-  - \`realm: "canvas"\` — searches canvas nodes by text/label
+  - \`realm: "pg"\` — searches features, initiatives, milestones, tasks, workspaces, and repositories by title/name (features also match on their brief/requirements/architecture plan content; tasks also match on description; workspaces also match on description/mission; repositories also match on description/URL), plus research docs (title/topic/summary/content), connection docs (name/summary/architecture), and org-canvas chat conversations (title + message content)
+  - \`realm: "canvas"\` — searches **authored** canvas nodes by text/label only. Projected/live cards (workspace/initiative/feature/milestone/repository/research) are NOT in this arm — find those via their pg types instead.
   - Omit \`realm\` to search both pg and canvas simultaneously
+  - Narrow pg results with \`type\`: \`"feature"\`, \`"initiative"\`, \`"milestone"\`, \`"task"\`, \`"workspace"\`, \`"repository"\`, \`"research"\`, \`"connection"\`, or \`"conversation"\`
+  - From a \`workspace\` URN, \`graph_neighbors\` walks \`HAS_MEMBER\` → workspace members, and each member's \`IS_USER\` → the underlying user
 
 ### Scope reminder
 

--- a/src/lib/graph-walker/registry.ts
+++ b/src/lib/graph-walker/registry.ts
@@ -321,4 +321,7 @@ export const PG_NODE_TYPES = new Set([
   "deployment",
   "workflowtask",
   "chatmessage",
+  "research",
+  "connection",
+  "conversation",
 ]);

--- a/src/lib/urn/access.ts
+++ b/src/lib/urn/access.ts
@@ -6,6 +6,10 @@
  *   Org-scoped:        initiative, milestone, research
  *     → verify ctx.orgId matches the SourceControlOrg for the URN's {org}
  *
+ *   Org-membership:    workspace, workspacemember, user
+ *     → verify the URN's {org} maps to ctx.orgId AND the entity belongs to a
+ *       workspace under that org. Org-level granularity (org-page graph walker).
+ *
  *   Workspace-scoped:  feature, task, repository, workflowtask, chatmessage, deployment
  *     → verify ctx.workspaceId matches the entity's workspaceId
  *       (or ctx.userId is a WorkspaceMember of that workspace as fallback)
@@ -26,7 +30,12 @@ export interface PgAccessContext {
 // Org-scoped entities
 // ---------------------------------------------------------------------------
 
-const ORG_SCOPED_TYPES = new Set(["initiative", "milestone", "research"]);
+const ORG_SCOPED_TYPES = new Set([
+  "initiative",
+  "milestone",
+  "research",
+  "connection",
+]);
 
 async function checkOrgScoped(
   org: string,
@@ -38,6 +47,67 @@ async function checkOrgScoped(
     select: { id: true },
   });
   return row?.id === ctx.orgId;
+}
+
+// ---------------------------------------------------------------------------
+// Org-membership entities (workspace / member / user)
+//
+// These have no per-workspace `ctx.workspaceId` to match against — they are
+// gated at org granularity: the URN's {org} must resolve to `ctx.orgId`, and
+// the entity must belong to a (non-deleted) workspace under that org. This is
+// the org-page graph-walker scope; it intentionally does NOT require the
+// caller to be a member of the specific workspace.
+// ---------------------------------------------------------------------------
+
+const ORG_MEMBERSHIP_TYPES = new Set(["workspace", "workspacemember", "user"]);
+
+async function checkOrgMembership(
+  type: string,
+  id: string,
+  org: string,
+  ctx: PgAccessContext
+): Promise<boolean> {
+  if (!ctx.orgId) return false;
+
+  // The URN's {org} (githubLogin) must map to the authorized org.
+  const orgRow = await db.sourceControlOrg.findUnique({
+    where: { githubLogin: org },
+    select: { id: true },
+  });
+  if (orgRow?.id !== ctx.orgId) return false;
+
+  if (type === "workspace") {
+    const ws = await db.workspace.findFirst({
+      where: { id, sourceControlOrgId: ctx.orgId, deleted: false },
+      select: { id: true },
+    });
+    return ws !== null;
+  }
+
+  if (type === "workspacemember") {
+    const member = await db.workspaceMember.findFirst({
+      where: {
+        id,
+        workspace: { sourceControlOrgId: ctx.orgId, deleted: false },
+      },
+      select: { id: true },
+    });
+    return member !== null;
+  }
+
+  if (type === "user") {
+    // A user is visible if they are a member of any workspace under the org.
+    const member = await db.workspaceMember.findFirst({
+      where: {
+        userId: id,
+        workspace: { sourceControlOrgId: ctx.orgId, deleted: false },
+      },
+      select: { id: true },
+    });
+    return member !== null;
+  }
+
+  return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -172,6 +242,10 @@ export async function checkPgAccess(
 
   if (ORG_SCOPED_TYPES.has(parsed.type)) {
     return checkOrgScoped(parsed.org, ctx);
+  }
+
+  if (ORG_MEMBERSHIP_TYPES.has(parsed.type)) {
+    return checkOrgMembership(parsed.type, parsed.id, parsed.org, ctx);
   }
 
   if (WORKSPACE_SCOPED_TYPES.has(parsed.type)) {

--- a/src/services/orgs/nodeDetail.ts
+++ b/src/services/orgs/nodeDetail.ts
@@ -42,7 +42,10 @@ export async function loadNodeDetail(
   orgId: string,
 ): Promise<NodeDetail | null> {
   switch (kind) {
-    case "ws": {
+    // "ws" is the canvas projector's live-node token; "workspace" is the
+    // pg-realm URN type. Both resolve identically.
+    case "ws":
+    case "workspace": {
       const ws = await db.workspace.findFirst({
         where: { id, sourceControlOrgId: orgId, deleted: false },
         select: {
@@ -66,7 +69,10 @@ export async function loadNodeDetail(
         },
       };
     }
-    case "repo": {
+    // "repo" is the canvas projector's live-node token; "repository" is the
+    // pg-realm URN type. Both resolve identically.
+    case "repo":
+    case "repository": {
       const repo = await db.repository.findFirst({
         where: { id, workspace: { sourceControlOrgId: orgId, deleted: false } },
         select: {
@@ -253,6 +259,38 @@ export async function loadNodeDetail(
         },
       };
     }
+    case "connection": {
+      // Connection rows belong to the org directly. They describe how two or
+      // more systems integrate; surface the summary as the body and the
+      // architecture/spec as structured extras.
+      const connection = await db.connection.findFirst({
+        where: { id, orgId },
+        select: {
+          id: true,
+          slug: true,
+          name: true,
+          summary: true,
+          architecture: true,
+          openApiSpec: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      });
+      if (!connection) return null;
+      return {
+        kind: "connection",
+        id: connection.id,
+        name: connection.name,
+        description: connection.summary,
+        extras: {
+          slug: connection.slug,
+          architecture: connection.architecture,
+          openApiSpec: connection.openApiSpec,
+          createdAt: connection.createdAt,
+          updatedAt: connection.updatedAt,
+        },
+      };
+    }
     case "task": {
       const task = await db.task.findFirst({
         where: {
@@ -286,6 +324,82 @@ export async function loadNodeDetail(
           workspaceSlug: task.workspace.slug,
           feature: task.feature,
         },
+      };
+    }
+    case "conversation": {
+      // Org-canvas chat conversation (SharedConversation). Scoped to the org
+      // via the direct sourceControlOrgId column so cross-org reads return null.
+      const convo = await db.sharedConversation.findFirst({
+        where: { id, sourceControlOrgId: orgId },
+        select: {
+          id: true,
+          title: true,
+          messages: true,
+          lastMessageAt: true,
+          source: true,
+        },
+      });
+      if (!convo) return null;
+      return {
+        kind: "conversation",
+        id: convo.id,
+        name: convo.title ?? "(untitled conversation)",
+        // Conversations have no description column; the message transcript is
+        // the body. Surface it as a structured extra rather than flattening.
+        description: null,
+        extras: {
+          messages: convo.messages,
+          lastMessageAt: convo.lastMessageAt,
+          source: convo.source,
+        },
+      };
+    }
+    case "workspacemember": {
+      // Scoped to the org via the member's workspace.sourceControlOrgId.
+      const member = await db.workspaceMember.findFirst({
+        where: {
+          id,
+          workspace: { sourceControlOrgId: orgId, deleted: false },
+        },
+        select: {
+          id: true,
+          role: true,
+          description: true,
+          user: { select: { id: true, name: true, image: true } },
+          workspace: { select: { id: true, slug: true, name: true } },
+        },
+      });
+      if (!member) return null;
+      return {
+        kind: "workspacemember",
+        id: member.id,
+        name: member.user.name ?? "(unnamed member)",
+        description: member.description,
+        extras: {
+          role: member.role,
+          user: member.user,
+          workspaceSlug: member.workspace.slug,
+          workspaceName: member.workspace.name,
+        },
+      };
+    }
+    case "user": {
+      // A user is visible only if they are a member of a workspace under
+      // the org — enforced via the membership existence check.
+      const membership = await db.workspaceMember.findFirst({
+        where: {
+          userId: id,
+          workspace: { sourceControlOrgId: orgId, deleted: false },
+        },
+        select: { user: { select: { id: true, name: true, image: true } } },
+      });
+      if (!membership) return null;
+      return {
+        kind: "user",
+        id: membership.user.id,
+        name: membership.user.name ?? "(unnamed user)",
+        description: null,
+        extras: { image: membership.user.image },
       };
     }
     default:


### PR DESCRIPTION
## Summary

Builds on the graph_walker capability (#4509) and URN scheme (#4508). Makes **every addressable pg entity discoverable via `graph_search`** and resolvable via `graph_get`, with org-level access wiring for the org-page graph walker. Previously the pg search arm only matched `feature.title`, `initiative.name`, and `milestone.name`.

Scope note: this is intended for org-page use, so access for the new org-membership types is enforced at **org granularity** (not per-workspace).

## `searchPg` (`graphWalkerTools.ts`)
- **feature**: now matches `brief`/`requirements`/`architecture` in addition to `title`, and excludes soft-deleted rows
- **task** (title/description, excludes deleted+archived), **workspace** (name/description/mission), **repository** (name/description/repositoryUrl), **research** (title/topic/summary/content), **connection** (name/summary/architecture)
- **conversations**: new `searchConversations` arm over `SharedConversation`, matching `title` + JSON message content via `messages::text ILIKE`
- **Bug fix:** pg URNs were built with the org **cuid** in the `{org}` segment, but `graph_get`/`graph_neighbors` key off the **githubLogin** — so search results weren't round-trippable. Now resolved once per call and threaded into every arm.

## `access.ts` (`checkPgAccess`)
- New **org-membership tier** for `workspace`/`workspacemember`/`user` (previously fell through to `false`, which silently killed the registry's `HAS_MEMBER`/`IS_USER` edges at runtime). Enables `workspace → members → users` traversal.
- `connection` added to `ORG_SCOPED_TYPES`.

## `nodeDetail.ts` (`loadNodeDetail`)
- Reconciled token mismatches so `graph_get` resolves search URNs: `ws`/`workspace` and `repo`/`repository`.
- New cases: `conversation`, `workspacemember`, `user`, `connection`.

## Misc
- `registry.ts`: `research`/`connection`/`conversation` added to `PG_NODE_TYPES`.
- `prompt.ts`: documents the new pg types + `type` filters, clarifies the canvas arm searches **authored nodes only** (projected cards are reached via pg types), and notes the workspace→members→users path.

## Docs
- Adds `docs/plans/neo4j-graph-mirror.md` — proposed plan for mirroring a subset of Postgres into Neo4j via a single Prisma client extension (no route changes).

## Known limitations / follow-ups
- `graph_get`'s pg resolver still enforces only org-level access (not per-workspace) — acceptable for org-page scope; called out previously.
- `Feature.personas` (a `String[]`) isn't searched (needs `has`/`hasSome`, not `contains`).

## Testing
- `graphWalkerTools.test.ts` extended with db mocks + cases for every new arm, the githubLogin URN fix, null-title/empty-title fallbacks, and type-filter exclusion.
- `npx vitest run src/__tests__/unit/lib/ai/ src/__tests__/unit/lib/urn/ src/__tests__/unit/lib/graph-walker/` — all green. Lint + typecheck clean on changed source files.