### PR TITLE
fix(jarvis): stop chat mirror leaking across workspaces

### DIFF
--- a/src/__tests__/unit/services/jarvis-mirror-cron.test.ts
+++ b/src/__tests__/unit/services/jarvis-mirror-cron.test.ts
@@ -146,6 +146,41 @@ describe("runJarvisMirror", () => {
     expect(where.status).toEqual({ not: "SENDING" });
   });
 
+  it("keeps chat scoped to the workspace via AND, with no clobbering top-level OR", async () => {
+    setupDb({ workspaces: [{ id: "w1", slug: "w1", jarvisSyncState: null }] });
+    await runJarvisMirror();
+    const where = (mockedDb.chatMessage as any).findMany.mock.calls[0][0].where;
+    // The workspace scope must live under AND — never as a bare top-level OR
+    // that a spread keyset could overwrite.
+    expect(where.OR).toBeUndefined();
+    expect(where.AND).toEqual([
+      { OR: [{ task: { workspaceId: "w1" } }, { feature: { workspaceId: "w1" } }] },
+      {}, // no cursor yet
+    ]);
+  });
+
+  it("REGRESSION: chat keeps the workspace filter even once a chat cursor exists", async () => {
+    const cursor = { at: AT.toISOString(), id: "m0" };
+    setupDb({
+      workspaces: [{ id: "w1", slug: "w1", jarvisSyncState: { chat: cursor } }],
+    });
+    await runJarvisMirror();
+    const where = (mockedDb.chatMessage as any).findMany.mock.calls[0][0].where;
+    // Both the workspace scope AND the keyset cursor must be present and ANDed.
+    // (Previously the cursor's `OR` overwrote the workspace `OR`, leaking every
+    // workspace's chat into this one.)
+    expect(where.OR).toBeUndefined();
+    expect(where.AND).toEqual([
+      { OR: [{ task: { workspaceId: "w1" } }, { feature: { workspaceId: "w1" } }] },
+      {
+        OR: [
+          { updatedAt: { gt: new Date(cursor.at) } },
+          { updatedAt: new Date(cursor.at), id: { gt: "m0" } },
+        ],
+      },
+    ]);
+  });
+
   it("passes the stored keyset cursor into the feature query", async () => {
     const cursor = { at: AT.toISOString(), id: "f0" };
     setupDb({

--- a/src/services/jarvis-mirror-cron.ts
+++ b/src/services/jarvis-mirror-cron.ts
@@ -212,11 +212,21 @@ async function mirrorWorkspace(
       // Skip text-less messages (e.g. artifact-only assistant turns) — they
       // carry no `message` content and are just noise in the graph.
       message: { not: "" },
-      OR: [
-        { task: { workspaceId: workspace.id } },
-        { feature: { workspaceId: workspace.id } },
+      // Both the workspace scope and the keyset cursor are expressed as `OR`
+      // fragments. They MUST be combined under `AND` — a second top-level `OR`
+      // key (from the spread) would otherwise overwrite the first, silently
+      // dropping the workspace filter once a cursor exists and leaking every
+      // workspace's chat into this one. (Feature/Task queries are immune: they
+      // scope by a plain `workspaceId`, not an `OR`.)
+      AND: [
+        {
+          OR: [
+            { task: { workspaceId: workspace.id } },
+            { feature: { workspaceId: workspace.id } },
+          ],
+        },
+        keysetWhere(state.chat),
       ],
-      ...keysetWhere(state.chat),
     },
     orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
     take: maxPerType,


### PR DESCRIPTION
## Problem

The Jarvis graph-mirror cron was copying **one workspace's chat messages into other workspaces' knowledge graphs**. Symptoms: chat-derived nodes (and stub `HiveFeature`/`HiveTask` endpoints with `workspace_id: null`) showing up on the wrong swarm — e.g. a `hive` feature's chat appearing in a different workspace's graph.

## Root cause

In `mirrorWorkspace`, the chat query expressed **both** the workspace scope and the keyset cursor as top-level `OR` keys in the same `where` object:

```ts
OR: [ { task: { workspaceId } }, { feature: { workspaceId } } ],
...keysetWhere(state.chat),   // ALSO returns { OR: [...] }
```

Because of the duplicate `OR` key, the spread keyset `OR` **overwrites** the workspace `OR`. So on every run after the first (once `state.chat` is set), the chat query ran with **no workspace filter** and pulled *every* workspace's chat messages (globally ordered by `updatedAt,id`) into whichever workspace was being mirrored.

- **Feature/Task queries were unaffected** — they scope by a plain `workspaceId` (not an `OR`), so the keyset just *adds* a clause. That's why full feature/task nodes always carried the correct `workspace_id`, and only **chat** (plus the stub endpoints its `HAS_MESSAGE` edges create) leaked.
- This is also a **data-privacy** issue: chat content was duplicated into graphs of unrelated workspaces.

## Fix

Combine the workspace `OR` and the keyset under `AND` so neither clobbers the other:

```ts
AND: [
  { OR: [ { task: { workspaceId } }, { feature: { workspaceId } } ] },
  keysetWhere(state.chat),
]
```

`keysetWhere` returns `{}` when there's no cursor, so `AND: [ {OR…}, {} ]` is valid and matches the same rows as before — just correctly scoped.

## Tests

- Adds a test asserting the chat `where` uses `AND` with no bare top-level `OR`.
- Adds a **regression** test asserting the workspace filter survives once a chat cursor exists (the exact failure mode).
- All 13 cron tests pass.

## Follow-ups (not in this PR)

1. **Cleanup of already-leaked data** — foreign `HiveChatMessage` nodes + `workspace_id: null` stub endpoints already written to various swarms need a read-then-delete reconciliation (write op, per-swarm keys).
2. **Stamp `workspace_id` on `HiveChatMessage` nodes** (`chatMessageToNode` currently omits it), which would make future audits/cleanup trivial.