### PR TITLE
feat(org_agent): return ?chat= link so the org chat auto-loads

### DIFF
--- a/src/lib/mcp/orgMcpTools.ts
+++ b/src/lib/mcp/orgMcpTools.ts
@@ -328,7 +328,12 @@ export function registerOrgTools(
               select: { githubLogin: true },
             });
             if (org) {
-              const path = `/org/${org.githubLogin}/chat/shared/${conversationId}`;
+              // `?chat=<id>` on the org page auto-loads the conversation
+              // (OrgCanvasView reads the `chat` param and fetches the
+              // isShared-gated row). Preferred over /chat/shared/<id> so
+              // the link drops the user straight into the live org canvas
+              // with the chat open.
+              const path = `/org/${org.githubLogin}?chat=${conversationId}`;
               const base = process.env.NEXTAUTH_URL?.replace(/\/$/, "");
               shareLink = base ? `${base}${path}` : path;
             }

--- a/src/lib/mcp/orgMcpTools.ts
+++ b/src/lib/mcp/orgMcpTools.ts
@@ -316,11 +316,15 @@ export function registerOrgTools(
         let shareLink: string | undefined;
         if (LINK_RETURNING_PURPOSES.has(authExtra.purpose)) {
           try {
+            // Persist the FULL turn (via the run's steps), not just the
+            // prose, so `propose_*` tool calls survive and render as an
+            // approvable card when the conversation is opened.
+            const steps = await result.steps;
             const conversationId = await createSharedOrgAgentConversation({
               orgId: authExtra.orgId,
               userId: authExtra.userId,
               prompt: args.prompt,
-              answer,
+              steps,
               workspaceSlugs: slugs,
             });
             const org = await db.sourceControlOrg.findUnique({

--- a/src/services/org-canvas-conversation.ts
+++ b/src/services/org-canvas-conversation.ts
@@ -21,6 +21,7 @@ import type { CachedConcepts } from "@/lib/ai/runCanvasAgent";
 import { generateTitle } from "@/lib/ai/conversationHelpers";
 import {
   appendTurnMessages,
+  messagesFromSteps,
   type StoredMessage,
   type StoredAttachment,
 } from "@/services/canvas-turn-persistence";
@@ -134,31 +135,40 @@ export async function persistCanvasUserMessage(args: {
 }
 
 /**
- * Persist a single-shot org-agent exchange (one user prompt + one
- * assistant answer) as a fresh, shareable org-canvas conversation, and
+ * Persist a single-shot org-agent exchange (one user prompt + the
+ * agent's full turn) as a fresh, shareable org-canvas conversation, and
  * return its id.
  *
  * Used by the `org_agent` MCP tool when invoked from a call/voice
- * context: the agent asks one question, and we want a durable, org-
+ * context: the agent asks/acts once, and we want a durable, org-
  * member-viewable record the caller can hand back as a link
  * (`/org/<login>?chat=<id>`, which auto-loads the conversation). Unlike
  * the interactive chat path, there is no prior conversation to
  * continue — each call mints its own row.
  *
+ * The assistant turn is reconstructed from the finished run's `steps`
+ * via `messagesFromSteps` — the SAME primitive the streaming chat route
+ * uses — so tool-call rows survive. This is what makes a `propose_*`
+ * card render and be approvable when the conversation is later opened:
+ * `<ProposalCard>` reads the persisted `toolCalls[{ toolName, output }]`
+ * entry. Persisting only the final prose would drop the proposal.
+ *
  * The row mirrors `persistCanvasUserMessage`'s org-canvas shape
- * (`workspaceId: null`, `sourceControlOrgId` set, `extraWorkspaceSlugs`
- * in `settings` so later org tooling can recover the slug set) but is
+ * (`workspaceId: null`, `sourceControlOrgId` set, `source: "org-canvas"`
+ * so it appears in the org chat list, `extraWorkspaceSlugs` in
+ * `settings` so later org tooling can recover the slug set) but is
  * created `isShared: true` so any org member can open it, and carries
- * both turns in one atomic create.
+ * the whole turn in one atomic create.
  */
 export async function createSharedOrgAgentConversation(args: {
   orgId: string;
   userId: string;
   prompt: string;
-  answer: string;
+  /** Finished run steps, e.g. `await result.steps` from `runCanvasAgent`. */
+  steps: Parameters<typeof messagesFromSteps>[0];
   workspaceSlugs: string[];
 }): Promise<string> {
-  const { orgId, userId, prompt, answer, workspaceSlugs } = args;
+  const { orgId, userId, prompt, steps, workspaceSlugs } = args;
 
   const turnId = randomUUID();
   const now = new Date();
@@ -169,22 +179,19 @@ export async function createSharedOrgAgentConversation(args: {
     content: prompt,
     timestamp: now.toISOString(),
   };
-  const assistantRow: StoredMessage = {
-    id: `${turnId}-a0`,
-    role: "assistant",
-    content: answer,
-    timestamp: now.toISOString(),
-  };
+  // `${turnId}-a` prefix namespaces the assistant rows away from the
+  // `${turnId}-u` user row (matches the streaming route's convention).
+  const assistantRows = messagesFromSteps(steps, `${turnId}-a`);
 
   const created = await db.sharedConversation.create({
     data: {
       sourceControlOrgId: orgId,
       userId,
       workspaceId: null,
-      messages: [userRow, assistantRow] as unknown as never,
+      messages: [userRow, ...assistantRows] as unknown as never,
       title: generateTitle([userRow]),
       lastMessageAt: now,
-      source: "org-agent",
+      source: "org-canvas",
       settings: { extraWorkspaceSlugs: workspaceSlugs } as unknown as never,
       followUpQuestions: [],
       isShared: true,

--- a/src/services/org-canvas-conversation.ts
+++ b/src/services/org-canvas-conversation.ts
@@ -140,9 +140,10 @@ export async function persistCanvasUserMessage(args: {
  *
  * Used by the `org_agent` MCP tool when invoked from a call/voice
  * context: the agent asks one question, and we want a durable, org-
- * member-viewable record at `/org/<login>/chat/shared/<id>` to hand
- * back as a link. Unlike the interactive chat path, there is no prior
- * conversation to continue — each call mints its own row.
+ * member-viewable record the caller can hand back as a link
+ * (`/org/<login>?chat=<id>`, which auto-loads the conversation). Unlike
+ * the interactive chat path, there is no prior conversation to
+ * continue — each call mints its own row.
  *
  * The row mirrors `persistCanvasUserMessage`'s org-canvas shape
  * (`workspaceId: null`, `sourceControlOrgId` set, `extraWorkspaceSlugs`


### PR DESCRIPTION
## What
Change the link `org_agent` hands back (for `call-link` purpose) from the standalone viewer path to the **org canvas page with the chat pre-opened**:

- Before: `/org/<login>/chat/shared/<id>`
- After: `https://hive.sphinx.chat/org/<login>?chat=<id>`

## Why
`OrgCanvasView` reads the `?chat=<id>` query param (`src/app/org/[githubLogin]/_components/OrgCanvasView.tsx:219`) and fetches the conversation via `/api/orgs/<login>/chat/conversations/<id>`, dropping the user straight into the live org canvas with the chat open. That route is `isShared`-gated and org-scoped; the conversation `org_agent` creates is already `isShared: true`, so any org member who opens the link auto-loads it.

## Follow-up to #4526
Builds on the merged org-scope call-link work. Only the URL format (and two doc comments) change; persistence/auth behavior is unchanged.