### PR TITLE
fix(mcp): return canonical web links from feature/task tools

### DIFF
--- a/src/__tests__/unit/lib/mcp/mcpTools.test.ts
+++ b/src/__tests__/unit/lib/mcp/mcpTools.test.ts
@@ -179,7 +179,11 @@ describe("needsAttention flag derivation", () => {
 // fetchLatestPullRequestForMcp and is covered by integration tests.
 // ---------------------------------------------------------------------------
 
-import { shapePullRequestSummary } from "@/lib/mcp/mcpTools";
+import {
+  shapePullRequestSummary,
+  featureLink,
+  taskLink,
+} from "@/lib/mcp/mcpTools";
 
 describe("shapePullRequestSummary", () => {
   test("returns null when no PR artifact exists", () => {
@@ -289,5 +293,32 @@ describe("shapePullRequestSummary", () => {
       mergeable: false,
       failedChecks: ["build", "lint"],
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Canonical link builders
+//
+// These guard against agents fabricating URLs: the read/list tools embed a
+// real `link` built from these helpers so the agent can copy it verbatim
+// rather than guessing a (wrong) host/path.
+// ---------------------------------------------------------------------------
+
+describe("featureLink / taskLink", () => {
+  test("featureLink points at the /plan/<id> page on the canonical host", () => {
+    expect(featureLink("hive", "cmqub5562000oi804pfippkoc")).toBe(
+      "https://hive.sphinx.chat/w/hive/plan/cmqub5562000oi804pfippkoc",
+    );
+  });
+
+  test("taskLink points at the /task/<id> page on the canonical host", () => {
+    expect(taskLink("hive", "cmqub8utw0001l004699htqfp")).toBe(
+      "https://hive.sphinx.chat/w/hive/task/cmqub8utw0001l004699htqfp",
+    );
+  });
+
+  test("uses the workspace slug verbatim", () => {
+    expect(featureLink("my-team", "f1")).toContain("/w/my-team/plan/f1");
+    expect(taskLink("my-team", "t1")).toContain("/w/my-team/task/t1");
   });
 });

--- a/src/lib/mcp/handler.ts
+++ b/src/lib/mcp/handler.ts
@@ -238,7 +238,7 @@ function createServer(
     {
       title: "List Features",
       description:
-        "List features in the workspace, ordered by last updated. Returns feature names, IDs, statuses, and last-updated timestamps. Maximum 40 results.",
+        "List features in the workspace, ordered by last updated. Returns feature names, IDs, statuses, last-updated timestamps, and a `link` to the feature's plan page. Maximum 40 results. When sharing a feature with the user, use the `link` field verbatim — never construct a URL yourself.",
       inputSchema: {},
     },
     async (_args, extra) => {
@@ -254,7 +254,7 @@ function createServer(
     {
       title: "Read Feature",
       description:
-        "Read a feature's plan details and full chat message history. Also indicates whether the planning workflow is currently running.",
+        "Read a feature's plan details and full chat message history. Also indicates whether the planning workflow is currently running, and returns a `link` to the feature's plan page. When sharing the feature with the user, use the `link` field verbatim — never construct a URL yourself.",
       inputSchema: {
         featureId: z
           .string()
@@ -313,7 +313,7 @@ function createServer(
     {
       title: "List Tasks",
       description:
-        "List tasks in the workspace, ordered by last updated. Returns task titles, IDs, statuses, priorities, featureIds, and last-updated timestamps. Maximum 40 results. When `featureId` is provided, scopes results to tasks belonging to that feature.",
+        "List tasks in the workspace, ordered by last updated. Returns task titles, IDs, statuses, priorities, featureIds, last-updated timestamps, and a `link` to each task page. Maximum 40 results. When `featureId` is provided, scopes results to tasks belonging to that feature. When sharing a task with the user, use the `link` field verbatim — never construct a URL yourself.",
       inputSchema: {
         featureId: z
           .string()
@@ -336,7 +336,7 @@ function createServer(
     {
       title: "Read Task",
       description:
-        "Read a task's details and full chat message history. Also indicates whether the task workflow is currently running.",
+        "Read a task's details and full chat message history. Also indicates whether the task workflow is currently running, and returns a `link` to the task page. When sharing the task with the user, use the `link` field verbatim — never construct a URL yourself.",
       inputSchema: {
         taskId: z
           .string()

--- a/src/lib/mcp/mcpTools.ts
+++ b/src/lib/mcp/mcpTools.ts
@@ -40,6 +40,30 @@ function mcpOk(data: unknown): McpToolResult {
 }
 
 // ---------------------------------------------------------------------------
+// Canonical Hive URLs
+// ---------------------------------------------------------------------------
+
+/**
+ * Public base URL for the Hive app. Single source of truth for the
+ * web links surfaced through MCP tool results so agents can hand the
+ * user a real, clickable URL instead of guessing one (the cause of
+ * fabricated links like `hive.stakwork.com/.../features/<id>`).
+ */
+const HIVE_BASE_URL =
+  process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, "") ||
+  "https://hive.sphinx.chat";
+
+/** Canonical web link to a feature's plan page. */
+export function featureLink(workspaceSlug: string, featureId: string): string {
+  return `${HIVE_BASE_URL}/w/${workspaceSlug}/plan/${featureId}`;
+}
+
+/** Canonical web link to a task page. */
+export function taskLink(workspaceSlug: string, taskId: string): string {
+  return `${HIVE_BASE_URL}/w/${workspaceSlug}/task/${taskId}`;
+}
+
+// ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
 
@@ -372,6 +396,7 @@ export async function mcpListFeatures(
         title: f.title,
         status: f.status,
         updatedAt: f.updatedAt.toISOString(),
+        link: featureLink(auth.workspaceSlug, f.id),
       })),
     );
   } catch (error) {
@@ -416,6 +441,7 @@ export async function mcpReadFeature(
       brief: feature!.brief,
       requirements: feature!.requirements,
       architecture: feature!.architecture,
+      link: featureLink(auth.workspaceSlug, feature!.id),
       chatHistory,
     });
   } catch (error) {
@@ -564,6 +590,7 @@ export async function mcpListTasks(
         priority: t.priority,
         featureId: t.featureId,
         updatedAt: t.updatedAt.toISOString(),
+        link: taskLink(auth.workspaceSlug, t.id),
       })),
     );
   } catch (error) {
@@ -613,6 +640,7 @@ export async function mcpReadTask(
       isWorkflowRunning: task!.workflowStatus === "IN_PROGRESS",
       featureId: task!.featureId,
       branch: task!.branch,
+      link: taskLink(auth.workspaceSlug, task!.id),
       chatHistory,
       pullRequest,
     });
@@ -1178,8 +1206,6 @@ async function fetchStatusItems(
     }),
   ]);
 
-  const base = `https://hive.sphinx.chat/w/${auth.workspaceSlug}`;
-
   const merged: StatusItem[] = [
     ...tasks.map((t) => ({
       type: "task" as const,
@@ -1190,7 +1216,7 @@ async function fetchStatusItems(
       workflowStatus: t.workflowStatus,
       needsAttention: t.workflowStatus === "COMPLETED",
       updatedAt: t.updatedAt.toISOString(),
-      link: `${base}/task/${t.id}`,
+      link: taskLink(auth.workspaceSlug, t.id),
       branch: t.branch,
     })),
     ...features.map((f) => ({
@@ -1202,7 +1228,7 @@ async function fetchStatusItems(
       workflowStatus: f.workflowStatus,
       needsAttention: f.workflowStatus === "COMPLETED",
       updatedAt: f.updatedAt.toISOString(),
-      link: `${base}/plan/${f.id}`,
+      link: featureLink(auth.workspaceSlug, f.id),
       brief: f.brief,
     })),
   ];


### PR DESCRIPTION
## Problem

When asked to share a link to a feature or task, the Hive MCP agent fabricated URLs — e.g. `https://hive.stakwork.com/w/hive/features/<id>` — where **both the host and the path were wrong** (the real route is `https://hive.sphinx.chat/w/<slug>/plan/<id>`, and `/features/` does not exist).

Root cause: the read/list MCP tools (`read_feature`, `list_features`, `read_task`, `list_tasks`) returned only the bare `id`. With no URL to copy, the model synthesized one from naming cues (repo org "stakwork" → wrong host; the "Feature" object → a plausible-but-nonexistent `/features/` path). Notably `check_status` already returned a correct `link`, so the right shape existed in the codebase — the read/list tools just didn't expose it.

## Fix

Hand the agent the exact link instead of relying on it to assemble one.

- Add `HIVE_BASE_URL` as a single source of truth (prefers `NEXT_PUBLIC_APP_URL`, falls back to `https://hive.sphinx.chat`) plus exported `featureLink()` / `taskLink()` helpers.
- Embed a `link` field in the output of `read_feature`, `list_features`, `read_task`, and `list_tasks`.
- Refactor `check_status` to reuse the helpers, removing the duplicated hardcoded base URL.
- Update the four tool descriptions to use the returned `link` verbatim and never construct a URL.
- Add unit tests locking the canonical `/plan/<id>` and `/task/<id>` formats.

## Testing

- `src/__tests__/unit/lib/mcp/mcpTools.test.ts` — 22 tests pass (3 new).
- No type errors in the edited files.