### PR TITLE
feat(graph-walker): label cross-realm kg neighbors via batched by-refs

### DIFF
--- a/src/__tests__/unit/lib/ai/graphWalkerTools.test.ts
+++ b/src/__tests__/unit/lib/ai/graphWalkerTools.test.ts
@@ -58,6 +58,7 @@ vi.mock("@/lib/urn/resolvers/kg", () => ({
 vi.mock("@/lib/ai/kg-adapter", () => ({
   kgGetNode: vi.fn(),
   kgGetNeighbors: vi.fn(),
+  kgGetNodesByRefs: vi.fn(),
   kgSearch: vi.fn(),
 }));
 
@@ -106,7 +107,7 @@ import { pgNeighbors } from "@/lib/graph-walker";
 import { buildGraphWalkerTools } from "@/lib/ai/graphWalkerTools";
 import { resolveCapabilities } from "@/lib/ai/capabilities";
 import { resolveKgSeam } from "@/lib/urn/resolvers/kg";
-import { kgGetNode, kgGetNeighbors, kgSearch } from "@/lib/ai/kg-adapter";
+import { kgGetNode, kgGetNeighbors, kgGetNodesByRefs, kgSearch } from "@/lib/ai/kg-adapter";
 import { getSwarmAccessByWorkspaceId } from "@/lib/helpers/swarm-access";
 
 // ---------------------------------------------------------------------------
@@ -124,6 +125,7 @@ const mockAsBlob = asBlob as ReturnType<typeof vi.fn>;
 const mockResolveKgSeam = resolveKgSeam as ReturnType<typeof vi.fn>;
 const mockKgGetNode = kgGetNode as ReturnType<typeof vi.fn>;
 const mockKgGetNeighbors = kgGetNeighbors as ReturnType<typeof vi.fn>;
+const mockKgGetNodesByRefs = kgGetNodesByRefs as ReturnType<typeof vi.fn>;
 const mockKgSearch = kgSearch as ReturnType<typeof vi.fn>;
 const mockGetSwarmAccessByWorkspaceId = getSwarmAccessByWorkspaceId as ReturnType<typeof vi.fn>;
 
@@ -433,6 +435,59 @@ describe("buildGraphWalkerTools", () => {
       );
       // opaque-external neighbor stays untouched (no title)
       expect(neighbors.find((n) => n.urn === "stakwork:workflow:42")?.title).toBeUndefined();
+    });
+
+    it("pg arm labels cross-realm kg neighbors (implemented-by concepts) via a batched by-refs call", async () => {
+      // Real-ish parser so both pg and kg URNs resolve to {realm,type,id,workspace}.
+      mockParseUrn.mockImplementation((urn: string) => {
+        const [, org, realm, type, ...idParts] = urn.split(":");
+        if (realm === "kg") {
+          const [workspace, kgType, ...rest] = [type, ...idParts];
+          return { realm, org, workspace, type: kgType, id: rest.join(":") };
+        }
+        return { realm, org, type, id: idParts.join(":") };
+      });
+
+      // A pg feature whose neighbors include pg siblings AND kg concepts that
+      // arrived through the Postgres UrnEdge bridge (no title from pgNeighbors).
+      mockPgNeighbors.mockResolvedValue([
+        { urn: "urn:myorg:pg:milestone:ms-1", edgeType: "BELONGS_TO_MILESTONE", direction: "forward" },
+        { urn: "urn:myorg:kg:my-ws:concept:c1", edgeType: "implemented-by", direction: "forward" },
+        { urn: "urn:myorg:kg:my-ws:concept:c2", edgeType: "implemented-by", direction: "forward" },
+      ]);
+      dbMilestone.findMany.mockResolvedValue([{ id: "ms-1", name: "Canvas Workflow" }]);
+
+      mockResolveKgSeam.mockResolvedValue({
+        workspace: "my-ws",
+        swarmUrl: "https://jarvis.example.com",
+        jarvisUrl: "https://jarvis.example.com",
+        swarmApiKey: "key-123",
+      });
+      mockKgGetNodesByRefs.mockResolvedValue(
+        new Map([
+          ["c1", "Integration Tests"],
+          ["c2", "Org Canvas"],
+        ]),
+      );
+
+      const tools = getTools();
+      const result = await tools.graph_neighbors.execute(
+        { urn: "urn:myorg:pg:feature:feat-1" },
+        {} as never,
+      );
+
+      // One batched call covering both concept ref_ids
+      expect(mockKgGetNodesByRefs).toHaveBeenCalledTimes(1);
+      expect(mockKgGetNodesByRefs).toHaveBeenCalledWith(
+        "https://jarvis.example.com",
+        "key-123",
+        expect.arrayContaining(["c1", "c2"]),
+      );
+
+      const neighbors = (result as { neighbors: Array<{ urn: string; title?: string }> }).neighbors;
+      expect(neighbors.find((n) => n.urn.includes("ms-1"))?.title).toBe("Canvas Workflow");
+      expect(neighbors.find((n) => n.urn.includes("concept:c1"))?.title).toBe("Integration Tests");
+      expect(neighbors.find((n) => n.urn.includes("concept:c2"))?.title).toBe("Org Canvas");
     });
 
     it("kg arm maps the derived node name onto each neighbor's title", async () => {

--- a/src/__tests__/unit/lib/ai/kg-adapter.test.ts
+++ b/src/__tests__/unit/lib/ai/kg-adapter.test.ts
@@ -7,7 +7,7 @@
 // @vitest-environment node
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { kgGetNode, kgGetNeighbors, kgSearch } from "@/lib/ai/kg-adapter";
+import { kgGetNode, kgGetNeighbors, kgGetNodesByRefs, kgSearch } from "@/lib/ai/kg-adapter";
 
 const JARVIS_URL = "https://jarvis.example.com";
 const API_KEY = "test-api-key";
@@ -385,6 +385,80 @@ describe("kgGetNeighbors", () => {
 
     const { reachable } = await kgGetNeighbors(JARVIS_URL, API_KEY, QUERIED_REF);
     expect(reachable).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// kgGetNodesByRefs
+// ---------------------------------------------------------------------------
+
+describe("kgGetNodesByRefs", () => {
+  it("POSTs ref_ids to /v2/nodes/by-refs and returns a ref_id→name map", async () => {
+    const raw = {
+      nodes: [
+        { ref_id: "c1", node_type: "Concept", properties: { name: "Integration Tests" } },
+        { ref_id: "c2", node_type: "Concept", properties: { name: "Org Canvas" } },
+      ],
+    };
+    globalThis.fetch = mockFetch(raw);
+
+    const map = await kgGetNodesByRefs(JARVIS_URL, API_KEY, ["c1", "c2"]);
+
+    expect(map.get("c1")).toBe("Integration Tests");
+    expect(map.get("c2")).toBe("Org Canvas");
+
+    const [calledUrl, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(calledUrl).toBe(`${JARVIS_URL}/v2/nodes/by-refs`);
+    expect(init).toMatchObject({
+      method: "POST",
+      headers: { "x-api-token": API_KEY, "Content-Type": "application/json" },
+    });
+    expect(JSON.parse(init.body as string)).toEqual({ ref_ids: ["c1", "c2"] });
+  });
+
+  it("derives names from fallback property keys (file_name) and skips unlabeled nodes", async () => {
+    const raw = {
+      nodes: [
+        { ref_id: "f1", node_type: "File", properties: { file_name: "kg-adapter.ts" } },
+        { ref_id: "x1", node_type: "Mystery", properties: { weight: 3 } },
+      ],
+    };
+    globalThis.fetch = mockFetch(raw);
+
+    const map = await kgGetNodesByRefs(JARVIS_URL, API_KEY, ["f1", "x1"]);
+
+    expect(map.get("f1")).toBe("kg-adapter.ts");
+    expect(map.has("x1")).toBe(false);
+  });
+
+  it("dedups and drops empty ref_ids before sending", async () => {
+    globalThis.fetch = mockFetch({ nodes: [] });
+
+    await kgGetNodesByRefs(JARVIS_URL, API_KEY, ["a", "a", "", "b"]);
+
+    const init = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1];
+    expect(JSON.parse(init.body as string)).toEqual({ ref_ids: ["a", "b"] });
+  });
+
+  it("returns an empty map without calling fetch when given no ref_ids", async () => {
+    globalThis.fetch = mockFetch({ nodes: [] });
+
+    const map = await kgGetNodesByRefs(JARVIS_URL, API_KEY, []);
+
+    expect(map.size).toBe(0);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty map on non-2xx response", async () => {
+    globalThis.fetch = mockFetch(null, false, 401);
+    const map = await kgGetNodesByRefs(JARVIS_URL, API_KEY, ["c1"]);
+    expect(map.size).toBe(0);
+  });
+
+  it("returns an empty map on fetch throw", async () => {
+    globalThis.fetch = mockFetchThrow();
+    const map = await kgGetNodesByRefs(JARVIS_URL, API_KEY, ["c1"]);
+    expect(map.size).toBe(0);
   });
 });
 

--- a/src/lib/ai/graphWalkerTools.ts
+++ b/src/lib/ai/graphWalkerTools.ts
@@ -29,7 +29,7 @@ import type { UrnEdgeNeighbor } from "@/lib/urn";
 import { pgNeighbors } from "@/lib/graph-walker";
 import type { NeighborResult, PgNeighborContext } from "@/lib/graph-walker";
 import { resolveKgSeam } from "@/lib/urn/resolvers/kg";
-import { kgGetNode, kgGetNeighbors, kgSearch } from "./kg-adapter";
+import { kgGetNode, kgGetNeighbors, kgGetNodesByRefs, kgSearch } from "./kg-adapter";
 import { getSwarmAccessByWorkspaceId } from "@/lib/helpers/swarm-access";
 import { getJarvisUrl } from "@/lib/utils/swarm";
 
@@ -278,6 +278,55 @@ async function attachPgTitles<T extends { urn: string }>(
     const p = parseUrn(n.urn);
     if (!p || p.realm !== "pg") return n;
     const label = labelByKey.get(`${p.type}:${p.id}`);
+    return label ? { ...n, title: label } : n;
+  });
+}
+
+/**
+ * Attach a `title` to kg-realm neighbors that don't already have one. These are
+ * cross-realm neighbors reached through a Postgres `UrnEdge` bridge (e.g. a
+ * feature's `implemented-by` concepts): the edge row carries no node label, and
+ * `attachPgTitles` skips them because they're kg-realm. Their names live only in
+ * Jarvis, so we resolve them in ONE batched `by-refs` call per swarm.
+ *
+ * Best-effort: an unresolvable seam or failed fetch just leaves `title` unset
+ * rather than failing the traversal. Skips neighbors that already have a title
+ * (e.g. anything the kg arm already labeled).
+ */
+async function attachKgTitles<T extends { urn: string; title?: string }>(
+  neighbors: T[],
+  ctx: { userId: string },
+): Promise<T[]> {
+  // Group untitled kg ref_ids by swarm seam. A single traversal's neighbors
+  // normally share one workspace, but grouping keeps it correct if not.
+  const refsByWorkspace = new Map<string, { seamUrn: string; refIds: Set<string> }>();
+  for (const n of neighbors) {
+    if (n.title) continue;
+    const p = parseUrn(n.urn);
+    if (!p || p.realm !== "kg") continue;
+    const entry = refsByWorkspace.get(p.workspace) ?? { seamUrn: n.urn, refIds: new Set<string>() };
+    entry.refIds.add(p.id);
+    refsByWorkspace.set(p.workspace, entry);
+  }
+  if (refsByWorkspace.size === 0) return neighbors;
+
+  // ref_id → label, merged across all swarms touched by this traversal.
+  const labelByRef = new Map<string, string>();
+  await Promise.all(
+    [...refsByWorkspace.values()].map(async ({ seamUrn, refIds }) => {
+      const seam = await resolveKgSeam(seamUrn, ctx);
+      if (!seam) return; // best-effort — no seam, no labels
+      const labels = await kgGetNodesByRefs(seam.jarvisUrl, seam.swarmApiKey, [...refIds]);
+      for (const [ref, name] of labels) labelByRef.set(ref, name);
+    }),
+  );
+  if (labelByRef.size === 0) return neighbors;
+
+  return neighbors.map((n) => {
+    if (n.title) return n;
+    const p = parseUrn(n.urn);
+    if (!p || p.realm !== "kg") return n;
+    const label = labelByRef.get(p.id);
     return label ? { ...n, title: label } : n;
   });
 }
@@ -839,7 +888,13 @@ export function buildGraphWalkerTools(
           case "pg": {
             const ctx: PgNeighborContext = { userId, orgId };
             const results = await pgNeighbors(urn, ctx);
-            const neighbors = await attachPgTitles(results);
+            // pg-native neighbors get labels from Postgres; cross-realm kg
+            // neighbors (e.g. `implemented-by` concepts) are labeled in one
+            // batched Jarvis call since their names live only in the swarm.
+            const neighbors = await attachKgTitles(
+              await attachPgTitles(results),
+              { userId },
+            );
             return { neighbors };
           }
           case "canvas": {
@@ -849,8 +904,12 @@ export function buildGraphWalkerTools(
             ]);
             const merged = deduplicateByUrn([...canvasEdges, ...urnEdges]);
             // Canvas structural neighbors are already labeled from node text;
-            // this also labels any pg-realm cross-realm UrnEdge neighbors.
-            const neighbors = await attachPgTitles(merged);
+            // attachPgTitles labels pg-realm UrnEdge neighbors, attachKgTitles
+            // labels kg-realm ones (batched, names sourced from the swarm).
+            const neighbors = await attachKgTitles(
+              await attachPgTitles(merged),
+              { userId },
+            );
             return { neighbors };
           }
           case "kg": {

--- a/src/lib/ai/kg-adapter.ts
+++ b/src/lib/ai/kg-adapter.ts
@@ -224,6 +224,61 @@ export async function kgGetNode(
 }
 
 // ---------------------------------------------------------------------------
+// kgGetNodesByRefs
+// ---------------------------------------------------------------------------
+
+/**
+ * Max ref_ids to send in a single by-refs batch. Mirrors KG_NEIGHBOR_CAP — a
+ * traversal never surfaces more kg neighbors than that, so one POST covers a
+ * whole hop's worth of cross-realm labels.
+ */
+const KG_BY_REFS_CAP = KG_NEIGHBOR_CAP;
+
+/**
+ * Bulk-resolve human-readable labels for a list of kg ref_ids in ONE request,
+ * via `POST /v2/nodes/by-refs` (the internal boltwall bulk-fetch — gated by the
+ * swarm `x-api-token`, which we already hold). Used to label cross-realm kg
+ * neighbors that arrive through a Postgres `UrnEdge` bridge (e.g. a feature's
+ * `implemented-by` concepts), where the bare edge carries no node properties.
+ *
+ * Returns a `Map<ref_id, name>` containing only entries with a non-empty derived
+ * name. Soft-deleted / muted nodes are excluded server-side. Returns an empty
+ * map on any error — labeling is best-effort and must never fail a traversal.
+ */
+export async function kgGetNodesByRefs(
+  jarvisUrl: string,
+  swarmApiKey: string,
+  refIds: string[],
+): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  const unique = [...new Set(refIds.filter((r) => r))].slice(0, KG_BY_REFS_CAP);
+  if (unique.length === 0) return out;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), KG_FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${jarvisUrl.replace(/\/$/, "")}/v2/nodes/by-refs`, {
+      method: "POST",
+      headers: { ...authHeaders(swarmApiKey), "Content-Type": "application/json" },
+      body: JSON.stringify({ ref_ids: unique }),
+      signal: controller.signal,
+    });
+    if (!res.ok) return out;
+    const data = (await res.json()) as { nodes?: JarvisNode[] };
+    for (const node of data.nodes ?? []) {
+      if (!node?.ref_id) continue;
+      const name = deriveNodeName(node, (node.properties ?? {}) as Record<string, unknown>);
+      if (name) out.set(node.ref_id, name);
+    }
+    return out;
+  } catch {
+    return out;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // kgGetNeighbors
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

`graph_neighbors` returned `kg` nodes (e.g. a feature's `implemented-by` **concepts**) with **no `title`**, while their pg siblings (initiative/milestone/task/chatmessage) were labeled. From a `graph_walker` log:

```json
{ "urn": "urn:stakwork:kg:hive:concept:41cbd69c-...", "edgeType": "implemented-by", "direction": "forward" }
```

The concept names exist in Neo4j — confirmed against a live swarm, e.g. `41cbd69c-…` → `"Integration Tests"`.

## Root cause

Concept neighbors reach a `pg:feature` through a **Postgres `UrnEdge` bridge** (the `implemented-by` edges written by `feature-concept-bridge.ts`). On that path:

1. `pgNeighbors` copies only `urn / edgeType / direction` from the `UrnEdge` row — no label.
2. `attachPgTitles` bails on anything that isn't pg-realm, so the `kg:concept` URN passes through untouched.
3. The kg arm (which derives names via `deriveNodeName`) is never reached, because we entered through the `pg` arm.

Net: the edge lives in Postgres, but the name lives only in Jarvis, and we never made the second hop to fetch it.

## Fix (read-time enrichment, batched)

- **`kg-adapter.ts`** — new `kgGetNodesByRefs(jarvisUrl, swarmApiKey, refIds)`: a single `POST /v2/nodes/by-refs` resolving a whole hop's worth of kg ref_ids, mapped through `deriveNodeName` to `Map<ref_id, name>`. Dedups/caps at 50, best-effort (empty map on error), same abort-timeout as other kg calls.
- **`graphWalkerTools.ts`** — new `attachKgTitles(neighbors, { userId })`: collects untitled kg-realm neighbors, resolves the seam once per swarm, batch-fetches labels, attaches `title`. Skips neighbors that already have one. Wired into the `pg` **and** `canvas` arms after `attachPgTitles`.

Cost: **one extra Jarvis round-trip per traversal** (not per concept), only when untitled kg neighbors are present. Read-time, so existing edges are covered with no backfill or schema change. The name belongs to the node, not the edge — so we don't denormalize it onto `UrnEdge`.

## Result

```
implemented-by → Integration Tests
implemented-by → Org Canvas
implemented-by → Conversational Feature Planning
```

## Tests

- 6 new unit tests for `kgGetNodesByRefs` (POST shape/headers, fallback-key name derivation, dedup, empty-input short-circuit, error paths).
- 1 end-to-end test proving the `pg` arm labels bridged `implemented-by` concepts via a single batched call.
- All 73 tests in the two suites pass; typecheck + lint clean on touched source.

Verified the `/v2/nodes/by-refs` endpoint and concept names live against a running swarm.