### PR TITLE
fix(org-canvas): stop sub-canvas drill-in from triggering a full page reload

### DIFF
--- a/src/app/org/[githubLogin]/_components/OrgCanvasView.tsx
+++ b/src/app/org/[githubLogin]/_components/OrgCanvasView.tsx
@@ -8,7 +8,7 @@ import {
   useCallback,
   useRef,
 } from "react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import type { CanvasEdge, CanvasNode, EdgeUpdate } from "system-canvas";
 import type { ImperativePanelHandle } from "react-resizable-panels";
 import { useWorkspace } from "@/hooks/useWorkspace";
@@ -77,7 +77,6 @@ interface OrgCanvasViewProps {
  * drilling.
  */
 export function OrgCanvasView({ githubLogin, orgId, orgName }: OrgCanvasViewProps) {
-  const router = useRouter();
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const { slug: workspaceSlug } = useWorkspace();
@@ -233,13 +232,18 @@ export function OrgCanvasView({ githubLogin, orgId, orgName }: OrgCanvasViewProp
 
   const setUrlSlug = useCallback(
     (slug: string | null) => {
-      const params = new URLSearchParams(searchParams.toString());
+      // `history.replaceState` (NOT `router.replace`) so updating this
+      // deep-link param never triggers a Next navigation / RSC fetch on
+      // this `protected` route. A router navigation re-runs middleware +
+      // the async `page.tsx` DB query, and any redirect/500 there
+      // degrades to a full hard reload. See CANVAS.md "Deep links".
+      const params = new URLSearchParams(window.location.search);
       if (slug) params.set("c", slug);
       else params.delete("c");
       const qs = params.toString();
-      router.replace(`${pathname}${qs ? `?${qs}` : ""}`, { scroll: false });
+      window.history.replaceState(null, "", `${pathname}${qs ? `?${qs}` : ""}`);
     },
-    [router, pathname, searchParams],
+    [pathname],
   );
 
   /**
@@ -257,13 +261,15 @@ export function OrgCanvasView({ githubLogin, orgId, orgName }: OrgCanvasViewProp
    */
   const setUrlResearchSlug = useCallback(
     (slug: string | null) => {
-      const params = new URLSearchParams(searchParams.toString());
+      // `history.replaceState` (NOT `router.replace`) — see `setUrlSlug`
+      // above for why a router navigation can cause a full page reload.
+      const params = new URLSearchParams(window.location.search);
       if (slug) params.set("r", slug);
       else params.delete("r");
       const qs = params.toString();
-      router.replace(`${pathname}${qs ? `?${qs}` : ""}`, { scroll: false });
+      window.history.replaceState(null, "", `${pathname}${qs ? `?${qs}` : ""}`);
     },
-    [router, pathname, searchParams],
+    [pathname],
   );
 
   useEffect(() => {

--- a/src/app/org/[githubLogin]/connections/OrgCanvasBackground.tsx
+++ b/src/app/org/[githubLogin]/connections/OrgCanvasBackground.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import {
   AddNodeButton,
   SystemCanvas,
@@ -399,7 +399,6 @@ export function OrgCanvasBackground({
   //      We wire `onBreadcrumbClick` to update both `currentRef`
   //      state and the URL so going back to root clears `?canvas=`.
   // -------------------------------------------------------------------
-  const router = useRouter();
   const searchParams = useSearchParams();
   // Stay on the current route when writing canvas URL params. The
   // canvas only lives at `/org/{login}` today, but reading the
@@ -456,16 +455,26 @@ export function OrgCanvasBackground({
    */
   const writeCanvasUrlParam = useCallback(
     (ref: string) => {
-      const params = new URLSearchParams(searchParams.toString());
+      // `history.replaceState`, NOT `router.replace`: drilling into a
+      // sub-canvas is a pure client-side canvas interaction, and this
+      // param is write-only after mount (refresh/share only — see the
+      // deep-link block below). A `router.replace` here re-runs the
+      // route through middleware + the async `page.tsx` DB query on
+      // this `protected` route; any redirect (expired session) or 500
+      // there makes the App Router fall back to a FULL hard reload
+      // (visible browser-tab spinner). `history.replaceState` updates
+      // the URL bar with zero navigation, and still syncs with
+      // `useSearchParams` in Next 15.
+      const params = new URLSearchParams(window.location.search);
       if (ref === "") {
         params.delete("canvas");
       } else {
         params.set("canvas", ref);
       }
       const qs = params.toString();
-      router.replace(`${pathname}${qs ? `?${qs}` : ""}`, { scroll: false });
+      window.history.replaceState(null, "", `${pathname}${qs ? `?${qs}` : ""}`);
     },
-    [router, pathname, searchParams],
+    [pathname],
   );
 
   /**


### PR DESCRIPTION
## Problem

Sometimes navigating into an initiative (or any sub-canvas) triggers a full document reload — the browser-tab loading spinner appears and the whole page reboots. It's intermittent.

## Root cause

Drilling into a sub-canvas writes the `?canvas=<ref>` query param via `router.replace` (and the connection/research viewers do the same with `?c=` / `?r=`). Even though only the query string changes, `router.replace` is a Next navigation, so the App Router re-runs the route pipeline for `/org/[githubLogin]`:

1. **Middleware runs.** `/org/**` isn't in `ROUTE_POLICIES`, so it resolves to `protected` and calls `getToken(...)`. If the session JWT is missing/expired, middleware returns a redirect to `/`.
2. **The async page re-queries the DB.** `page.tsx` runs `db.sourceControlOrg.findFirst` on every `?canvas=` change.

When that soft-navigation RSC request comes back as a **middleware redirect** or **errors (500)**, the App Router can't reconcile it client-side and **degrades to a full hard navigation** — the tab spinner. That's why it's intermittent: it only surfaces when the round-trip redirects (session boundary) or the DB query flakes.

## Fix

These params are **write-only after mount** (refresh/share only — see CANVAS.md "Deep links"), so they never need to hit the router. Switch all three URL writers — `writeCanvasUrlParam` (`?canvas=`), `setUrlSlug` (`?c=`), `setUrlResearchSlug` (`?r=`) — from `router.replace` to `window.history.replaceState`. That updates the URL bar with **zero Next navigation** (no middleware run, no `page.tsx` DB re-query, no redirect/500 opportunity) while still syncing with `useSearchParams` in Next 15.

Each writer now reads live URL state via `window.location.search`, so the callback deps shrink to `[pathname]`; removed the now-unused `useRouter`/`router` from both files.

## Verification

- `tsc --noEmit` clean for both files.
- eslint: only one pre-existing unrelated warning (`markDirty` dep), no errors and no exhaustive-deps complaints on the changed callbacks.

## Note for reviewers

To see which trigger was actually firing in production: DevTools → Network, drill into an initiative, look for the `?canvas=...&_rsc=` request. A **307** means session-expiry redirects (may warrant separate session-refresh hardening); a **500** means the `page.tsx` DB query was flaking. This fix stops both from reloading the page either way.