### PR TITLE
fix(backfill): resumable, timeout-safe feature→concept backfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "seed:action-nodes": "tsx scripts/helpers/seed-graph-action-nodes.ts",
     "seed:workflow-versions": "tsx scripts/helpers/seed-workflow-versions.ts",
     "test:decrypt": "tsx scripts/helpers/decrypt-and-log.ts",
+    "backfill:feature-concepts": "tsx scripts/backfill-feature-concepts.ts",
     "test:pr-docs": "tsx scripts/test-pr-docs.ts",
     "decrypt-json": "tsx scripts/decrypt-json-file.ts"
   },

--- a/scripts/backfill-feature-concepts.ts
+++ b/scripts/backfill-feature-concepts.ts
@@ -1,0 +1,76 @@
+/**
+ * Backfill Feature→Concept (`implemented-by`) UrnEdges to completion.
+ *
+ * Runs the resumable backfill in-process, looping batches until done. Because
+ * it does NOT go through the serverless HTTP route, there is no
+ * FUNCTION_INVOCATION_TIMEOUT — it just runs until every feature is processed.
+ *
+ * Usage:
+ *   npx dotenv-cli -e .env.prod -- npx tsx scripts/backfill-feature-concepts.ts <orgId> [workspaceId]
+ *
+ * Options (env or flags):
+ *   --batch=N     features per batch (default 50)
+ *   --budget=MS   per-batch wall-clock budget in ms (default 120000)
+ *
+ * Requires DATABASE_URL and the swarm encryption key (the backfill decrypts
+ * each workspace's swarm API key to call stakgraph) — provide via .env.prod.
+ */
+
+import { backfillFeatureConceptEdges } from "@/lib/graph-walker";
+
+function parseFlag(name: string): string | undefined {
+  const hit = process.argv.find((a) => a.startsWith(`--${name}=`));
+  return hit?.split("=")[1];
+}
+
+async function main() {
+  const positional = process.argv.slice(2).filter((a) => !a.startsWith("--"));
+  const orgId = positional[0];
+  const workspaceId = positional[1];
+
+  if (!orgId) {
+    console.error(
+      "Usage: tsx scripts/backfill-feature-concepts.ts <orgId> [workspaceId] [--batch=N] [--budget=MS]",
+    );
+    process.exit(1);
+  }
+
+  const batchSize = parseFlag("batch") ? Number(parseFlag("batch")) : undefined;
+  const budgetMs = parseFlag("budget") ? Number(parseFlag("budget")) : undefined;
+
+  let cursor: string | undefined;
+  let batch = 0;
+  const totals = { featuresProcessed: 0, edgesUpserted: 0, skipped: 0, skippedNoRefId: 0 };
+
+  console.info(`[backfill] starting org=${orgId}${workspaceId ? ` workspace=${workspaceId}` : ""}`);
+
+  for (;;) {
+    const res = await backfillFeatureConceptEdges({ orgId, workspaceId, cursor, batchSize, budgetMs });
+    batch++;
+    totals.featuresProcessed += res.featuresProcessed;
+    totals.edgesUpserted += res.edgesUpserted;
+    totals.skipped += res.skipped;
+    totals.skippedNoRefId += res.skippedNoRefId;
+
+    console.info(
+      `[backfill] batch ${batch}: +${res.featuresProcessed} features, +${res.edgesUpserted} edges ` +
+        `(running totals: ${totals.featuresProcessed} features, ${totals.edgesUpserted} edges) ` +
+        `${res.hasMore ? `→ continuing after ${res.nextCursor}` : "→ done"}`,
+    );
+
+    if (!res.hasMore) break;
+    cursor = res.nextCursor ?? undefined;
+    if (!cursor) {
+      console.warn("[backfill] hasMore was true but no cursor returned — stopping to avoid a loop");
+      break;
+    }
+  }
+
+  console.info("[backfill] complete", totals);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("[backfill] fatal", err);
+  process.exit(1);
+});

--- a/src/__tests__/unit/lib/graph-walker/feature-concept-bridge.test.ts
+++ b/src/__tests__/unit/lib/graph-walker/feature-concept-bridge.test.ts
@@ -369,4 +369,75 @@ describe("backfillFeatureConceptEdges", () => {
       expect(result.edgesUpserted).toBe(2);
     });
   });
+
+  describe("resumability (cursor / batch / budget)", () => {
+    it("queries a keyset page: id asc, take = batchSize + 1, id > cursor", async () => {
+      mockDb.feature.findMany.mockResolvedValue([]);
+
+      await backfillFeatureConceptEdges({
+        orgId: ORG_ID,
+        cursor: "feat-cursor",
+        batchSize: 10,
+      });
+
+      expect(mockDb.feature.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ id: { gt: "feat-cursor" } }),
+          orderBy: { id: "asc" },
+          take: 11,
+        }),
+      );
+    });
+
+    it("returns hasMore + nextCursor when more rows remain than the batch", async () => {
+      // batchSize 2 → take 2 → fetch 3 (the extra signals 'more remain')
+      mockDb.feature.findMany.mockResolvedValue([
+        { id: "f1" },
+        { id: "f2" },
+        { id: "f3" },
+      ]);
+      // linkFeatureToConcepts: findUnique → undefined → ZERO_RESULT, no throw
+      mockDb.feature.findUnique.mockResolvedValue(undefined);
+
+      const result = await backfillFeatureConceptEdges({
+        orgId: ORG_ID,
+        batchSize: 2,
+      });
+
+      expect(result.featuresProcessed).toBe(2); // only the batch, not the probe row
+      expect(result.hasMore).toBe(true);
+      expect(result.nextCursor).toBe("f2"); // last processed id
+    });
+
+    it("returns hasMore=false and nextCursor=null when the batch isn't full", async () => {
+      mockDb.feature.findMany.mockResolvedValue([{ id: "f1" }]);
+      mockDb.feature.findUnique.mockResolvedValue(undefined);
+
+      const result = await backfillFeatureConceptEdges({
+        orgId: ORG_ID,
+        batchSize: 50,
+      });
+
+      expect(result.hasMore).toBe(false);
+      expect(result.nextCursor).toBeNull();
+    });
+
+    it("stops before the timeout when the budget is exhausted, resuming from the incoming cursor", async () => {
+      mockDb.feature.findMany.mockResolvedValue([{ id: "f1" }, { id: "f2" }]);
+      mockDb.feature.findUnique.mockResolvedValue(undefined);
+
+      // budgetMs negative → the time check trips on the first iteration, so
+      // nothing is processed and the caller is told to resume from where it was.
+      const result = await backfillFeatureConceptEdges({
+        orgId: ORG_ID,
+        cursor: "prev",
+        batchSize: 50,
+        budgetMs: -1,
+      });
+
+      expect(result.featuresProcessed).toBe(0);
+      expect(result.hasMore).toBe(true);
+      expect(result.nextCursor).toBe("prev");
+    });
+  });
 });

--- a/src/app/api/admin/graph/feature-concept-backfill/route.ts
+++ b/src/app/api/admin/graph/feature-concept-backfill/route.ts
@@ -2,12 +2,22 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireSuperAdmin } from "@/lib/auth/require-superadmin";
 import { backfillFeatureConceptEdges } from "@/lib/graph-walker";
 
+// Give each batch room to run; the backfill also self-limits via `budgetMs`
+// (default 120s) so it returns a resumable cursor before this cap is hit.
+export const maxDuration = 300;
+
 export async function POST(request: NextRequest) {
   const authResult = await requireSuperAdmin(request);
   if (authResult instanceof NextResponse) return authResult;
 
   try {
-    const body = (await request.json()) as { orgId?: string; workspaceId?: string };
+    const body = (await request.json()) as {
+      orgId?: string;
+      workspaceId?: string;
+      cursor?: string;
+      batchSize?: number;
+      budgetMs?: number;
+    };
 
     if (!body.orgId) {
       return NextResponse.json({ error: "orgId is required" }, { status: 400 });
@@ -16,6 +26,9 @@ export async function POST(request: NextRequest) {
     const result = await backfillFeatureConceptEdges({
       orgId: body.orgId,
       workspaceId: body.workspaceId,
+      cursor: body.cursor,
+      batchSize: body.batchSize,
+      budgetMs: body.budgetMs,
     });
 
     return NextResponse.json(result);

--- a/src/lib/graph-walker/feature-concept-bridge.ts
+++ b/src/lib/graph-walker/feature-concept-bridge.ts
@@ -38,6 +38,13 @@ export interface BackfillResult {
   edgesUpserted: number;
   skipped: number;
   skippedNoRefId: number;
+  /**
+   * Keyset cursor: the id of the last feature processed in this batch. Pass it
+   * back as `cursor` to resume after it. `null` when the run reached the end.
+   */
+  nextCursor: string | null;
+  /** True when more features remain beyond this batch (call again with `nextCursor`). */
+  hasMore: boolean;
 }
 
 const ZERO_RESULT: FeatureConceptResult = {
@@ -221,34 +228,76 @@ export async function linkFeatureToConcepts(
 // Backfill
 // ---------------------------------------------------------------------------
 
+const DEFAULT_BATCH_SIZE = 50;
+const MAX_BATCH_SIZE = 500;
+const DEFAULT_BUDGET_MS = 120_000;
+
 /**
- * Backfill Feature→Concept edges for all features in an org (optionally
- * scoped to a single workspace). Safe to re-run at any time.
+ * Backfill Feature→Concept edges for features in an org (optionally scoped to a
+ * single workspace).
+ *
+ * RESUMABLE & BOUNDED. Each call processes at most `batchSize` features and runs
+ * for at most `budgetMs`, then returns a keyset `cursor`. This is what keeps the
+ * job under a serverless function timeout: instead of one unbounded loop over
+ * thousands of features (which gets killed mid-way by FUNCTION_INVOCATION_TIMEOUT
+ * and never reaches the tail), the caller drives it in safe chunks, passing the
+ * returned `nextCursor` back until `hasMore` is false.
+ *
+ * Features are walked in a stable `id asc` keyset order so progress is monotonic
+ * — every call advances past the previous cursor regardless of whether edges were
+ * produced (features with no PRs / no concepts won't be re-processed on resume).
+ * Idempotent — safe to re-run or overlap.
  */
 export async function backfillFeatureConceptEdges({
   orgId,
   workspaceId,
+  cursor,
+  batchSize = DEFAULT_BATCH_SIZE,
+  budgetMs = DEFAULT_BUDGET_MS,
 }: {
   orgId: string;
   workspaceId?: string;
+  /** Resume after this feature id (exclusive). Omit to start from the beginning. */
+  cursor?: string;
+  /** Max features to process this call. Clamped to [1, 500]. */
+  batchSize?: number;
+  /** Soft wall-clock budget; stop early (with a resumable cursor) once exceeded. */
+  budgetMs?: number;
 }): Promise<BackfillResult> {
-  const features = await db.feature.findMany({
+  const take = Math.min(Math.max(Math.trunc(batchSize), 1), MAX_BATCH_SIZE);
+  const start = Date.now();
+
+  // Fetch one extra row to detect whether more remain past this batch.
+  const rows = await db.feature.findMany({
     where: {
       deleted: false,
       workspace: {
         sourceControlOrgId: orgId,
         ...(workspaceId ? { id: workspaceId } : {}),
       },
+      ...(cursor ? { id: { gt: cursor } } : {}),
     },
     select: { id: true },
+    orderBy: { id: "asc" },
+    take: take + 1,
   });
+
+  const moreBeyondBatch = rows.length > take;
+  const batch = moreBeyondBatch ? rows.slice(0, take) : rows;
 
   let featuresProcessed = 0;
   let edgesUpserted = 0;
   let skipped = 0;
   let skippedNoRefId = 0;
+  let lastProcessedId: string | null = null;
+  let stoppedEarly = false;
 
-  for (const feature of features) {
+  for (const feature of batch) {
+    // Stop before the function times out; the cursor lets the caller resume.
+    if (Date.now() - start > budgetMs) {
+      stoppedEarly = true;
+      break;
+    }
     try {
       const result = await linkFeatureToConcepts(feature.id);
       featuresProcessed++;
@@ -262,16 +311,34 @@ export async function backfillFeatureConceptEdges({
       });
       skipped++;
     }
+    lastProcessedId = feature.id;
   }
 
-  console.info("[FeatureConceptBridge] backfill complete", {
+  // More work remains if we cut the batch short, or there were rows past it.
+  const hasMore = stoppedEarly || moreBeyondBatch;
+  // Resume after the last id we actually processed. If we processed nothing this
+  // call (e.g. budget already exceeded), keep the incoming cursor so the caller
+  // doesn't skip unprocessed features.
+  const nextCursor = hasMore ? (lastProcessedId ?? cursor ?? null) : null;
+
+  console.info("[FeatureConceptBridge] backfill batch complete", {
     orgId,
     workspaceId,
     featuresProcessed,
     edgesUpserted,
     skipped,
     skippedNoRefId,
+    hasMore,
+    nextCursor,
+    elapsedMs: Date.now() - start,
   });
 
-  return { featuresProcessed, edgesUpserted, skipped, skippedNoRefId };
+  return {
+    featuresProcessed,
+    edgesUpserted,
+    skipped,
+    skippedNoRefId,
+    nextCursor,
+    hasMore,
+  };
 }


### PR DESCRIPTION
## Problem

The feature→concept backfill (`backfillFeatureConceptEdges`) was a single unbounded loop over **every** feature in the org, calling stakgraph once per PR. On a large org it ran past the serverless cap and was killed with **FUNCTION_INVOCATION_TIMEOUT** partway through — and because re-running restarted from the beginning (no ordering, no cursor), it re-did the same prefix and died at the same spot, never reaching the tail.

Observed on prod: 1054 concept edges landed on the first ~454 features processed, but the features processed *after* the first timeout — which happened to include nearly all initiative-attached features — got **zero** edges. (E.g. the Canvas Chat initiative: 28 features, only 1 with a concept edge.) Re-running the curl couldn't recover it.

## Fix — make it resumable and bounded

- **Keyset pagination** (`id asc`, `where id > cursor`) so progress is monotonic. Every call advances past the previous cursor regardless of whether edges were produced, so no-PR / no-concept features are never re-walked on resume.
- **Per-call `batchSize` cap** (default 50, max 500) **+ soft wall-clock `budgetMs`** (default 120s). A call always returns a resumable cursor *before* the function can time out. The response now includes `{ nextCursor, hasMore }`.
- **Route** accepts `cursor` / `batchSize` / `budgetMs` and sets `maxDuration = 300`.
- **Driver script** `scripts/backfill-feature-concepts.ts` (`npm run backfill:feature-concepts`) loops batches **in-process to completion with no HTTP timeout at all** — the simplest way to fully backfill a large org.

Still idempotent (`upsertEdge`); safe to re-run or overlap.

## How to finish the prod backfill

**Option A — one shot, no timeout (recommended):**
```bash
npx dotenv-cli -e .env.prod -- npx tsx scripts/backfill-feature-concepts.ts <orgId> [workspaceId]
```
Runs every batch until `hasMore` is false, printing running totals.

**Option B — drive the endpoint with a cursor loop:**
```bash
CURSOR=null
while : ; do
  RESP=$(curl -s -X POST https://YOUR_DOMAIN/api/admin/graph/feature-concept-backfill \
    -H 'Content-Type: application/json' \
    -H "Cookie: __Secure-next-auth.session-token=$TOKEN" \
    -d "{\"orgId\":\"<orgId>\",\"cursor\":$CURSOR,\"batchSize\":50}")
  echo "$RESP"
  [ "$(echo "$RESP" | jq -r .hasMore)" = true ] || break
  CURSOR=$(echo "$RESP" | jq -c .nextCursor)
done
```

## Tests
Adds resumability tests (keyset cursor filter, `hasMore`/`nextCursor`, budget early-stop). Full `feature-concept-bridge` suite passes (15); changed sources typecheck clean.

Note: this only fixes *coverage delivery*. Whether a given feature ends up with concept edges still depends on its tasks having merged PRs that stakgraph maps to concepts — which is why planning-only features (and unattached initiatives) legitimately stay empty.