### PR TITLE
fix: unwrap concepts array from stakgraph /gitree/prs response

### DIFF
--- a/src/__tests__/unit/lib/graph-walker/feature-concept-bridge.test.ts
+++ b/src/__tests__/unit/lib/graph-walker/feature-concept-bridge.test.ts
@@ -123,7 +123,7 @@ function mockFetchSuccess(concepts: unknown[]) {
   global.fetch = vi.fn().mockResolvedValueOnce({
     ok: true,
     status: 200,
-    json: async () => concepts,
+    json: async () => ({ concepts }),
   } as unknown as Response);
 }
 
@@ -242,13 +242,13 @@ describe("linkFeatureToConcepts", () => {
         .mockResolvedValueOnce({
           ok: true,
           status: 200,
-          json: async () => [CONCEPT_WITH_REF],
+          json: async () => ({ concepts: [CONCEPT_WITH_REF] }),
         } as unknown as Response)
         // Second run
         .mockResolvedValueOnce({
           ok: true,
           status: 200,
-          json: async () => [CONCEPT_WITH_REF],
+          json: async () => ({ concepts: [CONCEPT_WITH_REF] }),
         } as unknown as Response);
 
       const result1 = await linkFeatureToConcepts(FEATURE_ID);
@@ -355,12 +355,12 @@ describe("backfillFeatureConceptEdges", () => {
         .mockResolvedValueOnce({
           ok: true,
           status: 200,
-          json: async () => [CONCEPT_WITH_REF],
+          json: async () => ({ concepts: [CONCEPT_WITH_REF] }),
         } as unknown as Response)
         .mockResolvedValueOnce({
           ok: true,
           status: 200,
-          json: async () => [CONCEPT_WITH_REF],
+          json: async () => ({ concepts: [CONCEPT_WITH_REF] }),
         } as unknown as Response);
 
       const result = await backfillFeatureConceptEdges({ orgId: ORG_ID });

--- a/src/lib/graph-walker/feature-concept-bridge.ts
+++ b/src/lib/graph-walker/feature-concept-bridge.ts
@@ -177,7 +177,8 @@ export async function linkFeatureToConcepts(
         continue;
       }
 
-      concepts = (await response.json()) as StakgraphConcept[];
+      const body = (await response.json()) as { concepts?: StakgraphConcept[] };
+      concepts = body.concepts ?? [];
     } catch (err) {
       console.error("[FeatureConceptBridge] fetch failed", {
         featureId,


### PR DESCRIPTION
## Problem

The Feature→Concept bridge (`linkFeatureToConcepts`) treated the entire stakgraph response body as the concepts array:

```ts
concepts = (await response.json()) as StakgraphConcept[];
```

But `GET {swarmUrl}/gitree/prs/:prNumber` actually returns an **object**:

```json
{ "pr": { ... }, "concepts": [ { "id": "...", "ref_id": "...", "name": "...", "description": "..." } ] }
```

So `concepts` was the wrapper object, and `for (const concept of concepts)` threw `TypeError: not iterable`. That throw is outside the local try/catch, so it propagated to:

- the **backfill** loop's per-feature catch → counted as `skipped`
- the **live path** (`tasks/[taskId]/messages/save`) fire-and-forget `.catch` → silently swallowed

Net result: **no Feature→Concept `UrnEdge` rows were ever created** by either path. A backfill run reported `{ featuresProcessed: 787, edgesUpserted: 0, skipped: 1017, skippedNoRefId: 0 }` — `skippedNoRefId: 0` was the tell that we never reached concept parsing.

## Fix

Unwrap `body.concepts`:

```ts
const body = (await response.json()) as { concepts?: StakgraphConcept[] };
concepts = body.concepts ?? [];
```

Single function, used by both callers — fixes the backfill and the live path at once.

## Tests

The existing unit mocks encoded the wrong (bare-array) shape, which is why they passed against the bug. Updated `mockFetchSuccess` and the two inline fetch mocks to return `{ concepts: [...] }`, so the suite now matches the real swarm contract and guards the regression. All 11 tests pass.

## Verification

Confirmed against a live swarm (`/gitree/prs/1`) that the response shape is `{ pr, concepts }` and concepts carry `ref_id`.

After merge + deploy: re-run the backfill (idempotent) to repair historical features; new PRs link automatically via the live path.