### PR TITLE
Fix SelectItem crash by replacing empty string value with __all__ in AddEdgePanel

### DIFF
--- a/src/__tests__/unit/components/lingo/AddEdgePanel.test.tsx
+++ b/src/__tests__/unit/components/lingo/AddEdgePanel.test.tsx
@@ -183,7 +183,7 @@ describe("AddEdgePanel", () => {
   });
 
   describe("Default 'All types' state", () => {
-    it("node-type select defaults to empty string (All types)", async () => {
+    it("node-type select defaults to __all__ (All types)", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({ node_types: [] }),
@@ -193,10 +193,10 @@ describe("AddEdgePanel", () => {
 
       // The first select-wrapper rendered is the node-type select
       const wrappers = screen.getAllByTestId("select-wrapper");
-      expect(wrappers[0]).toHaveAttribute("data-value", "");
+      expect(wrappers[0]).toHaveAttribute("data-value", "__all__");
     });
 
-    it("renders 'All types' SelectItem with empty value", async () => {
+    it("renders 'All types' SelectItem with __all__ value", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({ node_types: [] }),
@@ -205,13 +205,13 @@ describe("AddEdgePanel", () => {
       render(<AddEdgePanel {...defaultProps} />);
 
       await waitFor(() => {
-        const allTypesItem = screen.getByTestId("select-item-");
+        const allTypesItem = screen.getByTestId("select-item-__all__");
         expect(allTypesItem).toBeInTheDocument();
         expect(allTypesItem).toHaveTextContent("All types");
       });
     });
 
-    it("search does not include type= param when selectedType is empty", async () => {
+    it("search does not include type= param when selectedType is __all__", async () => {
       vi.useFakeTimers({ shouldAdvanceTime: true });
 
       mockFetch

--- a/src/app/w/[slug]/learn/lingo/components/AddEdgePanel.tsx
+++ b/src/app/w/[slug]/learn/lingo/components/AddEdgePanel.tsx
@@ -49,7 +49,7 @@ export function AddEdgePanel({
   onEdgeCreated,
 }: AddEdgePanelProps) {
   const [nodeTypes, setNodeTypes] = useState<string[]>([]);
-  const [selectedType, setSelectedType] = useState<string>("");
+  const [selectedType, setSelectedType] = useState<string>("__all__");
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResults, setSearchResults] = useState<LingoNode[]>([]);
   const [targetNode, setTargetNode] = useState<LingoNode | null>(null);
@@ -96,7 +96,7 @@ export function AddEdgePanel({
       setIsSearching(true);
       try {
         const params = new URLSearchParams({ q: searchQuery });
-        if (selectedType) params.set("type", selectedType);
+        if (selectedType !== "__all__") params.set("type", selectedType);
         const res = await fetch(
           `/api/workspaces/${workspaceSlug}/lingo/nodes/search?${params}`,
         );
@@ -164,7 +164,7 @@ export function AddEdgePanel({
                 <SelectValue placeholder="Any type" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="">All types</SelectItem>
+                <SelectItem value="__all__">All types</SelectItem>
                 <SelectItem value="Lingo">Lingo</SelectItem>
                 {nodeTypes
                   .filter((t) => t !== "Lingo")


### PR DESCRIPTION
Generated with Hive: Fix SelectItem crash by replacing empty string value with __all__ in AddEdgePanel