### PR TITLE
fix(jarvis): harden mirror + PR-link crons against slow/absent swarms

### DIFF
--- a/src/__tests__/unit/services/jarvis-mirror-cron.test.ts
+++ b/src/__tests__/unit/services/jarvis-mirror-cron.test.ts
@@ -159,6 +159,28 @@ describe("runJarvisMirror", () => {
     ]);
   });
 
+  it("skips the swarm (no error) when the bulk endpoint 404s", async () => {
+    mockedAddNodeBulk.mockResolvedValue({
+      success: false,
+      endpointMissing: true,
+      errors: ["Request failed with status 404"],
+    });
+    setupDb({
+      workspaces: [{ id: "w1", slug: "w1", jarvisSyncState: null }],
+      features: [{ id: "f1", title: "F1", updatedAt: AT }],
+      tasks: [{ id: "t1", title: "T1", updatedAt: AT, feature: null }],
+    });
+
+    const res = await runJarvisMirror();
+
+    expect(res.results[0].skipped).toBe("jarvis bulk endpoint missing (404)");
+    expect(res.results[0].errors).toBeUndefined();
+    // Bailed on the first 404 — never attempted the task type.
+    expect(mockedAddNodeBulk).toHaveBeenCalledTimes(1);
+    // No cursor persisted for a skipped swarm.
+    expect((mockedDb.workspace as any).update).not.toHaveBeenCalled();
+  });
+
   it("continues to other workspaces when one throws", async () => {
     setupDb({
       workspaces: [

--- a/src/__tests__/unit/services/jarvis-pr-link-cron.test.ts
+++ b/src/__tests__/unit/services/jarvis-pr-link-cron.test.ts
@@ -9,7 +9,7 @@ vi.mock("@/lib/helpers/jarvis-config", () => ({
 
 vi.mock("@/services/swarm/api/nodes", () => ({
   addEdgeBulk: vi.fn(async () => ({ success: true, errors: [] })),
-  searchLatestByTypes: vi.fn(async () => []),
+  searchLatestByTypes: vi.fn(async () => ({ ok: true, nodes: [] })),
 }));
 
 import { getJarvisConfigForWorkspace } from "@/lib/helpers/jarvis-config";
@@ -50,8 +50,11 @@ beforeEach(() => {
   delete process.env.USE_MOCKS;
   mockedConfig.mockResolvedValue(CFG as any);
   mockedAddEdgeBulk.mockResolvedValue({ success: true, errors: [] });
-  mockedSearch.mockResolvedValue([]);
+  mockedSearch.mockResolvedValue({ ok: true, nodes: [] });
 });
+
+// Wrap PR nodes in the SearchLatestResult envelope the function now returns.
+const found = (...nodes: ReturnType<typeof prNode>[]) => ({ ok: true as const, nodes });
 
 describe("runJarvisPrLink", () => {
   it("skips entirely when USE_MOCKS is set", async () => {
@@ -84,12 +87,15 @@ describe("runJarvisPrLink", () => {
         { id: "t1", title: "T1", chatMessages: [prArtifact("https://github.com/stakwork/hive/pull/4542")] },
       ],
     });
-    mockedSearch.mockResolvedValue([prNode("stakwork/hive", 4542, "ref-4542", 1782430995)]);
+    mockedSearch.mockResolvedValue(found(prNode("stakwork/hive", 4542, "ref-4542", 1782430995)));
 
     const res = await runJarvisPrLink();
 
-    // backfill: full pull
-    expect(mockedSearch).toHaveBeenCalledWith(CFG, { PullRequest: 100_000 }, { withProperties: true });
+    // backfill: full pull (with a generous timeout so it isn't aborted)
+    expect(mockedSearch).toHaveBeenCalledWith(CFG, { PullRequest: 100_000 }, {
+      withProperties: true,
+      timeoutMs: expect.any(Number),
+    });
 
     const edgeArg = mockedAddEdgeBulk.mock.calls[0][1];
     expect(edgeArg).toHaveLength(1);
@@ -118,7 +124,7 @@ describe("runJarvisPrLink", () => {
         { id: "t1", title: "T1", chatMessages: [prArtifact("https://github.com/stakwork/hive/pull/9999")] },
       ],
     });
-    mockedSearch.mockResolvedValue([prNode("stakwork/hive", 4542, "ref-4542", 1782430995)]);
+    mockedSearch.mockResolvedValue(found(prNode("stakwork/hive", 4542, "ref-4542", 1782430995)));
 
     const res = await runJarvisPrLink();
 
@@ -148,14 +154,19 @@ describe("runJarvisPrLink", () => {
       ],
     });
     // Newest node is above the high-water, oldest returned is below it ⇒ boundary reached.
-    mockedSearch.mockResolvedValue([
-      prNode("stakwork/hive", 4542, "ref-4542", 1782430995),
-      prNode("stakwork/hive", 4000, "ref-old", 1781000000),
-    ]);
+    mockedSearch.mockResolvedValue(
+      found(
+        prNode("stakwork/hive", 4542, "ref-4542", 1782430995),
+        prNode("stakwork/hive", 4000, "ref-old", 1781000000),
+      ),
+    );
 
     await runJarvisPrLink();
 
-    expect(mockedSearch).toHaveBeenCalledWith(CFG, { PullRequest: 2_000 }, { withProperties: true });
+    expect(mockedSearch).toHaveBeenCalledWith(CFG, { PullRequest: 2_000 }, {
+      withProperties: true,
+      timeoutMs: expect.any(Number),
+    });
   });
 
   it("marks tasks with an unparseable PR url as linked so they stop being scanned", async () => {
@@ -174,6 +185,62 @@ describe("runJarvisPrLink", () => {
     expect(res.results[0].linked).toBe(1);
   });
 
+  it("surfaces a transient PR-fetch failure and leaves tasks unmarked (retry)", async () => {
+    setupDb({
+      workspaces: [{ id: "w1", slug: "w1", jarvisSyncState: null }],
+      tasks: [
+        { id: "t1", title: "T1", chatMessages: [prArtifact("https://github.com/stakwork/hive/pull/4542")] },
+      ],
+    });
+    mockedSearch.mockResolvedValue({
+      ok: false,
+      nodes: [],
+      status: 408,
+      error: "Request failed with status 408",
+    });
+
+    const res = await runJarvisPrLink();
+
+    expect(mockedAddEdgeBulk).not.toHaveBeenCalled();
+    expect((mockedDb.task as any).updateMany).not.toHaveBeenCalled();
+    expect((mockedDb.workspace as any).update).not.toHaveBeenCalled();
+    expect(res.results[0]).toMatchObject({ linked: 0, pending: 1 });
+    expect(res.results[0].errors?.[0]).toContain("PR fetch failed");
+  });
+
+  it("skips the workspace quietly when the search endpoint 404s", async () => {
+    setupDb({
+      workspaces: [{ id: "w1", slug: "w1", jarvisSyncState: null }],
+      tasks: [
+        { id: "t1", title: "T1", chatMessages: [prArtifact("https://github.com/stakwork/hive/pull/4542")] },
+      ],
+    });
+    mockedSearch.mockResolvedValue({ ok: false, nodes: [], status: 404, endpointMissing: true });
+
+    const res = await runJarvisPrLink();
+
+    expect(res.results[0].skipped).toBe("jarvis search endpoint missing (404)");
+    expect(res.results[0].errors).toBeUndefined();
+    expect(mockedAddEdgeBulk).not.toHaveBeenCalled();
+    expect((mockedDb.task as any).updateMany).not.toHaveBeenCalled();
+  });
+
+  it("skips the workspace quietly when the edge endpoint 404s", async () => {
+    setupDb({
+      workspaces: [{ id: "w1", slug: "w1", jarvisSyncState: null }],
+      tasks: [
+        { id: "t1", title: "T1", chatMessages: [prArtifact("https://github.com/stakwork/hive/pull/4542")] },
+      ],
+    });
+    mockedSearch.mockResolvedValue(found(prNode("stakwork/hive", 4542, "ref-4542", 1782430995)));
+    mockedAddEdgeBulk.mockResolvedValue({ success: false, endpointMissing: true, errors: ["404"] });
+
+    const res = await runJarvisPrLink();
+
+    expect(res.results[0].skipped).toBe("jarvis edge endpoint missing (404)");
+    expect((mockedDb.task as any).updateMany).not.toHaveBeenCalled();
+  });
+
   it("self-chains (capped) only when the batch is full AND progress was made", async () => {
     const tasks = Array.from({ length: 2 }, (_, i) => ({
       id: `t${i}`,
@@ -181,10 +248,12 @@ describe("runJarvisPrLink", () => {
       chatMessages: [prArtifact(`https://github.com/stakwork/hive/pull/${4000 + i}`)],
     }));
     setupDb({ workspaces: [{ id: "w1", slug: "w1", jarvisSyncState: null }], tasks });
-    mockedSearch.mockResolvedValue([
-      prNode("stakwork/hive", 4000, "r0", 1782430000),
-      prNode("stakwork/hive", 4001, "r1", 1782430995),
-    ]);
+    mockedSearch.mockResolvedValue(
+      found(
+        prNode("stakwork/hive", 4000, "r0", 1782430000),
+        prNode("stakwork/hive", 4001, "r1", 1782430995),
+      ),
+    );
 
     const res = await runJarvisPrLink({ maxPerRun: 2 });
 

--- a/src/__tests__/unit/services/swarm/api/nodes.test.ts
+++ b/src/__tests__/unit/services/swarm/api/nodes.test.ts
@@ -505,6 +505,32 @@ describe("addEdgeBulk", () => {
       expect(result.errors[0]).toBe("Network timeout");
     });
 
+    test("flags endpointMissing on a 404 (endpoint absent on this backend)", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        text: async () => "404 page not found",
+      });
+
+      const result = await addEdgeBulk(config, edgeList);
+
+      expect(result.success).toBe(false);
+      expect(result.endpointMissing).toBe(true);
+    });
+
+    test("does not flag endpointMissing on a non-404 failure", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => "boom",
+      });
+
+      const result = await addEdgeBulk(config, edgeList);
+
+      expect(result.success).toBe(false);
+      expect(result.endpointMissing).toBeFalsy();
+    });
+
     test("handles empty edge list gracefully", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/src/services/jarvis-mirror-cron.ts
+++ b/src/services/jarvis-mirror-cron.ts
@@ -38,6 +38,14 @@ const LOG = "JARVIS_MIRROR";
 export const DEFAULT_MAX_PER_TYPE = 500;
 export const BULK_CHUNK = 100;
 
+// Wall-clock cap for a single workspace's mirror pass. The route allows 300 s
+// total across all workspaces (processed sequentially), so no one swarm —
+// especially an unreachable one whose every request burns the full request
+// timeout — may dominate the budget. Once exceeded, the workspace's remaining
+// entity types are skipped this run and retried (from the unadvanced cursor)
+// on the next.
+export const WORKSPACE_BUDGET_MS = 60_000;
+
 type EntityType = "feature" | "task" | "chat";
 
 interface Cursor {
@@ -85,6 +93,18 @@ function parseState(raw: unknown): SyncState {
   return {};
 }
 
+/**
+ * Signals a 404 from the swarm: the bulk endpoint doesn't exist on this
+ * backend (capability/version mismatch). Thrown to unwind the whole workspace
+ * pass — there's no point sending the remaining entity types or retrying.
+ */
+class EndpointMissingError extends Error {
+  constructor() {
+    super("jarvis bulk endpoint not found (404)");
+    this.name = "EndpointMissingError";
+  }
+}
+
 /** Returns false if any chunk failed (errors collected into `errors`). */
 async function pushNodes(
   config: JarvisConnectionConfig,
@@ -94,6 +114,7 @@ async function pushNodes(
   let ok = true;
   for (const part of chunk(nodes, BULK_CHUNK)) {
     const res = await addNodeBulk(config, part, { reprocess: true });
+    if (res.endpointMissing) throw new EndpointMissingError();
     if (!res.success) {
       ok = false;
       errors.push(...res.errors);
@@ -111,6 +132,7 @@ async function pushEdges(
   let ok = true;
   for (const part of chunk(edges, BULK_CHUNK)) {
     const res = await addEdgeBulk(config, part);
+    if (res.endpointMissing) throw new EndpointMissingError();
     if (!res.success) {
       ok = false;
       errors.push(...res.errors);
@@ -130,6 +152,12 @@ async function mirrorWorkspace(
   const counts: Record<EntityType, number> = { feature: 0, task: 0, chat: 0 };
   let capped = false;
 
+  // Stop starting new entity types once the per-workspace budget is spent, so a
+  // slow/unreachable swarm yields back to the next workspace. Cursors only
+  // advance on a completed type, so skipped types simply retry next run.
+  const deadline = Date.now() + WORKSPACE_BUDGET_MS;
+  const overBudget = () => Date.now() >= deadline;
+
   // --- Features ---
   const features = await db.feature.findMany({
     where: { workspaceId: workspace.id, deleted: false, ...keysetWhere(state.feature) },
@@ -147,6 +175,8 @@ async function mirrorWorkspace(
       if (features.length === maxPerType) capped = true;
     }
   }
+
+  if (overBudget()) return { workspaceId: workspace.id, slug: workspace.slug, counts, capped, errors };
 
   // --- Tasks (+ HAS_TASK edges) ---
   const tasks = await db.task.findMany({
@@ -171,6 +201,8 @@ async function mirrorWorkspace(
       if (tasks.length === maxPerType) capped = true;
     }
   }
+
+  if (overBudget()) return { workspaceId: workspace.id, slug: workspace.slug, counts, capped, errors };
 
   // --- Chat messages (+ HAS_MESSAGE edges) ---
   // No direct workspaceId on ChatMessage — reach it via task or feature.
@@ -261,6 +293,13 @@ export async function runJarvisMirror(
       }
       results.push(result);
     } catch (error) {
+      // A 404 means this swarm's jarvis-backend lacks the bulk endpoints
+      // (version mismatch). Skip it quietly instead of logging an error and
+      // having the route treat it as retryable noise.
+      if (error instanceof EndpointMissingError) {
+        results.push({ workspaceId: ws.id, slug: ws.slug, skipped: "jarvis bulk endpoint missing (404)" });
+        continue;
+      }
       logger.error(`[JARVIS MIRROR] Failed for workspace ${ws.slug}`, LOG, { error });
       results.push({
         workspaceId: ws.id,

--- a/src/services/jarvis-pr-link-cron.ts
+++ b/src/services/jarvis-pr-link-cron.ts
@@ -27,6 +27,7 @@ import { logger } from "@/lib/logger";
 import { ArtifactType } from "@prisma/client";
 import { getJarvisConfigForWorkspace } from "@/lib/helpers/jarvis-config";
 import { addEdgeBulk, searchLatestByTypes } from "@/services/swarm/api/nodes";
+import type { JarvisGraphNode } from "@/services/swarm/api/nodes";
 import type { JarvisConnectionConfig } from "@/types/jarvis";
 import {
   PULL_REQUEST,
@@ -46,6 +47,17 @@ const FULL_LIMIT = 100_000;
 // Newest-window size for incremental fetches; widened if the boundary (a node
 // at-or-below the high-water) isn't reached.
 const INCREMENTAL_LIMIT = 2_000;
+
+// The PR backfill is the one heavy read here (~7 s / ~6 MB for ~3400 PRs with
+// properties, more on larger swarms), so it must NOT use the default 7 s write
+// timeout — that would abort a legitimate full pull and silently link nothing.
+const PR_FETCH_TIMEOUT_MS = 45_000;
+
+// Wall-clock cap for a single workspace's link pass. The route allows 300 s
+// across all workspaces (sequential), so no one swarm — especially a slow or
+// unreachable one — may dominate. Once exceeded, remaining edge chunks are left
+// for the next run (tasks aren't marked, so they simply retry).
+export const WORKSPACE_BUDGET_MS = 60_000;
 
 interface SyncState {
   prLink?: { highWater?: string };
@@ -86,21 +98,35 @@ function readHighWaterSec(state: SyncState): number {
   return Number.isNaN(t) ? 0 : Math.floor(t / 1000);
 }
 
+type PrFetch =
+  | { ok: true; nodes: JarvisGraphNode[]; newestSec: number }
+  | { ok: false; endpointMissing: boolean; error?: string };
+
 /**
  * Fetch `PullRequest` nodes newer than `sinceSec` (0 = backfill / all), with
- * properties. Returns the matching nodes plus the newest `date_added_to_graph`
- * observed across the whole fetch (for advancing the high-water). The endpoint
- * has no server-side filter, so for incremental fetches we widen the window
- * until a node at-or-below the boundary appears (proving completeness).
+ * properties. On success returns the matching nodes plus the newest
+ * `date_added_to_graph` observed (for advancing the high-water). On any read
+ * failure returns `ok:false` (NOT an empty set) so the caller can retry instead
+ * of mistaking a transient failure for "no PRs to link." The endpoint has no
+ * server-side filter, so for incremental fetches we widen the window until a
+ * node at-or-below the boundary appears (proving completeness).
  */
 async function fetchPrNodesSince(
   config: JarvisConnectionConfig,
   sinceSec: number,
-): Promise<{ nodes: Awaited<ReturnType<typeof searchLatestByTypes>>; newestSec: number }> {
+): Promise<PrFetch> {
   let limit = sinceSec === 0 ? FULL_LIMIT : INCREMENTAL_LIMIT;
 
   for (;;) {
-    const nodes = await searchLatestByTypes(config, { [PULL_REQUEST]: limit }, { withProperties: true });
+    const res = await searchLatestByTypes(
+      config,
+      { [PULL_REQUEST]: limit },
+      { withProperties: true, timeoutMs: PR_FETCH_TIMEOUT_MS },
+    );
+    if (!res.ok) {
+      return { ok: false, endpointMissing: !!res.endpointMissing, error: res.error };
+    }
+    const nodes = res.nodes;
     const newestSec = nodes[0]?.date_added_to_graph ?? 0;
     const oldestSec = nodes[nodes.length - 1]?.date_added_to_graph ?? 0;
 
@@ -113,16 +139,14 @@ async function fetchPrNodesSince(
         sinceSec === 0
           ? nodes
           : nodes.filter((n) => (n.date_added_to_graph ?? 0) > sinceSec);
-      return { nodes: filtered, newestSec };
+      return { ok: true, nodes: filtered, newestSec };
     }
     limit = Math.min(limit * 4, FULL_LIMIT);
   }
 }
 
 /** repo#number → ref_id, from PR graph nodes. Skips nodes missing properties. */
-function buildPrMap(
-  nodes: Awaited<ReturnType<typeof searchLatestByTypes>>,
-): Map<string, string> {
+function buildPrMap(nodes: JarvisGraphNode[]): Map<string, string> {
   const map = new Map<string, string>();
   for (const n of nodes) {
     const repo = n.properties?.repo;
@@ -188,37 +212,93 @@ async function linkWorkspace(
 
   const state = parseState(workspace.jarvisSyncState);
   const sinceSec = readHighWaterSec(state);
-  const { nodes, newestSec } = await fetchPrNodesSince(config, sinceSec);
+
+  const fetched = await fetchPrNodesSince(config, sinceSec);
+  if (!fetched.ok) {
+    // 404 ⇒ this backend lacks the search endpoint (version mismatch): skip
+    // quietly. Any other failure (timeout/5xx) is transient — surface it and
+    // leave every task unmarked so the next run retries.
+    if (fetched.endpointMissing) {
+      return { workspaceId: workspace.id, slug: workspace.slug, skipped: "jarvis search endpoint missing (404)" };
+    }
+    return {
+      workspaceId: workspace.id,
+      slug: workspace.slug,
+      linked: 0,
+      pending: tasks.length,
+      capped: false,
+      errors: [`PR fetch failed: ${fetched.error ?? "unknown"}`],
+    };
+  }
+  const { nodes, newestSec } = fetched;
   const prMap = buildPrMap(nodes);
 
-  const edges: ReturnType<typeof taskPrEdge>[] = [];
-  const linkedTaskIds: string[] = [];
+  // Tasks with no resolvable PR URL are marked unconditionally (no edge to
+  // write). Tasks whose PRs all resolve are queued with their edges so they can
+  // be marked only once those edges actually land.
+  const noEdgeTaskIds: string[] = [];
+  const resolved: { taskId: string; edges: ReturnType<typeof taskPrEdge>[] }[] = [];
   let pending = 0;
 
   for (const task of tasks) {
     const refs = taskPrRefs(task);
-
-    // No usable PR URL on the artifact(s): nothing to ever resolve — mark linked
-    // so it stops consuming a scan slot every run.
     if (refs.length === 0) {
-      linkedTaskIds.push(task.id);
+      noEdgeTaskIds.push(task.id);
       continue;
     }
-
     const refIds = refs.map((r) => prMap.get(prNodeKey(r.repo, r.number)));
     if (refIds.some((id) => !id)) {
       // At least one PR not ingested yet — retry next run, don't mark.
       pending++;
       continue;
     }
-
-    for (const refId of refIds) edges.push(taskPrEdge(task.id, task.title, refId!));
-    linkedTaskIds.push(task.id);
+    resolved.push({ taskId: task.id, edges: refIds.map((id) => taskPrEdge(task.id, task.title, id!)) });
   }
 
-  for (const part of chunk(edges, BULK_CHUNK)) {
-    const res = await addEdgeBulk(config, part);
-    if (!res.success) errors.push(...res.errors);
+  const linkedTaskIds: string[] = [...noEdgeTaskIds];
+  let endpointMissing = false;
+  let budgetHit = false;
+
+  // Flush edges in BULK_CHUNK batches, marking a task linked ONLY after its
+  // edges land (never split a task's edges across batches). Stop on the
+  // per-workspace budget so a slow swarm yields to the next.
+  const deadline = Date.now() + WORKSPACE_BUDGET_MS;
+  let batchEdges: ReturnType<typeof taskPrEdge>[] = [];
+  let batchTaskIds: string[] = [];
+
+  const flush = async (): Promise<boolean> => {
+    if (batchEdges.length === 0) return true;
+    const res = await addEdgeBulk(config, batchEdges);
+    if (res.endpointMissing) {
+      endpointMissing = true;
+      batchEdges = [];
+      batchTaskIds = [];
+      return false;
+    }
+    if (res.success) linkedTaskIds.push(...batchTaskIds);
+    else errors.push(...res.errors);
+    batchEdges = [];
+    batchTaskIds = [];
+    return true;
+  };
+
+  for (const { taskId, edges: taskEdges } of resolved) {
+    if (Date.now() >= deadline) {
+      budgetHit = true;
+      break;
+    }
+    if (batchEdges.length + taskEdges.length > BULK_CHUNK) {
+      if (!(await flush())) break; // endpointMissing — stop writing
+    }
+    batchEdges.push(...taskEdges);
+    batchTaskIds.push(taskId);
+  }
+  if (!endpointMissing) await flush();
+
+  // A 404 from the edge endpoint means this backend can't take the writes at
+  // all — skip quietly rather than spam errors (mirrors the search-404 path).
+  if (endpointMissing && linkedTaskIds.length === 0) {
+    return { workspaceId: workspace.id, slug: workspace.slug, skipped: "jarvis edge endpoint missing (404)" };
   }
 
   if (linkedTaskIds.length > 0) {
@@ -228,10 +308,11 @@ async function linkWorkspace(
     });
   }
 
-  // Capped only when we hit the batch limit AND made progress, so a batch of
-  // perpetually-pending tasks can't trigger runaway self-chaining.
+  // Capped when there's more to do AND we made progress, so a batch of
+  // perpetually-pending tasks can't trigger runaway self-chaining. Either we
+  // filled the task batch, or the budget cut the edge writes short.
   const linked = linkedTaskIds.length;
-  const capped = tasks.length === maxPerRun && linked > 0;
+  const capped = (tasks.length === maxPerRun || budgetHit) && linked > 0;
 
   // Advance the high-water only on a fully-drained pass (see file header).
   if (!capped && newestSec > sinceSec) {
@@ -280,7 +361,7 @@ export async function runJarvisPrLink(
       const result = await linkWorkspace(ws, config, maxPerRun);
       if (result.capped) anyCapped = true;
       if (result.errors && result.errors.length > 0) {
-        logger.warn(`[JARVIS PR LINK] ${ws.slug}: ${result.errors.length} edge errors`, LOG, {
+        logger.warn(`[JARVIS PR LINK] ${ws.slug}: ${result.errors.length} errors`, LOG, {
           errors: result.errors.slice(0, 5),
         });
       }

--- a/src/services/swarm/api/nodes.ts
+++ b/src/services/swarm/api/nodes.ts
@@ -8,18 +8,31 @@ interface JarvisApiResponse {
   status: number;
   error?: string;
   body?: unknown;
+  // True when the swarm answered 404 — the endpoint doesn't exist on this
+  // backend (capability/version mismatch), so callers should skip it rather
+  // than retry. Distinct from a transport failure.
+  notFound?: boolean;
 }
+
+// Cap each request so a single unreachable/hung swarm can't dominate the cron's
+// 300 s budget. undici's default *connect* timeout is 10 s and there's no
+// request timeout at all, so a swarm that accepts the connection then stalls
+// could block far longer — this bounds the whole round-trip. Writes are small
+// and should be fast; heavy reads (e.g. the PR backfill) override via `timeoutMs`.
+const REQUEST_TIMEOUT_MS = 7_000;
 
 async function jarvisRequest({
   config,
   endpoint,
   method = "GET",
   data,
+  timeoutMs = REQUEST_TIMEOUT_MS,
 }: {
   config: JarvisConnectionConfig;
   endpoint: string;
   method?: "GET" | "POST" | "PUT" | "DELETE";
   data?: unknown;
+  timeoutMs?: number;
 }): Promise<JarvisApiResponse> {
   try {
     const url = `${config.jarvisUrl.replace(/\/$/, "")}${endpoint.startsWith("/") ? "" : "/"}${endpoint}`;
@@ -33,6 +46,7 @@ async function jarvisRequest({
       method,
       headers,
       ...(data ? { body: JSON.stringify(data) } : {}),
+      signal: AbortSignal.timeout(timeoutMs),
     });
 
     if (!response.ok) {
@@ -41,6 +55,7 @@ async function jarvisRequest({
       return {
         ok: false,
         status: response.status,
+        notFound: response.status === 404,
         error: `Request failed with status ${response.status}`,
       };
     }
@@ -178,7 +193,7 @@ export async function addEdgeBulk(
     source: JarvisEdgeEndpoint;
     target: JarvisEdgeEndpoint;
   }>,
-): Promise<{ success: boolean; errors: string[] }> {
+  ): Promise<{ success: boolean; errors: string[]; endpointMissing?: boolean }> {
   if (edgeList.length === 0) return { success: true, errors: [] };
   const result = await jarvisRequest({
     config,
@@ -190,6 +205,7 @@ export async function addEdgeBulk(
   if (!result.ok) {
     return {
       success: false,
+      endpointMissing: result.notFound,
       errors: [result.error || `Failed to create edges (status: ${result.status})`],
     };
   }
@@ -219,7 +235,7 @@ export async function addNodeBulk(
   config: JarvisConnectionConfig,
   nodes: Array<{ node_type: string; node_data: Record<string, unknown> }>,
   opts?: { reprocess?: boolean },
-): Promise<{ success: boolean; errors: string[] }> {
+): Promise<{ success: boolean; errors: string[]; endpointMissing?: boolean }> {
   if (nodes.length === 0) return { success: true, errors: [] };
 
   const nodeList = opts?.reprocess
@@ -236,6 +252,7 @@ export async function addNodeBulk(
   if (!result.ok) {
     return {
       success: false,
+      endpointMissing: result.notFound,
       errors: [result.error || `Failed to create nodes (status: ${result.status})`],
     };
   }
@@ -265,30 +282,53 @@ export interface JarvisGraphNode {
   properties?: Record<string, unknown>;
 }
 
+export interface SearchLatestResult {
+  /** False on any transport/HTTP failure — distinct from a successful empty read. */
+  ok: boolean;
+  nodes: JarvisGraphNode[];
+  status?: number;
+  /** True when the endpoint 404s (absent on this backend). */
+  endpointMissing?: boolean;
+  error?: string;
+}
+
 /**
  * Read nodes of the given types via `POST /graph/search/latest-by-types`,
  * newest-ingested-first (ordered `date_added_to_graph` DESC). The endpoint has
  * no hard cap — it returns up to the requested per-type limit or the real total,
  * whichever is smaller. `withProperties` is required to read schema properties
  * (e.g. a PullRequest's `number`/`repo`), at the cost of heavier payloads.
- * Returns `[]` on any error (never throws).
+ *
+ * Never throws. Returns `{ ok }` so callers can distinguish a *failed* read
+ * (timeout/404/5xx) from a legitimately *empty* one — the two must not be
+ * conflated, or a transient fetch failure looks like "nothing to link." Heavy
+ * reads (e.g. the PR backfill) should pass a longer `timeoutMs`.
  */
 export async function searchLatestByTypes(
   config: JarvisConnectionConfig,
   nodeTypes: Record<string, number>,
-  opts?: { withProperties?: boolean },
-): Promise<JarvisGraphNode[]> {
+  opts?: { withProperties?: boolean; timeoutMs?: number },
+): Promise<SearchLatestResult> {
   const result = await jarvisRequest({
     config,
     endpoint: "/graph/search/latest-by-types",
     method: "POST",
     data: { nodeTypes, include_properties: opts?.withProperties ?? false },
+    timeoutMs: opts?.timeoutMs,
   });
 
-  if (!result.ok) return [];
+  if (!result.ok) {
+    return {
+      ok: false,
+      nodes: [],
+      status: result.status,
+      endpointMissing: result.notFound,
+      error: result.error,
+    };
+  }
 
   const body = result.body as { nodes?: JarvisGraphNode[] } | undefined;
-  return Array.isArray(body?.nodes) ? body!.nodes : [];
+  return { ok: true, nodes: Array.isArray(body?.nodes) ? body!.nodes : [], status: result.status };
 }
 
 export async function updateNode(


### PR DESCRIPTION
## Why

The `[JARVIS PR LINK]` cron was timing out at the 300s Vercel limit. Root cause from the prod log: each request to an unreachable/slow swarm blocked ~60s (gateway 408, and `jarvisRequest` had **no fetch timeout**), and 15 workspaces are processed serially — a handful of stalls exhausts the budget and the run dies mid-loop without self-chaining.

This PR is **survival/diagnostics hardening** for both jarvis crons. It does **not** fix the underlying edge-write 408s (server-side: jarvis-backend `RESULTED_IN` schema / `Hivetask(task_id)` index) — it makes Hive survive and clearly report them.

## Changes

**`nodes.ts`**
- `jarvisRequest`: per-call timeout (default 7s) via `AbortSignal.timeout`, overridable with `timeoutMs`. A hung swarm now fails in 7s, not 60s.
- `searchLatestByTypes`: returns `{ ok, nodes, status, endpointMissing, error }` instead of a bare `[]`, so a failed read is no longer indistinguishable from "no PRs."

**PR-link cron (`jarvis-pr-link-cron.ts`)**
- `PR_FETCH_TIMEOUT_MS = 45_000` for the heavy backfill fetch, so it isn't aborted by the 7s write default (the full pull was measured at ~7s/6MB and would otherwise be killed).
- 404 from the search **or** edge endpoint → workspace skipped quietly (version mismatch), not error noise.
- Transient fetch failures surfaced as errors; tasks left **unmarked** so they retry instead of silently looking linked.
- `WORKSPACE_BUDGET_MS = 60_000` per-workspace wall-clock cap on the edge-write phase. Tasks are marked linked **only after their edges land** (per-task batching, never split across chunks), so a budget-cut run can't false-mark.

**Mirror cron (`jarvis-mirror-cron.ts`)** *(included from in-flight work on the same files)*
- Skip a workspace on a bulk-endpoint 404; 60s per-workspace budget.

## Tests
- Updated mocks to the new `searchLatestByTypes` shape.
- Added coverage: transient fetch failure (retry, unmarked), search-404 skip, edge-404 skip.
- `npm run test:unit` for these suites: **66 passing**.

## Note
PR linking still won't *succeed* on affected swarms until the server-side `RESULTED_IN` edge write is fixed — currently **0 RESULTED_IN edges exist**. That's the next diagnosis step.