### PR TITLE
fix(kg): enable kg realm in agent docs + cap graph_neighbors

### DIFF
--- a/src/__tests__/unit/lib/ai/kg-adapter.test.ts
+++ b/src/__tests__/unit/lib/ai/kg-adapter.test.ts
@@ -211,6 +211,39 @@ describe("kgGetNeighbors", () => {
     expect(neighbors).toHaveLength(0);
   });
 
+  it("caps neighbors at 50 (hot node with many edges)", async () => {
+    const edges = Array.from({ length: 200 }, (_, i) => ({
+      source: QUERIED_REF,
+      target: `n-${i}`,
+      edge_type: "MODIFIES",
+      properties: {},
+    }));
+    globalThis.fetch = mockFetch({ nodes: [], edges });
+
+    const { neighbors, reachable } = await kgGetNeighbors(
+      JARVIS_URL,
+      API_KEY,
+      QUERIED_REF,
+    );
+
+    expect(reachable).toBe(true);
+    expect(neighbors).toHaveLength(50);
+  });
+
+  it("dedups a neighbor reached via multiple parallel edges", async () => {
+    const edges = [
+      { source: QUERIED_REF, target: "dup", edge_type: "MODIFIES", properties: {} },
+      { source: QUERIED_REF, target: "dup", edge_type: "MODIFIES", properties: {} },
+      { source: QUERIED_REF, target: "other", edge_type: "MODIFIES", properties: {} },
+    ];
+    globalThis.fetch = mockFetch({ nodes: [], edges });
+
+    const { neighbors } = await kgGetNeighbors(JARVIS_URL, API_KEY, QUERIED_REF);
+
+    expect(neighbors).toHaveLength(2);
+    expect(neighbors.map((n) => n.ref_id).sort()).toEqual(["dup", "other"]);
+  });
+
   it("reachable: false when fetch throws", async () => {
     globalThis.fetch = mockFetchThrow();
 

--- a/src/lib/ai/graphWalkerTools.ts
+++ b/src/lib/ai/graphWalkerTools.ts
@@ -4,10 +4,10 @@
  * Exposes three agent tools:
  *   - `graph_get`       — resolve a single URN to its full node content
  *   - `graph_neighbors` — return all adjacent URNs reachable in one hop
- *   - `graph_search`    — keyword search across pg and canvas realms
+ *   - `graph_search`    — keyword search across pg, canvas, and kg realms
  *
- * v1 scope: pg and canvas realms are fully implemented.
- * kg realm is a clearly-marked stub returning { error: "kg realm not yet enabled" }.
+ * All three realms are live: pg (Postgres roadmap), canvas (canvas nodes), and
+ * kg (the swarm knowledge graph, served by Jarvis v2 over HTTP).
  *
  * All tools are read-only — no node creation, edge writes, or swarm mutations.
  */
@@ -606,7 +606,7 @@ export function buildGraphWalkerTools(
       description:
         "Resolve a single URN to its full node content. " +
         "Routes by realm: `pg` and `canvas` URNs are resolved locally; " +
-        "`kg` URNs are not yet enabled in v1. " +
+        "`kg` URNs are resolved live from the swarm knowledge graph (Jarvis). " +
         "Use this when you have a specific URN and need the entity's data.",
       inputSchema: z.object({
         urn: z.string().describe(

--- a/src/lib/ai/kg-adapter.ts
+++ b/src/lib/ai/kg-adapter.ts
@@ -56,6 +56,13 @@ export interface KgNeighborsResponse {
 // ---------------------------------------------------------------------------
 
 /**
+ * Max neighbors returned in a single hop. Mirrors pgNeighbors' DEFAULT_CAP (50).
+ * A hot kg node (e.g. a concept) can connect to hundreds of files/edges; without
+ * a cap the tool result floods the agent's context and token budget.
+ */
+const KG_NEIGHBOR_CAP = 50;
+
+/**
  * Encode an array as a Python list literal string, e.g. `["MODIFIES","CITES"]`.
  * This is the format Jarvis v2 expects for filter params.
  */
@@ -181,6 +188,7 @@ export async function kgGetNeighbors(
     }
 
     const neighbors: KgNeighborResult[] = [];
+    const seen = new Set<string>();
     for (const edge of data.edges ?? []) {
       const direction: "forward" | "reverse" =
         edge.source === refId ? "forward" : "reverse";
@@ -188,6 +196,11 @@ export async function kgGetNeighbors(
 
       // Skip if the neighbor is the queried node itself (self-loop guard / source dedup)
       if (neighborRefId === refId) continue;
+
+      // Dedup by neighbor — a node can be reached via multiple parallel edges
+      // (e.g. several MODIFIES). Keep the first occurrence.
+      if (seen.has(neighborRefId)) continue;
+      seen.add(neighborRefId);
 
       const nodeDetail = nodeMap.get(neighborRefId);
       // If the node detail isn't in the nodes array, derive what we can from the edge
@@ -203,6 +216,9 @@ export async function kgGetNeighbors(
         ref_id: neighborRefId,
         ...(importance !== undefined ? { importance } : {}),
       });
+
+      // Cap to keep tool output within the agent's context/token budget.
+      if (neighbors.length >= KG_NEIGHBOR_CAP) break;
     }
 
     return { neighbors, reachable: true };

--- a/src/lib/constants/prompt.ts
+++ b/src/lib/constants/prompt.ts
@@ -544,6 +544,7 @@ Always check the chat history's **last ASSISTANT message** first. The planner en
 - You can see the planner's most recent \`FORM\` artifact (its structured clarifying question with options) in \`read_feature\`'s chat history. The user typically answers FORMs on the per-feature plan page (the \`AttentionList\` surfaces them on canvas entry), but if you have the answer from prior context — or the question is purely procedural — you can answer it yourself with \`send_to_feature_planner\` and tell the user one line.
 - "Keep moving forward" beats "be thorough." A short *"Told the planner to proceed to architecture"* is a better reply than a 200-word review.
 - **Plan stages run in order: brief → requirements → architecture.** Check \`read_feature\`’s \`brief\`, \`requirements\`, and \`architecture\` fields — only when all three are populated is the plan ready for task generation.
+- **Before telling the planner to write architecture or generate tasks, make sure any contract it depends on that's owned by ANOTHER workspace gets verified against that workspace.** The biggest source of bugs is a plan that codes against an endpoint, field name, type, or data shape that doesn't actually exist or has drifted. The per-feature planner only sees its OWN workspace's codebase — it can't see a contract another team owns, so left alone it will guess. When the plan leans on a cross-workspace shape, **instruct the planner to go look into that workspace and confirm the real contract before it proceeds**: include \`@that-workspace\` in your \`send_to_feature_planner\` message — the \`@slug\` attaches that workspace's swarm as a sub-agent the planner can query — AND explicitly tell it to verify the exact route / field names / types there before writing the architecture. Attaching the workspace alone is not enough; the planner has to be *told* to use it. If the plan still comes back citing a cross-workspace contract that looks guessed or unconfirmed, escalate: spend your own \`<slug>__repo_agent\` to confirm it yourself, then fold the verified shape back via \`send_to_feature_planner\`. (Shapes wholly inside the feature's own workspace need none of this — the planner verifies those itself; don't slow the plan down for them.)
 - **When the plan looks complete, keep it moving — proactively generate tasks.** Once \`brief\`, \`requirements\`, and \`architecture\` are all populated and the architecture looks sound, **don't stop and wait for permission** — go ahead and drive task generation by calling \`send_to_feature_planner\` with *"The architecture looks complete — please generate the tasks now."* The planner triggers the generation run. Tell the user one line: *"Architecture's done and looks solid — told the planner to generate tasks."* This is exactly the kind of forward motion you exist to provide; a finished plan that just sits there waiting is the failure mode. Only hold off and ask the user first if (a) you spotted a real architectural blocker, or (b) the user explicitly said they want to review the plan before tasks. You don't generate tasks yourself (you have no such tool) — you delegate to the planner, which owns that run. (Once tasks exist, *starting* them is the user's call — a **Start Tasks** button appears on the feature's card in this chat; don't try to start them yourself.)
 
 #### When a planner wakes you (not the user)
@@ -673,7 +674,7 @@ pg / canvas  →  urn:{org}:{realm}:{type}:{id}
 kg           →  urn:{org}:kg:{workspace}:{type}:{id}
 \`\`\`
 
-Realms: \`pg\` (Postgres roadmap entities), \`canvas\` (canvas nodes), \`kg\` (workspace knowledge-graph — not yet enabled in v1).
+Realms: \`pg\` (Postgres roadmap entities), \`canvas\` (canvas nodes), \`kg\` (the swarm code knowledge-graph — concepts, files, functions, data models).
 
 ### Tools
 
@@ -684,13 +685,14 @@ Realms: \`pg\` (Postgres roadmap entities), \`canvas\` (canvas nodes), \`kg\` (w
 - **\`graph_search({ query, realm?, type?, workspace?, limit? })\`** — Discover nodes by keyword. Returns \`{ urn, type, title, realm }[]\` ranked results. Scope with \`realm\` and/or \`type\` to narrow results:
   - \`realm: "pg"\` — searches features, initiatives, milestones, tasks, workspaces, and repositories by title/name (features also match on their brief/requirements/architecture plan content; tasks also match on description; workspaces also match on description/mission; repositories also match on description/URL), plus research docs (title/topic/summary/content), connection docs (name/summary/architecture), and org-canvas chat conversations (title + message content)
   - \`realm: "canvas"\` — searches **authored** canvas nodes by text/label only. Projected/live cards (workspace/initiative/feature/milestone/repository/research) are NOT in this arm — find those via their pg types instead.
-  - Omit \`realm\` to search both pg and canvas simultaneously
+  - \`realm: "kg"\` — searches the swarm code knowledge-graph (concepts, files, functions, …). Provide \`workspace\` to search one workspace's swarm, or omit it to fan out across all your member workspaces.
+  - Omit \`realm\` to search pg and canvas simultaneously (kg is searched only when explicitly requested with \`realm: "kg"\`)
   - Narrow pg results with \`type\`: \`"feature"\`, \`"initiative"\`, \`"milestone"\`, \`"task"\`, \`"workspace"\`, \`"repository"\`, \`"research"\`, \`"connection"\`, or \`"conversation"\`
   - From a \`workspace\` URN, \`graph_neighbors\` walks \`HAS_MEMBER\` → workspace members, and each member's \`IS_USER\` → the underlying user
 
 ### Scope reminder
 
-pg and canvas realms are live. **kg realm is not yet enabled** — \`graph_get\` or \`graph_neighbors\` with a \`kg\` URN, or \`graph_search\` with \`realm: "kg"\`, will return \`{ error: "kg realm not yet enabled" }\`. Default (no realm) searches pg + canvas only, not kg.
+All three realms are live (pg, canvas, kg). The chain that connects roadmap to code: a \`pg:feature\` links to \`kg:concept\` nodes (edge type \`implemented-by\`, surfaced by \`graph_neighbors\`), and from a \`kg:concept\` you can walk to the files/functions that implement it (filter with \`node_type\`, e.g. \`["File"]\`). kg traversal talks to the live swarm, so it can fail if the swarm is unconfigured/unreachable — those calls return an \`{ error }\` you should treat as "unavailable", not "empty". Default \`graph_search\` (no realm) searches pg + canvas; request \`realm: "kg"\` to search the code graph.
 
 ### Read-only
 


### PR DESCRIPTION
Two follow-ups after the kg realm was unstubbed (#4513), found during a review of the graph-walker stack against a live swarm.

## 1. The agent was still told kg is disabled (blocker)

#4513 unstubbed the kg code and updated the `graph_neighbors`/`graph_search` **tool** descriptions, but missed the agent's **capability prompt** — the text the model actually reasons over. It still said:

> **kg realm is not yet enabled** … Default (no realm) searches pg + canvas only, not kg.

Plus `graph_get`'s description ("`kg` URNs are not yet enabled in v1") and the file header ("clearly-marked stub"). Net effect: kg works, but the model believes it's disabled and won't call it — DOA in production.

Updated `getGraphWalkerCapabilitySnippet` (`prompt.ts`), the `graph_get` description, and the header to:
- describe all three realms (pg / canvas / kg) as live,
- document the roadmap→code chain: `pg:feature → (implemented-by) kg:concept → files/functions` (filter with `node_type: ["File"]`),
- note kg traversal hits the live swarm, so an `{ error }` means "unavailable", not "empty",
- add the `realm: "kg"` search guidance (single `workspace` or fan-out).

## 2. `graph_neighbors` on kg nodes was uncapped (high)

`pgNeighbors` caps at 50; `kgGetNeighbors` returned **every** edge. Verified live: a single concept node connects to **120 `File` nodes / 794 edges** — an unfiltered `graph_neighbors` would flood the agent's context and token budget.

Now dedups neighbors by `ref_id` (a node reachable via several parallel `MODIFIES` edges collapses to one) and caps at 50, matching `pgNeighbors`' `DEFAULT_CAP`. Server-side `node_type`/`edge_type` filters (which Jarvis honors — confirmed in `get_node_edges`) still narrow before the cap when supplied.

## Tests
`kg-adapter` gains cap + dedup tests; `kg-adapter` (22) and `graphWalkerTools` (37) suites pass. Production sources typecheck clean.

## Not included (product decisions, flagged separately)
- `graph_get` is org-scoped but `graph_neighbors` requires workspace membership — cross-workspace neighbor traversal is silently dropped for org-but-not-workspace members.
- `graph_get` returns null for `deployment`/`workflowtask`/`chatmessage` neighbor URNs (no `loadNodeDetail` case).
- The two `requiresMigration` registry edges (`repository→HAS_TASK`, `feature→BLOCKED_BY_FEATURE`) stay disabled until their indexes ship.