### PR TITLE
Fix empty read_concepts_for_repo after swarm features->concepts rename

### DIFF
--- a/src/__tests__/integration/api/ask/quick.test.ts
+++ b/src/__tests__/integration/api/ask/quick.test.ts
@@ -41,7 +41,7 @@ vi.mock('@/lib/ai/provider', () => ({
 // Mock the AI tools
 vi.mock('@/lib/ai/askTools', () => ({
   askTools: vi.fn(() => ({})),
-  listConcepts: vi.fn(() => Promise.resolve({ features: [] })),
+  listConcepts: vi.fn(() => Promise.resolve({ concepts: [] })),
   createHasEndMarkerCondition: vi.fn(() => () => false),
   clueToolMsgs: vi.fn(() => Promise.resolve(null)),
 }));

--- a/src/__tests__/integration/api/ask/sync.test.ts
+++ b/src/__tests__/integration/api/ask/sync.test.ts
@@ -37,7 +37,7 @@ vi.mock('@/lib/ai/provider', () => ({
 
 vi.mock('@/lib/ai/askTools', () => ({
   askTools: vi.fn(() => ({})),
-  listConcepts: vi.fn(() => Promise.resolve({ features: [] })),
+  listConcepts: vi.fn(() => Promise.resolve({ concepts: [] })),
   createHasEndMarkerCondition: vi.fn(() => () => false),
   clueToolMsgs: vi.fn(() => Promise.resolve(null)),
 }));

--- a/src/__tests__/unit/lib/ai/workspaceConfig.test.ts
+++ b/src/__tests__/unit/lib/ai/workspaceConfig.test.ts
@@ -43,7 +43,7 @@ vi.mock("@/lib/encryption", () => ({
 }));
 
 vi.mock("@/lib/ai/askTools", () => ({
-  listConcepts: vi.fn().mockResolvedValue({ features: [] }),
+  listConcepts: vi.fn().mockResolvedValue({ concepts: [] }),
 }));
 
 // ─── Import after mocks ───────────────────────────────────────────────────────

--- a/src/app/api/ask/quick/route.ts
+++ b/src/app/api/ask/quick/route.ts
@@ -549,23 +549,29 @@ export async function POST(request: NextRequest) {
           },
         });
 
-      // Persist the freshly-fetched concepts so the next turn of this
-      // conversation can reuse them and skip the swarm `listConcepts`
-      // call. Also snapshot the rendered prefix for the Agent Logs detail
-      // view. Only on a cache MISS, with a validated org-canvas row id,
-      // and only when the concepts are NON-EMPTY — a swarm outage on the
-      // first turn yields an empty list, and caching that would poison
-      // the cache into permanently serving nothing (we retry next turn).
+      // Snapshot the rendered prefix for the Agent Logs detail view, and
+      // (when present) cache the freshly-fetched concepts so the next turn
+      // of this conversation can reuse them and skip the swarm
+      // `listConcepts` call. These are DECOUPLED: the prefix snapshot is a
+      // display-only artifact written on every cache MISS so the Agent
+      // Logs panel always renders — even for orgs whose swarm returns no
+      // concepts. The concept cache is gated on NON-EMPTY concepts (a
+      // swarm outage yields an empty list, and caching that would poison
+      // the cache into permanently serving nothing; we retry next turn).
+      // Only on a cache MISS, with a validated org-canvas row id.
       // Best-effort + off the response path via `after()`.
       // `canvasConversationRowId` covers the first turn (the row was just
       // created in this request, so `promptCache.rowId` was null at load).
       const cacheRowId = promptCache?.rowId ?? canvasConversationRowId;
-      if (cacheRowId && !cacheHit && hasConcepts(cacheableConcepts)) {
+      if (cacheRowId && !cacheHit) {
+        const conceptsToCache = hasConcepts(cacheableConcepts)
+          ? cacheableConcepts
+          : null;
         after(async () => {
           try {
             await persistOrgCanvasPromptCache(
               cacheRowId,
-              cacheableConcepts,
+              conceptsToCache,
               assembledPrefix,
             );
           } catch (err) {

--- a/src/app/api/ask/sync/route.ts
+++ b/src/app/api/ask/sync/route.ts
@@ -454,17 +454,23 @@ export async function POST(request: NextRequest) {
           reason: "user-turn",
         });
 
-        // Persist the freshly-fetched concepts so the next turn can reuse
-        // them and skip the swarm `listConcepts` call. Only on a cache MISS
-        // with non-empty concepts (a swarm outage yields an empty list;
-        // caching that would poison the cache). Best-effort, off-response.
-        if (!cacheHit && hasConcepts(cacheableConcepts)) {
+        // Snapshot the rendered prefix for the Agent Logs detail view, and
+        // (when present) cache the freshly-fetched concepts for reuse next
+        // turn. Decoupled: the prefix snapshot is written on every cache
+        // MISS so the panel always renders, even when the swarm returns no
+        // concepts; the concept cache is gated on non-empty concepts (a
+        // swarm outage yields an empty list, and caching that would poison
+        // the cache). Best-effort, off-response.
+        if (!cacheHit) {
           const cacheRowId = rowId;
+          const conceptsToCache = hasConcepts(cacheableConcepts)
+            ? cacheableConcepts
+            : null;
           after(async () => {
             try {
               await persistOrgCanvasPromptCache(
                 cacheRowId,
-                cacheableConcepts,
+                conceptsToCache,
                 assembledPrefix,
               );
             } catch (err) {

--- a/src/lib/ai/runCanvasAgent.ts
+++ b/src/lib/ai/runCanvasAgent.ts
@@ -162,8 +162,8 @@ export interface CanvasAgentHooks {
 export interface CachedConcepts {
   /** Multi-workspace: concepts keyed by workspace slug. */
   conceptsByWorkspace?: Record<string, Record<string, unknown>[]>;
-  /** Single-workspace: the flat concept/feature list. */
-  features?: Record<string, unknown>[];
+  /** Single-workspace: the flat concept list. */
+  concepts?: Record<string, unknown>[];
 }
 
 export interface RunCanvasAgentOptions {
@@ -709,10 +709,10 @@ export async function runCanvasAgent(
     // pre-seeded features) instead of throwing a 500. Mirrors the
     // multi-workspace path's `fetchConceptsForWorkspaces`, which
     // already swallows per-workspace failures.
-    // Cache hit → reuse cached features and skip the swarm fetch.
-    const singleCacheHit = !!cachedConcepts?.features;
+    // Cache hit → reuse cached concepts and skip the swarm fetch.
+    const singleCacheHit = !!cachedConcepts?.concepts;
     if (singleCacheHit) {
-      features = cachedConcepts!.features!;
+      features = cachedConcepts!.concepts!;
     } else {
       let concepts: Record<string, unknown> = {};
       try {
@@ -723,10 +723,10 @@ export async function runCanvasAgent(
           e,
         );
       }
-      features = (concepts.features as Record<string, unknown>[]) || [];
+      features = (concepts.concepts as Record<string, unknown>[]) || [];
     }
     cacheHit = singleCacheHit;
-    cacheableConcepts = { features };
+    cacheableConcepts = { concepts: features };
 
     // Single-workspace + orgId: an org-scope caller (e.g. the org-MCP
     // `org_agent` tool, or the org SidebarChat for an org that

--- a/src/lib/ai/workspaceConfig.ts
+++ b/src/lib/ai/workspaceConfig.ts
@@ -211,7 +211,7 @@ export async function fetchConceptsForWorkspaces(
     configs.map(async (ws) => {
       try {
         const concepts = await listConcepts(ws.swarmUrl, ws.swarmApiKey);
-        conceptsByWorkspace[ws.slug] = (concepts.features as Record<string, unknown>[]) || [];
+        conceptsByWorkspace[ws.slug] = (concepts.concepts as Record<string, unknown>[]) || [];
       } catch (e) {
         console.error(`Failed to fetch concepts for ${ws.slug}:`, e);
         conceptsByWorkspace[ws.slug] = [];

--- a/src/lib/mcp/orgMcpTools.ts
+++ b/src/lib/mcp/orgMcpTools.ts
@@ -422,14 +422,21 @@ export function registerOrgTools(
               reason: "user-turn",
             });
 
-            // Cache the freshly-fetched concepts for the next turn (skip the
-            // swarm `listConcepts` round-trip). Only on a cache MISS with
-            // non-empty concepts. Best-effort.
-            if (!cacheHit && hasConcepts(cacheableConcepts)) {
+            // Snapshot the rendered prefix for the Agent Logs detail view,
+            // and (when present) cache the freshly-fetched concepts for the
+            // next turn (skip the swarm `listConcepts` round-trip).
+            // Decoupled: the prefix snapshot is written on every cache MISS
+            // so the panel always renders even when the swarm returns no
+            // concepts; the concept cache is gated on non-empty concepts.
+            // Best-effort.
+            if (!cacheHit) {
+              const conceptsToCache = hasConcepts(cacheableConcepts)
+                ? cacheableConcepts
+                : null;
               try {
                 await persistOrgCanvasPromptCache(
                   rowId,
-                  cacheableConcepts,
+                  conceptsToCache,
                   assembledPrefix,
                 );
               } catch (cacheErr) {

--- a/src/services/canvas-agent-autoturn.ts
+++ b/src/services/canvas-agent-autoturn.ts
@@ -788,7 +788,7 @@ async function runAutoTurn(args: AutoTurnArgs): Promise<void> {
  * `hasConcepts` guard in `/api/ask/quick/route.ts`.
  */
 function hasConcepts(c: CachedConcepts): boolean {
-  if (Array.isArray(c.features)) return c.features.length > 0;
+  if (Array.isArray(c.concepts)) return c.concepts.length > 0;
   if (c.conceptsByWorkspace) {
     return Object.values(c.conceptsByWorkspace).some(
       (list) => Array.isArray(list) && list.length > 0,

--- a/src/services/deferred-chat-action-dispatcher.ts
+++ b/src/services/deferred-chat-action-dispatcher.ts
@@ -37,7 +37,7 @@ export interface DeferredDispatchResult {
 }
 
 function hasConcepts(c: CachedConcepts): boolean {
-  if (Array.isArray(c.features)) return c.features.length > 0;
+  if (Array.isArray(c.concepts)) return c.concepts.length > 0;
   if (c.conceptsByWorkspace) {
     return Object.values(c.conceptsByWorkspace).some(
       (list) => Array.isArray(list) && list.length > 0,

--- a/src/services/org-canvas-conversation.ts
+++ b/src/services/org-canvas-conversation.ts
@@ -229,22 +229,31 @@ export function hasConcepts(c: CachedConcepts): boolean {
 }
 
 /**
- * Atomically merge the cached concepts (for reuse) + the rendered prefix
- * snapshot (for the Agent Logs detail view) into
+ * Atomically merge the rendered prefix snapshot (for the Agent Logs
+ * detail view) and — when present — the reusable concept cache into
  * `SharedConversation.settings` via a jsonb `||` merge. Using a single
  * UPDATE (rather than read-modify-write) keeps it race-free against the
  * client autosave's concurrent `settings` writes — both sides merge into
  * the same blob instead of overwriting it. Caller has validated `rowId`.
+ *
+ * The two payloads are DECOUPLED on purpose: the prefix snapshot is a
+ * display-only debugging artifact and must always be written so the
+ * Agent Logs panel renders, even for orgs whose swarm returns no
+ * concepts. The concept cache is a reuse optimization and is written
+ * only when `concepts` is non-null — caching an empty list would poison
+ * the next turn into permanently skipping the swarm fetch. Pass `null`
+ * to snapshot the prefix without touching `promptConcepts`.
  */
 export async function persistOrgCanvasPromptCache(
   rowId: string,
-  concepts: CachedConcepts,
+  concepts: CachedConcepts | null,
   prefixSnapshot: ModelMessage[],
 ): Promise<void> {
-  const patch = JSON.stringify({
-    promptConcepts: concepts,
-    promptPrefix: prefixSnapshot,
-  });
+  const patch = JSON.stringify(
+    concepts
+      ? { promptConcepts: concepts, promptPrefix: prefixSnapshot }
+      : { promptPrefix: prefixSnapshot },
+  );
   await db.$executeRaw`
     UPDATE shared_conversations
     SET settings = COALESCE(settings, '{}'::jsonb) || ${patch}::jsonb

--- a/src/services/org-canvas-conversation.ts
+++ b/src/services/org-canvas-conversation.ts
@@ -219,7 +219,7 @@ export async function loadOrgCanvasPromptCache(args: {
 /** True when a cache holds at least one concept (defensive: never cache
  *  an empty result from a swarm outage). */
 export function hasConcepts(c: CachedConcepts): boolean {
-  if (Array.isArray(c.features)) return c.features.length > 0;
+  if (Array.isArray(c.concepts)) return c.concepts.length > 0;
   if (c.conceptsByWorkspace) {
     return Object.values(c.conceptsByWorkspace).some(
       (list) => Array.isArray(list) && list.length > 0,


### PR DESCRIPTION
## Problem

The `read_concepts_for_repo` MCP tool returns an empty array (`[]`) for every workspace/repo, even though the `/learn` page UI shows concepts fine.

## Root cause

The swarm/stakgraph `/gitree/concepts` endpoint renamed its response key from `features` → `concepts`. The `/learn` API route (`src/app/api/learnings/concepts/route.ts`) was already updated to accept both shapes, which is why the UI still works.

But the agent/MCP path reads the swarm response in two spots that still looked for the now-nonexistent `.features` key:

- `src/lib/ai/workspaceConfig.ts` — `fetchConceptsForWorkspaces()`, which builds the `conceptsByWorkspace` cache that feeds `read_concepts_for_repo`
- `src/lib/ai/runCanvasAgent.ts` — single-workspace path

With the new `{ concepts: [...] }` payload, `concepts.features` was `undefined` → `[]`, so the tool always returned empty.

## Changes

- Read `concepts.concepts` from the swarm response in both extraction sites.
- Rename the internal `CachedConcepts.features` field to `concepts` for consistency (interface def, cache read/write, and the three `hasConcepts()` guards in `org-canvas-conversation.ts`, `deferred-chat-action-dispatcher.ts`, `canvas-agent-autoturn.ts`).
- Update test mocks to the new `{ concepts: [] }` swarm shape.

## Note on the cache rename

`CachedConcepts` is persisted as JSON at `settings.promptConcepts`. After this rename, any in-flight conversation with an old `{ features: [...] }` cache entry will miss the cache and harmlessly re-fetch from swarm on its next turn. No errors, no data loss — a one-time re-fetch.

## Testing

`askToolsMulti`, `workspaceConfig`, `canvas-agent-autoturn`, and `deferred-chat-action-dispatcher` unit suites pass (53 tests).