### PR TITLE
Persist @mention sub-agents across planning conversation turns

### DIFF
--- a/src/__tests__/unit/services/roadmap/resolve-extra-swarms.test.ts
+++ b/src/__tests__/unit/services/roadmap/resolve-extra-swarms.test.ts
@@ -143,6 +143,37 @@ describe("resolveExtraSwarms", () => {
     expect(result).toHaveLength(2);
   });
 
+  it("accumulates mentions across an array of messages (conversation)", async () => {
+    mockFindFirst
+      .mockResolvedValueOnce(makeWorkspace({ slug: "ws-a" }))
+      .mockResolvedValueOnce(
+        makeWorkspace({
+          slug: "ws-b",
+          repositories: [{ repositoryUrl: "https://github.com/org/repo-b" }],
+        }),
+      );
+
+    const result = await resolveExtraSwarms(
+      ["first turn mentions @ws-a", "later turn adds @ws-b"],
+      "user-1",
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.name)).toEqual(["ws-a", "ws-b"]);
+  });
+
+  it("deduplicates a slug repeated across multiple messages", async () => {
+    mockFindFirst.mockResolvedValueOnce(makeWorkspace());
+
+    const result = await resolveExtraSwarms(
+      ["turn 1 @my-workspace", "turn 2 @my-workspace again"],
+      "user-1",
+    );
+
+    expect(mockFindFirst).toHaveBeenCalledTimes(1);
+    expect(result).toHaveLength(1);
+  });
+
   it("returns an empty array when there are no @ mentions", async () => {
     const result = await resolveExtraSwarms("no mentions here", "user-1");
 

--- a/src/services/roadmap/feature-chat.ts
+++ b/src/services/roadmap/feature-chat.ts
@@ -164,9 +164,14 @@ const FEATURE_SELECT_FOR_CHAT = {
 } as const;
 
 /**
- * Parse @workspace-slug mentions from a message, resolve each to swarm
- * credentials, and return them as extraSwarms for the Stakwork workflow.
+ * Parse @workspace-slug mentions from one or more messages, resolve each to
+ * swarm credentials, and return them as extraSwarms for the Stakwork workflow.
  * Silently skips slugs that are not accessible, have no swarm, or have no repos.
+ *
+ * Accepts either a single message string or an array of messages (e.g. the
+ * whole planning conversation). Mentions are accumulated across all messages
+ * and de-duplicated by slug, so a swarm mentioned on any turn stays attached
+ * on every subsequent turn.
  */
 interface SubAgent {
   name: string,
@@ -178,11 +183,17 @@ interface SubAgent {
 }
 
 export async function resolveExtraSwarms(
-  message: string,
+  messages: string | string[],
   userId: string,
 ): Promise<SubAgent[]> {
-  const slugMatches = [...message.matchAll(/\B@([\w-]+)/g)];
-  const uniqueSlugs = [...new Set(slugMatches.map((m) => m[1]))];
+  const texts = Array.isArray(messages) ? messages : [messages];
+  const uniqueSlugs = [
+    ...new Set(
+      texts.flatMap((text) =>
+        [...(text ?? "").matchAll(/\B@([\w-]+)/g)].map((m) => m[1]),
+      ),
+    ),
+  ];
 
   const encryptionService = EncryptionService.getInstance();
   const results: SubAgent[] = [];
@@ -450,7 +461,20 @@ export async function sendFeatureChatMessage({
         ? feature.planUpdatedAt > lastPlanArtifact.createdAt
         : false;
 
-    const extraSwarms = await resolveExtraSwarms(message, userId);
+    // Accumulate @mentions across the WHOLE conversation, not just the
+    // current message. A swarm mentioned on any earlier turn must remain
+    // attached on every subsequent turn, and a newly-mentioned swarm is
+    // added to (not replacing) the previously-mentioned ones.
+    const priorMessageTexts = [...dbHistory, ...(bodyHistory ?? [])]
+      .filter(
+        (m) => String((m as { role?: string }).role).toUpperCase() === "USER",
+      )
+      .map((m) => (m as { message?: string }).message)
+      .filter((t): t is string => typeof t === "string");
+    const extraSwarms = await resolveExtraSwarms(
+      [...priorMessageTexts, message],
+      userId,
+    );
 
     // Generate presigned download URLs for any attachments
     const attachmentUrls = await Promise.all(


### PR DESCRIPTION
## Problem

When `@mention`-ing another swarm by slug in plan mode, `subAgents` was only computed from the **current** message. So a swarm mentioned on turn 1 was silently dropped on every follow-up turn that didn't repeat the mention. The user had to re-`@mention` the swarm in every message for it to stay attached.

## Fix

`resolveExtraSwarms` now accumulates `@slug` mentions across the **whole planning conversation** — all prior `USER` messages (from DB history + any body-supplied history) plus the current message — de-duplicated by slug.

Behavior now:
- Turn 1: `@swarm-a` → `[swarm-a]` sent
- Turn 2: `@swarm-b` → **both** `[swarm-a, swarm-b]` sent (union, deduped)
- Turn 3: no mention → still `[swarm-a, swarm-b]` (stays attached)

## Changes

- `resolveExtraSwarms` accepts `string | string[]` and unions mentions across all messages (`src/services/roadmap/feature-chat.ts`). Existing single-string callers (diagram create/edit routes) are unaffected.
- Call site gathers prior `USER` message texts from the conversation history and passes them alongside the current message.

## Tests

- Existing single-string tests still pass.
- Added coverage for multi-message accumulation and cross-message dedup.
- `npm run test:unit` for the affected suites passes (resolve-extra-swarms: 11 passing, feature-chat: 25 passing).

> Note: this resolves mentions from the DB conversation (source of truth) each turn. If we'd prefer to *persist* resolved sub-agents on the feature record instead of re-parsing, that's a larger follow-up.