### PR TITLE
Gate workflow tasks to stakwork workspace + nudge canvas agent on missing workspaces

### DIFF
--- a/src/__tests__/unit/lib/mcp/mcpCreateWorkflowTask.test.ts
+++ b/src/__tests__/unit/lib/mcp/mcpCreateWorkflowTask.test.ts
@@ -21,6 +21,10 @@ import { mcpCreateWorkflowTask } from "@/lib/mcp/mcpTools";
 const AUTH = {
   userId: "user-1",
   workspaceId: "ws-1",
+  // Workflow tasks are gated to the stakwork workspace (see
+  // isWorkflowTasksEnabled); the slug must be "stakwork" for the create
+  // path to run.
+  workspaceSlug: "stakwork",
   role: "DEVELOPER" as const,
   workspaceOwnerId: "owner-1",
 };
@@ -99,6 +103,31 @@ describe("mcpCreateWorkflowTask — workflowTaskType threading", () => {
 
     expect(result.isError).toBe(true);
     expect(mockCreateTicket).not.toHaveBeenCalled();
+  });
+});
+
+describe("mcpCreateWorkflowTask — stakwork-only gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDbFeature.findUnique.mockResolvedValue({
+      workspaceId: "ws-1",
+      createdById: "feature-creator-1",
+    });
+    mockCreateTicket.mockResolvedValue(BASE_TASK);
+  });
+
+  it("rejects workflow-task creation on a non-stakwork workspace", async () => {
+    const result = await mcpCreateWorkflowTask(
+      { ...AUTH, workspaceSlug: "some-other-workspace" },
+      "feature-1",
+      { title: "Task" },
+      { workflowTaskType: "SKILL" },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(mockCreateTicket).not.toHaveBeenCalled();
+    // Should reject before even looking up the feature.
+    expect(mockDbFeature.findUnique).not.toHaveBeenCalled();
   });
 });
 

--- a/src/lib/constants/prompt.ts
+++ b/src/lib/constants/prompt.ts
@@ -297,6 +297,8 @@ ${canvasSystemPrompt}
 ${workspaceList}
 ${memberRoster}
 
+**This list is the complete, authoritative set of workspaces you can access — there are no others.** If the user names a workspace, repository, or project that is NOT in the list above, do NOT silently fall back to a different one and answer as if it were what they meant. Correctness matters more than appearing helpful: tell the user that workspace/repo isn't available to you, show the ones that ARE, and ask which they mean (or whether they want you to proceed with one of them). Only substitute a different workspace when the user's intent is unambiguous (e.g. an obvious typo or a clear alias for a listed workspace). When in doubt, ask — a clarifying question is always better than confidently answering about the wrong workspace.
+
 ## Tool Naming Convention
 Tools are prefixed with workspace slugs. For each workspace you have:
 ${conceptToolLines}

--- a/src/lib/mcp/handler.ts
+++ b/src/lib/mcp/handler.ts
@@ -17,6 +17,7 @@ import {
   mcpCreateTask,
   mcpCreateFeatureTask,
   mcpCreateWorkflowTask,
+  isWorkflowTasksEnabled,
   mcpUpdateTask,
   mcpSendToTaskAgent,
   mcpSendMessage,
@@ -519,6 +520,8 @@ function createServer(
       description: [
         "Create a WORKFLOW task anchored to a feature in this workspace. Use this when the work is executed by running, building, or configuring a Stakwork **workflow** — a Lambda-based, DAG-style automation pipeline. Do NOT use this for code changes; use `create_feature_task` for those.",
         "",
+        "**Availability.** Workflow tasks are ONLY supported on the `stakwork` workspace. On any other workspace this tool will reject the call — treat the work as a coding task via `create_feature_task` instead.",
+        "",
         "Workflow tasks split into two kinds, both handled by this tool:",
         "- **Existing workflow** — running, triggering, or reconfiguring a workflow that already exists. Pass `workflowId` (integer).",
         "- **New workflow** — building a brand-new workflow in the editor. Omit `workflowId` entirely (never set it to null).",
@@ -629,6 +632,19 @@ function createServer(
       // workspace owner) when no hint matches.
       const result = await getWorkspaceAuth(authExtra, "create_workflow_task");
       if (result.error) return result.error;
+      // Gate: workflow tasks are stakwork-only (belt-and-suspenders with
+      // the same check inside mcpCreateWorkflowTask).
+      if (!isWorkflowTasksEnabled(result.auth!)) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Error: workflow tasks are only supported on the stakwork workspace",
+            },
+          ],
+          isError: true,
+        };
+      }
       return mcpCreateWorkflowTask(
         result.auth!,
         featureId,

--- a/src/lib/mcp/mcpTools.ts
+++ b/src/lib/mcp/mcpTools.ts
@@ -4,6 +4,7 @@ import { createFeature } from "@/services/roadmap/features";
 import { sendFeatureChatMessage } from "@/services/roadmap/feature-chat";
 import { createTicket } from "@/services/roadmap/tickets";
 import { sendMessageToStakwork } from "@/services/task-workflow";
+import { isDevelopmentMode } from "@/lib/runtime";
 import type { PullRequestContent } from "@/lib/chat";
 import {
   ArtifactType,
@@ -31,6 +32,21 @@ export interface McpToolResult {
 
 function mcpError(text: string): McpToolResult {
   return { content: [{ type: "text", text }], isError: true };
+}
+
+/**
+ * Workflow tasks are a Stakwork-workflow concept and are only supported
+ * on the `stakwork` workspace (or any workspace in development mode).
+ * Mirrors the gate used for the workflow editor / execution surface
+ * (see `task-workflow.ts`, `stakwork-run.ts`, `workflow-editor/route.ts`).
+ *
+ * Used as the single source of truth for the `create_workflow_task`
+ * tool — both the MCP handler's runtime guard and the implementation
+ * below short-circuit through it, so the surface cannot widen by
+ * accident.
+ */
+export function isWorkflowTasksEnabled(auth: WorkspaceAuth): boolean {
+  return auth.workspaceSlug === "stakwork" || isDevelopmentMode();
 }
 
 function mcpOk(data: unknown): McpToolResult {
@@ -832,6 +848,12 @@ export async function mcpCreateWorkflowTask(
   creatorHint?: string,
 ): Promise<McpToolResult> {
   try {
+    if (!isWorkflowTasksEnabled(auth)) {
+      return mcpError(
+        "Error: workflow tasks are only supported on the stakwork workspace",
+      );
+    }
+
     const feature = await db.feature.findUnique({
       where: { id: featureId },
       select: { workspaceId: true, createdById: true },


### PR DESCRIPTION
## Summary

Two correctness-focused changes for canvas chat / the workflow-task tool:

### 1. Gate `create_workflow_task` to the `stakwork` workspace
Workflow tasks are a Stakwork-workflow concept and should only be creatable on the `stakwork` workspace (or in development mode), matching the existing gates for the workflow editor/execution surface (`task-workflow.ts`, `stakwork-run.ts`, `workflow-editor/route.ts`).

- Add `isWorkflowTasksEnabled(auth)` helper as the single source of truth (`src/lib/mcp/mcpTools.ts`)
- Enforce it inside `mcpCreateWorkflowTask` — protects every caller (canvas chat, plan agent, generic MCP)
- Belt-and-suspenders runtime guard in the MCP handler callback (`src/lib/mcp/handler.ts`)
- Note the stakwork-only constraint in the tool description

Respects `isDevelopmentMode()` like the sibling gates, so workflow tasks still work on any workspace in dev.

### 2. Nudge the canvas agent to ask when a workspace isn't available
The multi-workspace canvas agent would silently substitute a different workspace when the user named one that doesn't exist in the org. Added a correctness note right after the authoritative workspace list (`getMultiWorkspaceSystemPrompt`) telling the agent to surface the available workspaces and ask, rather than guessing — only substituting on unambiguous typos/aliases.

## Test plan
- `tsc` clean on edited files
- Existing prompt unit tests pass (`prompt-date.test.ts`, `prompt-user-identity.test.ts`)