### PR TITLE
Fix Lingo nodes search to use v2 endpoint and update test assertion

### DIFF
--- a/src/__tests__/unit/api/workspaces/lingo-routes.test.ts
+++ b/src/__tests__/unit/api/workspaces/lingo-routes.test.ts
@@ -505,6 +505,7 @@ describe("GET /api/workspaces/[slug]/lingo/nodes/search", () => {
     );
     await GET(req, { params: Promise.resolve({ slug: SLUG }) });
     const [calledUrl] = mockFetch.mock.calls[0] as [string];
+    expect(calledUrl).toContain("/v2/nodes/search");
     expect(calledUrl).toContain("q=pod");
     expect(calledUrl).toContain("type=Jargon");
   });

--- a/src/app/api/workspaces/[slug]/lingo/nodes/search/route.ts
+++ b/src/app/api/workspaces/[slug]/lingo/nodes/search/route.ts
@@ -58,7 +58,7 @@ export async function GET(
   if (type) queryParams.set("type", type);
 
   try {
-    const response = await fetch(`${jarvisUrl}/nodes/search?${queryParams}`, {
+    const response = await fetch(`${jarvisUrl}/v2/nodes/search?${queryParams}`, {
       method: "GET",
       headers: {
         "x-api-token": swarmApiKey,


### PR DESCRIPTION
Generated with Hive: Fix Lingo nodes search to use v2 endpoint and update test assertion