### PR TITLE
feat: rename learnings "features" -> "concepts"

### DIFF
--- a/src/__tests__/integration/api/learnings-concepts-id.test.ts
+++ b/src/__tests__/integration/api/learnings-concepts-id.test.ts
@@ -435,7 +435,7 @@ describe("GET /api/learnings/concepts/[id] - Data Integrity", () => {
 
     // Verify URL format: https://{hostname}:3355/gitree/concepts/{id}
     expect(fetchUrl).toMatch(
-      /^https:\/\/feature-integrity-swarm\.sphinx\.chat:3355\/gitree\/features\/feature-123$/
+      /^https:\/\/feature-integrity-swarm\.sphinx\.chat:3355\/gitree\/concepts\/feature-123$/
     );
 
     fetchSpy.mockRestore();
@@ -464,7 +464,7 @@ describe("GET /api/learnings/concepts/[id] - Data Integrity", () => {
     const fetchUrl = fetchCall[0] as string;
 
     // Verify localhost uses http:// instead of https://
-    expect(fetchUrl).toMatch(/^http:\/\/localhost:3355\/gitree\/features\/feature-123$/);
+    expect(fetchUrl).toMatch(/^http:\/\/localhost:3355\/gitree\/concepts\/feature-123$/);
 
     fetchSpy.mockRestore();
   });

--- a/src/__tests__/integration/api/learnings-concepts-id.test.ts
+++ b/src/__tests__/integration/api/learnings-concepts-id.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { GET } from "@/app/api/learnings/features/[id]/route";
+import { GET } from "@/app/api/learnings/concepts/[id]/route";
 import { db } from "@/lib/db";
 import { EncryptionService } from "@/lib/encryption";
 import {
@@ -13,7 +13,7 @@ import {
 } from "@/__tests__/support/helpers";
 import type { User, Workspace, Swarm } from "@prisma/client";
 
-describe("GET /api/learnings/features/[id] - Authorization", () => {
+describe("GET /api/learnings/concepts/[id] - Authorization", () => {
   let owner: User;
   let workspace: Workspace;
   let swarm: Swarm;
@@ -76,7 +76,7 @@ describe("GET /api/learnings/features/[id] - Authorization", () => {
   });
 
   it("should return 401 for unauthenticated requests", async () => {
-    const request = createGetRequest(`/api/learnings/features/feature-123?workspace=${workspace.slug}`);
+    const request = createGetRequest(`/api/learnings/concepts/feature-123?workspace=${workspace.slug}`);
     const response = await GET(request, { params: Promise.resolve({ id: "feature-123" }) });
 
     expect(response.status).toBe(401);
@@ -85,7 +85,7 @@ describe("GET /api/learnings/features/[id] - Authorization", () => {
   });
 
   it("should return 400 when workspace parameter is missing", async () => {
-    const request = createAuthenticatedGetRequest("/api/learnings/features/feature-123", owner);
+    const request = createAuthenticatedGetRequest("/api/learnings/concepts/feature-123", owner);
     const response = await GET(request, { params: Promise.resolve({ id: "feature-123" }) });
 
     expect(response.status).toBe(400);
@@ -95,7 +95,7 @@ describe("GET /api/learnings/features/[id] - Authorization", () => {
 
   it("should return 400 when id parameter is missing", async () => {
     const request = createAuthenticatedGetRequest(
-      `/api/learnings/features/?workspace=${workspace.slug}`,
+      `/api/learnings/concepts/?workspace=${workspace.slug}`,
       owner
     );
     // Simulate missing id by passing empty string
@@ -108,7 +108,7 @@ describe("GET /api/learnings/features/[id] - Authorization", () => {
 
   it("should return 403 for non-member access", async () => {
     const request = createAuthenticatedGetRequest(
-      `/api/learnings/features/feature-123?workspace=${workspace.slug}`,
+      `/api/learnings/concepts/feature-123?workspace=${workspace.slug}`,
       nonMember
     );
     const response = await GET(request, { params: Promise.resolve({ id: "feature-123" }) });
@@ -127,7 +127,7 @@ describe("GET /api/learnings/features/[id] - Authorization", () => {
     });
 
     const request = createAuthenticatedGetRequest(
-      `/api/learnings/features/feature-123?workspace=${workspace.slug}`,
+      `/api/learnings/concepts/feature-123?workspace=${workspace.slug}`,
       owner
     );
     const response = await GET(request, { params: Promise.resolve({ id: "feature-123" }) });
@@ -148,14 +148,14 @@ describe("GET /api/learnings/features/[id] - Authorization", () => {
     );
 
     const request = createAuthenticatedGetRequest(
-      `/api/learnings/features/feature-123?workspace=${workspace.slug}`,
+      `/api/learnings/concepts/feature-123?workspace=${workspace.slug}`,
       memberViewer
     );
     const response = await GET(request, { params: Promise.resolve({ id: "feature-123" }) });
 
     expect(response.status).toBe(200);
     expect(fetchSpy).toHaveBeenCalledWith(
-      expect.stringContaining("https://test-feature-swarm.sphinx.chat:3355/gitree/features/feature-123"),
+      expect.stringContaining("https://test-feature-swarm.sphinx.chat:3355/gitree/concepts/feature-123"),
       expect.objectContaining({
         method: "GET",
         headers: expect.objectContaining({
@@ -176,7 +176,7 @@ describe("GET /api/learnings/features/[id] - Authorization", () => {
     );
 
     const request = createAuthenticatedGetRequest(
-      `/api/learnings/features/feature-123?workspace=${workspace.slug}`,
+      `/api/learnings/concepts/feature-123?workspace=${workspace.slug}`,
       memberDeveloper
     );
     const response = await GET(request, { params: Promise.resolve({ id: "feature-123" }) });
@@ -194,7 +194,7 @@ describe("GET /api/learnings/features/[id] - Authorization", () => {
     );
 
     const request = createAuthenticatedGetRequest(
-      `/api/learnings/features/feature-123?workspace=${workspace.slug}`,
+      `/api/learnings/concepts/feature-123?workspace=${workspace.slug}`,
       memberAdmin
     );
     const response = await GET(request, { params: Promise.resolve({ id: "feature-123" }) });
@@ -212,7 +212,7 @@ describe("GET /api/learnings/features/[id] - Authorization", () => {
     );
 
     const request = createAuthenticatedGetRequest(
-      `/api/learnings/features/feature-123?workspace=${workspace.slug}`,
+      `/api/learnings/concepts/feature-123?workspace=${workspace.slug}`,
       owner
     );
     const response = await GET(request, { params: Promise.resolve({ id: "feature-123" }) });
@@ -222,7 +222,7 @@ describe("GET /api/learnings/features/[id] - Authorization", () => {
   });
 });
 
-describe("GET /api/learnings/features/[id] - Data Integrity", () => {
+describe("GET /api/learnings/concepts/[id] - Data Integrity", () => {
   let owner: User;
   let workspace: Workspace;
   let swarm: Swarm;
@@ -268,7 +268,7 @@ describe("GET /api/learnings/features/[id] - Data Integrity", () => {
     });
 
     const request = createAuthenticatedGetRequest(
-      `/api/learnings/features/feature-123?workspace=${newScenario.workspace.slug}`,
+      `/api/learnings/concepts/feature-123?workspace=${newScenario.workspace.slug}`,
       newScenario.owner
     );
     const response = await GET(request, { params: Promise.resolve({ id: "feature-123" }) });
@@ -285,7 +285,7 @@ describe("GET /api/learnings/features/[id] - Data Integrity", () => {
     });
 
     const request = createAuthenticatedGetRequest(
-      `/api/learnings/features/feature-123?workspace=${workspace.slug}`,
+      `/api/learnings/concepts/feature-123?workspace=${workspace.slug}`,
       owner
     );
     const response = await GET(request, { params: Promise.resolve({ id: "feature-123" }) });
@@ -304,7 +304,7 @@ describe("GET /api/learnings/features/[id] - Data Integrity", () => {
     );
 
     const request = createAuthenticatedGetRequest(
-      `/api/learnings/features/feature-123?workspace=${workspace.slug}`,
+      `/api/learnings/concepts/feature-123?workspace=${workspace.slug}`,
       owner
     );
     const response = await GET(request, { params: Promise.resolve({ id: "feature-123" }) });
@@ -331,7 +331,7 @@ describe("GET /api/learnings/features/[id] - Data Integrity", () => {
 
     const featureId = "feature-with-special-chars/123";
     const request = createAuthenticatedGetRequest(
-      `/api/learnings/features/${encodeURIComponent(featureId)}?workspace=${workspace.slug}`,
+      `/api/learnings/concepts/${encodeURIComponent(featureId)}?workspace=${workspace.slug}`,
       owner
     );
     const response = await GET(request, { params: Promise.resolve({ id: featureId }) });
@@ -342,7 +342,7 @@ describe("GET /api/learnings/features/[id] - Data Integrity", () => {
     const fetchCall = fetchSpy.mock.calls[0];
     const fetchUrl = fetchCall[0] as string;
     expect(fetchUrl).toContain(
-      `gitree/features/${encodeURIComponent(featureId)}`
+      `gitree/concepts/${encodeURIComponent(featureId)}`
     );
 
     fetchSpy.mockRestore();
@@ -364,7 +364,7 @@ describe("GET /api/learnings/features/[id] - Data Integrity", () => {
     );
 
     const request = createAuthenticatedGetRequest(
-      `/api/learnings/features/feature-123?workspace=${workspace.slug}`,
+      `/api/learnings/concepts/feature-123?workspace=${workspace.slug}`,
       owner
     );
     const response = await GET(request, { params: Promise.resolve({ id: "feature-123" }) });
@@ -390,7 +390,7 @@ describe("GET /api/learnings/features/[id] - Data Integrity", () => {
     );
 
     const request = createAuthenticatedGetRequest(
-      `/api/learnings/features/feature-123?workspace=${workspace.slug}`,
+      `/api/learnings/concepts/feature-123?workspace=${workspace.slug}`,
       owner
     );
     const response = await GET(request, { params: Promise.resolve({ id: "feature-123" }) });
@@ -406,7 +406,7 @@ describe("GET /api/learnings/features/[id] - Data Integrity", () => {
     );
 
     const request = createAuthenticatedGetRequest(
-      `/api/learnings/features/feature-123?workspace=${workspace.slug}`,
+      `/api/learnings/concepts/feature-123?workspace=${workspace.slug}`,
       owner
     );
     const response = await GET(request, { params: Promise.resolve({ id: "feature-123" }) });
@@ -425,7 +425,7 @@ describe("GET /api/learnings/features/[id] - Data Integrity", () => {
     );
 
     const request = createAuthenticatedGetRequest(
-      `/api/learnings/features/feature-123?workspace=${workspace.slug}`,
+      `/api/learnings/concepts/feature-123?workspace=${workspace.slug}`,
       owner
     );
     await GET(request, { params: Promise.resolve({ id: "feature-123" }) });
@@ -433,7 +433,7 @@ describe("GET /api/learnings/features/[id] - Data Integrity", () => {
     const fetchCall = fetchSpy.mock.calls[0];
     const fetchUrl = fetchCall[0] as string;
 
-    // Verify URL format: https://{hostname}:3355/gitree/features/{id}
+    // Verify URL format: https://{hostname}:3355/gitree/concepts/{id}
     expect(fetchUrl).toMatch(
       /^https:\/\/feature-integrity-swarm\.sphinx\.chat:3355\/gitree\/features\/feature-123$/
     );
@@ -455,7 +455,7 @@ describe("GET /api/learnings/features/[id] - Data Integrity", () => {
     );
 
     const request = createAuthenticatedGetRequest(
-      `/api/learnings/features/feature-123?workspace=${workspace.slug}`,
+      `/api/learnings/concepts/feature-123?workspace=${workspace.slug}`,
       owner
     );
     await GET(request, { params: Promise.resolve({ id: "feature-123" }) });
@@ -478,7 +478,7 @@ describe("GET /api/learnings/features/[id] - Data Integrity", () => {
     );
 
     const request = createAuthenticatedGetRequest(
-      `/api/learnings/features/feature-123?workspace=${workspace.slug}`,
+      `/api/learnings/concepts/feature-123?workspace=${workspace.slug}`,
       owner
     );
     await GET(request, { params: Promise.resolve({ id: "feature-123" }) });

--- a/src/__tests__/integration/api/learnings/concepts/create.test.ts
+++ b/src/__tests__/integration/api/learnings/concepts/create.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { POST } from '@/app/api/learnings/features/create/route';
+import { POST } from '@/app/api/learnings/concepts/create/route';
 import { db } from '@/lib/db';
 import { EncryptionService } from '@/lib/encryption';
 import {
@@ -44,7 +44,7 @@ async function createGitHubAuth(userId: string, username: string = 'test-github-
   });
 }
 
-describe('POST /api/learnings/features/create - Authorization', () => {
+describe('POST /api/learnings/concepts/create - Authorization', () => {
   let owner: User;
   let workspace: Workspace;
   let swarm: Swarm;
@@ -132,7 +132,7 @@ describe('POST /api/learnings/features/create - Authorization', () => {
 
   it('should return 401 for unauthenticated requests', async () => {
     const request = createPostRequest(
-      `/api/learnings/features/create`,
+      `/api/learnings/concepts/create`,
       {
         workspace: workspace.slug,
         prompt: 'Add user authentication',
@@ -148,7 +148,7 @@ describe('POST /api/learnings/features/create - Authorization', () => {
 
   it('should return 400 when workspace parameter is missing', async () => {
     const request = createAuthenticatedPostRequest(
-      `/api/learnings/features/create`,
+      `/api/learnings/concepts/create`,
       {
         prompt: 'Add user authentication',
         name: 'Authentication Feature',
@@ -164,7 +164,7 @@ describe('POST /api/learnings/features/create - Authorization', () => {
 
   it('should return 400 when prompt parameter is missing', async () => {
     const request = createAuthenticatedPostRequest(
-      `/api/learnings/features/create`,
+      `/api/learnings/concepts/create`,
       {
         workspace: workspace.slug,
         name: 'Authentication Feature',
@@ -180,7 +180,7 @@ describe('POST /api/learnings/features/create - Authorization', () => {
 
   it('should return 400 when name parameter is missing', async () => {
     const request = createAuthenticatedPostRequest(
-      `/api/learnings/features/create`,
+      `/api/learnings/concepts/create`,
       {
         workspace: workspace.slug,
         prompt: 'Add user authentication',
@@ -196,7 +196,7 @@ describe('POST /api/learnings/features/create - Authorization', () => {
 
   it('should return 403 for non-member access', async () => {
     const request = createAuthenticatedPostRequest(
-      `/api/learnings/features/create`,
+      `/api/learnings/concepts/create`,
       {
         workspace: workspace.slug,
         prompt: 'Add user authentication',
@@ -220,7 +220,7 @@ describe('POST /api/learnings/features/create - Authorization', () => {
     });
 
     const request = createAuthenticatedPostRequest(
-      `/api/learnings/features/create`,
+      `/api/learnings/concepts/create`,
       {
         workspace: workspace.slug,
         prompt: 'Add user authentication',
@@ -243,7 +243,7 @@ describe('POST /api/learnings/features/create - Authorization', () => {
     await createGitHubAuth(memberViewer.id, 'test-viewer-github');
 
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url: any) => {
-      if (url.includes('/gitree/create-feature')) {
+      if (url.includes('/gitree/create-concept')) {
         return new Response(JSON.stringify({ request_id: 'req-123' }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
@@ -265,7 +265,7 @@ describe('POST /api/learnings/features/create - Authorization', () => {
     });
 
     const request = createAuthenticatedPostRequest(
-      `/api/learnings/features/create`,
+      `/api/learnings/concepts/create`,
       {
         workspace: workspace.slug,
         prompt: 'Add user authentication',
@@ -283,7 +283,7 @@ describe('POST /api/learnings/features/create - Authorization', () => {
     await createGitHubAuth(memberDeveloper.id, 'test-developer-github');
 
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url: any) => {
-      if (url.includes('/gitree/create-feature')) {
+      if (url.includes('/gitree/create-concept')) {
         return new Response(JSON.stringify({ request_id: 'req-456' }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
@@ -305,7 +305,7 @@ describe('POST /api/learnings/features/create - Authorization', () => {
     });
 
     const request = createAuthenticatedPostRequest(
-      `/api/learnings/features/create`,
+      `/api/learnings/concepts/create`,
       {
         workspace: workspace.slug,
         prompt: 'Add developer tools',
@@ -321,7 +321,7 @@ describe('POST /api/learnings/features/create - Authorization', () => {
 
   it.skip('should allow OWNER role to create features', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url: any) => {
-      if (url.includes('/gitree/create-feature')) {
+      if (url.includes('/gitree/create-concept')) {
         return new Response(JSON.stringify({ request_id: 'req-789' }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
@@ -343,7 +343,7 @@ describe('POST /api/learnings/features/create - Authorization', () => {
     });
 
     const request = createAuthenticatedPostRequest(
-      `/api/learnings/features/create`,
+      `/api/learnings/concepts/create`,
       {
         workspace: workspace.slug,
         prompt: 'Add payment processing',
@@ -358,7 +358,7 @@ describe('POST /api/learnings/features/create - Authorization', () => {
   });
 });
 
-describe('POST /api/learnings/features/create - Infrastructure Requirements', () => {
+describe('POST /api/learnings/concepts/create - Infrastructure Requirements', () => {
   let owner: User;
   let workspace: Workspace;
   let swarm: Swarm;
@@ -438,7 +438,7 @@ describe('POST /api/learnings/features/create - Infrastructure Requirements', ()
     });
 
     const request = createAuthenticatedPostRequest(
-      `/api/learnings/features/create`,
+      `/api/learnings/concepts/create`,
       {
         workspace: newScenario.workspace.slug,
         prompt: 'Add feature',
@@ -478,7 +478,7 @@ describe('POST /api/learnings/features/create - Infrastructure Requirements', ()
     await createGitHubAuth(newScenario.owner.id, 'no-repo-github');
 
     const request = createAuthenticatedPostRequest(
-      `/api/learnings/features/create`,
+      `/api/learnings/concepts/create`,
       {
         workspace: newScenario.workspace.slug,
         prompt: 'Add feature',
@@ -521,7 +521,7 @@ describe('POST /api/learnings/features/create - Infrastructure Requirements', ()
     });
 
     const request = createAuthenticatedPostRequest(
-      `/api/learnings/features/create`,
+      `/api/learnings/concepts/create`,
       {
         workspace: newScenario.workspace.slug,
         prompt: 'Add feature',
@@ -543,7 +543,7 @@ describe('POST /api/learnings/features/create - Infrastructure Requirements', ()
     });
 
     const request = createAuthenticatedPostRequest(
-      `/api/learnings/features/create`,
+      `/api/learnings/concepts/create`,
       {
         workspace: workspace.slug,
         prompt: 'Add feature',
@@ -559,7 +559,7 @@ describe('POST /api/learnings/features/create - Infrastructure Requirements', ()
   });
 });
 
-describe('POST /api/learnings/features/create - Swarm Integration', () => {
+describe('POST /api/learnings/concepts/create - Swarm Integration', () => {
   let owner: User;
   let workspace: Workspace;
   let swarm: Swarm;
@@ -627,9 +627,9 @@ describe('POST /api/learnings/features/create - Swarm Integration', () => {
     vi.restoreAllMocks();
   });
 
-  it.skip('should call swarm gitree/create-feature endpoint with correct parameters', async () => {
+  it.skip('should call swarm gitree/create-concept endpoint with correct parameters', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url: any, options: any) => {
-      if (url.includes('/gitree/create-feature')) {
+      if (url.includes('/gitree/create-concept')) {
         const body = JSON.parse(options.body);
         expect(body.prompt).toBe('Add user authentication system');
         expect(body.name).toBe('Authentication Feature');
@@ -657,7 +657,7 @@ describe('POST /api/learnings/features/create - Swarm Integration', () => {
     });
 
     const request = createAuthenticatedPostRequest(
-      `/api/learnings/features/create`,
+      `/api/learnings/concepts/create`,
       {
         workspace: workspace.slug,
         prompt: 'Add user authentication system',
@@ -674,7 +674,7 @@ describe('POST /api/learnings/features/create - Swarm Integration', () => {
   it.skip('should poll progress endpoint until completion', async () => {
     let pollCount = 0;
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url: any) => {
-      if (url.includes('/gitree/create-feature')) {
+      if (url.includes('/gitree/create-concept')) {
         return new Response(JSON.stringify({ request_id: 'req-poll-test' }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
@@ -703,7 +703,7 @@ describe('POST /api/learnings/features/create - Swarm Integration', () => {
     });
 
     const request = createAuthenticatedPostRequest(
-      `/api/learnings/features/create`,
+      `/api/learnings/concepts/create`,
       {
         workspace: workspace.slug,
         prompt: 'Test polling',
@@ -727,7 +727,7 @@ describe('POST /api/learnings/features/create - Swarm Integration', () => {
     );
 
     const request = createAuthenticatedPostRequest(
-      `/api/learnings/features/create`,
+      `/api/learnings/concepts/create`,
       {
         workspace: workspace.slug,
         prompt: 'Test failure',
@@ -745,7 +745,7 @@ describe('POST /api/learnings/features/create - Swarm Integration', () => {
 
   it.skip('should return error when progress polling fails', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url: any) => {
-      if (url.includes('/gitree/create-feature')) {
+      if (url.includes('/gitree/create-concept')) {
         return new Response(JSON.stringify({ request_id: 'req-fail' }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
@@ -764,7 +764,7 @@ describe('POST /api/learnings/features/create - Swarm Integration', () => {
     });
 
     const request = createAuthenticatedPostRequest(
-      `/api/learnings/features/create`,
+      `/api/learnings/concepts/create`,
       {
         workspace: workspace.slug,
         prompt: 'Test error',
@@ -789,7 +789,7 @@ describe('POST /api/learnings/features/create - Swarm Integration', () => {
     );
 
     const request = createAuthenticatedPostRequest(
-      `/api/learnings/features/create`,
+      `/api/learnings/concepts/create`,
       {
         workspace: workspace.slug,
         prompt: 'Test no request_id',
@@ -814,7 +814,7 @@ describe('POST /api/learnings/features/create - Swarm Integration', () => {
     };
 
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url: any) => {
-      if (url.includes('/gitree/create-feature')) {
+      if (url.includes('/gitree/create-concept')) {
         return new Response(JSON.stringify({ request_id: 'req-success' }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
@@ -836,7 +836,7 @@ describe('POST /api/learnings/features/create - Swarm Integration', () => {
     });
 
     const request = createAuthenticatedPostRequest(
-      `/api/learnings/features/create`,
+      `/api/learnings/concepts/create`,
       {
         workspace: workspace.slug,
         prompt: 'Create successful feature',
@@ -860,7 +860,7 @@ describe('POST /api/learnings/features/create - Swarm Integration', () => {
     );
 
     const request = createAuthenticatedPostRequest(
-      `/api/learnings/features/create`,
+      `/api/learnings/concepts/create`,
       {
         workspace: workspace.slug,
         prompt: 'Test network error',

--- a/src/__tests__/unit/components/LearnSidebar.test.tsx
+++ b/src/__tests__/unit/components/LearnSidebar.test.tsx
@@ -17,8 +17,8 @@ vi.mock("@/app/w/[slug]/learn/components/UsageDisplay", () => ({
   UsageDisplay: () => <span data-testid="usage-display" />,
 }));
 
-vi.mock("@/app/w/[slug]/learn/components/CreateFeatureModal", () => ({
-  CreateFeatureModal: () => null,
+vi.mock("@/app/w/[slug]/learn/components/CreateConceptModal", () => ({
+  CreateConceptModal: () => null,
 }));
 
 vi.mock("@/lib/date-utils", () => ({

--- a/src/__tests__/unit/components/LearnViewer.test.tsx
+++ b/src/__tests__/unit/components/LearnViewer.test.tsx
@@ -78,7 +78,7 @@ function makeFetchMock(overrides?: { docs?: unknown; concepts?: unknown; diagram
     if (url.includes("/api/learnings/docs")) {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(overrides?.docs ?? DOCS_RESPONSE) });
     }
-    if (url.includes("/api/learnings/features") && !url.includes("/documentation")) {
+    if (url.includes("/api/learnings/concepts") && !url.includes("/documentation")) {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(overrides?.concepts ?? CONCEPTS_RESPONSE) });
     }
     if (url.includes("/api/learnings/diagrams")) {

--- a/src/__tests__/unit/lib/ai/askTools.test.ts
+++ b/src/__tests__/unit/lib/ai/askTools.test.ts
@@ -143,7 +143,7 @@ describe("askTools", () => {
 
       expect(result).toEqual(mockFeatures);
       expect(mockFetch).toHaveBeenCalledWith(
-        `${mockSwarmUrl}/gitree/features`,
+        `${mockSwarmUrl}/gitree/concepts`,
         expect.objectContaining({
           method: "GET",
           headers: {
@@ -191,7 +191,7 @@ describe("askTools", () => {
 
       expect(result).toEqual(mockFeatureData);
       expect(mockFetch).toHaveBeenCalledWith(
-        `${mockSwarmUrl}/gitree/features/${encodeURIComponent("feature-1")}`,
+        `${mockSwarmUrl}/gitree/concepts/${encodeURIComponent("feature-1")}`,
         expect.objectContaining({
           method: "GET",
           headers: {
@@ -233,7 +233,7 @@ describe("askTools", () => {
       await tools.learn_concept.execute({ conceptId: "feature/with/slashes" });
 
       expect(mockFetch).toHaveBeenCalledWith(
-        `${mockSwarmUrl}/gitree/features/${encodeURIComponent("feature/with/slashes")}`,
+        `${mockSwarmUrl}/gitree/concepts/${encodeURIComponent("feature/with/slashes")}`,
         expect.any(Object)
       );
     });
@@ -894,7 +894,7 @@ describe("askTools", () => {
       await tools.learn_concept.execute({ conceptId: "special!@#$%^&*()" });
 
       expect(mockFetch).toHaveBeenCalledWith(
-        `${mockSwarmUrl}/gitree/features/${encodeURIComponent("special!@#$%^&*()")}`,
+        `${mockSwarmUrl}/gitree/concepts/${encodeURIComponent("special!@#$%^&*()")}`,
         expect.any(Object)
       );
     });

--- a/src/app/api/learnings/concepts/[id]/documentation/route.ts
+++ b/src/app/api/learnings/concepts/[id]/documentation/route.ts
@@ -29,7 +29,7 @@ export async function PUT(
 
     const { baseSwarmUrl, decryptedSwarmApiKey } = swarmConfig;
 
-    const swarmUrl = `${baseSwarmUrl}/gitree/features/${encodeURIComponent(id)}/documentation`;
+    const swarmUrl = `${baseSwarmUrl}/gitree/concepts/${encodeURIComponent(id)}/documentation`;
 
     const response = await fetch(swarmUrl, {
       method: "PUT",

--- a/src/app/api/learnings/concepts/[id]/route.ts
+++ b/src/app/api/learnings/concepts/[id]/route.ts
@@ -27,7 +27,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 
     const { baseSwarmUrl, decryptedSwarmApiKey } = swarmConfig;
 
-    const swarmUrl = `${baseSwarmUrl}/gitree/features/${encodeURIComponent(id)}`;
+    const swarmUrl = `${baseSwarmUrl}/gitree/concepts/${encodeURIComponent(id)}`;
 
     const response = await fetch(swarmUrl, {
       method: "GET",
@@ -42,7 +42,9 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     }
 
     const data = await response.json();
-    return NextResponse.json(data);
+    // stakgraph renamed the `feature` payload key -> `concept`; expose both.
+    const concept = data?.concept ?? data?.feature;
+    return NextResponse.json(concept ? { ...data, feature: concept, concept } : data);
   } catch (error) {
     console.error("Feature by ID API proxy error:", error);
     return NextResponse.json({ error: "Failed to fetch feature data" }, { status: 500 });

--- a/src/app/api/learnings/concepts/create/route.ts
+++ b/src/app/api/learnings/concepts/create/route.ts
@@ -52,8 +52,8 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "GitHub PAT not found for this user" }, { status: 404 });
     }
 
-    // Call gitree/create-feature endpoint
-    const swarmUrl = `${baseSwarmUrl}/gitree/create-feature`;
+    // Call gitree/create-concept endpoint
+    const swarmUrl = `${baseSwarmUrl}/gitree/create-concept`;
 
     const response = await fetch(swarmUrl, {
       method: "POST",
@@ -112,7 +112,7 @@ export async function POST(request: NextRequest) {
         // Success! Return feature data
         return NextResponse.json({
           success: true,
-          feature: progressData.result?.feature,
+          feature: progressData.result?.concept ?? progressData.result?.feature,
           usage: progressData.result?.usage,
         });
       } else if (progressData.status === "failed") {

--- a/src/app/api/learnings/concepts/route.ts
+++ b/src/app/api/learnings/concepts/route.ts
@@ -22,7 +22,7 @@ export async function GET(request: NextRequest) {
 
     const { baseSwarmUrl, decryptedSwarmApiKey } = swarmConfig;
 
-    const swarmUrl = `${baseSwarmUrl}/gitree/features`;
+    const swarmUrl = `${baseSwarmUrl}/gitree/concepts`;
 
     const response = await fetch(swarmUrl, {
       method: "GET",
@@ -37,11 +37,14 @@ export async function GET(request: NextRequest) {
     }
 
     const data = await response.json();
+    // stakgraph renamed `features` -> `concepts`; accept both for compatibility.
     const features = Array.isArray(data)
       ? data
-      : Array.isArray(data?.features)
-        ? data.features
-        : [];
+      : Array.isArray(data?.concepts)
+        ? data.concepts
+        : Array.isArray(data?.features)
+          ? data.features
+          : [];
     return NextResponse.json({
       features,
       lastProcessedTimestamp: data.lastProcessedTimestamp ?? null,

--- a/src/app/api/mock/stakgraph/gitree/concepts/[id]/documentation/route.ts
+++ b/src/app/api/mock/stakgraph/gitree/concepts/[id]/documentation/route.ts
@@ -35,13 +35,13 @@ export async function PUT(
 
     const { id } = await params;
 
-    console.log(`[StakgraphMock] PUT /gitree/features/${id}/documentation`);
+    console.log(`[StakgraphMock] PUT /gitree/concepts/${id}/documentation`);
 
     return NextResponse.json({ success: true, id });
   } catch (error) {
-    console.error("[StakgraphMock] PUT /gitree/features/:id/documentation error:", error);
+    console.error("[StakgraphMock] PUT /gitree/concepts/:id/documentation error:", error);
     return NextResponse.json(
-      { error: "Failed to update feature documentation" },
+      { error: "Failed to update concept documentation" },
       { status: 500 }
     );
   }

--- a/src/app/api/workspaces/[slug]/graph/gitree/route.ts
+++ b/src/app/api/workspaces/[slug]/graph/gitree/route.ts
@@ -81,9 +81,9 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     const queryString = Object.keys(apiParams).length > 0 ? `?${new URLSearchParams(apiParams).toString()}` : '';
 
     console.log(queryString);
-    console.log(`${graphUrl}/gitree/all-features-graph${queryString}`);
+    console.log(`${graphUrl}/gitree/all-concepts-graph${queryString}`);
 
-    const apiResult = await fetch(`${graphUrl}/gitree/all-features-graph?per_type_limits=Function:100,Class:5,Library:1,Import:1,Datamodel:100,File:10,IntegrationTest:5,UnitTest:5,Var:5`, {
+    const apiResult = await fetch(`${graphUrl}/gitree/all-concepts-graph?per_type_limits=Function:100,Class:5,Library:1,Import:1,Datamodel:100,File:10,IntegrationTest:5,UnitTest:5,Var:5`, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",

--- a/src/app/w/[slug]/learn/components/CreateConceptModal.tsx
+++ b/src/app/w/[slug]/learn/components/CreateConceptModal.tsx
@@ -21,17 +21,17 @@ interface Repository {
   repositoryUrl: string;
 }
 
-interface CreateFeatureModalProps {
+interface CreateConceptModalProps {
   isOpen: boolean;
   onClose: () => void;
   workspaceSlug: string;
-  onFeatureCreated?: () => void;
+  onConceptCreated?: () => void;
   repositories: Repository[];
   selectedRepoId: string;
   onRepoChange: (repoId: string) => void;
 }
 
-export function CreateFeatureModal({ isOpen, onClose, workspaceSlug, onFeatureCreated, repositories, selectedRepoId, onRepoChange }: CreateFeatureModalProps) {
+export function CreateConceptModal({ isOpen, onClose, workspaceSlug, onConceptCreated, repositories, selectedRepoId, onRepoChange }: CreateConceptModalProps) {
   const [name, setName] = useState("");
   const [prompt, setPrompt] = useState("");
   const [isCreating, setIsCreating] = useState(false);
@@ -58,7 +58,7 @@ export function CreateFeatureModal({ isOpen, onClose, workspaceSlug, onFeatureCr
     setError(null);
 
     try {
-      const response = await fetch("/api/learnings/features/create", {
+      const response = await fetch("/api/learnings/concepts/create", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -73,21 +73,21 @@ export function CreateFeatureModal({ isOpen, onClose, workspaceSlug, onFeatureCr
 
       if (!response.ok) {
         const errorData = await response.json();
-        throw new Error(errorData.error || "Failed to create feature");
+        throw new Error(errorData.error || "Failed to create concept");
       }
 
       const data = await response.json();
 
       if (data.success) {
         // Success!
-        onFeatureCreated?.();
+        onConceptCreated?.();
         handleClose();
       } else {
         throw new Error("Unexpected response format");
       }
     } catch (err) {
-      console.error("Error creating feature:", err);
-      setError(err instanceof Error ? err.message : "Failed to create feature");
+      console.error("Error creating concept:", err);
+      setError(err instanceof Error ? err.message : "Failed to create concept");
     } finally {
       setIsCreating(false);
     }
@@ -107,7 +107,7 @@ export function CreateFeatureModal({ isOpen, onClose, workspaceSlug, onFeatureCr
       <DialogContent className="sm:max-w-[500px]">
         <DialogHeader>
           <DialogTitle>Create New Concept</DialogTitle>
-          <DialogDescription>Generate documentation for a specific feature of your codebase.</DialogDescription>
+          <DialogDescription>Generate documentation for a specific concept of your codebase.</DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit}>

--- a/src/app/w/[slug]/learn/components/LearnSidebar.tsx
+++ b/src/app/w/[slug]/learn/components/LearnSidebar.tsx
@@ -25,7 +25,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { UsageDisplay } from "./UsageDisplay";
-import { CreateFeatureModal } from "./CreateFeatureModal";
+import { CreateConceptModal } from "./CreateConceptModal";
 import { formatRelativeOrDate } from "@/lib/date-utils";
 import {
   DropdownMenu,
@@ -168,7 +168,7 @@ export function LearnSidebar({
     const fetchProcessingState = async () => {
       try {
         const response = await fetch(
-          `/api/learnings/features?workspace=${encodeURIComponent(workspaceSlug)}`
+          `/api/learnings/concepts?workspace=${encodeURIComponent(workspaceSlug)}`
         );
         if (response.ok) {
           const data = await response.json();
@@ -224,7 +224,7 @@ export function LearnSidebar({
       } else {
         // Re-fetch to get updated state
         const featuresResponse = await fetch(
-          `/api/learnings/features?workspace=${encodeURIComponent(workspaceSlug)}`
+          `/api/learnings/concepts?workspace=${encodeURIComponent(workspaceSlug)}`
         );
         if (featuresResponse.ok) {
           const data = await featuresResponse.json();
@@ -279,7 +279,7 @@ export function LearnSidebar({
     }
   };
 
-  const handleFeatureCreated = () => {
+  const handleConceptCreated = () => {
     onConceptCreated?.();
   };
 
@@ -694,11 +694,11 @@ export function LearnSidebar({
       </div>
       )}
 
-      <CreateFeatureModal
+      <CreateConceptModal
         isOpen={isCreateModalOpen}
         onClose={() => setIsCreateModalOpen(false)}
         workspaceSlug={workspaceSlug}
-        onFeatureCreated={handleFeatureCreated}
+        onConceptCreated={handleConceptCreated}
         repositories={repositories}
         selectedRepoId={selectedRepoId}
         onRepoChange={setSelectedRepoId}

--- a/src/app/w/[slug]/learn/components/LearnViewer.tsx
+++ b/src/app/w/[slug]/learn/components/LearnViewer.tsx
@@ -87,7 +87,7 @@ export function LearnViewer({ workspaceSlug }: LearnViewerProps) {
         // Fetch docs, concepts, and diagrams in parallel
         const [docsResponse, conceptsResponse] = await Promise.all([
           fetch(`/api/learnings/docs?workspace=${workspaceSlug}`),
-          fetch(`/api/learnings/features?workspace=${workspaceSlug}`),
+          fetch(`/api/learnings/concepts?workspace=${workspaceSlug}`),
         ]);
 
         if (docsResponse.ok) {
@@ -130,7 +130,7 @@ export function LearnViewer({ workspaceSlug }: LearnViewerProps) {
 
         if (conceptsResponse.ok) {
           const conceptsData = await conceptsResponse.json();
-          setConcepts(Array.isArray(conceptsData) ? conceptsData : conceptsData.features || []);
+          setConcepts(Array.isArray(conceptsData) ? conceptsData : conceptsData.concepts || conceptsData.features || []);
         }
         setIsConceptsLoading(false);
       } catch (error) {
@@ -181,11 +181,11 @@ export function LearnViewer({ workspaceSlug }: LearnViewerProps) {
   const refreshConcepts = async () => {
     try {
       const response = await fetch(
-        `/api/learnings/features?workspace=${workspaceSlug}`
+        `/api/learnings/concepts?workspace=${workspaceSlug}`
       );
       if (response.ok) {
         const data = await response.json();
-        setConcepts(Array.isArray(data) ? data : data.features || []);
+        setConcepts(Array.isArray(data) ? data : data.concepts || data.features || []);
       }
     } catch (error) {
       console.error("Failed to refresh concepts:", error);
@@ -209,11 +209,11 @@ export function LearnViewer({ workspaceSlug }: LearnViewerProps) {
     if (!content) {
       try {
         const response = await fetch(
-          `/api/learnings/features/${encodeURIComponent(id)}?workspace=${workspaceSlug}`
+          `/api/learnings/concepts/${encodeURIComponent(id)}?workspace=${workspaceSlug}`
         );
         if (response.ok) {
           const data = await response.json();
-          const documentation = data?.feature?.documentation || "";
+          const documentation = data?.concept?.documentation || data?.feature?.documentation || "";
           setActiveItem({ type: "concept", id, name, content: documentation });
           setConcepts((prev) =>
             prev.map((c) => (c.id === id ? { ...c, content: documentation } : c))
@@ -286,7 +286,7 @@ export function LearnViewer({ workspaceSlug }: LearnViewerProps) {
         toast.success("Documentation saved successfully");
       } else if (activeItem.type === "concept" && activeItem.id) {
         const response = await fetch(
-          `/api/learnings/features/${encodeURIComponent(activeItem.id)}/documentation`,
+          `/api/learnings/concepts/${encodeURIComponent(activeItem.id)}/documentation`,
           {
             method: "PUT",
             headers: { "Content-Type": "application/json" },

--- a/src/components/knowledge-graph/index.tsx
+++ b/src/components/knowledge-graph/index.tsx
@@ -149,7 +149,7 @@ const GraphComponentInner = ({
 
         case 'concepts':
           // Filter for communication nodes
-          const conceptsNodeTypes = JSON.stringify(['Function', 'Endpoint', 'Feature', 'File']);
+          const conceptsNodeTypes = JSON.stringify(['Function', 'Endpoint', 'Feature', 'Concept', 'File']);
           requestUrl = `/api/workspaces/${slug}/graph/gitree?node_type=${encodeURIComponent(conceptsNodeTypes)}&limit=10000&limit_mode=per_type`;
           break;
 

--- a/src/config/middleware.ts
+++ b/src/config/middleware.ts
@@ -118,8 +118,8 @@ export const ROUTE_POLICIES: ReadonlyArray<RoutePolicy> = [
   // POST/PUT siblings on the same paths fall through to `protected`.
   { path: "/api/learnings/diagrams", strategy: "exact", access: "public", methods: ["GET"] },
   { path: "/api/learnings/docs", strategy: "exact", access: "public", methods: ["GET"] },
-  { path: "/api/learnings/features", strategy: "exact", access: "public", methods: ["GET"] },
-  { path: "/api/learnings/features/*", strategy: "pattern", access: "public", methods: ["GET"] },
+  { path: "/api/learnings/concepts", strategy: "exact", access: "public", methods: ["GET"] },
+  { path: "/api/learnings/concepts/*", strategy: "pattern", access: "public", methods: ["GET"] },
   { path: "/api/workspaces/*/learn/config", strategy: "pattern", access: "public", methods: ["GET"] },
 
   // Public dashboard chat. The single POST endpoint that drives

--- a/src/lib/ai/askTools.ts
+++ b/src/lib/ai/askTools.ts
@@ -18,7 +18,7 @@ import { getBifrostForLLM } from "@/services/bifrost/orchestrator";
 import { swarmFetch } from "./concepts";
 
 export async function listConcepts(swarmUrl: string, swarmApiKey: string): Promise<Record<string, unknown>> {
-  const r = await swarmFetch(`${swarmUrl}/gitree/features`, {
+  const r = await swarmFetch(`${swarmUrl}/gitree/concepts`, {
     method: "GET",
     headers: {
       "Content-Type": "application/json",
@@ -192,7 +192,7 @@ export function askTools(swarmUrl: string, swarmApiKey: string, repoUrls: string
       }),
       execute: async ({ conceptId }: { conceptId: string }) => {
         try {
-          const res = await swarmFetch(`${swarmUrl}/gitree/features/${encodeURIComponent(conceptId)}`, {
+          const res = await swarmFetch(`${swarmUrl}/gitree/concepts/${encodeURIComponent(conceptId)}`, {
             method: "GET",
             headers: {
               "Content-Type": "application/json",

--- a/src/lib/ai/askToolsMulti.ts
+++ b/src/lib/ai/askToolsMulti.ts
@@ -141,7 +141,7 @@ export function askToolsMulti(
       execute: async ({ conceptId }: { conceptId: string }) => {
         try {
           const res = await fetch(
-            `${ws.swarmUrl}/gitree/features/${encodeURIComponent(conceptId)}`,
+            `${ws.swarmUrl}/gitree/concepts/${encodeURIComponent(conceptId)}`,
             {
               method: "GET",
               headers: {

--- a/src/lib/ai/message-sanitizer.ts
+++ b/src/lib/ai/message-sanitizer.ts
@@ -90,7 +90,7 @@ export async function sanitizeAndCompleteToolCalls(
         const conceptId = toolCall.input?.conceptId;
         if (conceptId) {
           console.log(`🔧 Executing missing tool call: learn_concept(${conceptId})`);
-          const res = await swarmFetch(`${swarmUrl}/gitree/features/${encodeURIComponent(conceptId)}`, {
+          const res = await swarmFetch(`${swarmUrl}/gitree/concepts/${encodeURIComponent(conceptId)}`, {
             method: "GET",
             headers: {
               "Content-Type": "application/json",
@@ -108,7 +108,7 @@ export async function sanitizeAndCompleteToolCalls(
       } else if (toolCall.toolName === "list_concepts") {
         // Execute list_concepts
         console.log(`🔧 Executing missing tool call: list_concepts()`);
-        const res = await swarmFetch(`${swarmUrl}/gitree/features`, {
+        const res = await swarmFetch(`${swarmUrl}/gitree/concepts`, {
           method: "GET",
           headers: {
             "Content-Type": "application/json",

--- a/src/lib/mcp/mcpTools.ts
+++ b/src/lib/mcp/mcpTools.ts
@@ -317,7 +317,7 @@ export async function mcpLearnConcept(
 ): Promise<McpToolResult> {
   try {
     const res = await fetch(
-      `${credentials.swarmUrl}/gitree/features/${encodeURIComponent(conceptId)}`,
+      `${credentials.swarmUrl}/gitree/concepts/${encodeURIComponent(conceptId)}`,
       {
         method: "GET",
         headers: {
@@ -331,7 +331,7 @@ export async function mcpLearnConcept(
 
     const data = await res.json();
     const documentation =
-      data.feature?.documentation || "No documentation available";
+      data.concept?.documentation || data.feature?.documentation || "No documentation available";
     return { content: [{ type: "text", text: documentation }] };
   } catch (error) {
     console.error("Error fetching concept:", error);


### PR DESCRIPTION
## Why

stakgraph migrated its gitree knowledge-graph nodes from the **`Feature`** label to **`Concept`** and renamed the gitree HTTP endpoints (`/gitree/features*` -> `/gitree/concepts*`, with the old paths kept only as deprecated aliases). The UI already calls these **concepts**, so this brings hive in line and stops relying on the deprecated aliases.

> Pairs with stakgraph PR #1401.

## Changes

**hive API routes** (`git mv`):
- `/api/learnings/features*` -> `/api/learnings/concepts*` (list, `[id]`, `[id]/documentation`, `create`)
- `src/config/middleware.ts` public-access path patterns updated

**Upstream swarm calls** — moved off the deprecated aliases to the new endpoints (`/gitree/concepts*`, `/gitree/all-concepts-graph`, `/gitree/create-concept`):
- the learnings routes, `workspaces/[slug]/graph/gitree` proxy, `lib/ai/askTools`, `lib/ai/askToolsMulti`, `lib/mcp/mcpTools`, `lib/ai/message-sanitizer`, and the `mock/stakgraph/gitree` route (dir renamed to `concepts`)

**Response shape** — read the new `concepts`/`concept` keys, with `features`/`feature` fallback so it works against not-yet-migrated swarms:
- learnings list/detail proxies, `LearnViewer`, `mcpTools`, create route

**Knowledge graph** — concept node-type list now includes `Concept` (kept `Feature` for back-compat).

**Component rename** — `CreateFeatureModal` -> `CreateConceptModal` (file, component, props, `onConceptCreated`, UI copy). The unrelated `DashboardChat/CreateFeatureModal` (plan/task launcher, hive's own roadmap "feature") is intentionally left untouched.

**Tests** — updated integration/unit test paths, imports, and mocked upstream URLs.

## Notes

- The `features`/`feature` fallbacks make this safe to deploy independent of swarm migration timing.
- Typecheck: no new source errors in touched files (only stale, gitignored `.next-dev` generated route types, which regenerate on build; plus pre-existing Prisma-client drift unrelated to this change).
- hive's own `db.feature` / task-domain "feature" entity is unchanged — only the stakgraph-concept surface was renamed.