### PR TITLE
feat(graph-walker): label graph_neighbors results with human-readable titles

### DIFF
--- a/src/__tests__/unit/lib/ai/graphWalkerTools.test.ts
+++ b/src/__tests__/unit/lib/ai/graphWalkerTools.test.ts
@@ -395,6 +395,90 @@ describe("buildGraphWalkerTools", () => {
       expect(result).toEqual({ neighbors: fakeNeighbors });
     });
 
+    it("pg arm attaches a human-readable title to each neighbor (batched per type)", async () => {
+      // Real-ish URN parser so attachPgTitles groups neighbors by type/id.
+      mockParseUrn.mockImplementation((urn: string) => {
+        const [, org, realm, type, ...idParts] = urn.split(":");
+        if (realm === "kg") {
+          const [workspace, kgType, ...rest] = [type, ...idParts];
+          return { realm, org, workspace, type: kgType, id: rest.join(":") };
+        }
+        return { realm, org, type, id: idParts.join(":") };
+      });
+
+      mockPgNeighbors.mockResolvedValue([
+        { urn: "urn:myorg:pg:initiative:init-1", edgeType: "BELONGS_TO_INITIATIVE", direction: "forward" },
+        { urn: "urn:myorg:pg:milestone:ms-1", edgeType: "BELONGS_TO_MILESTONE", direction: "forward" },
+        // opaque-external neighbor — no pg recipe, must pass through untouched
+        { urn: "stakwork:workflow:42", edgeType: "REFERENCES_WORKFLOW", direction: "forward" },
+      ]);
+      dbInitiative.findMany.mockResolvedValue([{ id: "init-1", name: "Canvas Chat" }]);
+      dbMilestone.findMany.mockResolvedValue([{ id: "ms-1", name: "Planner Agent & Tooling" }]);
+
+      const tools = getTools();
+      const result = await tools.graph_neighbors.execute(
+        { urn: "urn:myorg:pg:feature:feat-1" },
+        {} as never,
+      );
+
+      // Batched: one query per distinct neighbor type
+      expect(dbInitiative.findMany).toHaveBeenCalledWith({
+        where: { id: { in: ["init-1"] } },
+        select: { id: true, name: true },
+      });
+      const neighbors = (result as { neighbors: Array<{ urn: string; title?: string }> }).neighbors;
+      expect(neighbors.find((n) => n.urn.includes("init-1"))?.title).toBe("Canvas Chat");
+      expect(neighbors.find((n) => n.urn.includes("ms-1"))?.title).toBe(
+        "Planner Agent & Tooling",
+      );
+      // opaque-external neighbor stays untouched (no title)
+      expect(neighbors.find((n) => n.urn === "stakwork:workflow:42")?.title).toBeUndefined();
+    });
+
+    it("kg arm maps the derived node name onto each neighbor's title", async () => {
+      mockParseUrn.mockReturnValue({
+        realm: "kg",
+        org: "myorg",
+        workspace: "my-ws",
+        type: "concept",
+        id: "c1",
+      });
+      mockResolveKgSeam.mockResolvedValue({
+        workspace: "my-ws",
+        swarmUrl: "https://jarvis.example.com",
+        jarvisUrl: "https://jarvis.example.com",
+        swarmApiKey: "key-123",
+      });
+      mockKgGetNeighbors.mockResolvedValue({
+        neighbors: [
+          {
+            urn: "",
+            edgeType: "MODIFIES",
+            direction: "forward",
+            node_type: "File",
+            ref_id: "file-ref",
+            name: "graphWalkerTools.ts",
+          },
+        ],
+        reachable: true,
+      });
+      mockFormatUrn.mockImplementation(
+        (p: { realm: string; org: string; workspace?: string; type: string; id: string }) =>
+          `urn:${p.org}:${p.realm}:${p.workspace ? p.workspace + ":" : ""}${p.type}:${p.id}`,
+      );
+
+      const tools = getTools();
+      const result = await tools.graph_neighbors.execute(
+        { urn: "urn:myorg:kg:my-ws:concept:c1" },
+        {} as never,
+      );
+
+      const neighbors = (result as { neighbors: Array<{ title?: string; name?: string }> }).neighbors;
+      expect(neighbors[0].title).toBe("graphWalkerTools.ts");
+      // raw `name` is folded into `title`, not duplicated on the output
+      expect(neighbors[0].name).toBeUndefined();
+    });
+
     it("canvas arm unions canvas structural edges with UrnEdge neighbors and deduplicates", async () => {
       const canvasUrn = "urn:myorg:canvas:node:ws~ref1.nodeA";
       mockParseUrn.mockReturnValue({

--- a/src/__tests__/unit/lib/ai/kg-adapter.test.ts
+++ b/src/__tests__/unit/lib/ai/kg-adapter.test.ts
@@ -268,6 +268,62 @@ describe("kgGetNeighbors", () => {
     expect(neighbors).toHaveLength(0);
   });
 
+  it("propagates the neighbor's top-level name as the neighbor label", async () => {
+    const raw = {
+      nodes: [
+        { ref_id: QUERIED_REF, node_type: "Concept", name: "Unit Tests" },
+        { ref_id: "ref-file", node_type: "File", name: "graphWalkerTools.ts" },
+      ],
+      edges: [
+        { source: QUERIED_REF, target: "ref-file", edge_type: "MODIFIES", properties: {} },
+      ],
+    };
+    globalThis.fetch = mockFetch(raw);
+
+    const { neighbors } = await kgGetNeighbors(JARVIS_URL, API_KEY, QUERIED_REF);
+
+    expect(neighbors[0].name).toBe("graphWalkerTools.ts");
+  });
+
+  it("derives a neighbor label from properties when there is no top-level name", async () => {
+    const raw = {
+      nodes: [
+        { ref_id: QUERIED_REF, node_type: "Concept" },
+        // No top-level name; label lives under properties.file_name
+        {
+          ref_id: "ref-file",
+          node_type: "File",
+          properties: { file_name: "kg-adapter.ts" },
+        },
+      ],
+      edges: [
+        { source: QUERIED_REF, target: "ref-file", edge_type: "MODIFIES", properties: {} },
+      ],
+    };
+    globalThis.fetch = mockFetch(raw);
+
+    const { neighbors } = await kgGetNeighbors(JARVIS_URL, API_KEY, QUERIED_REF);
+
+    expect(neighbors[0].name).toBe("kg-adapter.ts");
+  });
+
+  it("leaves the neighbor label empty when no recognizable field exists", async () => {
+    const raw = {
+      nodes: [
+        { ref_id: QUERIED_REF, node_type: "Concept" },
+        { ref_id: "ref-x", node_type: "Mystery", properties: { weight: 3 } },
+      ],
+      edges: [
+        { source: QUERIED_REF, target: "ref-x", edge_type: "REL", properties: {} },
+      ],
+    };
+    globalThis.fetch = mockFetch(raw);
+
+    const { neighbors } = await kgGetNeighbors(JARVIS_URL, API_KEY, QUERIED_REF);
+
+    expect(neighbors[0].name).toBe("");
+  });
+
   it("importance passthrough from edge.properties.importance", async () => {
     const raw = {
       nodes: [

--- a/src/__tests__/unit/lib/ai/kg-adapter.test.ts
+++ b/src/__tests__/unit/lib/ai/kg-adapter.test.ts
@@ -222,6 +222,16 @@ describe("kgGetNeighbors", () => {
     expect(calledUrl).toContain("limit=50");
   });
 
+  it("requests importance-ordered neighbors so the cap keeps the most important", async () => {
+    globalThis.fetch = mockFetch({ nodes: [], edges: [] });
+
+    await kgGetNeighbors(JARVIS_URL, API_KEY, QUERIED_REF);
+
+    const calledUrl = (globalThis.fetch as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(calledUrl).toContain("sort_by=importance");
+  });
+
   it("caps neighbors at 50 (hot node with many edges)", async () => {
     const edges = Array.from({ length: 200 }, (_, i) => ({
       source: QUERIED_REF,

--- a/src/lib/ai/graphWalkerTools.ts
+++ b/src/lib/ai/graphWalkerTools.ts
@@ -89,6 +89,14 @@ async function resolveCanvasNeighbors(
   const blob = asBlob(row.data);
   const results: NeighborResult[] = [];
 
+  // Map each canvas node id → its display text so each neighbor carries a
+  // human-readable label alongside its URN (the URN still holds the node id).
+  const nodeText = new Map<string, string>();
+  for (const node of blob.nodes ?? []) {
+    const text = node.text ?? node.label ?? "";
+    if (text) nodeText.set(node.id, truncateLabel(text));
+  }
+
   for (const edge of blob.edges ?? []) {
     if (edge.fromNode === nodeId) {
       results.push({
@@ -100,6 +108,7 @@ async function resolveCanvasNeighbors(
         }),
         edgeType: edge.label ?? "canvas_edge",
         direction: "forward",
+        ...(nodeText.has(edge.toNode) ? { title: nodeText.get(edge.toNode) } : {}),
       });
     } else if (edge.toNode === nodeId) {
       results.push({
@@ -111,6 +120,7 @@ async function resolveCanvasNeighbors(
         }),
         edgeType: edge.label ?? "canvas_edge",
         direction: "reverse",
+        ...(nodeText.has(edge.fromNode) ? { title: nodeText.get(edge.fromNode) } : {}),
       });
     }
   }
@@ -129,6 +139,146 @@ function deduplicateByUrn(
     if (seen.has(item.urn)) return false;
     seen.add(item.urn);
     return true;
+  });
+}
+
+/** Max length of a neighbor's display label. */
+const LABEL_MAX = 160;
+
+/** Trim and truncate a label for display in neighbor lists. */
+function truncateLabel(s: string, max = LABEL_MAX): string {
+  const trimmed = s.trim();
+  return trimmed.length > max ? trimmed.slice(0, max) : trimmed;
+}
+
+/**
+ * Per-pg-type recipe for resolving a human-readable label.
+ *
+ * `accessor` is the Prisma client property; `select` is the (id + candidate
+ * fields) projection; `pick` chooses the best semantic identifier from the row,
+ * falling back across fields since not every row populates the primary one.
+ *
+ * Access is already enforced upstream (pgNeighbors / UrnEdge.neighborsOf only
+ * emit authorized URNs), so these lookups query by id alone.
+ */
+type PgTitleRecipe = {
+  accessor: string;
+  select: Record<string, unknown>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  pick: (row: any) => string;
+};
+
+const PG_TITLE_RECIPES: Record<string, PgTitleRecipe> = {
+  feature: {
+    accessor: "feature",
+    select: { id: true, title: true },
+    pick: (r) => r.title ?? "",
+  },
+  task: {
+    accessor: "task",
+    select: { id: true, title: true },
+    pick: (r) => r.title ?? "",
+  },
+  milestone: {
+    accessor: "milestone",
+    select: { id: true, name: true },
+    pick: (r) => r.name ?? "",
+  },
+  initiative: {
+    accessor: "initiative",
+    select: { id: true, name: true },
+    pick: (r) => r.name ?? "",
+  },
+  repository: {
+    accessor: "repository",
+    select: { id: true, name: true, repositoryUrl: true },
+    pick: (r) => r.name || r.repositoryUrl || "",
+  },
+  workspace: {
+    accessor: "workspace",
+    select: { id: true, name: true, slug: true },
+    pick: (r) => r.name || r.slug || "",
+  },
+  connection: {
+    accessor: "connection",
+    select: { id: true, name: true },
+    pick: (r) => r.name ?? "",
+  },
+  research: {
+    accessor: "research",
+    select: { id: true, title: true, topic: true, summary: true },
+    pick: (r) => r.title || r.topic || r.summary || "",
+  },
+  conversation: {
+    accessor: "sharedConversation",
+    select: { id: true, title: true },
+    pick: (r) => r.title || "(untitled conversation)",
+  },
+  user: {
+    accessor: "user",
+    select: { id: true, name: true, email: true },
+    pick: (r) => r.name || r.email || "",
+  },
+  workspacemember: {
+    accessor: "workspaceMember",
+    select: { id: true, description: true, user: { select: { name: true, email: true } } },
+    pick: (r) => r.user?.name || r.user?.email || r.description || "",
+  },
+  chatmessage: {
+    accessor: "chatMessage",
+    select: { id: true, message: true },
+    pick: (r) => r.message ?? "",
+  },
+};
+
+/**
+ * Attach a best-effort `title` to every pg-realm neighbor by batch-fetching the
+ * display label per distinct type (one query per type). Non-pg neighbors
+ * (kg / canvas / opaque-external) pass through untouched — they're labeled by
+ * their own realm arms. Enrichment is best-effort: a failed/empty lookup just
+ * leaves `title` unset rather than failing the whole traversal.
+ */
+async function attachPgTitles<T extends { urn: string }>(
+  neighbors: T[],
+): Promise<T[]> {
+  const idsByType = new Map<string, Set<string>>();
+  for (const n of neighbors) {
+    const p = parseUrn(n.urn);
+    if (!p || p.realm !== "pg" || !PG_TITLE_RECIPES[p.type]) continue;
+    const set = idsByType.get(p.type) ?? new Set<string>();
+    set.add(p.id);
+    idsByType.set(p.type, set);
+  }
+  if (idsByType.size === 0) return neighbors;
+
+  // key: `${type}:${id}` → label
+  const labelByKey = new Map<string, string>();
+  await Promise.all(
+    [...idsByType.entries()].map(async ([type, ids]) => {
+      const recipe = PG_TITLE_RECIPES[type];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const model = (db as any)[recipe.accessor];
+      if (!model?.findMany) return;
+      try {
+        const rows: Array<{ id: string }> = await model.findMany({
+          where: { id: { in: [...ids] } },
+          select: recipe.select,
+        });
+        for (const row of rows ?? []) {
+          const label = truncateLabel(recipe.pick(row));
+          if (label) labelByKey.set(`${type}:${row.id}`, label);
+        }
+      } catch {
+        // best-effort — never fail neighbor traversal over a label lookup
+      }
+    }),
+  );
+
+  return neighbors.map((n) => {
+    const p = parseUrn(n.urn);
+    if (!p || p.realm !== "pg") return n;
+    const label = labelByKey.get(`${p.type}:${p.id}`);
+    return label ? { ...n, title: label } : n;
   });
 }
 
@@ -689,7 +839,8 @@ export function buildGraphWalkerTools(
           case "pg": {
             const ctx: PgNeighborContext = { userId, orgId };
             const results = await pgNeighbors(urn, ctx);
-            return { neighbors: results };
+            const neighbors = await attachPgTitles(results);
+            return { neighbors };
           }
           case "canvas": {
             const [canvasEdges, urnEdges] = await Promise.all([
@@ -697,7 +848,10 @@ export function buildGraphWalkerTools(
               UrnEdge.neighborsOf(urn),
             ]);
             const merged = deduplicateByUrn([...canvasEdges, ...urnEdges]);
-            return { neighbors: merged };
+            // Canvas structural neighbors are already labeled from node text;
+            // this also labels any pg-realm cross-realm UrnEdge neighbors.
+            const neighbors = await attachPgTitles(merged);
+            return { neighbors };
           }
           case "kg": {
             const seam = await resolveKgSeam(urn, { userId });
@@ -709,7 +863,10 @@ export function buildGraphWalkerTools(
               { edgeTypes: edge_type, nodeTypes: node_type },
             );
             if (!reachable) return { error: "swarm unreachable" };
-            const neighbors = raw.map((n) => ({
+            // Surface the derived node label as `title` (consistent with the pg
+            // and canvas arms), alongside the URN/ref_id the agent still needs
+            // to dereference or traverse further.
+            const neighbors = raw.map(({ name, ...n }) => ({
               ...n,
               urn: formatUrn({
                 realm: "kg",
@@ -718,6 +875,7 @@ export function buildGraphWalkerTools(
                 type: n.node_type,
                 id: n.ref_id,
               }),
+              ...(name ? { title: name } : {}),
             }));
             return { neighbors };
           }

--- a/src/lib/ai/kg-adapter.ts
+++ b/src/lib/ai/kg-adapter.ts
@@ -44,6 +44,8 @@ interface JarvisExpandEdgesResponse {
 export interface KgNeighborResult extends NeighborResult {
   node_type: string;
   ref_id: string;
+  /** Best-effort human-readable label for the neighbor (see deriveNodeName). */
+  name: string;
 }
 
 export interface KgNeighborsResponse {
@@ -106,24 +108,71 @@ async function kgFetch(url: string, swarmApiKey: string): Promise<Response> {
 }
 
 /**
- * Jarvis nodes do not carry a top-level `name` for most node types — the human
- * label lives in `properties` under a type-dependent key. Derive the best
- * available label, falling back to "".
+ * Max length of a derived label. Long text blobs (summary/description/content)
+ * are valid last-resort identifiers but must be truncated so a single neighbor
+ * row doesn't flood the agent's context.
+ */
+const LABEL_MAX = 160;
+
+/**
+ * Jarvis nodes do not carry a top-level `name` for most node types — and
+ * different node types (File, Function, Concept, Endpoint, Datamodel, Page,
+ * Person, Episode, …) keep their human label under wildly different keys.
+ *
+ * Rather than enumerate every type, try a generous ordered list of candidate
+ * keys: short, identifier-like fields first (name/title/file/path/symbol), then
+ * progressively longer descriptive fields as a last resort. The goal is to give
+ * the agent *some* semantic identifier alongside the URN/ref_id (not in place of
+ * it) so it can tell neighbors apart. Returns "" only when nothing usable exists.
  */
 function deriveNodeName(
   node: { name?: unknown },
   properties: Record<string, unknown>,
 ): string {
   const candidates = [
+    // Top-level name (rare but authoritative)
     node?.name,
     properties.name,
+    // Generic human labels
     properties.title,
+    properties.label,
+    properties.display_name,
+    properties.displayName,
+    properties.identifier,
+    // Code-graph identifiers (File / Function / Class / Endpoint / Datamodel)
+    properties.file_name,
+    properties.fileName,
+    properties.file,
+    properties.path,
+    properties.symbol,
+    properties.function_name,
+    properties.class_name,
+    properties.method_name,
+    properties.operation_id,
+    properties.endpoint,
+    properties.route,
+    properties.url,
+    // Misc keys
     properties.entity,
+    properties.key,
+    properties.slug,
     properties.episode_title,
     properties.show_title,
+    properties.username,
+    properties.email,
+    // Long descriptive fields — valid but truncated last-resort labels
+    properties.summary,
+    properties.description,
+    properties.text,
+    properties.content,
+    properties.body,
+    properties.docs,
   ];
   for (const c of candidates) {
-    if (typeof c === "string" && c.length > 0) return c;
+    if (typeof c === "string" && c.trim().length > 0) {
+      const trimmed = c.trim();
+      return trimmed.length > LABEL_MAX ? trimmed.slice(0, LABEL_MAX) : trimmed;
+    }
   }
   return "";
 }
@@ -217,11 +266,16 @@ export async function kgGetNeighbors(
 
     const data = (await res.json()) as JarvisExpandEdgesResponse;
 
-    // Build a lookup map for node details keyed by ref_id, excluding the queried node itself.
-    const nodeMap = new Map<string, { node_type: string }>();
+    // Build a lookup map for node details keyed by ref_id, excluding the queried
+    // node itself. Derive a human-readable label here while we still have the
+    // node's properties — otherwise the caller only sees a bare ref_id.
+    const nodeMap = new Map<string, { node_type: string; name: string }>();
     for (const node of data.nodes ?? []) {
       if (node.ref_id !== refId) {
-        nodeMap.set(node.ref_id, { node_type: node.node_type });
+        nodeMap.set(node.ref_id, {
+          node_type: node.node_type,
+          name: deriveNodeName(node, (node.properties ?? {}) as Record<string, unknown>),
+        });
       }
     }
 
@@ -252,6 +306,7 @@ export async function kgGetNeighbors(
         direction,
         node_type,
         ref_id: neighborRefId,
+        name: nodeDetail?.name ?? "",
         ...(importance !== undefined ? { importance } : {}),
       });
 

--- a/src/lib/ai/kg-adapter.ts
+++ b/src/lib/ai/kg-adapter.ts
@@ -250,9 +250,16 @@ export async function kgGetNeighbors(
   try {
     // `limit` is mandatory — it bounds the Cypher traversal so a hub node
     // doesn't OOM Neo4j. We cap the output client-side at KG_NEIGHBOR_CAP too.
+    //
+    // `sort_by=importance` makes Jarvis order edges by their `importance`
+    // property BEFORE applying `limit` (depth=1 only), so the cap keeps the most
+    // important neighbors (e.g. a Concept's documentation files, scored 0.5–1.0)
+    // instead of an arbitrary slice. Harmless for edges without importance —
+    // Jarvis coalesces a missing value to 0.
     const params = new URLSearchParams({
       expand: "edges",
       limit: String(KG_QUERY_LIMIT),
+      sort_by: "importance",
     });
     if (opts?.edgeTypes && opts.edgeTypes.length > 0) {
       params.set("edge_type", toPythonListLiteral(opts.edgeTypes));

--- a/src/lib/constants/prompt.ts
+++ b/src/lib/constants/prompt.ts
@@ -680,7 +680,7 @@ Realms: \`pg\` (Postgres roadmap entities), \`canvas\` (canvas nodes), \`kg\` (t
 
 - **\`graph_get({ urn })\`** — Resolve a single URN to its full node content. Use this when you have a specific URN and need the entity's complete data.
 
-- **\`graph_neighbors({ urn, depth? })\`** — Return all adjacent URNs reachable in one hop, with \`edgeType\` and \`direction\`. Use this to explore what a node is connected to without fetching the full content of each neighbor.
+- **\`graph_neighbors({ urn, depth? })\`** — Return all adjacent URNs reachable in one hop, each with \`edgeType\`, \`direction\`, and a best-effort \`title\` (a human-readable label — e.g. a feature's title, a file's name, a concept's name). Use the \`title\` to decide which neighbor to follow without having to \`graph_get\` every one. kg neighbors also carry \`node_type\` and \`ref_id\`; \`title\` may be absent for a node type that exposes no recognizable label.
 
 - **\`graph_search({ query, realm?, type?, workspace?, limit? })\`** — Discover nodes by keyword. Returns \`{ urn, type, title, realm }[]\` ranked results. Scope with \`realm\` and/or \`type\` to narrow results:
   - \`realm: "pg"\` — searches features, initiatives, milestones, tasks, workspaces, and repositories by title/name (features also match on their brief/requirements/architecture plan content; tasks also match on description; workspaces also match on description/mission; repositories also match on description/URL), plus research docs (title/topic/summary/content), connection docs (name/summary/architecture), and org-canvas chat conversations (title + message content)

--- a/src/lib/graph-walker/pg-neighbors.ts
+++ b/src/lib/graph-walker/pg-neighbors.ts
@@ -22,6 +22,13 @@ export interface NeighborResult {
   urn: string;
   edgeType: string;
   direction: "forward" | "reverse";
+  /**
+   * Best-effort human-readable label for the neighbor, surfaced alongside (not
+   * in place of) the URN. Populated by the graph_neighbors tool layer (pg
+   * titles, canvas node text, kg node name) so the agent can tell neighbors
+   * apart without dereferencing each URN.
+   */
+  title?: string;
   /** Importance score — only populated by the kg realm arm (from edge.properties.importance) */
   importance?: number;
 }


### PR DESCRIPTION
## Problem

`graph_neighbors` returned **bare URNs** (pg realm) and **bare ref_ids** (kg realm) with no human-readable identifier. Walking the feature→concept→file chain produced output like:

```
{ "urn": "urn:stakwork:pg:feature:cmqdwzbtp0001la04pc1r44qv", "edgeType": "HAS_FEATURE", "direction": "reverse" }
{ "urn": "urn:stakwork:kg:hive:File:9044381a-846f-42f7-bdb9-7d049919ce61", "node_type": "File", ... }
```

The agent couldn't tell neighbors apart without `graph_get`-ing every single one — slow and token-hungry.

## Change

Every neighbor now carries a best-effort **`title`** *alongside* its URL/ref_id (not replacing it), so the agent can pick which edge to follow at a glance.

- **kg** (`kg-adapter.ts`): `deriveNodeName` now tries a generous, ordered candidate list — short identifiers first (`name`/`title`/`file`/`path`/`symbol`/`function_name`/`endpoint`/…) then long descriptive fields (`summary`/`description`/`content`/`docs`, truncated to 160 chars) as a last resort. `kgGetNeighbors` keeps the derived label (it was being discarded) and returns it; the tool folds it into `title`.
- **pg** (`graphWalkerTools.ts`): new `attachPgTitles` batch-resolves a label per neighbor type — **one query per distinct type** (feature/task→title, milestone/initiative/repo/workspace/connection→name, research→title‖topic‖summary, conversation→title, user→name‖email, workspacemember→user.name, chatmessage→message). Lookups are by id only since access is already enforced upstream by `pgNeighbors`.
- **canvas**: structural neighbors get `title` from the target node's text/label.
- **prompt**: documents the new `title` field on `graph_neighbors` output.

## Verified against a live swarm

`?expand=edges` returns node `properties`, so the labels resolve correctly. Example for the "Unit Tests" concept's File neighbors:

```
Concept c9253bde -> 'Unit Tests'
File    9044381a -> 'utils.test.ts'
File    48c948ce -> 'repositoryParser.test.ts'
File    ec11d699 -> 'responses.test.ts'
File    fb7b4570 -> 'db.test.ts'
```

## Tests

Adds coverage for kg name propagation / property fallback / empty-when-unknown, and pg + kg title attachment. All affected suites pass (95 tests). No new typecheck errors in touched files.

## Notes

- `title` may be absent for a node type that exposes no recognizable label — the code degrades gracefully rather than guessing.
- For `File` nodes the basename (`name`) is used as the label; `properties.file` holds the full repo-relative path if we ever want to disambiguate same-named files.