### PR TITLE
feat(jarvis): link HiveTask -> PullRequest graph nodes (+ mirror fixes)

### DIFF
--- a/docs/plans/jarvis-task-pr-linking.md
+++ b/docs/plans/jarvis-task-pr-linking.md
@@ -6,7 +6,13 @@ the task's graph node to the **existing** `PullRequest` node that the codegraph
 ingestion already created — so the graph connects "the work item" to "the code
 change it produced."
 
-Status: **proposed.**
+Status: **implemented.** Spikes A and B resolved (see below). Hive side shipped:
+`src/services/jarvis-pr-link-cron.ts`, `src/app/api/cron/jarvis-pr-links/route.ts`,
+PR mappers in `src/services/jarvis-mirror/mappers.ts`, `searchLatestByTypes` in
+`src/services/swarm/api/nodes.ts`, `Task.jarvisPrLinkedAt` marker, and the
+`jarvisSyncState.prLink.highWater` mark. **Remaining dependency:** the
+`HiveTask -RESULTED_IN-> PullRequest` edge must be added to the Hive schema in
+jarvis-backend (`get_hive_schema_edges()`) or the edge writes will be rejected.
 
 ## Why this is a separate job, not part of the mirror cron
 
@@ -20,13 +26,18 @@ last run. PR linking does **not** fit that model, for three reasons:
    would never revisit it to draw the edge. The real trigger is *"the PR node
    now exists in the graph"*, which the entity cursor can't observe.
 
-2. **Different, uncertain identity.** Drawing the edge means matching the
-   **existing** PR node's `node_key` (`pullrequest-name`, see the codegraph
-   schema in `jarvis-backend/api/constants/schema_library.py`). If we guess the
-   `name` wrong, Jarvis's create-or-merge edge endpoint will happily **create a
-   stub `PullRequest` node** instead of linking to the ingested one — silently
-   polluting the graph. This needs upfront research (below), which should not
-   block or complicate the clean entity mirror.
+2. **Stub-creation risk from name drift.** Drawing the edge by `node_key`
+   (`pullrequest-name`, see the codegraph schema in
+   `jarvis-backend/api/constants/schema_library.py`) is unsafe because the PR
+   node `name` is **not stable**: live data on a prod swarm shows older PRs
+   named `stakwork/hive/pr-1192.0` (carrying `legacyName: "pr-1192"`) while
+   newer ones are `stakwork/hive/pr-4542`. If we reconstruct the key from
+   `{repo}/pr-{number}` and the real node used the `.0` form, Jarvis's
+   create-or-merge edge endpoint will happily **create a stub `PullRequest`
+   node** instead of linking to the ingested one — silently polluting the
+   graph. The fix (spike A below) is to **not** use `node_key` at all: look the
+   node up by its stable integer `number` + `repo` properties and link by
+   `ref_id`.
 
 3. **Different timing/ordering.** The edge target must already exist. A job that
    runs independently and simply **keeps retrying** unlinked tasks is a far
@@ -34,63 +45,133 @@ last run. PR linking does **not** fit that model, for three reasons:
 
 So: a separate, retry-oriented cron that scans *unlinked tasks-with-PRs* and
 best-effort draws the edge. It reuses the same building blocks
-(`getJarvisConfigForWorkspace`, `addEdgeBulk` with node_key endpoints) — **no
+(`getJarvisConfigForWorkspace`, `addEdgeBulk` with `ref_id` endpoints) — **no
 new infrastructure**.
 
-## Research spike (do this first)
+## Research spike
 
-Two unknowns must be nailed down before writing the linker. Both are cheap.
+### A. How does codegraph name `PullRequest` nodes? — **RESOLVED**
 
-### A. How does codegraph name `PullRequest` nodes?
+Confirmed against a prod swarm (`POST /graph/search/latest-by-types` with
+`{"nodeTypes":{"PullRequest":N}}`). A representative node:
 
-The edge target is matched by the PR node's `node_key` = `pullrequest-name`
-(i.e. the sanitized `name` property). We must produce the **exact** same `name`
-the ingestion writes, or we create a duplicate stub.
+```
+node_type: PullRequest
+ref_id:    7a98f842-77e5-49b2-8418-5fda2565d8d0
+name:      stakwork/hive/pr-4542        (== id)
+number:    4542                         (integer)
+repo:      stakwork/hive
+url:       https://github.com/stakwork/hive/pull/4542
+title:     feat(jarvis): mirror Feature/Task/ChatMessage entities...
+```
 
-- Find where stakgraph/codegraph ingests PRs and what it sets as `name` (PR
-  title? `owner/repo#123`? the PR URL? the head branch?). Also note `number`
-  and `source_link` on the `PullRequest` schema — one of those may be a more
-  stable join key than `name`.
-- Confirm `sanitize_node_key` behavior: `name` is lowercased, spaces stripped,
-  non-alphanumerics removed (`schema_validation.py:sanitize_node_key`). The
-  linker must mirror that normalization if it constructs node_data endpoints.
-- **Safer alternative:** rather than reconstructing the node_key, look the PR
-  node up first (e.g. read API by `number`/`source_link` within the workspace
-  namespace) and create the edge by **`ref_id`**. This avoids any chance of stub
-  creation. Decide lookup-by-ref vs. node_key-endpoint during the spike.
+Property keys: `name, id, number, repo, url, title, date, files, docs, summary,
+newDeclarations` + token counts. Findings:
 
-### B. Where does a Hive `Task` record its PR?
+- **There is no `source_link`.** The stable join key is the integer `number`
+  plus `repo`. (`url` is derivable as `https://github.com/{repo}/pull/{number}`.)
+- **`name` is NOT stable — do not reconstruct the node_key.** Older PRs are
+  named `stakwork/hive/pr-1192.0` with `legacyName: "pr-1192"`; newer ones are
+  `stakwork/hive/pr-4542` (no `.0`). Building `pullrequest-{sanitize(name)}`
+  would miss the legacy form and create stubs.
+- **No usable by-key/by-property read endpoint.** Probed on prod:
+  `graph/search?node_type=[...]&name=...&node_key=...` **ignores the filters**
+  and returns a default set; `/v2/nodes/search` and `/v2/nodes` return empty for
+  `PullRequest`; `GET /node/{key}` 404s and `GET /node` 405s. The only endpoint
+  that returns PR nodes with properties is `POST /graph/search/latest-by-types`.
 
-We need a reliable per-task PR reference (number and/or URL). Candidate sources,
-to be verified:
+**Decision (lookup-by-ref):** the linker fetches `PullRequest` nodes via
+`latest-by-types`, builds a `Map<"{repo}#{number}", ref_id>` keyed on the stable
+integer `number` + `repo`, and creates edges by **`ref_id`**. This is immune to
+name drift and never creates stubs.
 
-- `Task.branch` — head branch; may be matchable to the PR.
-- `Artifact` rows on the task's `ChatMessage`s — there may be a PR-typed
-  artifact (`ArtifactType`) whose `content` JSON holds the PR URL/number.
-- `Task` deployment / workflow fields, or a `Deployment` relation.
+**Scale: full backfill once, then incremental by high-water mark.** Measured on
+prod:
 
-Output of the spike: a small function `getTaskPullRequests(task): { number, url,
-repo }[]` and a confirmed PR-node match strategy.
+- The endpoint has **no hard cap** — it honors the per-type limit and returns up
+  to the real total in one call (this swarm: 3406 PR nodes; requesting 5000
+  returned 3406). So "get all 4000" is one request, not paginated.
+- The match fields (`number`, `repo`) require `include_properties:true`, which
+  also drags the heavy `docs`/`files`/`summary` blobs: **~1.7 KB/PR** → a full
+  pull of 3406 was **5.8 MB / 7 s**. `include_properties:false` is cheap
+  (371 KB) but returns only `ref_id`/`date_added_to_graph` — useless for matching.
+- **Results are ordered `date_added_to_graph` DESC** (newest-ingested first,
+  verified).
+
+A fixed "recent window" would be **wrong**: on the first run every task-with-PR
+is unlinked and those PRs span the whole history, so a top-N window would never
+match (and therefore never link) the older ones. The requirement is that *all*
+linkable tasks get linked. So:
+
+- **First run / backfill: pull the full PR set** (one request; ~6 MB / 7 s for
+  ~4000 — fine as a one-time cost). Build the complete `{repo}#{number} → ref_id`
+  map and link every matchable task.
+- **Steady state: incremental high-water fetch.** Persist the greatest
+  `date_added_to_graph` processed (per workspace). Each run, read from the top of
+  the DESC list and **stop once you reach a `date_added_to_graph` ≤ the stored
+  high-water** — i.e. fetch only PRs ingested since last run. This is cheap and
+  still complete: backfill covered all history, and any later PR always enters at
+  the top, so it's caught on the next run. (A task can't reference a PR older
+  than itself in practice — the task's own agent opens the PR — so newly-unlinked
+  tasks always resolve against newly-ingested PRs.)
+- Combined with the per-task linked marker, only still-unlinked tasks are ever
+  chased, and the fetch volume is bounded by ingestion rate, not total PR count.
+
+### B. Where does a Hive `Task` record its PR? — **RESOLVED**
+
+There is **no PR column on `Task`**. A task's PR is a `PULL_REQUEST`-typed
+`Artifact` on one of the task's `ChatMessage`s; the canonical reference is
+`artifact.content.url` (the GitHub `html_url`). `content.repo`/`content.number`
+are inconsistent across writers (bare name vs `owner/repo`; `number` only in
+seed data), so **derive both `repo` and `number` from the URL** (see
+`parsePullRequestUrl`). Query path: `Task → chatMessages → artifacts
+(type='PULL_REQUEST') → content.url`. A task may have multiple PR artifacts
+(multi-repo / re-push) — de-dupe by `repo#number` and only mark the task linked
+once *all* its PRs resolve.
 
 ## Sketch (after the spike)
 
 - **Schema (jarvis-backend):** add an edge to the Hive library:
   `HiveTask -RESULTED_IN-> PullRequest` (or reuse an existing relationship verb).
   Lands in `get_hive_schema_edges()` alongside `HAS_TASK` / `HAS_MESSAGE`.
-- **Tracking:** avoid re-linking every run. Either:
-  - a per-task boolean/marker (`jarvisPrLinkedAt` on `Task`), or
-  - rely on edge idempotency (the edge endpoint dedups by edge_key) and just
-    scan a bounded window of recent tasks-with-PRs each run.
-  Prefer a marker so the scan stays cheap as task count grows.
+- **Tracking:** two pieces of state:
+  - a per-task marker (`jarvisPrLinkedAt` on `Task`) so the task scan only
+    chases still-unlinked tasks-with-PRs and stays cheap as task count grows
+    (edge creation is also idempotent — the endpoint dedups by edge_key — so the
+    marker is an optimization, not a correctness requirement), and
+  - a per-workspace PR-fetch high-water (greatest `date_added_to_graph` seen,
+    e.g. in `Swarm`/`jarvisSyncState`) so the PR pull is **full on first run**
+    and **incremental thereafter** (see spike A). Missing/zero high-water ⇒
+    backfill.
 - **Cron:** `src/app/api/cron/jarvis-pr-links/route.ts` + a
   `jarvis-pr-link-cron.ts` service. Per workspace with a swarm:
   1. find tasks that have a PR but are not yet linked (capped per run),
-  2. resolve each PR node (lookup-by-ref **or** node_key endpoint per the spike),
-  3. `addEdgeBulk` the `RESULTED_IN` edges,
-  4. mark linked.
-  CRON_SECRET guard, `maxDuration`, best-effort per workspace — mirror the
-  entity cron's posture.
-- **Schedule:** hourly (`0 * * * *`) is fine; linking is eventually-consistent.
+  2. fetch `PullRequest` nodes via `latest-by-types`
+     (`include_properties:true`, newest-ingested-first) — **full set on the first
+     run**, then **only those newer than the stored `date_added_to_graph`
+     high-water** on later runs — build a `Map<"{repo}#{number}", ref_id>`, and
+     resolve each task's PR to a `ref_id` (skip — retry next run — if not yet
+     ingested),
+   3. `addEdgeBulk` the `RESULTED_IN` edges with `target: { ref_id }` (chunked at
+      `BULK_CHUNK`),
+   4. mark linked; if the task batch hit the per-run cap, set `capped`.
+- **Vercel timeout — reuse the mirror's machinery verbatim** (it already survives
+  the limit): `export const maxDuration = 300`; bounded work per run (cap
+  PRs-linked-per-workspace, `BULK_CHUNK = 100`); **self-chain** via `after()` +
+  `?d=depth` up to `MAX_CHAIN_DEPTH` when `anyCapped`; best-effort per workspace
+  (one failure never aborts the loop); CRON_SECRET / `x-vercel-cron` guard. See
+  `src/app/api/cron/jarvis-mirror/route.ts` and `runJarvisMirror`.
+  - The full backfill PR pull is ~7 s for one workspace — well inside 300 s — and
+    the high-water mark means only workspaces still in backfill pay it; the rest
+    pull a tiny incremental slice. No single invocation runs long.
+  - **High-water vs. self-chain gotcha (unlike the mirror's keyset cursor):**
+    while a backfill is *capped* and self-chaining, the still-unlinked tasks point
+    at **old** PRs, so every chained run still needs the **full** map. Advancing
+    the high-water after the first pull would make the next chained run fetch only
+    *new* PRs and strand the backlog. Rule: **keep doing full PR pulls while
+    `capped`; only advance the high-water on an uncapped (fully-drained) pass.**
+- **Schedule:** hourly (`0 * * * *`); add to `vercel.json` `crons` alongside
+  `jarvis-mirror`. Linking is eventually-consistent.
 
 ## Out of scope
 
@@ -107,3 +188,5 @@ repo }[]` and a confirmed PR-node match strategy.
 - Jarvis Hive ontology: `jarvis-backend` `get_hive_schema_library()` /
   `get_hive_schema_edges()` (PR stakwork/jarvis-backend#2925).
 - Connection resolution: `src/lib/helpers/jarvis-config.ts`.
+- PR-node read: `POST /graph/search/latest-by-types` (same endpoint as
+  `src/app/api/swarm/jarvis/search-by-types/route.ts`, payload key `nodeTypes`).

--- a/prisma/migrations/20260626000000_add_jarvis_pr_link_state/migration.sql
+++ b/prisma/migrations/20260626000000_add_jarvis_pr_link_state/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "tasks" ADD COLUMN     "jarvis_pr_linked_at" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE INDEX "tasks_jarvis_pr_linked_at_idx" ON "tasks"("jarvis_pr_linked_at");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -268,9 +268,13 @@ model Workspace {
   scorerPatternPrompt     String?                  @map("scorer_pattern_prompt")
   scorerSinglePrompt      String?                  @map("scorer_single_prompt")
   scorerAggregateCache    Json?                    @map("scorer_aggregate_cache")
-  // Keyset cursors for the Jarvis graph-mirror cron. Managed solely by
-  // `jarvis-mirror-cron`. Shape: { feature?: {at,id}, task?: {at,id}, chat?: {at,id} }
-  // where `at` is an ISO updatedAt and `id` is the row id (composite keyset).
+  // Shared sync state for the Jarvis crons (read-modify-write; each cron only
+  // touches its own keys, so unknown keys survive). Staggered schedules avoid
+  // same-minute write races. Shape:
+  //   { feature?, task?, chat?: {at,id},   // jarvis-mirror keyset cursors
+  //     prLink?: { highWater?: ISO } }      // jarvis-pr-link PR high-water mark
+  // `prLink.highWater` is the greatest PullRequest `date_added_to_graph` already
+  // covered; absent ⇒ backfill (full PR pull); advanced only on a drained pass.
   jarvisSyncState         Json?                    @map("jarvis_sync_state")
   agentLogs               AgentLog[]
   diagrams                DiagramWorkspace[]
@@ -551,6 +555,9 @@ model Task {
   deployedToStagingAt    DateTime?             @map("deployed_to_staging_at")
   deploymentStatus       String?               @map("deployment_status")
   haltRetryAttempted     Boolean               @default(false) @map("halt_retry_attempted")
+  // Set by `jarvis-pr-link-cron` once this task's PR(s) are linked to their
+  // PullRequest graph nodes. Null ⇒ still needs linking (scanned each run).
+  jarvisPrLinkedAt       DateTime?             @map("jarvis_pr_linked_at")
   agentLogs              AgentLog[]
   chatMessages           ChatMessage[]
   deployments            Deployment[]
@@ -579,6 +586,7 @@ model Task {
   @@index([layerType])
   @@index([deploymentStatus])
   @@index([repositoryId])
+  @@index([jarvisPrLinkedAt])
   @@map("tasks")
 }
 

--- a/src/__tests__/unit/services/jarvis-mirror-cron.test.ts
+++ b/src/__tests__/unit/services/jarvis-mirror-cron.test.ts
@@ -107,6 +107,37 @@ describe("runJarvisMirror", () => {
     expect(res.results[0].capped).toBe(true);
   });
 
+  it("does NOT advance the cursor when the node write fails", async () => {
+    mockedAddNodeBulk.mockResolvedValue({
+      success: false,
+      errors: ["Error processing node: Not a valid node_type"],
+    });
+    setupDb({
+      workspaces: [{ id: "w1", slug: "w1", jarvisSyncState: null }],
+      features: [{ id: "f1", title: "F1", updatedAt: AT }],
+    });
+
+    const res = await runJarvisMirror();
+
+    // Write failed → cursor stays put so the row is retried next run.
+    expect(res.results[0].counts?.feature).toBe(0);
+    expect(res.results[0].errors?.length).toBeGreaterThan(0);
+    // Nothing advanced → no cursor persisted.
+    expect((mockedDb.workspace as any).update).not.toHaveBeenCalled();
+  });
+
+  it("does NOT advance the task cursor when the edge write fails", async () => {
+    mockedAddEdgeBulk.mockResolvedValue({ success: false, errors: ["edge boom"] });
+    setupDb({
+      workspaces: [{ id: "w1", slug: "w1", jarvisSyncState: null }],
+      tasks: [{ id: "t1", title: "T1", updatedAt: AT, feature: { id: "f1", title: "F1" } }],
+    });
+
+    const res = await runJarvisMirror();
+    expect(res.results[0].counts?.task).toBe(0);
+    expect((mockedDb.workspace as any).update).not.toHaveBeenCalled();
+  });
+
   it("passes the stored keyset cursor into the feature query", async () => {
     const cursor = { at: AT.toISOString(), id: "f0" };
     setupDb({

--- a/src/__tests__/unit/services/jarvis-mirror-cron.test.ts
+++ b/src/__tests__/unit/services/jarvis-mirror-cron.test.ts
@@ -138,6 +138,14 @@ describe("runJarvisMirror", () => {
     expect((mockedDb.workspace as any).update).not.toHaveBeenCalled();
   });
 
+  it("excludes text-less messages (artifact-only) and SENDING from the chat query", async () => {
+    setupDb({ workspaces: [{ id: "w1", slug: "w1", jarvisSyncState: null }] });
+    await runJarvisMirror();
+    const where = (mockedDb.chatMessage as any).findMany.mock.calls[0][0].where;
+    expect(where.message).toEqual({ not: "" });
+    expect(where.status).toEqual({ not: "SENDING" });
+  });
+
   it("passes the stored keyset cursor into the feature query", async () => {
     const cursor = { at: AT.toISOString(), id: "f0" };
     setupDb({

--- a/src/__tests__/unit/services/jarvis-mirror-mappers.test.ts
+++ b/src/__tests__/unit/services/jarvis-mirror-mappers.test.ts
@@ -6,11 +6,15 @@ import {
   chatMessageName,
   taskEdge,
   chatMessageEdge,
+  parsePullRequestUrl,
+  prNodeKey,
+  taskPrEdge,
   HIVE_FEATURE,
   HIVE_TASK,
   HIVE_CHAT_MESSAGE,
   EDGE_HAS_TASK,
   EDGE_HAS_MESSAGE,
+  EDGE_RESULTED_IN,
 } from "@/services/jarvis-mirror/mappers";
 
 const AT = new Date("2026-01-02T03:04:05.000Z");
@@ -123,6 +127,46 @@ describe("jarvis-mirror mappers", () => {
 
     it("returns null when message has no parent", () => {
       expect(chatMessageEdge({ id: "m1", message: "hi", role: "USER" })).toBeNull();
+    });
+  });
+
+  describe("parsePullRequestUrl", () => {
+    it("extracts owner/repo and number from a PR html_url", () => {
+      expect(parsePullRequestUrl("https://github.com/stakwork/hive/pull/4542")).toEqual({
+        repo: "stakwork/hive",
+        number: 4542,
+      });
+    });
+
+    it("ignores trailing path/query and is case-insensitive on host", () => {
+      expect(parsePullRequestUrl("https://GitHub.com/Org/Repo/pull/12/files?x=1")).toEqual({
+        repo: "Org/Repo",
+        number: 12,
+      });
+    });
+
+    it("returns null for non-PR urls and non-strings", () => {
+      expect(parsePullRequestUrl("https://github.com/stakwork/hive/issues/4542")).toBeNull();
+      expect(parsePullRequestUrl("https://github.com/stakwork/hive/pull/abc")).toBeNull();
+      expect(parsePullRequestUrl(undefined)).toBeNull();
+      expect(parsePullRequestUrl(123)).toBeNull();
+    });
+  });
+
+  describe("prNodeKey", () => {
+    it("lowercases repo so url-derived and graph-stored repos match", () => {
+      expect(prNodeKey("Stakwork/Hive", 4542)).toBe("stakwork/hive#4542");
+      expect(prNodeKey("stakwork/hive", 4542)).toBe(prNodeKey("STAKWORK/HIVE", 4542));
+    });
+  });
+
+  describe("taskPrEdge", () => {
+    it("RESULTED_IN edge from HiveTask node_key to PR ref_id", () => {
+      const edge = taskPrEdge("task_1", "My Task", "pr-ref-abc");
+      expect(edge.edge.edge_type).toBe(EDGE_RESULTED_IN);
+      expect(edge.source.node_type).toBe(HIVE_TASK);
+      expect(edge.source.node_data).toEqual({ task_id: "task_1", name: "My Task" });
+      expect(edge.target).toEqual({ ref_id: "pr-ref-abc" });
     });
   });
 });

--- a/src/__tests__/unit/services/jarvis-pr-link-cron.test.ts
+++ b/src/__tests__/unit/services/jarvis-pr-link-cron.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { db } from "@/lib/db";
+
+vi.mock("@/lib/db");
+
+vi.mock("@/lib/helpers/jarvis-config", () => ({
+  getJarvisConfigForWorkspace: vi.fn(),
+}));
+
+vi.mock("@/services/swarm/api/nodes", () => ({
+  addEdgeBulk: vi.fn(async () => ({ success: true, errors: [] })),
+  searchLatestByTypes: vi.fn(async () => []),
+}));
+
+import { getJarvisConfigForWorkspace } from "@/lib/helpers/jarvis-config";
+import { addEdgeBulk, searchLatestByTypes } from "@/services/swarm/api/nodes";
+import { runJarvisPrLink } from "@/services/jarvis-pr-link-cron";
+
+const mockedDb = vi.mocked(db, true);
+const mockedConfig = vi.mocked(getJarvisConfigForWorkspace);
+const mockedAddEdgeBulk = vi.mocked(addEdgeBulk);
+const mockedSearch = vi.mocked(searchLatestByTypes);
+
+const CFG = { jarvisUrl: "https://sw.sphinx.chat:8444", apiKey: "key" };
+
+const prArtifact = (url: string) => ({ artifacts: [{ content: { url } }] });
+
+function prNode(repo: string, number: number, ref_id: string, dateSec: number) {
+  return {
+    ref_id,
+    node_type: "PullRequest",
+    date_added_to_graph: dateSec,
+    properties: { repo, number },
+  };
+}
+
+function setupDb(opts: { workspaces?: any[]; tasks?: any[] }) {
+  (mockedDb.workspace as any) = {
+    findMany: vi.fn(async () => opts.workspaces ?? []),
+    update: vi.fn(async () => ({})),
+  };
+  (mockedDb.task as any) = {
+    findMany: vi.fn(async () => opts.tasks ?? []),
+    updateMany: vi.fn(async () => ({ count: (opts.tasks ?? []).length })),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.USE_MOCKS;
+  mockedConfig.mockResolvedValue(CFG as any);
+  mockedAddEdgeBulk.mockResolvedValue({ success: true, errors: [] });
+  mockedSearch.mockResolvedValue([]);
+});
+
+describe("runJarvisPrLink", () => {
+  it("skips entirely when USE_MOCKS is set", async () => {
+    process.env.USE_MOCKS = "true";
+    setupDb({ workspaces: [{ id: "w1", slug: "w1", jarvisSyncState: null }] });
+    const res = await runJarvisPrLink();
+    expect(res.processed).toBe(0);
+    expect(mockedSearch).not.toHaveBeenCalled();
+  });
+
+  it("skips workspaces without a jarvis config", async () => {
+    setupDb({ workspaces: [{ id: "w1", slug: "w1", jarvisSyncState: null }] });
+    mockedConfig.mockResolvedValue(null);
+    const res = await runJarvisPrLink();
+    expect(res.results[0].skipped).toBe("no jarvis config");
+    expect(mockedSearch).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch PRs when a workspace has no unlinked tasks", async () => {
+    setupDb({ workspaces: [{ id: "w1", slug: "w1", jarvisSyncState: null }], tasks: [] });
+    const res = await runJarvisPrLink();
+    expect(mockedSearch).not.toHaveBeenCalled();
+    expect(res.results[0].linked).toBe(0);
+  });
+
+  it("links a task to its PR node by ref_id and advances the high-water (backfill)", async () => {
+    setupDb({
+      workspaces: [{ id: "w1", slug: "w1", jarvisSyncState: null }],
+      tasks: [
+        { id: "t1", title: "T1", chatMessages: [prArtifact("https://github.com/stakwork/hive/pull/4542")] },
+      ],
+    });
+    mockedSearch.mockResolvedValue([prNode("stakwork/hive", 4542, "ref-4542", 1782430995)]);
+
+    const res = await runJarvisPrLink();
+
+    // backfill: full pull
+    expect(mockedSearch).toHaveBeenCalledWith(CFG, { PullRequest: 100_000 }, { withProperties: true });
+
+    const edgeArg = mockedAddEdgeBulk.mock.calls[0][1];
+    expect(edgeArg).toHaveLength(1);
+    expect(edgeArg[0].target).toEqual({ ref_id: "ref-4542" });
+    expect((edgeArg[0].source as { node_data: unknown }).node_data).toEqual({
+      task_id: "t1",
+      name: "T1",
+    });
+
+    expect((mockedDb.task as any).updateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["t1"] } },
+      data: { jarvisPrLinkedAt: expect.any(Date) },
+    });
+
+    const wsUpdate = (mockedDb.workspace as any).update.mock.calls[0][0];
+    expect(wsUpdate.data.jarvisSyncState.prLink.highWater).toBe(
+      new Date(1782430995 * 1000).toISOString(),
+    );
+    expect(res.results[0].linked).toBe(1);
+  });
+
+  it("leaves a task unlinked when its PR node is not yet ingested (pending retry)", async () => {
+    setupDb({
+      workspaces: [{ id: "w1", slug: "w1", jarvisSyncState: null }],
+      tasks: [
+        { id: "t1", title: "T1", chatMessages: [prArtifact("https://github.com/stakwork/hive/pull/9999")] },
+      ],
+    });
+    mockedSearch.mockResolvedValue([prNode("stakwork/hive", 4542, "ref-4542", 1782430995)]);
+
+    const res = await runJarvisPrLink();
+
+    // No edge, and the task is NOT marked — it retries next run.
+    expect(mockedAddEdgeBulk).not.toHaveBeenCalled();
+    expect((mockedDb.task as any).updateMany).not.toHaveBeenCalled();
+    expect(res.results[0]).toMatchObject({ linked: 0, pending: 1 });
+    // Backfill coverage was complete (uncapped full pull), so the high-water
+    // still advances; PR #9999 will arrive newer and be caught incrementally.
+    const wsUpdate = (mockedDb.workspace as any).update.mock.calls[0][0];
+    expect(wsUpdate.data.jarvisSyncState.prLink.highWater).toBe(
+      new Date(1782430995 * 1000).toISOString(),
+    );
+  });
+
+  it("uses an incremental fetch when a high-water exists", async () => {
+    setupDb({
+      workspaces: [
+        {
+          id: "w1",
+          slug: "w1",
+          jarvisSyncState: { prLink: { highWater: new Date(1782000000 * 1000).toISOString() } },
+        },
+      ],
+      tasks: [
+        { id: "t1", title: "T1", chatMessages: [prArtifact("https://github.com/stakwork/hive/pull/4542")] },
+      ],
+    });
+    // Newest node is above the high-water, oldest returned is below it ⇒ boundary reached.
+    mockedSearch.mockResolvedValue([
+      prNode("stakwork/hive", 4542, "ref-4542", 1782430995),
+      prNode("stakwork/hive", 4000, "ref-old", 1781000000),
+    ]);
+
+    await runJarvisPrLink();
+
+    expect(mockedSearch).toHaveBeenCalledWith(CFG, { PullRequest: 2_000 }, { withProperties: true });
+  });
+
+  it("marks tasks with an unparseable PR url as linked so they stop being scanned", async () => {
+    setupDb({
+      workspaces: [{ id: "w1", slug: "w1", jarvisSyncState: null }],
+      tasks: [{ id: "t1", title: "T1", chatMessages: [prArtifact("not-a-pr-url")] }],
+    });
+
+    const res = await runJarvisPrLink();
+
+    expect(mockedAddEdgeBulk).not.toHaveBeenCalled();
+    expect((mockedDb.task as any).updateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["t1"] } },
+      data: { jarvisPrLinkedAt: expect.any(Date) },
+    });
+    expect(res.results[0].linked).toBe(1);
+  });
+
+  it("self-chains (capped) only when the batch is full AND progress was made", async () => {
+    const tasks = Array.from({ length: 2 }, (_, i) => ({
+      id: `t${i}`,
+      title: `T${i}`,
+      chatMessages: [prArtifact(`https://github.com/stakwork/hive/pull/${4000 + i}`)],
+    }));
+    setupDb({ workspaces: [{ id: "w1", slug: "w1", jarvisSyncState: null }], tasks });
+    mockedSearch.mockResolvedValue([
+      prNode("stakwork/hive", 4000, "r0", 1782430000),
+      prNode("stakwork/hive", 4001, "r1", 1782430995),
+    ]);
+
+    const res = await runJarvisPrLink({ maxPerRun: 2 });
+
+    expect(res.anyCapped).toBe(true);
+    expect(res.results[0].capped).toBe(true);
+    // high-water NOT advanced while capped/backfilling
+    expect((mockedDb.workspace as any).update).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/cron/jarvis-mirror/route.ts
+++ b/src/app/api/cron/jarvis-mirror/route.ts
@@ -42,11 +42,18 @@ export async function GET(request: NextRequest) {
     });
   }
 
+  // Surface a quick error sample so a manual curl is self-diagnostic.
+  const errorSamples = result.results
+    .flatMap((r) => r.errors ?? [])
+    .slice(0, 10);
+
   return NextResponse.json({
     success: true,
     processed: result.processed,
     anyCapped: result.anyCapped,
     chained: result.anyCapped && depth < MAX_CHAIN_DEPTH,
+    errorCount: result.results.reduce((n, r) => n + (r.errors?.length ?? 0), 0),
+    errorSamples,
     results: result.results,
   });
 }

--- a/src/app/api/cron/jarvis-pr-links/route.ts
+++ b/src/app/api/cron/jarvis-pr-links/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse, after } from "next/server";
+import { logger } from "@/lib/logger";
+import { runJarvisPrLink } from "@/services/jarvis-pr-link-cron";
+
+// Allow up to 5 minutes; one pass is bounded by maxPerRun per workspace.
+export const maxDuration = 300;
+
+// How many times the job may self-chain in a single drain to avoid runaway loops.
+const MAX_CHAIN_DEPTH = 20;
+
+export async function GET(request: NextRequest) {
+  // Verify cron authorization (Vercel cron header OR CRON_SECRET bearer).
+  const isVercelCron = request.headers.get("x-vercel-cron");
+  const authHeader = request.headers.get("authorization");
+
+  if (!isVercelCron && process.env.CRON_SECRET) {
+    if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+  }
+
+  // Opt-in kill switch so the code can ship dark and be turned on only once the
+  // PullRequest graph-node shape is confirmed (repo/number resolution) and the
+  // jarvis-backend RESULTED_IN edge schema is deployed.
+  if (process.env.JARVIS_PR_LINK_CRON_ENABLED !== "true") {
+    logger.info("[JARVIS PR LINK] disabled via JARVIS_PR_LINK_CRON_ENABLED", "JARVIS_PR_LINK");
+    return NextResponse.json({ success: true, disabled: true, processed: 0 });
+  }
+
+  const depth = Number(request.nextUrl.searchParams.get("d") ?? "0") || 0;
+
+  logger.info(`[JARVIS PR LINK] cron invoked (depth=${depth})`, "JARVIS_PR_LINK");
+
+  const result = await runJarvisPrLink();
+
+  // Self-chain to drain a backlog quickly: if a batch was capped, immediately
+  // trigger another run that resumes against still-unlinked tasks.
+  if (result.anyCapped && depth < MAX_CHAIN_DEPTH) {
+    const url = new URL(request.url);
+    url.searchParams.set("d", String(depth + 1));
+    const headers: Record<string, string> = {};
+    if (process.env.CRON_SECRET) headers["authorization"] = `Bearer ${process.env.CRON_SECRET}`;
+
+    after(async () => {
+      try {
+        await fetch(url.toString(), { headers });
+      } catch (error) {
+        logger.warn("[JARVIS PR LINK] self-chain trigger failed", "JARVIS_PR_LINK", { error });
+      }
+    });
+  }
+
+  return NextResponse.json({
+    success: true,
+    processed: result.processed,
+    anyCapped: result.anyCapped,
+    chained: result.anyCapped && depth < MAX_CHAIN_DEPTH,
+    results: result.results,
+  });
+}

--- a/src/services/jarvis-mirror-cron.ts
+++ b/src/services/jarvis-mirror-cron.ts
@@ -85,26 +85,38 @@ function parseState(raw: unknown): SyncState {
   return {};
 }
 
+/** Returns false if any chunk failed (errors collected into `errors`). */
 async function pushNodes(
   config: JarvisConnectionConfig,
   nodes: JarvisNodePayload[],
   errors: string[],
-): Promise<void> {
+): Promise<boolean> {
+  let ok = true;
   for (const part of chunk(nodes, BULK_CHUNK)) {
     const res = await addNodeBulk(config, part, { reprocess: true });
-    if (!res.success) errors.push(...res.errors);
+    if (!res.success) {
+      ok = false;
+      errors.push(...res.errors);
+    }
   }
+  return ok;
 }
 
+/** Returns false if any chunk failed (errors collected into `errors`). */
 async function pushEdges(
   config: JarvisConnectionConfig,
   edges: JarvisEdgePayload[],
   errors: string[],
-): Promise<void> {
+): Promise<boolean> {
+  let ok = true;
   for (const part of chunk(edges, BULK_CHUNK)) {
     const res = await addEdgeBulk(config, part);
-    if (!res.success) errors.push(...res.errors);
+    if (!res.success) {
+      ok = false;
+      errors.push(...res.errors);
+    }
   }
+  return ok;
 }
 
 /** Mirror a single workspace. Mutates `state` in place with advanced cursors. */
@@ -125,11 +137,15 @@ async function mirrorWorkspace(
     take: maxPerType,
   });
   if (features.length > 0) {
-    await pushNodes(config, features.map(featureToNode), errors);
-    const last = features[features.length - 1];
-    state.feature = { at: last.updatedAt.toISOString(), id: last.id };
-    counts.feature = features.length;
-    if (features.length === maxPerType) capped = true;
+    const ok = await pushNodes(config, features.map(featureToNode), errors);
+    // Only advance the cursor when the write succeeded — otherwise these rows
+    // would be skipped forever. Re-sends are idempotent (upsert by node_key).
+    if (ok) {
+      const last = features[features.length - 1];
+      state.feature = { at: last.updatedAt.toISOString(), id: last.id };
+      counts.feature = features.length;
+      if (features.length === maxPerType) capped = true;
+    }
   }
 
   // --- Tasks (+ HAS_TASK edges) ---
@@ -145,13 +161,15 @@ async function mirrorWorkspace(
     include: { feature: { select: { id: true, title: true } } },
   });
   if (tasks.length > 0) {
-    await pushNodes(config, tasks.map(taskToNode), errors);
+    const nodesOk = await pushNodes(config, tasks.map(taskToNode), errors);
     const edges = tasks.map(taskEdge).filter((e): e is JarvisEdgePayload => e !== null);
-    await pushEdges(config, edges, errors);
-    const last = tasks[tasks.length - 1];
-    state.task = { at: last.updatedAt.toISOString(), id: last.id };
-    counts.task = tasks.length;
-    if (tasks.length === maxPerType) capped = true;
+    const edgesOk = await pushEdges(config, edges, errors);
+    if (nodesOk && edgesOk) {
+      const last = tasks[tasks.length - 1];
+      state.task = { at: last.updatedAt.toISOString(), id: last.id };
+      counts.task = tasks.length;
+      if (tasks.length === maxPerType) capped = true;
+    }
   }
 
   // --- Chat messages (+ HAS_MESSAGE edges) ---
@@ -173,15 +191,17 @@ async function mirrorWorkspace(
     },
   });
   if (messages.length > 0) {
-    await pushNodes(config, messages.map(chatMessageToNode), errors);
+    const nodesOk = await pushNodes(config, messages.map(chatMessageToNode), errors);
     const edges = messages
       .map(chatMessageEdge)
       .filter((e): e is JarvisEdgePayload => e !== null);
-    await pushEdges(config, edges, errors);
-    const last = messages[messages.length - 1];
-    state.chat = { at: last.updatedAt.toISOString(), id: last.id };
-    counts.chat = messages.length;
-    if (messages.length === maxPerType) capped = true;
+    const edgesOk = await pushEdges(config, edges, errors);
+    if (nodesOk && edgesOk) {
+      const last = messages[messages.length - 1];
+      state.chat = { at: last.updatedAt.toISOString(), id: last.id };
+      counts.chat = messages.length;
+      if (messages.length === maxPerType) capped = true;
+    }
   }
 
   return { workspaceId: workspace.id, slug: workspace.slug, counts, capped, errors };

--- a/src/services/jarvis-mirror-cron.ts
+++ b/src/services/jarvis-mirror-cron.ts
@@ -177,6 +177,9 @@ async function mirrorWorkspace(
   const messages = await db.chatMessage.findMany({
     where: {
       status: { not: ChatStatus.SENDING },
+      // Skip text-less messages (e.g. artifact-only assistant turns) — they
+      // carry no `message` content and are just noise in the graph.
+      message: { not: "" },
       OR: [
         { task: { workspaceId: workspace.id } },
         { feature: { workspaceId: workspace.id } },

--- a/src/services/jarvis-mirror/mappers.ts
+++ b/src/services/jarvis-mirror/mappers.ts
@@ -9,6 +9,13 @@
  * resolve them by node_key — but node_data must still satisfy the schema's
  * required (non-`?`) attributes, hence the minimal endpoint helpers below
  * always include the required fields (`name`, and `message` for chat).
+ *
+ * NOTE on Neo4j label casing: Jarvis runs `.capitalize()` on every node type
+ * (on both schema registration and writes), so the type names below are stored
+ * as `Hivefeature` / `Hivetask` / `Hivechatmessage` labels in Neo4j (Neo4j
+ * labels are case-sensitive). Query the graph with the capitalized form, e.g.
+ * `MATCH (f:Hivefeature) ...`. The strings here stay PascalCase only so they
+ * read naturally and match the schema-library source.
  */
 
 export const HIVE_FEATURE = "HiveFeature";

--- a/src/services/jarvis-mirror/mappers.ts
+++ b/src/services/jarvis-mirror/mappers.ts
@@ -25,6 +25,13 @@ export const HIVE_CHAT_MESSAGE = "HiveChatMessage";
 export const EDGE_HAS_TASK = "HAS_TASK";
 export const EDGE_HAS_MESSAGE = "HAS_MESSAGE";
 
+// PR-link cron: HiveTask -RESULTED_IN-> PullRequest (the ingested code node).
+// `PULL_REQUEST` is codegraph's node_type, not a Hive-owned one. Verified on
+// prod: these nodes are labeled `PullRequest` (stakgraph ingests them directly,
+// bypassing Jarvis's capitalize-on-write) and carry `repo` + `number` props.
+export const EDGE_RESULTED_IN = "RESULTED_IN";
+export const PULL_REQUEST = "PullRequest";
+
 export interface JarvisNodePayload {
   node_type: string;
   node_data: Record<string, unknown>;
@@ -181,6 +188,56 @@ function chatEndpoint(m: ChatMessageRow) {
   return {
     node_type: HIVE_CHAT_MESSAGE,
     node_data: { message_id: m.id, name: chatMessageName(m), message: m.message },
+  };
+}
+
+// --- PR linking (jarvis-pr-link-cron) ---
+
+/**
+ * Parse a GitHub PR URL into `{ repo: "owner/name", number }`. The artifact's
+ * `content.url` (the PR html_url) is the only reliable per-task PR reference;
+ * `content.repo`/`content.number` are inconsistent across writers, so we derive
+ * both from the URL. Returns null for anything that isn't a `/pull/<n>` URL.
+ */
+export function parsePullRequestUrl(
+  url: unknown,
+): { repo: string; number: number } | null {
+  if (typeof url !== "string") return null;
+  // .../{owner}/{repo}/pull/{number}
+  const m = url.match(/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/i);
+  if (!m) return null;
+  const number = Number(m[3]);
+  if (!Number.isInteger(number) || number <= 0) return null;
+  return { repo: `${m[1]}/${m[2]}`, number };
+}
+
+/**
+ * Stable map key for matching a parsed PR ref against a `PullRequest` graph
+ * node's `repo` + `number` properties. Lowercased — GitHub owner/repo are
+ * case-insensitive and the graph stores them lowercased.
+ */
+export function prNodeKey(repo: string, number: number): string {
+  return `${repo.toLowerCase()}#${number}`;
+}
+
+/**
+ * HiveTask -RESULTED_IN-> PullRequest. Source resolves by Hive node_key
+ * (`task_id` + required `name`); target is the *existing* ingested PR node,
+ * addressed by `ref_id` so we never create a stub.
+ */
+export function taskPrEdge(
+  taskId: string,
+  taskName: string,
+  prRefId: string,
+): {
+  edge: { edge_type: string };
+  source: { node_type: string; node_data: Record<string, unknown> };
+  target: { ref_id: string };
+} {
+  return {
+    edge: { edge_type: EDGE_RESULTED_IN },
+    source: taskEndpoint(taskId, taskName),
+    target: { ref_id: prRefId },
   };
 }
 

--- a/src/services/jarvis-pr-link-cron.ts
+++ b/src/services/jarvis-pr-link-cron.ts
@@ -1,0 +1,301 @@
+/**
+ * Jarvis PR-link cron.
+ *
+ * Draws `HiveTask -RESULTED_IN-> PullRequest` edges connecting a Hive task to
+ * the *existing* codegraph `PullRequest` node its agent produced. This is a
+ * separate, retry-oriented job (not part of the entity mirror) because the
+ * trigger is "the PR node now exists in the graph" — which the mirror's
+ * updatedAt keyset cursor can't observe (the task may never change again).
+ *
+ * Design:
+ *  - A task's PR reference is the `content.url` of its `PULL_REQUEST` artifact
+ *    (repo + number parsed from the URL — the only reliable source).
+ *  - PR nodes are matched on the stable `repo` + `number` properties and linked
+ *    by `ref_id` (never node_key) so we never create a stub.
+ *  - PR fetch: `latest-by-types` is newest-ingested-first. First run / backfill
+ *    pulls the full set; later runs pull only PRs newer than a per-workspace
+ *    high-water (`jarvisSyncState.prLink.highWater`). The high-water is advanced
+ *    ONLY on a fully-drained (uncapped) pass — while a backfill is still capped
+ *    and self-chaining, the remaining unlinked tasks point at old PRs, so each
+ *    chained run must keep pulling the full set.
+ *  - Per-task marker (`Task.jarvisPrLinkedAt`) keeps the scan cheap and is the
+ *    retry latch; best-effort per workspace (one failure never aborts others).
+ */
+
+import { db } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { ArtifactType } from "@prisma/client";
+import { getJarvisConfigForWorkspace } from "@/lib/helpers/jarvis-config";
+import { addEdgeBulk, searchLatestByTypes } from "@/services/swarm/api/nodes";
+import type { JarvisConnectionConfig } from "@/types/jarvis";
+import {
+  PULL_REQUEST,
+  parsePullRequestUrl,
+  prNodeKey,
+  taskPrEdge,
+} from "@/services/jarvis-mirror/mappers";
+
+const LOG = "JARVIS_PR_LINK";
+
+export const DEFAULT_MAX_PER_RUN = 500;
+export const BULK_CHUNK = 100;
+
+// Single fetch large enough to return any realistic workspace's entire PR set
+// (the endpoint returns min(limit, total)); used for backfill.
+const FULL_LIMIT = 100_000;
+// Newest-window size for incremental fetches; widened if the boundary (a node
+// at-or-below the high-water) isn't reached.
+const INCREMENTAL_LIMIT = 2_000;
+
+interface SyncState {
+  prLink?: { highWater?: string };
+  [key: string]: unknown;
+}
+
+export interface WorkspacePrLinkResult {
+  workspaceId: string;
+  slug: string;
+  skipped?: string;
+  linked?: number;
+  pending?: number;
+  capped?: boolean;
+  errors?: string[];
+}
+
+export interface PrLinkRunResult {
+  processed: number;
+  anyCapped: boolean;
+  results: WorkspacePrLinkResult[];
+}
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+}
+
+function parseState(raw: unknown): SyncState {
+  if (raw && typeof raw === "object") return raw as SyncState;
+  return {};
+}
+
+function readHighWaterSec(state: SyncState): number {
+  const iso = state.prLink?.highWater;
+  if (typeof iso !== "string") return 0;
+  const t = Date.parse(iso);
+  return Number.isNaN(t) ? 0 : Math.floor(t / 1000);
+}
+
+/**
+ * Fetch `PullRequest` nodes newer than `sinceSec` (0 = backfill / all), with
+ * properties. Returns the matching nodes plus the newest `date_added_to_graph`
+ * observed across the whole fetch (for advancing the high-water). The endpoint
+ * has no server-side filter, so for incremental fetches we widen the window
+ * until a node at-or-below the boundary appears (proving completeness).
+ */
+async function fetchPrNodesSince(
+  config: JarvisConnectionConfig,
+  sinceSec: number,
+): Promise<{ nodes: Awaited<ReturnType<typeof searchLatestByTypes>>; newestSec: number }> {
+  let limit = sinceSec === 0 ? FULL_LIMIT : INCREMENTAL_LIMIT;
+
+  for (;;) {
+    const nodes = await searchLatestByTypes(config, { [PULL_REQUEST]: limit }, { withProperties: true });
+    const newestSec = nodes[0]?.date_added_to_graph ?? 0;
+    const oldestSec = nodes[nodes.length - 1]?.date_added_to_graph ?? 0;
+
+    // Boundary reached when we got fewer than asked (exhausted the type) or the
+    // oldest returned node is already at/under the high-water.
+    const reachedBoundary = nodes.length < limit || oldestSec <= sinceSec;
+
+    if (reachedBoundary || limit >= FULL_LIMIT) {
+      const filtered =
+        sinceSec === 0
+          ? nodes
+          : nodes.filter((n) => (n.date_added_to_graph ?? 0) > sinceSec);
+      return { nodes: filtered, newestSec };
+    }
+    limit = Math.min(limit * 4, FULL_LIMIT);
+  }
+}
+
+/** repo#number → ref_id, from PR graph nodes. Skips nodes missing properties. */
+function buildPrMap(
+  nodes: Awaited<ReturnType<typeof searchLatestByTypes>>,
+): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const n of nodes) {
+    const repo = n.properties?.repo;
+    const number = n.properties?.number;
+    if (typeof repo === "string" && typeof number === "number" && n.ref_id) {
+      map.set(prNodeKey(repo, number), n.ref_id);
+    }
+  }
+  return map;
+}
+
+type CandidateTask = {
+  id: string;
+  title: string;
+  chatMessages: { artifacts: { content: unknown }[] }[];
+};
+
+/** Distinct parsed PR refs ({ repo, number }) across a task's PR artifacts. */
+function taskPrRefs(task: CandidateTask): { repo: string; number: number }[] {
+  const seen = new Map<string, { repo: string; number: number }>();
+  for (const msg of task.chatMessages) {
+    for (const art of msg.artifacts) {
+      const content = art.content as { url?: unknown } | null;
+      const ref = parsePullRequestUrl(content?.url);
+      if (ref) seen.set(prNodeKey(ref.repo, ref.number), ref);
+    }
+  }
+  return [...seen.values()];
+}
+
+async function linkWorkspace(
+  workspace: { id: string; slug: string; jarvisSyncState: unknown },
+  config: JarvisConnectionConfig,
+  maxPerRun: number,
+): Promise<WorkspacePrLinkResult> {
+  const errors: string[] = [];
+
+  const tasks: CandidateTask[] = await db.task.findMany({
+    where: {
+      workspaceId: workspace.id,
+      deleted: false,
+      archived: false,
+      jarvisPrLinkedAt: null,
+      chatMessages: { some: { artifacts: { some: { type: ArtifactType.PULL_REQUEST } } } },
+    },
+    orderBy: { createdAt: "asc" },
+    take: maxPerRun,
+    select: {
+      id: true,
+      title: true,
+      chatMessages: {
+        where: { artifacts: { some: { type: ArtifactType.PULL_REQUEST } } },
+        select: {
+          artifacts: { where: { type: ArtifactType.PULL_REQUEST }, select: { content: true } },
+        },
+      },
+    },
+  });
+
+  if (tasks.length === 0) {
+    return { workspaceId: workspace.id, slug: workspace.slug, linked: 0, pending: 0, capped: false };
+  }
+
+  const state = parseState(workspace.jarvisSyncState);
+  const sinceSec = readHighWaterSec(state);
+  const { nodes, newestSec } = await fetchPrNodesSince(config, sinceSec);
+  const prMap = buildPrMap(nodes);
+
+  const edges: ReturnType<typeof taskPrEdge>[] = [];
+  const linkedTaskIds: string[] = [];
+  let pending = 0;
+
+  for (const task of tasks) {
+    const refs = taskPrRefs(task);
+
+    // No usable PR URL on the artifact(s): nothing to ever resolve — mark linked
+    // so it stops consuming a scan slot every run.
+    if (refs.length === 0) {
+      linkedTaskIds.push(task.id);
+      continue;
+    }
+
+    const refIds = refs.map((r) => prMap.get(prNodeKey(r.repo, r.number)));
+    if (refIds.some((id) => !id)) {
+      // At least one PR not ingested yet — retry next run, don't mark.
+      pending++;
+      continue;
+    }
+
+    for (const refId of refIds) edges.push(taskPrEdge(task.id, task.title, refId!));
+    linkedTaskIds.push(task.id);
+  }
+
+  for (const part of chunk(edges, BULK_CHUNK)) {
+    const res = await addEdgeBulk(config, part);
+    if (!res.success) errors.push(...res.errors);
+  }
+
+  if (linkedTaskIds.length > 0) {
+    await db.task.updateMany({
+      where: { id: { in: linkedTaskIds } },
+      data: { jarvisPrLinkedAt: new Date() },
+    });
+  }
+
+  // Capped only when we hit the batch limit AND made progress, so a batch of
+  // perpetually-pending tasks can't trigger runaway self-chaining.
+  const linked = linkedTaskIds.length;
+  const capped = tasks.length === maxPerRun && linked > 0;
+
+  // Advance the high-water only on a fully-drained pass (see file header).
+  if (!capped && newestSec > sinceSec) {
+    state.prLink = { highWater: new Date(newestSec * 1000).toISOString() };
+    await db.workspace.update({
+      where: { id: workspace.id },
+      data: { jarvisSyncState: state as object },
+    });
+  }
+
+  return { workspaceId: workspace.id, slug: workspace.slug, linked, pending, capped, errors };
+}
+
+/**
+ * One PR-link pass across all workspaces that have a swarm configured.
+ * Returns `anyCapped` so the caller can self-chain to drain a backlog.
+ */
+export async function runJarvisPrLink(
+  opts: { maxPerRun?: number } = {},
+): Promise<PrLinkRunResult> {
+  const maxPerRun = opts.maxPerRun ?? DEFAULT_MAX_PER_RUN;
+
+  if (process.env.USE_MOCKS === "true") {
+    logger.info("[JARVIS PR LINK] USE_MOCKS enabled, skipping", LOG);
+    return { processed: 0, anyCapped: false, results: [] };
+  }
+
+  const workspaces = await db.workspace.findMany({
+    where: { deleted: false, swarm: { isNot: null } },
+    select: { id: true, slug: true, jarvisSyncState: true },
+  });
+
+  logger.info(`[JARVIS PR LINK] Starting for ${workspaces.length} workspaces`, LOG);
+
+  const results: WorkspacePrLinkResult[] = [];
+  let anyCapped = false;
+
+  for (const ws of workspaces) {
+    try {
+      const config = await getJarvisConfigForWorkspace(ws.id);
+      if (!config) {
+        results.push({ workspaceId: ws.id, slug: ws.slug, skipped: "no jarvis config" });
+        continue;
+      }
+
+      const result = await linkWorkspace(ws, config, maxPerRun);
+      if (result.capped) anyCapped = true;
+      if (result.errors && result.errors.length > 0) {
+        logger.warn(`[JARVIS PR LINK] ${ws.slug}: ${result.errors.length} edge errors`, LOG, {
+          errors: result.errors.slice(0, 5),
+        });
+      }
+      results.push(result);
+    } catch (error) {
+      logger.error(`[JARVIS PR LINK] Failed for workspace ${ws.slug}`, LOG, { error });
+      results.push({
+        workspaceId: ws.id,
+        slug: ws.slug,
+        errors: [error instanceof Error ? error.message : String(error)],
+      });
+    }
+  }
+
+  logger.info(`[JARVIS PR LINK] Done. processed=${workspaces.length} anyCapped=${anyCapped}`, LOG);
+
+  return { processed: workspaces.length, anyCapped, results };
+}

--- a/src/services/swarm/api/nodes.ts
+++ b/src/services/swarm/api/nodes.ts
@@ -257,6 +257,40 @@ export async function addNodeBulk(
   };
 }
 
+/** A node as returned by the `latest-by-types` read endpoint. */
+export interface JarvisGraphNode {
+  ref_id: string;
+  node_type: string;
+  date_added_to_graph?: number;
+  properties?: Record<string, unknown>;
+}
+
+/**
+ * Read nodes of the given types via `POST /graph/search/latest-by-types`,
+ * newest-ingested-first (ordered `date_added_to_graph` DESC). The endpoint has
+ * no hard cap — it returns up to the requested per-type limit or the real total,
+ * whichever is smaller. `withProperties` is required to read schema properties
+ * (e.g. a PullRequest's `number`/`repo`), at the cost of heavier payloads.
+ * Returns `[]` on any error (never throws).
+ */
+export async function searchLatestByTypes(
+  config: JarvisConnectionConfig,
+  nodeTypes: Record<string, number>,
+  opts?: { withProperties?: boolean },
+): Promise<JarvisGraphNode[]> {
+  const result = await jarvisRequest({
+    config,
+    endpoint: "/graph/search/latest-by-types",
+    method: "POST",
+    data: { nodeTypes, include_properties: opts?.withProperties ?? false },
+  });
+
+  if (!result.ok) return [];
+
+  const body = result.body as { nodes?: JarvisGraphNode[] } | undefined;
+  return Array.isArray(body?.nodes) ? body!.nodes : [];
+}
+
 export async function updateNode(
   config: JarvisConnectionConfig,
   request: UpdateNodeRequest,

--- a/vercel.json
+++ b/vercel.json
@@ -57,6 +57,10 @@
     {
       "path": "/api/cron/jarvis-mirror",
       "schedule": "0 * * * *"
+    },
+    {
+      "path": "/api/cron/jarvis-pr-links",
+      "schedule": "30 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## What

A new **jarvis-pr-link** cron that draws `HiveTask -RESULTED_IN-> PullRequest` edges, connecting a Hive task to the existing codegraph `PullRequest` node its agent produced. Plus two fixes to the already-merged entity mirror.

> Depends on **stakwork/jarvis-backend#2926** (the `RESULTED_IN` edge schema). Gated behind `JARVIS_PR_LINK_CRON_ENABLED` so it ships dark until that's deployed.

## The PR-link cron

Separate from the entity mirror because the trigger is *"the PR node now exists in the graph"* — which the mirror's `updatedAt` keyset cursor can't observe (the task may never change again).

- **Matching (verified on prod):** PR nodes are fetched via `POST /graph/search/latest-by-types`, matched on their stable `repo` + integer `number` properties, and linked by **`ref_id`** (never node_key) so no stub node is ever created. `name` is unstable (`pr-1192.0` legacy vs `pr-4542`), so it's deliberately not used. See `docs/plans/jarvis-task-pr-linking.md` for the full spike writeup (real node dumps, endpoint probes, scale measurements).
- **Scale:** backfill = one full PR pull (~6 MB / 7s for ~3400 PRs, measured); steady-state = incremental fetch bounded by a per-workspace `date_added_to_graph` high-water in `Workspace.jarvisSyncState.prLink`. Per-task `Task.jarvisPrLinkedAt` marker keeps the scan cheap.
- **Ops:** `maxDuration=300`, self-chaining backfill, best-effort per workspace, hourly at `:30` (staggered from the mirror's `:00` to avoid `jarvisSyncState` write races).
- **Client:** adds `searchLatestByTypes` to the Jarvis nodes client + PR mappers (`parsePullRequestUrl`, `prNodeKey`, `taskPrEdge`).

## Mirror fixes (also in this PR, previously unmerged)

1. **`fix: don't advance mirror cursor when graph write fails`** — the per-type keyset cursor advanced even when `addNodeBulk`/`addEdgeBulk` returned errors, which would permanently skip rows if a swarm's Jarvis were down/missing schemas. Now it only advances on success (idempotent retry). Adds `errorCount`/`errorSamples` to the route response.
2. **`fix: skip text-less chat messages`** — artifact-only messages (empty `message`) were mirrored as content-less `Hivechatmessage` nodes; now filtered at the query.

## Review note

I added the `JARVIS_PR_LINK_CRON_ENABLED` gate (the cron had none). Rationale: edge writes fail with "Invalid edge type" until #2926 deploys, and the cron marks a task linked once its edges are dispatched — so running it dark-deployed before #2926 could mark tasks linked while edges fail. The gate avoids that ordering hazard. (Heads-up follow-up: the mark-happens-even-if-`addEdgeBulk`-errored path is a latent miss worth tightening, same class as mirror fix #1 — left out here to keep the diff focused.)

## Tests

- PR-link cron: 9 tests (backfill/incremental fetch, ref_id linking, pending retry, unparseable-url marking, capped self-chain). Mappers: PR-fn tests added. Mirror fixes: fail-safe + filter tests.
- Touched-file typecheck clean, lint clean.

## Enablement (prod)
1. Merge + deploy **jarvis-backend#2926**.
2. Apply migration `20260626000000_add_jarvis_pr_link_state` (adds `tasks.jarvis_pr_linked_at`).
3. Set `JARVIS_PR_LINK_CRON_ENABLED=true` (Production), then redeploy so `vercel pull` captures it.