### PR TITLE
feat(jarvis): mirror Feature/Task/ChatMessage entities to the graph

### DIFF
--- a/docs/plans/jarvis-task-pr-linking.md
+++ b/docs/plans/jarvis-task-pr-linking.md
@@ -1,0 +1,109 @@
+# Linking `HiveTask` → `PullRequest` in the graph
+
+A follow-up to the entity graph-mirror (`HiveFeature` / `HiveTask` /
+`HiveChatMessage`). When a task's autonomous agent opens a PR, draw an edge from
+the task's graph node to the **existing** `PullRequest` node that the codegraph
+ingestion already created — so the graph connects "the work item" to "the code
+change it produced."
+
+Status: **proposed.**
+
+## Why this is a separate job, not part of the mirror cron
+
+The entity mirror (`src/services/jarvis-mirror-cron.ts`) is **cursor-driven**:
+it only touches a Feature/Task/ChatMessage whose `updatedAt` advanced since the
+last run. PR linking does **not** fit that model, for three reasons:
+
+1. **Different trigger.** The `PullRequest` node is created by the
+   codegraph / stakgraph ingestion pipeline, often **after** the task row last
+   changed. The task's `updatedAt` may never move again, so the mirror cron
+   would never revisit it to draw the edge. The real trigger is *"the PR node
+   now exists in the graph"*, which the entity cursor can't observe.
+
+2. **Different, uncertain identity.** Drawing the edge means matching the
+   **existing** PR node's `node_key` (`pullrequest-name`, see the codegraph
+   schema in `jarvis-backend/api/constants/schema_library.py`). If we guess the
+   `name` wrong, Jarvis's create-or-merge edge endpoint will happily **create a
+   stub `PullRequest` node** instead of linking to the ingested one — silently
+   polluting the graph. This needs upfront research (below), which should not
+   block or complicate the clean entity mirror.
+
+3. **Different timing/ordering.** The edge target must already exist. A job that
+   runs independently and simply **keeps retrying** unlinked tasks is a far
+   better fit than threading "is the PR ingested yet?" into the cursor loop.
+
+So: a separate, retry-oriented cron that scans *unlinked tasks-with-PRs* and
+best-effort draws the edge. It reuses the same building blocks
+(`getJarvisConfigForWorkspace`, `addEdgeBulk` with node_key endpoints) — **no
+new infrastructure**.
+
+## Research spike (do this first)
+
+Two unknowns must be nailed down before writing the linker. Both are cheap.
+
+### A. How does codegraph name `PullRequest` nodes?
+
+The edge target is matched by the PR node's `node_key` = `pullrequest-name`
+(i.e. the sanitized `name` property). We must produce the **exact** same `name`
+the ingestion writes, or we create a duplicate stub.
+
+- Find where stakgraph/codegraph ingests PRs and what it sets as `name` (PR
+  title? `owner/repo#123`? the PR URL? the head branch?). Also note `number`
+  and `source_link` on the `PullRequest` schema — one of those may be a more
+  stable join key than `name`.
+- Confirm `sanitize_node_key` behavior: `name` is lowercased, spaces stripped,
+  non-alphanumerics removed (`schema_validation.py:sanitize_node_key`). The
+  linker must mirror that normalization if it constructs node_data endpoints.
+- **Safer alternative:** rather than reconstructing the node_key, look the PR
+  node up first (e.g. read API by `number`/`source_link` within the workspace
+  namespace) and create the edge by **`ref_id`**. This avoids any chance of stub
+  creation. Decide lookup-by-ref vs. node_key-endpoint during the spike.
+
+### B. Where does a Hive `Task` record its PR?
+
+We need a reliable per-task PR reference (number and/or URL). Candidate sources,
+to be verified:
+
+- `Task.branch` — head branch; may be matchable to the PR.
+- `Artifact` rows on the task's `ChatMessage`s — there may be a PR-typed
+  artifact (`ArtifactType`) whose `content` JSON holds the PR URL/number.
+- `Task` deployment / workflow fields, or a `Deployment` relation.
+
+Output of the spike: a small function `getTaskPullRequests(task): { number, url,
+repo }[]` and a confirmed PR-node match strategy.
+
+## Sketch (after the spike)
+
+- **Schema (jarvis-backend):** add an edge to the Hive library:
+  `HiveTask -RESULTED_IN-> PullRequest` (or reuse an existing relationship verb).
+  Lands in `get_hive_schema_edges()` alongside `HAS_TASK` / `HAS_MESSAGE`.
+- **Tracking:** avoid re-linking every run. Either:
+  - a per-task boolean/marker (`jarvisPrLinkedAt` on `Task`), or
+  - rely on edge idempotency (the edge endpoint dedups by edge_key) and just
+    scan a bounded window of recent tasks-with-PRs each run.
+  Prefer a marker so the scan stays cheap as task count grows.
+- **Cron:** `src/app/api/cron/jarvis-pr-links/route.ts` + a
+  `jarvis-pr-link-cron.ts` service. Per workspace with a swarm:
+  1. find tasks that have a PR but are not yet linked (capped per run),
+  2. resolve each PR node (lookup-by-ref **or** node_key endpoint per the spike),
+  3. `addEdgeBulk` the `RESULTED_IN` edges,
+  4. mark linked.
+  CRON_SECRET guard, `maxDuration`, best-effort per workspace — mirror the
+  entity cron's posture.
+- **Schedule:** hourly (`0 * * * *`) is fine; linking is eventually-consistent.
+
+## Out of scope
+
+- Linking PRs to `HiveFeature` (could be derived transitively via the task).
+- Commit / file-level links — the codegraph already models those; this plan is
+  only the task → PR bridge.
+
+## Related
+
+- Entity mirror: `src/services/jarvis-mirror-cron.ts`,
+  `src/services/jarvis-mirror/mappers.ts`, `src/services/swarm/api/nodes.ts`
+  (`addEdgeBulk` already accepts `{ node_type, node_data }` / `{ ref_id }`
+  endpoints).
+- Jarvis Hive ontology: `jarvis-backend` `get_hive_schema_library()` /
+  `get_hive_schema_edges()` (PR stakwork/jarvis-backend#2925).
+- Connection resolution: `src/lib/helpers/jarvis-config.ts`.

--- a/prisma/migrations/20260625225013_add_workspace_jarvis_sync_state/migration.sql
+++ b/prisma/migrations/20260625225013_add_workspace_jarvis_sync_state/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "workspaces" ADD COLUMN     "jarvis_sync_state" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -268,6 +268,10 @@ model Workspace {
   scorerPatternPrompt     String?                  @map("scorer_pattern_prompt")
   scorerSinglePrompt      String?                  @map("scorer_single_prompt")
   scorerAggregateCache    Json?                    @map("scorer_aggregate_cache")
+  // Keyset cursors for the Jarvis graph-mirror cron. Managed solely by
+  // `jarvis-mirror-cron`. Shape: { feature?: {at,id}, task?: {at,id}, chat?: {at,id} }
+  // where `at` is an ISO updatedAt and `id` is the row id (composite keyset).
+  jarvisSyncState         Json?                    @map("jarvis_sync_state")
   agentLogs               AgentLog[]
   diagrams                DiagramWorkspace[]
   discordChannels         DiscordChannel[]

--- a/src/__tests__/unit/services/jarvis-mirror-cron.test.ts
+++ b/src/__tests__/unit/services/jarvis-mirror-cron.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { db } from "@/lib/db";
+
+vi.mock("@/lib/db");
+
+vi.mock("@/lib/helpers/jarvis-config", () => ({
+  getJarvisConfigForWorkspace: vi.fn(),
+}));
+
+vi.mock("@/services/swarm/api/nodes", () => ({
+  addNodeBulk: vi.fn(async () => ({ success: true, errors: [] })),
+  addEdgeBulk: vi.fn(async () => ({ success: true, errors: [] })),
+}));
+
+import { getJarvisConfigForWorkspace } from "@/lib/helpers/jarvis-config";
+import { addNodeBulk, addEdgeBulk } from "@/services/swarm/api/nodes";
+import { runJarvisMirror } from "@/services/jarvis-mirror-cron";
+
+const mockedDb = vi.mocked(db, true);
+const mockedConfig = vi.mocked(getJarvisConfigForWorkspace);
+const mockedAddNodeBulk = vi.mocked(addNodeBulk);
+const mockedAddEdgeBulk = vi.mocked(addEdgeBulk);
+
+const CFG = { jarvisUrl: "https://sw.sphinx.chat:8444", apiKey: "key" };
+
+function setupDb(opts: {
+  workspaces?: any[];
+  features?: any[];
+  tasks?: any[];
+  messages?: any[];
+}) {
+  (mockedDb.workspace as any) = {
+    findMany: vi.fn(async () => opts.workspaces ?? []),
+    update: vi.fn(async () => ({})),
+  };
+  (mockedDb.feature as any) = { findMany: vi.fn(async () => opts.features ?? []) };
+  (mockedDb.task as any) = { findMany: vi.fn(async () => opts.tasks ?? []) };
+  (mockedDb.chatMessage as any) = { findMany: vi.fn(async () => opts.messages ?? []) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.USE_MOCKS;
+  mockedConfig.mockResolvedValue(CFG as any);
+  mockedAddNodeBulk.mockResolvedValue({ success: true, errors: [] });
+  mockedAddEdgeBulk.mockResolvedValue({ success: true, errors: [] });
+});
+
+const AT = new Date("2026-01-02T03:04:05.000Z");
+
+describe("runJarvisMirror", () => {
+  it("skips entirely when USE_MOCKS is set", async () => {
+    process.env.USE_MOCKS = "true";
+    setupDb({ workspaces: [{ id: "w1", slug: "w1", jarvisSyncState: null }] });
+    const res = await runJarvisMirror();
+    expect(res.processed).toBe(0);
+    expect(mockedAddNodeBulk).not.toHaveBeenCalled();
+  });
+
+  it("skips workspaces without a jarvis config", async () => {
+    setupDb({ workspaces: [{ id: "w1", slug: "w1", jarvisSyncState: null }] });
+    mockedConfig.mockResolvedValue(null);
+    const res = await runJarvisMirror();
+    expect(res.results[0].skipped).toBe("no jarvis config");
+    expect(mockedAddNodeBulk).not.toHaveBeenCalled();
+    expect((mockedDb.workspace as any).update).not.toHaveBeenCalled();
+  });
+
+  it("mirrors features/tasks/messages and advances the cursor", async () => {
+    setupDb({
+      workspaces: [{ id: "w1", slug: "w1", jarvisSyncState: null }],
+      features: [{ id: "f1", title: "F1", updatedAt: AT }],
+      tasks: [{ id: "t1", title: "T1", updatedAt: AT, feature: { id: "f1", title: "F1" } }],
+      messages: [
+        { id: "m1", message: "hi", role: "USER", updatedAt: AT, task: { id: "t1", title: "T1" }, feature: null },
+      ],
+    });
+
+    const res = await runJarvisMirror();
+
+    expect(mockedAddNodeBulk).toHaveBeenCalledTimes(3); // feature, task, chat
+    expect(mockedAddEdgeBulk).toHaveBeenCalledTimes(2); // task->feature, msg->task
+    expect(res.results[0].counts).toEqual({ feature: 1, task: 1, chat: 1 });
+
+    const updateArg = (mockedDb.workspace as any).update.mock.calls[0][0];
+    expect(updateArg.data.jarvisSyncState.feature).toEqual({ at: AT.toISOString(), id: "f1" });
+    expect(updateArg.data.jarvisSyncState.task).toEqual({ at: AT.toISOString(), id: "t1" });
+    expect(updateArg.data.jarvisSyncState.chat).toEqual({ at: AT.toISOString(), id: "m1" });
+  });
+
+  it("does not write the cursor when nothing changed", async () => {
+    setupDb({ workspaces: [{ id: "w1", slug: "w1", jarvisSyncState: null }] });
+    await runJarvisMirror();
+    expect((mockedDb.workspace as any).update).not.toHaveBeenCalled();
+  });
+
+  it("reports capped=true and anyCapped when a batch fills maxPerType", async () => {
+    const features = Array.from({ length: 2 }, (_, i) => ({
+      id: `f${i}`,
+      title: `F${i}`,
+      updatedAt: new Date(AT.getTime() + i),
+    }));
+    setupDb({ workspaces: [{ id: "w1", slug: "w1", jarvisSyncState: null }], features });
+
+    const res = await runJarvisMirror({ maxPerType: 2 });
+    expect(res.anyCapped).toBe(true);
+    expect(res.results[0].capped).toBe(true);
+  });
+
+  it("passes the stored keyset cursor into the feature query", async () => {
+    const cursor = { at: AT.toISOString(), id: "f0" };
+    setupDb({
+      workspaces: [{ id: "w1", slug: "w1", jarvisSyncState: { feature: cursor } }],
+    });
+    await runJarvisMirror();
+    const where = (mockedDb.feature as any).findMany.mock.calls[0][0].where;
+    expect(where.OR).toEqual([
+      { updatedAt: { gt: new Date(cursor.at) } },
+      { updatedAt: new Date(cursor.at), id: { gt: "f0" } },
+    ]);
+  });
+
+  it("continues to other workspaces when one throws", async () => {
+    setupDb({
+      workspaces: [
+        { id: "w1", slug: "w1", jarvisSyncState: null },
+        { id: "w2", slug: "w2", jarvisSyncState: null },
+        { id: "w3", slug: "w3", jarvisSyncState: null },
+      ],
+      features: [{ id: "f1", title: "F1", updatedAt: AT }],
+    });
+    mockedConfig.mockResolvedValueOnce(CFG as any); // w1 ok
+    mockedConfig.mockRejectedValueOnce(new Error("boom")); // w2 throws
+    mockedConfig.mockResolvedValueOnce(CFG as any); // w3 ok
+
+    const res = await runJarvisMirror();
+    expect(res.processed).toBe(3);
+    expect(res.results[1].errors?.[0]).toContain("boom");
+    expect(res.results[2].counts?.feature).toBe(1);
+  });
+});

--- a/src/__tests__/unit/services/jarvis-mirror-mappers.test.ts
+++ b/src/__tests__/unit/services/jarvis-mirror-mappers.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import {
+  featureToNode,
+  taskToNode,
+  chatMessageToNode,
+  chatMessageName,
+  taskEdge,
+  chatMessageEdge,
+  HIVE_FEATURE,
+  HIVE_TASK,
+  HIVE_CHAT_MESSAGE,
+  EDGE_HAS_TASK,
+  EDGE_HAS_MESSAGE,
+} from "@/services/jarvis-mirror/mappers";
+
+const AT = new Date("2026-01-02T03:04:05.000Z");
+
+describe("jarvis-mirror mappers", () => {
+  describe("featureToNode", () => {
+    it("maps id -> feature_id (node_key field) and title -> name", () => {
+      const node = featureToNode({
+        id: "feat_1",
+        title: "My Feature",
+        status: "BACKLOG",
+        priority: "LOW",
+        brief: "a brief",
+        workspaceId: "ws_1",
+        createdAt: AT,
+        updatedAt: AT,
+      });
+      expect(node.node_type).toBe(HIVE_FEATURE);
+      expect(node.node_data.feature_id).toBe("feat_1");
+      expect(node.node_data.name).toBe("My Feature");
+      expect(node.node_data.brief).toBe("a brief");
+      expect(node.node_data.updated_at).toBe(AT.toISOString());
+    });
+
+    it("omits null/undefined fields", () => {
+      const node = featureToNode({ id: "f", title: "t", brief: null, requirements: undefined });
+      expect("brief" in node.node_data).toBe(false);
+      expect("requirements" in node.node_data).toBe(false);
+      expect("assignee_id" in node.node_data).toBe(false);
+    });
+  });
+
+  describe("taskToNode", () => {
+    it("maps id -> task_id and includes feature_id when present", () => {
+      const node = taskToNode({ id: "task_1", title: "Do it", featureId: "feat_1" });
+      expect(node.node_type).toBe(HIVE_TASK);
+      expect(node.node_data.task_id).toBe("task_1");
+      expect(node.node_data.name).toBe("Do it");
+      expect(node.node_data.feature_id).toBe("feat_1");
+    });
+  });
+
+  describe("chatMessageToNode / chatMessageName", () => {
+    it("builds a short role-prefixed name and keeps full message", () => {
+      const m = { id: "m1", message: "Hello there friend", role: "USER" };
+      expect(chatMessageName(m)).toBe("user: Hello there friend");
+      const node = chatMessageToNode(m);
+      expect(node.node_type).toBe(HIVE_CHAT_MESSAGE);
+      expect(node.node_data.message_id).toBe("m1");
+      expect(node.node_data.message).toBe("Hello there friend");
+    });
+
+    it("truncates the name snippet but not the message", () => {
+      const long = "x".repeat(200);
+      const m = { id: "m1", message: long, role: "ASSISTANT" };
+      const name = chatMessageName(m);
+      expect(name.length).toBeLessThan(long.length);
+      expect(chatMessageToNode(m).node_data.message).toBe(long);
+    });
+  });
+
+  describe("taskEdge", () => {
+    it("returns HiveFeature -HAS_TASK-> HiveTask when task has a feature", () => {
+      const edge = taskEdge({
+        id: "task_1",
+        title: "T",
+        feature: { id: "feat_1", title: "F" },
+      });
+      expect(edge).not.toBeNull();
+      expect(edge!.edge.edge_type).toBe(EDGE_HAS_TASK);
+      expect(edge!.source).toEqual({
+        node_type: HIVE_FEATURE,
+        node_data: { feature_id: "feat_1", name: "F" },
+      });
+      expect(edge!.target).toEqual({
+        node_type: HIVE_TASK,
+        node_data: { task_id: "task_1", name: "T" },
+      });
+    });
+
+    it("returns null when task has no feature", () => {
+      expect(taskEdge({ id: "task_1", title: "T", feature: null })).toBeNull();
+    });
+  });
+
+  describe("chatMessageEdge", () => {
+    it("links to the task when message has a task parent", () => {
+      const edge = chatMessageEdge({
+        id: "m1",
+        message: "hi",
+        role: "USER",
+        task: { id: "task_1", title: "T" },
+      });
+      expect(edge!.edge.edge_type).toBe(EDGE_HAS_MESSAGE);
+      expect(edge!.source.node_type).toBe(HIVE_TASK);
+      expect((edge!.source.node_data as { task_id: string }).task_id).toBe("task_1");
+      expect(edge!.target.node_type).toBe(HIVE_CHAT_MESSAGE);
+    });
+
+    it("links to the feature when message has only a feature parent", () => {
+      const edge = chatMessageEdge({
+        id: "m1",
+        message: "hi",
+        role: "USER",
+        feature: { id: "feat_1", title: "F" },
+      });
+      expect(edge!.source.node_type).toBe(HIVE_FEATURE);
+      expect((edge!.source.node_data as { feature_id: string }).feature_id).toBe("feat_1");
+    });
+
+    it("returns null when message has no parent", () => {
+      expect(chatMessageEdge({ id: "m1", message: "hi", role: "USER" })).toBeNull();
+    });
+  });
+});

--- a/src/app/api/cron/jarvis-mirror/route.ts
+++ b/src/app/api/cron/jarvis-mirror/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse, after } from "next/server";
+import { logger } from "@/lib/logger";
+import { runJarvisMirror } from "@/services/jarvis-mirror-cron";
+
+// Allow up to 5 minutes; one pass is bounded by maxPerType per workspace.
+export const maxDuration = 300;
+
+// How many times the job may self-chain in a single drain to avoid runaway loops.
+const MAX_CHAIN_DEPTH = 20;
+
+export async function GET(request: NextRequest) {
+  // Verify cron authorization (Vercel cron header OR CRON_SECRET bearer).
+  const isVercelCron = request.headers.get("x-vercel-cron");
+  const authHeader = request.headers.get("authorization");
+
+  if (!isVercelCron && process.env.CRON_SECRET) {
+    if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+  }
+
+  const depth = Number(request.nextUrl.searchParams.get("d") ?? "0") || 0;
+
+  logger.info(`[JARVIS MIRROR] cron invoked (depth=${depth})`, "JARVIS_MIRROR");
+
+  const result = await runJarvisMirror();
+
+  // Self-chain to drain a backlog quickly: if a batch was capped, immediately
+  // trigger another run that resumes from the advanced cursors.
+  if (result.anyCapped && depth < MAX_CHAIN_DEPTH) {
+    const url = new URL(request.url);
+    url.searchParams.set("d", String(depth + 1));
+    const headers: Record<string, string> = {};
+    if (process.env.CRON_SECRET) headers["authorization"] = `Bearer ${process.env.CRON_SECRET}`;
+
+    after(async () => {
+      try {
+        await fetch(url.toString(), { headers });
+      } catch (error) {
+        logger.warn("[JARVIS MIRROR] self-chain trigger failed", "JARVIS_MIRROR", { error });
+      }
+    });
+  }
+
+  return NextResponse.json({
+    success: true,
+    processed: result.processed,
+    anyCapped: result.anyCapped,
+    chained: result.anyCapped && depth < MAX_CHAIN_DEPTH,
+    results: result.results,
+  });
+}

--- a/src/services/jarvis-mirror-cron.ts
+++ b/src/services/jarvis-mirror-cron.ts
@@ -1,0 +1,256 @@
+/**
+ * Jarvis graph-mirror cron.
+ *
+ * Periodically mirrors Hive PM entities (Feature, Task, ChatMessage) from
+ * Postgres into each workspace's Jarvis knowledge graph as HiveFeature /
+ * HiveTask / HiveChatMessage nodes (+ HAS_TASK / HAS_MESSAGE edges).
+ *
+ * Design:
+ *  - Per-workspace keyset cursor `(updatedAt, id)` per entity type, stored on
+ *    `Workspace.jarvisSyncState`. Idempotent: node identity is the Postgres id
+ *    (carried in the schema node_key), upserted via `reprocess: true`.
+ *  - Bounded work per run (`maxPerType`), chunked bulk HTTP calls (`BULK_CHUNK`).
+ *  - Best-effort: a failure for one workspace never aborts the others; graph
+ *    writes are non-fatal. The route self-chains when a batch is capped so a
+ *    backlog drains quickly.
+ *  - Live rows only (skips soft-deleted / archived); chat excludes in-flight
+ *    SENDING messages.
+ */
+
+import { db } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { ChatStatus } from "@prisma/client";
+import { getJarvisConfigForWorkspace } from "@/lib/helpers/jarvis-config";
+import { addNodeBulk, addEdgeBulk } from "@/services/swarm/api/nodes";
+import type { JarvisConnectionConfig } from "@/types/jarvis";
+import {
+  featureToNode,
+  taskToNode,
+  chatMessageToNode,
+  taskEdge,
+  chatMessageEdge,
+  type JarvisNodePayload,
+  type JarvisEdgePayload,
+} from "@/services/jarvis-mirror/mappers";
+
+const LOG = "JARVIS_MIRROR";
+
+export const DEFAULT_MAX_PER_TYPE = 500;
+export const BULK_CHUNK = 100;
+
+type EntityType = "feature" | "task" | "chat";
+
+interface Cursor {
+  at: string; // ISO updatedAt of last processed row
+  id: string; // id of last processed row
+}
+
+type SyncState = Partial<Record<EntityType, Cursor>>;
+
+export interface WorkspaceMirrorResult {
+  workspaceId: string;
+  slug: string;
+  skipped?: string;
+  counts?: Record<EntityType, number>;
+  capped?: boolean;
+  errors?: string[];
+}
+
+export interface MirrorRunResult {
+  processed: number;
+  anyCapped: boolean;
+  results: WorkspaceMirrorResult[];
+}
+
+/** Build a Prisma keyset `where` fragment for `(updatedAt, id) > cursor`. */
+function keysetWhere(cursor?: Cursor) {
+  if (!cursor) return {};
+  const at = new Date(cursor.at);
+  return {
+    OR: [
+      { updatedAt: { gt: at } },
+      { updatedAt: at, id: { gt: cursor.id } },
+    ],
+  };
+}
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+}
+
+function parseState(raw: unknown): SyncState {
+  if (raw && typeof raw === "object") return raw as SyncState;
+  return {};
+}
+
+async function pushNodes(
+  config: JarvisConnectionConfig,
+  nodes: JarvisNodePayload[],
+  errors: string[],
+): Promise<void> {
+  for (const part of chunk(nodes, BULK_CHUNK)) {
+    const res = await addNodeBulk(config, part, { reprocess: true });
+    if (!res.success) errors.push(...res.errors);
+  }
+}
+
+async function pushEdges(
+  config: JarvisConnectionConfig,
+  edges: JarvisEdgePayload[],
+  errors: string[],
+): Promise<void> {
+  for (const part of chunk(edges, BULK_CHUNK)) {
+    const res = await addEdgeBulk(config, part);
+    if (!res.success) errors.push(...res.errors);
+  }
+}
+
+/** Mirror a single workspace. Mutates `state` in place with advanced cursors. */
+async function mirrorWorkspace(
+  workspace: { id: string; slug: string },
+  config: JarvisConnectionConfig,
+  state: SyncState,
+  maxPerType: number,
+): Promise<WorkspaceMirrorResult> {
+  const errors: string[] = [];
+  const counts: Record<EntityType, number> = { feature: 0, task: 0, chat: 0 };
+  let capped = false;
+
+  // --- Features ---
+  const features = await db.feature.findMany({
+    where: { workspaceId: workspace.id, deleted: false, ...keysetWhere(state.feature) },
+    orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
+    take: maxPerType,
+  });
+  if (features.length > 0) {
+    await pushNodes(config, features.map(featureToNode), errors);
+    const last = features[features.length - 1];
+    state.feature = { at: last.updatedAt.toISOString(), id: last.id };
+    counts.feature = features.length;
+    if (features.length === maxPerType) capped = true;
+  }
+
+  // --- Tasks (+ HAS_TASK edges) ---
+  const tasks = await db.task.findMany({
+    where: {
+      workspaceId: workspace.id,
+      deleted: false,
+      archived: false,
+      ...keysetWhere(state.task),
+    },
+    orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
+    take: maxPerType,
+    include: { feature: { select: { id: true, title: true } } },
+  });
+  if (tasks.length > 0) {
+    await pushNodes(config, tasks.map(taskToNode), errors);
+    const edges = tasks.map(taskEdge).filter((e): e is JarvisEdgePayload => e !== null);
+    await pushEdges(config, edges, errors);
+    const last = tasks[tasks.length - 1];
+    state.task = { at: last.updatedAt.toISOString(), id: last.id };
+    counts.task = tasks.length;
+    if (tasks.length === maxPerType) capped = true;
+  }
+
+  // --- Chat messages (+ HAS_MESSAGE edges) ---
+  // No direct workspaceId on ChatMessage — reach it via task or feature.
+  const messages = await db.chatMessage.findMany({
+    where: {
+      status: { not: ChatStatus.SENDING },
+      OR: [
+        { task: { workspaceId: workspace.id } },
+        { feature: { workspaceId: workspace.id } },
+      ],
+      ...keysetWhere(state.chat),
+    },
+    orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
+    take: maxPerType,
+    include: {
+      task: { select: { id: true, title: true } },
+      feature: { select: { id: true, title: true } },
+    },
+  });
+  if (messages.length > 0) {
+    await pushNodes(config, messages.map(chatMessageToNode), errors);
+    const edges = messages
+      .map(chatMessageEdge)
+      .filter((e): e is JarvisEdgePayload => e !== null);
+    await pushEdges(config, edges, errors);
+    const last = messages[messages.length - 1];
+    state.chat = { at: last.updatedAt.toISOString(), id: last.id };
+    counts.chat = messages.length;
+    if (messages.length === maxPerType) capped = true;
+  }
+
+  return { workspaceId: workspace.id, slug: workspace.slug, counts, capped, errors };
+}
+
+/**
+ * Run one mirror pass across all workspaces that have a swarm configured.
+ * Returns `anyCapped` so the caller can self-chain to drain a backlog.
+ */
+export async function runJarvisMirror(
+  opts: { maxPerType?: number } = {},
+): Promise<MirrorRunResult> {
+  const maxPerType = opts.maxPerType ?? DEFAULT_MAX_PER_TYPE;
+
+  if (process.env.USE_MOCKS === "true") {
+    logger.info("[JARVIS MIRROR] USE_MOCKS enabled, skipping", LOG);
+    return { processed: 0, anyCapped: false, results: [] };
+  }
+
+  const workspaces = await db.workspace.findMany({
+    where: { deleted: false, swarm: { isNot: null } },
+    select: { id: true, slug: true, jarvisSyncState: true },
+  });
+
+  logger.info(`[JARVIS MIRROR] Starting for ${workspaces.length} workspaces`, LOG);
+
+  const results: WorkspaceMirrorResult[] = [];
+  let anyCapped = false;
+
+  for (const ws of workspaces) {
+    try {
+      const config = await getJarvisConfigForWorkspace(ws.id);
+      if (!config) {
+        results.push({ workspaceId: ws.id, slug: ws.slug, skipped: "no jarvis config" });
+        continue;
+      }
+
+      const state = parseState(ws.jarvisSyncState);
+      const result = await mirrorWorkspace(ws, config, state, maxPerType);
+
+      // Persist advanced cursors (best-effort, only if something moved).
+      if (result.counts && (result.counts.feature || result.counts.task || result.counts.chat)) {
+        await db.workspace.update({
+          where: { id: ws.id },
+          data: { jarvisSyncState: state as object },
+        });
+      }
+
+      if (result.capped) anyCapped = true;
+      if (result.errors && result.errors.length > 0) {
+        logger.warn(`[JARVIS MIRROR] ${ws.slug}: ${result.errors.length} graph errors`, LOG, {
+          errors: result.errors.slice(0, 5),
+        });
+      }
+      results.push(result);
+    } catch (error) {
+      logger.error(`[JARVIS MIRROR] Failed for workspace ${ws.slug}`, LOG, { error });
+      results.push({
+        workspaceId: ws.id,
+        slug: ws.slug,
+        errors: [error instanceof Error ? error.message : String(error)],
+      });
+    }
+  }
+
+  logger.info(
+    `[JARVIS MIRROR] Done. processed=${workspaces.length} anyCapped=${anyCapped}`,
+    LOG,
+  );
+
+  return { processed: workspaces.length, anyCapped, results };
+}

--- a/src/services/jarvis-mirror/mappers.ts
+++ b/src/services/jarvis-mirror/mappers.ts
@@ -1,0 +1,210 @@
+/**
+ * Pure mappers from Hive Postgres entities → Jarvis graph nodes/edges.
+ *
+ * Node identity is the Postgres id, carried in the schema node_key field
+ * (feature_id / task_id / message_id). See the `Hive` schema library in
+ * jarvis-backend (HiveFeature / HiveTask / HiveChatMessage).
+ *
+ * Edge endpoints are specified by `{ node_type, node_data }` so Jarvis can
+ * resolve them by node_key — but node_data must still satisfy the schema's
+ * required (non-`?`) attributes, hence the minimal endpoint helpers below
+ * always include the required fields (`name`, and `message` for chat).
+ */
+
+export const HIVE_FEATURE = "HiveFeature";
+export const HIVE_TASK = "HiveTask";
+export const HIVE_CHAT_MESSAGE = "HiveChatMessage";
+
+export const EDGE_HAS_TASK = "HAS_TASK";
+export const EDGE_HAS_MESSAGE = "HAS_MESSAGE";
+
+export interface JarvisNodePayload {
+  node_type: string;
+  node_data: Record<string, unknown>;
+}
+
+export interface JarvisEdgePayload {
+  edge: { edge_type: string; edge_data?: Record<string, unknown> };
+  source: { node_type: string; node_data: Record<string, unknown> };
+  target: { node_type: string; node_data: Record<string, unknown> };
+}
+
+// Minimal subset of fields each mapper reads. Kept loose so callers can pass
+// Prisma rows (with extra fields) directly.
+export interface FeatureRow {
+  id: string;
+  title: string;
+  status?: string | null;
+  priority?: string | null;
+  brief?: string | null;
+  requirements?: string | null;
+  architecture?: string | null;
+  workspaceId?: string | null;
+  assigneeId?: string | null;
+  createdAt?: Date | null;
+  updatedAt?: Date | null;
+}
+
+export interface TaskRow {
+  id: string;
+  title: string;
+  description?: string | null;
+  summary?: string | null;
+  status?: string | null;
+  priority?: string | null;
+  sourceType?: string | null;
+  branch?: string | null;
+  featureId?: string | null;
+  phaseId?: string | null;
+  workspaceId?: string | null;
+  repositoryId?: string | null;
+  assigneeId?: string | null;
+  createdAt?: Date | null;
+  updatedAt?: Date | null;
+  // Parent feature (selected for edge wiring); title needed for the endpoint.
+  feature?: { id: string; title: string } | null;
+}
+
+export interface ChatMessageRow {
+  id: string;
+  message: string;
+  role?: string | null;
+  status?: string | null;
+  taskId?: string | null;
+  featureId?: string | null;
+  userId?: string | null;
+  createdAt?: Date | null;
+  updatedAt?: Date | null;
+  // Parents (one of these is set); title needed for the endpoint.
+  task?: { id: string; title: string } | null;
+  feature?: { id: string; title: string } | null;
+}
+
+function iso(d?: Date | null): string | undefined {
+  return d ? new Date(d).toISOString() : undefined;
+}
+
+/** Drop undefined/null so Jarvis schema validation doesn't see empty props. */
+function clean(data: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(data)) {
+    if (v !== undefined && v !== null) out[k] = v;
+  }
+  return out;
+}
+
+const SNIPPET_LEN = 80;
+
+/** A short, human-readable `name` for a chat message node (title_key). */
+export function chatMessageName(m: ChatMessageRow): string {
+  const role = (m.role ?? "message").toString().toLowerCase();
+  const snippet = (m.message ?? "").replace(/\s+/g, " ").trim().slice(0, SNIPPET_LEN);
+  return snippet ? `${role}: ${snippet}` : role;
+}
+
+export function featureToNode(f: FeatureRow): JarvisNodePayload {
+  return {
+    node_type: HIVE_FEATURE,
+    node_data: clean({
+      feature_id: f.id,
+      name: f.title,
+      status: f.status,
+      priority: f.priority,
+      brief: f.brief,
+      requirements: f.requirements,
+      architecture: f.architecture,
+      workspace_id: f.workspaceId,
+      assignee_id: f.assigneeId,
+      created_at: iso(f.createdAt),
+      updated_at: iso(f.updatedAt),
+    }),
+  };
+}
+
+export function taskToNode(t: TaskRow): JarvisNodePayload {
+  return {
+    node_type: HIVE_TASK,
+    node_data: clean({
+      task_id: t.id,
+      name: t.title,
+      description: t.description,
+      summary: t.summary,
+      status: t.status,
+      priority: t.priority,
+      source_type: t.sourceType,
+      branch: t.branch,
+      feature_id: t.featureId,
+      phase_id: t.phaseId,
+      workspace_id: t.workspaceId,
+      repository_id: t.repositoryId,
+      assignee_id: t.assigneeId,
+      created_at: iso(t.createdAt),
+      updated_at: iso(t.updatedAt),
+    }),
+  };
+}
+
+export function chatMessageToNode(m: ChatMessageRow): JarvisNodePayload {
+  return {
+    node_type: HIVE_CHAT_MESSAGE,
+    node_data: clean({
+      message_id: m.id,
+      name: chatMessageName(m),
+      message: m.message,
+      role: m.role,
+      status: m.status,
+      task_id: m.taskId,
+      feature_id: m.featureId,
+      user_id: m.userId,
+      created_at: iso(m.createdAt),
+      updated_at: iso(m.updatedAt),
+    }),
+  };
+}
+
+// --- Edge endpoint helpers (identity + schema-required fields only) ---
+
+function featureEndpoint(id: string, title: string) {
+  return { node_type: HIVE_FEATURE, node_data: { feature_id: id, name: title } };
+}
+function taskEndpoint(id: string, title: string) {
+  return { node_type: HIVE_TASK, node_data: { task_id: id, name: title } };
+}
+function chatEndpoint(m: ChatMessageRow) {
+  return {
+    node_type: HIVE_CHAT_MESSAGE,
+    node_data: { message_id: m.id, name: chatMessageName(m), message: m.message },
+  };
+}
+
+/** HiveFeature -HAS_TASK-> HiveTask, when the task belongs to a feature. */
+export function taskEdge(t: TaskRow): JarvisEdgePayload | null {
+  if (!t.feature) return null;
+  return {
+    edge: { edge_type: EDGE_HAS_TASK },
+    source: featureEndpoint(t.feature.id, t.feature.title),
+    target: taskEndpoint(t.id, t.title),
+  };
+}
+
+/**
+ * HiveTask|HiveFeature -HAS_MESSAGE-> HiveChatMessage, depending on which
+ * parent the message is attached to. Returns null if neither parent is present.
+ */
+export function chatMessageEdge(m: ChatMessageRow): JarvisEdgePayload | null {
+  if (m.task) {
+    return {
+      edge: { edge_type: EDGE_HAS_MESSAGE },
+      source: taskEndpoint(m.task.id, m.task.title),
+      target: chatEndpoint(m),
+    };
+  }
+  if (m.feature) {
+    return {
+      edge: { edge_type: EDGE_HAS_MESSAGE },
+      source: featureEndpoint(m.feature.id, m.feature.title),
+      target: chatEndpoint(m),
+    };
+  }
+  return null;
+}

--- a/src/services/swarm/api/nodes.ts
+++ b/src/services/swarm/api/nodes.ts
@@ -70,12 +70,15 @@ async function jarvisRequest({
 export async function addNode(
   config: JarvisConnectionConfig,
   payload: { node_type: string; node_data: Record<string, unknown> },
+  opts?: { reprocess?: boolean },
 ): Promise<{ success: boolean; ref_id?: string; alreadyExists?: boolean; error?: string }> {
   const result = await jarvisRequest({
     config,
     endpoint: "/node",
     method: "POST",
-    data: payload,
+    // `reprocess: true` makes Jarvis update an existing node (matched by
+    // node_key) in place instead of returning an "already exists" warning.
+    data: opts?.reprocess ? { ...payload, reprocess: true } : payload,
   });
 
   if (!result.ok) {
@@ -121,12 +124,22 @@ export async function addNode(
   };
 }
 
+/**
+ * An edge endpoint can be specified either by its existing `ref_id`, or by
+ * `{ node_type, node_data }` — in which case Jarvis resolves (or creates) the
+ * node by its schema node_key. The node_key path lets callers wire edges
+ * purely from stable identifiers (e.g. a Postgres id) without tracking ref_ids.
+ */
+export type JarvisEdgeEndpoint =
+  | { ref_id: string }
+  | { node_type: string; node_data: Record<string, unknown> };
+
 export async function addEdge(
   config: JarvisConnectionConfig,
   payload: {
     edge: { edge_type: string; edge_data?: Record<string, unknown> };
-    source: { ref_id: string };
-    target: { ref_id: string };
+    source: JarvisEdgeEndpoint;
+    target: JarvisEdgeEndpoint;
   },
 ): Promise<{ success: boolean; error?: string }> {
   const result = await jarvisRequest({
@@ -162,10 +175,11 @@ export async function addEdgeBulk(
   config: JarvisConnectionConfig,
   edgeList: Array<{
     edge: { edge_type: string; weight?: number; edge_data?: Record<string, unknown> };
-    source: { ref_id: string };
-    target: { ref_id: string };
+    source: JarvisEdgeEndpoint;
+    target: JarvisEdgeEndpoint;
   }>,
 ): Promise<{ success: boolean; errors: string[] }> {
+  if (edgeList.length === 0) return { success: true, errors: [] };
   const result = await jarvisRequest({
     config,
     endpoint: "/node/edge/bulk",
@@ -190,6 +204,55 @@ export async function addEdgeBulk(
 
   return {
     success: body?.status?.toLowerCase() === "success",
+    errors,
+  };
+}
+
+/**
+ * Bulk create-or-merge nodes in a single request (Jarvis `/node/bulk`).
+ * With `reprocess: true`, existing nodes (matched by node_key) are updated in
+ * place. Jarvis processes the list sequentially in one Neo4j session, so this
+ * collapses many round-trips into one HTTP call. Errors are returned, never
+ * thrown. Callers should chunk large lists (see BULK_CHUNK in the mirror cron).
+ */
+export async function addNodeBulk(
+  config: JarvisConnectionConfig,
+  nodes: Array<{ node_type: string; node_data: Record<string, unknown> }>,
+  opts?: { reprocess?: boolean },
+): Promise<{ success: boolean; errors: string[] }> {
+  if (nodes.length === 0) return { success: true, errors: [] };
+
+  const nodeList = opts?.reprocess
+    ? nodes.map((n) => ({ ...n, reprocess: true }))
+    : nodes;
+
+  const result = await jarvisRequest({
+    config,
+    endpoint: "/node/bulk",
+    method: "POST",
+    data: { node_list: nodeList },
+  });
+
+  if (!result.ok) {
+    return {
+      success: false,
+      errors: [result.error || `Failed to create nodes (status: ${result.status})`],
+    };
+  }
+
+  const body = result.body as
+    | { status?: string; status_messages?: string[] }
+    | undefined;
+
+  const errors = (body?.status_messages ?? []).filter((m) =>
+    m.toLowerCase().startsWith("error"),
+  );
+
+  // Bulk node returns "Warning" when some nodes already existed (without
+  // reprocess); treat Success and Warning as non-fatal — only collected
+  // "ERROR:" messages indicate real failures.
+  return {
+    success: errors.length === 0,
     errors,
   };
 }

--- a/vercel.json
+++ b/vercel.json
@@ -53,6 +53,10 @@
     {
       "path": "/api/cron/automations",
       "schedule": "* * * * *"
+    },
+    {
+      "path": "/api/cron/jarvis-mirror",
+      "schedule": "0 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## What

Adds an hourly cron that mirrors Hive PM entities (Postgres) into each workspace's **Jarvis** knowledge graph:

| Postgres | Graph node | node_key |
|---|---|---|
| `Feature` | `HiveFeature` | `hivefeature-feature_id` |
| `Task` | `HiveTask` | `hivetask-task_id` |
| `ChatMessage` | `HiveChatMessage` | `hivechatmessage-message_id` |

Edges: `HiveFeature -HAS_TASK-> HiveTask`, `HiveTask -HAS_MESSAGE-> HiveChatMessage`, `HiveFeature -HAS_MESSAGE-> HiveChatMessage`.

> **Depends on** the Jarvis ontology PR: stakwork/jarvis-backend#2925 (registers the `Hive*` schemas). Merge + deploy that first.

## How

- **Per-workspace keyset cursor** `(updatedAt, id)` per entity type, stored on new `Workspace.jarvisSyncState` (JSON). Each run processes rows where `(updatedAt, id) > cursor`, then advances the cursor.
- **Idempotent**: node identity is the Postgres id (carried in the schema node_key), upserted via `reprocess: true`. **No ref_ids stored in Postgres** — edges resolve their endpoints by node_key.
- **Bounded + scalable**: `maxPerType=500` rows/run, bulk HTTP calls chunked at `BULK_CHUNK=100` (new `addNodeBulk` + node_key-capable `addEdgeBulk`). `maxDuration=300`, and the route **self-chains** (via `after()`) when a batch is capped so a backfill backlog drains fast.
- **Live rows only** (skips soft-deleted/archived); chat excludes in-flight `SENDING` messages. Best-effort: one workspace failure never aborts the others; graph writes are non-fatal.

## Files

- `prisma`: `Workspace.jarvisSyncState` + migration
- `src/services/swarm/api/nodes.ts`: `addNode(reprocess)`, new `addNodeBulk`, `addEdgeBulk` accepts `{node_type,node_data}` endpoints (`JarvisEdgeEndpoint`)
- `src/services/jarvis-mirror/mappers.ts`: pure entity→node/edge mappers
- `src/services/jarvis-mirror-cron.ts`: the run loop
- `src/app/api/cron/jarvis-mirror/route.ts`: CRON_SECRET-guarded route, `maxDuration=300`, self-chaining
- `vercel.json`: hourly schedule (`0 * * * *`). `/api/cron` is already a `system` route in middleware — no policy change needed.

## Tests

- New: mappers (10) + cron (7) — cursor advance, keyset query, cap/self-chain signal, USE_MOCKS + no-swarm skips, SENDING exclusion, per-workspace error isolation.
- Full unit suite green (10,937 passed). Existing Jarvis nodes-client callers unaffected (edge endpoint type only widened to a superset).

## Out of scope (follow-up)

`HiveTask → PullRequest` linking — different trigger (PR node appears later, via codegraph ingestion, task row unchanged) and uncertain PR node_key identity. Planned as a separate, retry-oriented cron.