### PR TITLE
fix(kg): send limit to Jarvis so hub nodes don't OOM Neo4j

### DIFF
--- a/src/__tests__/unit/lib/ai/kg-adapter.test.ts
+++ b/src/__tests__/unit/lib/ai/kg-adapter.test.ts
@@ -51,8 +51,8 @@ describe("kgGetNode", () => {
       properties: { file: "src/index.ts" },
     });
     expect(globalThis.fetch).toHaveBeenCalledWith(
-      `${JARVIS_URL}/v2/nodes/node-abc`,
-      { headers: { "x-api-token": API_KEY } },
+      `${JARVIS_URL}/v2/nodes/node-abc?limit=1`,
+      expect.objectContaining({ headers: { "x-api-token": API_KEY } }),
     );
   });
 
@@ -209,6 +209,17 @@ describe("kgGetNeighbors", () => {
 
     expect(reachable).toBe(true);
     expect(neighbors).toHaveLength(0);
+  });
+
+  it("sends a limit to Jarvis to bound the Cypher traversal (OOM guard)", async () => {
+    globalThis.fetch = mockFetch({ nodes: [], edges: [] });
+
+    await kgGetNeighbors(JARVIS_URL, API_KEY, QUERIED_REF);
+
+    const calledUrl = (globalThis.fetch as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(calledUrl).toContain("expand=edges");
+    expect(calledUrl).toContain("limit=50");
   });
 
   it("caps neighbors at 50 (hot node with many edges)", async () => {

--- a/src/lib/ai/kg-adapter.ts
+++ b/src/lib/ai/kg-adapter.ts
@@ -71,8 +71,13 @@ const KG_NEIGHBOR_CAP = 50;
  */
 const KG_QUERY_LIMIT = KG_NEIGHBOR_CAP;
 
-/** Fail fast instead of hanging the agent's tool call on a pathological node. */
-const KG_FETCH_TIMEOUT_MS = 25_000;
+/**
+ * Fail fast instead of hanging the agent's tool call on a pathological node.
+ * Kept tight on purpose: with `limit` bounding the Cypher, healthy queries
+ * return in ~1s, so anything past a few seconds means the graph is overloaded
+ * (or massive) and we'd rather surface that quickly than block the agent.
+ */
+const KG_FETCH_TIMEOUT_MS = 5_000;
 
 /**
  * Encode an array as a Python list literal string, e.g. `["MODIFIES","CITES"]`.

--- a/src/lib/ai/kg-adapter.ts
+++ b/src/lib/ai/kg-adapter.ts
@@ -63,6 +63,18 @@ export interface KgNeighborsResponse {
 const KG_NEIGHBOR_CAP = 50;
 
 /**
+ * Hard limit sent to Jarvis on every node/neighbor query. This is NOT just a
+ * result cap — Jarvis applies it inside the Cypher, which is what stops a hub
+ * node (a concept touching hundreds of files) from collecting its entire
+ * neighborhood into one row and blowing past Neo4j's per-transaction memory
+ * limit (a MemoryPoolOutOfMemoryError → 500 after ~50s). Always send it.
+ */
+const KG_QUERY_LIMIT = KG_NEIGHBOR_CAP;
+
+/** Fail fast instead of hanging the agent's tool call on a pathological node. */
+const KG_FETCH_TIMEOUT_MS = 25_000;
+
+/**
  * Encode an array as a Python list literal string, e.g. `["MODIFIES","CITES"]`.
  * This is the format Jarvis v2 expects for filter params.
  */
@@ -72,6 +84,20 @@ function toPythonListLiteral(arr: string[]): string {
 
 function authHeaders(swarmApiKey: string): Record<string, string> {
   return { "x-api-token": swarmApiKey };
+}
+
+/** fetch with an abort timeout so a slow/overloaded swarm fails fast. */
+async function kgFetch(url: string, swarmApiKey: string): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), KG_FETCH_TIMEOUT_MS);
+  try {
+    return await fetch(url, {
+      headers: authHeaders(swarmApiKey),
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 /**
@@ -115,8 +141,10 @@ export async function kgGetNode(
   refId: string,
 ): Promise<KgNode | null> {
   try {
-    const url = `${jarvisUrl}/v2/nodes/${encodeURIComponent(refId)}`;
-    const res = await fetch(url, { headers: authHeaders(swarmApiKey) });
+    // limit=1 keeps Jarvis from materializing the node's whole neighborhood
+    // (which OOMs Neo4j for hub nodes). We only read the node itself here.
+    const url = `${jarvisUrl}/v2/nodes/${encodeURIComponent(refId)}?limit=1`;
+    const res = await kgFetch(url, swarmApiKey);
     if (!res.ok) return null;
     const data = (await res.json()) as
       | JarvisNode
@@ -166,7 +194,12 @@ export async function kgGetNeighbors(
   opts?: KgGetNeighborsOpts,
 ): Promise<KgNeighborsResponse> {
   try {
-    const params = new URLSearchParams({ expand: "edges" });
+    // `limit` is mandatory — it bounds the Cypher traversal so a hub node
+    // doesn't OOM Neo4j. We cap the output client-side at KG_NEIGHBOR_CAP too.
+    const params = new URLSearchParams({
+      expand: "edges",
+      limit: String(KG_QUERY_LIMIT),
+    });
     if (opts?.edgeTypes && opts.edgeTypes.length > 0) {
       params.set("edge_type", toPythonListLiteral(opts.edgeTypes));
     }
@@ -174,7 +207,7 @@ export async function kgGetNeighbors(
       params.set("node_type", toPythonListLiteral(opts.nodeTypes));
     }
     const url = `${jarvisUrl}/v2/nodes/${encodeURIComponent(refId)}?${params.toString()}`;
-    const res = await fetch(url, { headers: authHeaders(swarmApiKey) });
+    const res = await kgFetch(url, swarmApiKey);
     if (!res.ok) return { neighbors: [], reachable: false };
 
     const data = (await res.json()) as JarvisExpandEdgesResponse;
@@ -262,7 +295,7 @@ export async function kgSearch(
       params.set("node_type", opts.type);
     }
     const url = `${jarvisUrl}/v2/nodes/search?${params.toString()}`;
-    const res = await fetch(url, { headers: authHeaders(swarmApiKey) });
+    const res = await kgFetch(url, swarmApiKey);
     if (!res.ok) return [];
     const data = (await res.json()) as JarvisSearchLiteResponse;
     const nodes = Array.isArray(data?.nodes) ? data.nodes : [];

--- a/src/lib/ai/kg-adapter.ts
+++ b/src/lib/ai/kg-adapter.ts
@@ -77,7 +77,7 @@ const KG_QUERY_LIMIT = KG_NEIGHBOR_CAP;
  * return in ~1s, so anything past a few seconds means the graph is overloaded
  * (or massive) and we'd rather surface that quickly than block the agent.
  */
-const KG_FETCH_TIMEOUT_MS = 5_000;
+const KG_FETCH_TIMEOUT_MS = 25_000;
 
 /**
  * Encode an array as a Python list literal string, e.g. `["MODIFIES","CITES"]`.


### PR DESCRIPTION
## Root cause (from prod Jarvis logs)

`graph_get` / `graph_neighbors` on a well-connected kg node (e.g. the concept `c9253bde…`, which touches hundreds of files) returned `node not found` / `swarm unreachable`. The swarm wasn't down — search worked the whole time. Jarvis logged the real cause:

```
neo4j.exceptions.TransientError: MemoryPoolOutOfMemoryError
  The allocation of an extra 2.0 MiB would use more than the limit 1.0 GiB.
  ... node_helper_v2.py:354 get_node_edges → results.single()
[500 INTERNAL SERVER ERROR] [elapsed: 49.7s]
```

`get_node_edges` collects a hub node's entire neighborhood into one row and blows past Neo4j's per-transaction memory limit → 500 after ~50s. On the deployed build **both** `graph_get` (no expand) and `graph_neighbors` (expand=edges) route through `get_node_edges`, so both die on hub nodes; `graph_search` uses a different lighter endpoint and was unaffected — which is exactly the symptom pattern reported.

## Fix

The adapter wasn't sending a `limit`. Jarvis applies `limit` **inside the Cypher**, so it bounds the traversal and prevents the OOM. Verified live against swarm38: the same node returns **200 in ~1s with a limit** vs a **50s 500 without**.

- `kgGetNode` → `?limit=1` (we only read the node itself).
- `kgGetNeighbors` → `limit=50` (`KG_QUERY_LIMIT`, matches the existing client-side cap).
- All kg requests now go through `kgFetch` with a **25s `AbortController` timeout**, so a pathological/overloaded swarm fails fast instead of hanging the agent's tool call (and the misleading 50s 'unreachable').

## Tests
Updated for the new URLs + a guard test asserting the `limit` is always sent. kg-adapter (23) + graphWalkerTools (37) pass; `kg-adapter.ts` typechecks clean.

## Strongly recommended follow-up (Jarvis side)
This makes Hive's graph walker safe, but **any** caller that hits `/v2/nodes/{id}` without a `limit` (the agent UI, ad-hoc tools) can still OOM the swarm's Neo4j. The durable fix is in jarvis-backend: give `get_node_edges` a sane **default LIMIT** (and/or a memory-bounded query) so the endpoint can't be made to exceed the transaction memory pool regardless of caller. Happy to do that next if you want.