### PR TITLE
Guard against missing ref_id in Lingo API and components to prevent crashes

### DIFF
--- a/src/__tests__/unit/api/workspaces/lingo-routes.test.ts
+++ b/src/__tests__/unit/api/workspaces/lingo-routes.test.ts
@@ -942,3 +942,104 @@ describe("POST /api/workspaces/[slug]/lingo/nodes", () => {
     expect(mockAddNode).not.toHaveBeenCalled();
   });
 });
+
+// ─── ref_id filter guards ─────────────────────────────────────────────────────
+
+describe("GET /api/workspaces/[slug]/lingo/nodes — ref_id filter", () => {
+  let GET: typeof import("@/app/api/workspaces/[slug]/lingo/nodes/route").GET;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    delete process.env.USE_MOCKS;
+    ({ GET } = await import("@/app/api/workspaces/[slug]/lingo/nodes/route"));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test("drops items missing ref_id and returns only valid nodes", async () => {
+    mockGetWorkspaceSwarmAccess.mockResolvedValueOnce({ success: true, data: SWARM_DATA });
+    const rawNodes = [
+      { ref_id: "valid-1", node_type: "Lingo", date_added_to_graph: 2000, properties: { name: "Valid Node" } },
+      { node_type: "Lingo", date_added_to_graph: 1000, properties: { name: "Missing ref_id" } },
+      null,
+      undefined,
+      { ref_id: "valid-2", node_type: "Lingo", date_added_to_graph: 500, properties: { name: "Another Valid" } },
+    ];
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ nodes: rawNodes }), { status: 200 }),
+    );
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/nodes`,
+    );
+    const res = await GET(req, { params: Promise.resolve({ slug: SLUG }) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.nodes).toHaveLength(2);
+    expect(body.data.nodes.map((n: { ref_id: string }) => n.ref_id)).toEqual(["valid-1", "valid-2"]);
+  });
+
+  test("returns empty array when all items lack ref_id", async () => {
+    mockGetWorkspaceSwarmAccess.mockResolvedValueOnce({ success: true, data: SWARM_DATA });
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ nodes: [null, { node_type: "Lingo" }] }), { status: 200 }),
+    );
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/nodes`,
+    );
+    const res = await GET(req, { params: Promise.resolve({ slug: SLUG }) });
+    const body = await res.json();
+    expect(body.data.nodes).toEqual([]);
+  });
+});
+
+describe("GET /api/workspaces/[slug]/lingo/nodes/search — ref_id filter", () => {
+  let GET: typeof import("@/app/api/workspaces/[slug]/lingo/nodes/search/route").GET;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    delete process.env.USE_MOCKS;
+    ({ GET } = await import("@/app/api/workspaces/[slug]/lingo/nodes/search/route"));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test("drops items missing ref_id and returns only valid search results", async () => {
+    mockGetWorkspaceSwarmAccess.mockResolvedValueOnce({ success: true, data: SWARM_DATA });
+    const rawNodes = [
+      { ref_id: "search-1", node_type: "Lingo", name: "Pod", date_added_to_graph: 1000 },
+      { node_type: "Lingo", name: "No ref_id item", date_added_to_graph: 900 },
+      null,
+      { ref_id: "search-2", node_type: "Lingo", name: "Pod Runner", date_added_to_graph: 800 },
+    ];
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify(rawNodes), { status: 200 }),
+    );
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/nodes/search?q=pod`,
+    );
+    const res = await GET(req, { params: Promise.resolve({ slug: SLUG }) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data).toHaveLength(2);
+    expect(body.data.map((n: { ref_id: string }) => n.ref_id)).toEqual(["search-1", "search-2"]);
+  });
+
+  test("returns empty array when all search results lack ref_id", async () => {
+    mockGetWorkspaceSwarmAccess.mockResolvedValueOnce({ success: true, data: SWARM_DATA });
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify([null, { name: "ghost" }]), { status: 200 }),
+    );
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/nodes/search?q=ghost`,
+    );
+    const res = await GET(req, { params: Promise.resolve({ slug: SLUG }) });
+    const body = await res.json();
+    expect(body.data).toEqual([]);
+  });
+});

--- a/src/__tests__/unit/api/workspaces/lingo-routes.test.ts
+++ b/src/__tests__/unit/api/workspaces/lingo-routes.test.ts
@@ -16,6 +16,7 @@ vi.mock("@/services/swarm/api/nodes", () => ({
   addNode: vi.fn(),
   addEdge: vi.fn(),
   patchEdge: vi.fn(),
+  deleteNode: vi.fn(),
 }));
 
 const mockFetch = vi.fn();
@@ -24,12 +25,13 @@ vi.stubGlobal("fetch", mockFetch);
 // ─── Imports after mocks ──────────────────────────────────────────────────────
 
 import { getWorkspaceSwarmAccess } from "@/lib/helpers/swarm-access";
-import { addNode, addEdge, patchEdge } from "@/services/swarm/api/nodes";
+import { addNode, addEdge, patchEdge, deleteNode } from "@/services/swarm/api/nodes";
 
 const mockGetWorkspaceSwarmAccess = vi.mocked(getWorkspaceSwarmAccess);
 const mockAddNode = vi.mocked(addNode);
 const mockAddEdge = vi.mocked(addEdge);
 const mockPatchEdge = vi.mocked(patchEdge);
+const mockDeleteNode = vi.mocked(deleteNode);
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -940,6 +942,134 @@ describe("POST /api/workspaces/[slug]/lingo/nodes", () => {
     expect(json.data.ref_id).toBe("mock-lingo-ref");
     expect(json.data.name).toBe("Mock Term");
     expect(mockAddNode).not.toHaveBeenCalled();
+  });
+});
+
+// ─── DELETE /lingo/nodes/[ref_id] ─────────────────────────────────────────────
+
+describe("DELETE /api/workspaces/[slug]/lingo/nodes/[ref_id]", () => {
+  let DELETE: typeof import("@/app/api/workspaces/[slug]/lingo/nodes/[ref_id]/route").DELETE;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    delete process.env.USE_MOCKS;
+    ({ DELETE } = await import("@/app/api/workspaces/[slug]/lingo/nodes/[ref_id]/route"));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test("returns 401 for unauthenticated request", async () => {
+    const req = new NextRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/nodes/node-001`,
+      { method: "DELETE" },
+    );
+    const res = await DELETE(req, {
+      params: Promise.resolve({ slug: SLUG, ref_id: "node-001" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("returns 403 on ACCESS_DENIED — deleteNode must NOT be called", async () => {
+    mockGetWorkspaceSwarmAccess.mockResolvedValueOnce({
+      success: false,
+      error: { type: "ACCESS_DENIED" },
+    });
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/nodes/node-001`,
+      { method: "DELETE" },
+    );
+    const res = await DELETE(req, {
+      params: Promise.resolve({ slug: SLUG, ref_id: "node-001" }),
+    });
+    expect(res.status).toBe(403);
+    expect(mockDeleteNode).not.toHaveBeenCalled();
+  });
+
+  test("returns 404 on WORKSPACE_NOT_FOUND", async () => {
+    mockGetWorkspaceSwarmAccess.mockResolvedValueOnce({
+      success: false,
+      error: { type: "WORKSPACE_NOT_FOUND" },
+    });
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/bad-slug/lingo/nodes/node-001`,
+      { method: "DELETE" },
+    );
+    const res = await DELETE(req, {
+      params: Promise.resolve({ slug: "bad-slug", ref_id: "node-001" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  test("returns 503 on SWARM_NOT_CONFIGURED", async () => {
+    mockGetWorkspaceSwarmAccess.mockResolvedValueOnce({
+      success: false,
+      error: { type: "SWARM_NOT_CONFIGURED" },
+    });
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/nodes/node-001`,
+      { method: "DELETE" },
+    );
+    const res = await DELETE(req, {
+      params: Promise.resolve({ slug: SLUG, ref_id: "node-001" }),
+    });
+    expect(res.status).toBe(503);
+  });
+
+  test("returns { success: true } when USE_MOCKS=true without calling deleteNode", async () => {
+    process.env.USE_MOCKS = "true";
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/nodes/node-001`,
+      { method: "DELETE" },
+    );
+    const res = await DELETE(req, {
+      params: Promise.resolve({ slug: SLUG, ref_id: "node-001" }),
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(mockDeleteNode).not.toHaveBeenCalled();
+  });
+
+  test("returns 200 { success: true } when deleteNode succeeds", async () => {
+    mockGetWorkspaceSwarmAccess.mockResolvedValueOnce({
+      success: true,
+      data: SWARM_DATA,
+    });
+    mockDeleteNode.mockResolvedValueOnce({ success: true });
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/nodes/node-001`,
+      { method: "DELETE" },
+    );
+    const res = await DELETE(req, {
+      params: Promise.resolve({ slug: SLUG, ref_id: "node-001" }),
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(mockDeleteNode).toHaveBeenCalledWith(
+      { jarvisUrl: expect.any(String), apiKey: SWARM_DATA.swarmApiKey },
+      "node-001",
+    );
+  });
+
+  test("returns 500 { success: false } when deleteNode fails", async () => {
+    mockGetWorkspaceSwarmAccess.mockResolvedValueOnce({
+      success: true,
+      data: SWARM_DATA,
+    });
+    mockDeleteNode.mockResolvedValueOnce({ success: false, error: "Jarvis error" });
+    const req = makeAuthenticatedRequest(
+      `http://localhost/api/workspaces/${SLUG}/lingo/nodes/node-001`,
+      { method: "DELETE" },
+    );
+    const res = await DELETE(req, {
+      params: Promise.resolve({ slug: SLUG, ref_id: "node-001" }),
+    });
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.success).toBe(false);
   });
 });
 

--- a/src/__tests__/unit/components/lingo/LingoExplorer.test.tsx
+++ b/src/__tests__/unit/components/lingo/LingoExplorer.test.tsx
@@ -632,6 +632,33 @@ describe("LingoExplorer", () => {
       expect(screen.queryByTestId("new-lingo-node-button")).not.toBeInTheDocument();
     });
 
+    it("renders without crash when a node is missing ref_id (key falls back to name)", async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              success: true,
+              data: {
+                nodes: [
+                  { ref_id: "valid-ref", name: "Valid Term", node_type: "Lingo", definition: null, date_added_to_graph: 1750000000 },
+                  // malformed: no ref_id, but has name for key fallback
+                  { name: "No Ref Term", node_type: "Lingo", definition: null, date_added_to_graph: 1749000000 },
+                ],
+                hasMore: false,
+              },
+            }),
+            { status: 200 },
+          ),
+        );
+
+      expect(() => render(<LingoExplorer workspaceSlug={SLUG} />)).not.toThrow();
+
+      // Valid node still renders
+      await waitFor(() =>
+        expect(screen.getByTestId("lingo-card-valid-ref")).toBeInTheDocument(),
+      );
+    });
+
     it("handleNodeCreated prepends node to list and navigates to detail view", async () => {
       mockFetch
         .mockResolvedValueOnce({

--- a/src/__tests__/unit/components/lingo/LingoExplorer.test.tsx
+++ b/src/__tests__/unit/components/lingo/LingoExplorer.test.tsx
@@ -43,9 +43,12 @@ vi.mock("@/app/w/[slug]/learn/lingo/components/LingoCard", () => ({
 }));
 
 vi.mock("@/app/w/[slug]/learn/lingo/components/NeighborView", () => ({
-  NeighborView: ({ node, edges, onDeleteEdge, onNavigate, onAddEdge }: any) => (
+  NeighborView: ({ node, edges, onDeleteEdge, onDeleteNode, onNavigate, onAddEdge }: any) => (
     <div data-testid="neighbor-view">
       <span data-testid="detail-node-name">{node.name}</span>
+      <button data-testid="delete-node-button" onClick={() => onDeleteNode(node.ref_id)}>
+        Delete node
+      </button>
       {edges.map((e: any) => (
         <div key={e.edge_ref_id}>
           <button
@@ -660,6 +663,7 @@ describe("LingoExplorer", () => {
     });
 
     it("handleNodeCreated prepends node to list and navigates to detail view", async () => {
+
       mockFetch
         .mockResolvedValueOnce({
           ok: true,
@@ -699,6 +703,142 @@ describe("LingoExplorer", () => {
         expect(screen.queryByTestId("create-lingo-node-dialog")).not.toBeInTheDocument();
         expect(screen.getByTestId("neighbor-view")).toBeInTheDocument();
       });
+    });
+  });
+
+  describe("Optimistic node delete", () => {
+    async function setupDetailView() {
+      const nodes = makeNodes(2);
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ success: true, data: { nodes, hasMore: false } }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(makeNeighborData("jargon-1")),
+        });
+
+      render(<LingoExplorer workspaceSlug={SLUG} />);
+      await waitFor(() => screen.getByTestId("lingo-card-jargon-1"));
+      fireEvent.click(screen.getByTestId("lingo-card-jargon-1"));
+      await waitFor(() => screen.getByTestId("neighbor-view"));
+    }
+
+    it("clicking delete button hides the node from the list and navigates back to list view", async () => {
+      await setupDetailView();
+
+      fireEvent.click(screen.getByTestId("delete-node-button"));
+
+      // Navigates back to list view
+      await waitFor(() => {
+        expect(screen.queryByTestId("neighbor-view")).not.toBeInTheDocument();
+        expect(screen.getByTestId("lingo-card-grid")).toBeInTheDocument();
+      });
+
+      // Node is hidden from list
+      expect(screen.queryByTestId("lingo-card-jargon-1")).not.toBeInTheDocument();
+      // Other node still visible
+      expect(screen.getByTestId("lingo-card-jargon-2")).toBeInTheDocument();
+
+      // Toast shown
+      expect(toast).toHaveBeenCalledWith(
+        "Node removed",
+        expect.objectContaining({ action: expect.objectContaining({ label: "Undo" }) }),
+      );
+    });
+
+    it("clicking Undo in the toast restores the node in the list", async () => {
+      await setupDetailView();
+
+      let capturedToastOptions: any;
+      vi.mocked(toast).mockImplementationOnce((_msg: any, opts: any) => {
+        capturedToastOptions = opts;
+        return "toast-id";
+      });
+
+      fireEvent.click(screen.getByTestId("delete-node-button"));
+
+      // Node hidden initially
+      await waitFor(() =>
+        expect(screen.queryByTestId("lingo-card-jargon-1")).not.toBeInTheDocument(),
+      );
+
+      // Undo
+      act(() => {
+        capturedToastOptions?.action?.onClick?.();
+      });
+
+      // Node reappears
+      await waitFor(() => {
+        expect(screen.getByTestId("lingo-card-jargon-1")).toBeInTheDocument();
+      });
+
+      // No DELETE fetch called
+      const deleteCalls = mockFetch.mock.calls.filter(
+        (c: any[]) => typeof c[0] === "string" && c[0].includes("/lingo/nodes/jargon-1") && c[1]?.method === "DELETE",
+      );
+      expect(deleteCalls).toHaveLength(0);
+    });
+
+    it("confirming (toast dismiss without undo) calls DELETE endpoint", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ success: true }),
+      });
+
+      await setupDetailView();
+
+      let capturedToastOptions: any;
+      vi.mocked(toast).mockImplementationOnce((_msg: any, opts: any) => {
+        capturedToastOptions = opts;
+        return "toast-id";
+      });
+
+      fireEvent.click(screen.getByTestId("delete-node-button"));
+
+      await act(async () => {
+        capturedToastOptions?.onAutoClose?.();
+      });
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          `/api/workspaces/${SLUG}/lingo/nodes/jargon-1`,
+          expect.objectContaining({ method: "DELETE" }),
+        );
+      });
+    });
+
+    it("API failure reverts the optimistic hide and shows an error toast", async () => {
+      await setupDetailView();
+
+      let capturedToastOptions: any;
+      vi.mocked(toast).mockImplementationOnce((_msg: any, opts: any) => {
+        capturedToastOptions = opts;
+        return "toast-id";
+      });
+
+      fireEvent.click(screen.getByTestId("delete-node-button"));
+
+      // Node hidden initially
+      await waitFor(() =>
+        expect(screen.queryByTestId("lingo-card-jargon-1")).not.toBeInTheDocument(),
+      );
+
+      // Simulate API failure
+      mockFetch.mockResolvedValueOnce({ ok: false });
+
+      await act(async () => {
+        capturedToastOptions?.onAutoClose?.();
+      });
+
+      // Node reappears after error
+      await waitFor(() => {
+        expect(screen.getByTestId("lingo-card-jargon-1")).toBeInTheDocument();
+      });
+
+      // Error toast shown
+      expect(toast.error).toHaveBeenCalledWith("Failed to delete node");
     });
   });
 });

--- a/src/__tests__/unit/components/lingo/NeighborView.test.tsx
+++ b/src/__tests__/unit/components/lingo/NeighborView.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock("lucide-react", () => ({
+  Trash2: () => <svg data-testid="trash-icon" />,
+  Plus: () => <svg data-testid="plus-icon" />,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, onClick, ...props }: any) => (
+    <button onClick={onClick} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+// ─── Import after mocks ────────────────────────────────────────────────────────
+
+import { NeighborView } from "@/app/w/[slug]/learn/lingo/components/NeighborView";
+import type { LingoNode } from "@/app/api/mock/lingo/nodes";
+import type { NeighborEdge, NeighborNode } from "@/app/api/mock/lingo/neighbors";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const baseNode: LingoNode = {
+  ref_id: "node-1",
+  name: "Test Node",
+  node_type: "Lingo",
+  definition: "A test definition",
+  date_added_to_graph: 1700000000,
+};
+
+function makeEdge(overrides: Partial<NeighborEdge> = {}): NeighborEdge {
+  return {
+    edge_ref_id: "edge-1",
+    edge_type: "RELATED_TO",
+    neighbor_node: {
+      ref_id: "neighbor-1",
+      name: "Neighbor Node",
+      node_type: "Lingo",
+    } as NeighborNode,
+    ...overrides,
+  };
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("NeighborView", () => {
+  describe("visibleEdges filter — ref_id guard", () => {
+    it("renders valid edges normally", () => {
+      const edges = [makeEdge()];
+      render(
+        <NeighborView
+          node={baseNode}
+          edges={edges}
+          deletedEdgeIds={new Set()}
+          onDeleteEdge={vi.fn()}
+          onNavigate={vi.fn()}
+          onAddEdge={vi.fn()}
+        />,
+      );
+      expect(screen.getByTestId("neighbor-edge-list")).toBeInTheDocument();
+      expect(screen.getByTestId("neighbor-edge-edge-1")).toBeInTheDocument();
+    });
+
+    it("renders zero connections and no crash when neighbor_node is undefined", () => {
+      const edgeWithUndefinedNeighbor = makeEdge({
+        neighbor_node: undefined as unknown as NeighborNode,
+      });
+      expect(() =>
+        render(
+          <NeighborView
+            node={baseNode}
+            edges={[edgeWithUndefinedNeighbor]}
+            deletedEdgeIds={new Set()}
+            onDeleteEdge={vi.fn()}
+            onNavigate={vi.fn()}
+            onAddEdge={vi.fn()}
+          />,
+        ),
+      ).not.toThrow();
+
+      expect(screen.queryByTestId("neighbor-edge-list")).not.toBeInTheDocument();
+      expect(
+        screen.getByText("No connections yet. Add one to enrich the graph."),
+      ).toBeInTheDocument();
+    });
+
+    it("renders zero connections when neighbor_node exists but ref_id is missing", () => {
+      const edgeWithNoRefId = makeEdge({
+        neighbor_node: { name: "Ghost", node_type: "Lingo" } as unknown as NeighborNode,
+      });
+      render(
+        <NeighborView
+          node={baseNode}
+          edges={[edgeWithNoRefId]}
+          deletedEdgeIds={new Set()}
+          onDeleteEdge={vi.fn()}
+          onNavigate={vi.fn()}
+          onAddEdge={vi.fn()}
+        />,
+      );
+      expect(screen.queryByTestId("neighbor-edge-list")).not.toBeInTheDocument();
+      expect(
+        screen.getByText("No connections yet. Add one to enrich the graph."),
+      ).toBeInTheDocument();
+    });
+
+    it("filters out malformed edges and still renders valid ones", () => {
+      const edges = [
+        makeEdge({ edge_ref_id: "edge-valid", neighbor_node: { ref_id: "nb-1", name: "Good Node", node_type: "Lingo" } as NeighborNode }),
+        makeEdge({ edge_ref_id: "edge-bad", neighbor_node: undefined as unknown as NeighborNode }),
+      ];
+      render(
+        <NeighborView
+          node={baseNode}
+          edges={edges}
+          deletedEdgeIds={new Set()}
+          onDeleteEdge={vi.fn()}
+          onNavigate={vi.fn()}
+          onAddEdge={vi.fn()}
+        />,
+      );
+      expect(screen.getByTestId("neighbor-edge-list")).toBeInTheDocument();
+      expect(screen.getByTestId("neighbor-edge-edge-valid")).toBeInTheDocument();
+      expect(screen.queryByTestId("neighbor-edge-edge-bad")).not.toBeInTheDocument();
+    });
+
+    it("still respects deletedEdgeIds alongside the ref_id guard", () => {
+      const edges = [
+        makeEdge({ edge_ref_id: "edge-deleted" }),
+        makeEdge({ edge_ref_id: "edge-visible", neighbor_node: { ref_id: "nb-2", name: "Visible", node_type: "Lingo" } as NeighborNode }),
+      ];
+      render(
+        <NeighborView
+          node={baseNode}
+          edges={edges}
+          deletedEdgeIds={new Set(["edge-deleted"])}
+          onDeleteEdge={vi.fn()}
+          onNavigate={vi.fn()}
+          onAddEdge={vi.fn()}
+        />,
+      );
+      expect(screen.queryByTestId("neighbor-edge-edge-deleted")).not.toBeInTheDocument();
+      expect(screen.getByTestId("neighbor-edge-edge-visible")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/app/api/workspaces/[slug]/lingo/nodes/[ref_id]/route.ts
+++ b/src/app/api/workspaces/[slug]/lingo/nodes/[ref_id]/route.ts
@@ -3,6 +3,7 @@ import { getMiddlewareContext, requireAuth } from "@/lib/middleware/utils";
 import { getWorkspaceSwarmAccess } from "@/lib/helpers/swarm-access";
 import { getJarvisUrl } from "@/lib/utils/swarm";
 import { getNeighborData } from "@/app/api/mock/lingo/neighbors";
+import { deleteNode } from "@/services/swarm/api/nodes";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -66,4 +67,42 @@ export async function GET(
     console.error("[Lingo nodes/[ref_id]] Jarvis fetch failed", err);
     return NextResponse.json({ success: false, error: "Node not found" }, { status: 404 });
   }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string; ref_id: string }> },
+) {
+  const { slug, ref_id } = await params;
+  const ctx = getMiddlewareContext(request);
+  const user = requireAuth(ctx);
+  if (user instanceof NextResponse) return user;
+
+  // Mock fallback
+  if (process.env.USE_MOCKS === "true") {
+    return NextResponse.json({ success: true });
+  }
+
+  const swarmResult = await getWorkspaceSwarmAccess(slug, user.id);
+  if (!swarmResult.success) {
+    const { type } = swarmResult.error;
+    if (type === "WORKSPACE_NOT_FOUND") {
+      return NextResponse.json({ success: false, error: "Workspace not found" }, { status: 404 });
+    }
+    if (type === "ACCESS_DENIED") {
+      return NextResponse.json({ success: false, error: "Access denied" }, { status: 403 });
+    }
+    return NextResponse.json({ success: false, error: "Swarm unavailable" }, { status: 503 });
+  }
+
+  const { swarmName, swarmApiKey } = swarmResult.data;
+  const jarvisUrl = getJarvisUrl(swarmName);
+
+  const result = await deleteNode({ jarvisUrl, apiKey: swarmApiKey }, ref_id);
+
+  if (!result.success) {
+    return NextResponse.json({ success: false, error: result.error }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
 }

--- a/src/app/api/workspaces/[slug]/lingo/nodes/route.ts
+++ b/src/app/api/workspaces/[slug]/lingo/nodes/route.ts
@@ -76,18 +76,26 @@ export async function GET(
 
     const data = await response.json();
     const rawNodes = Array.isArray(data) ? data : (data?.nodes ?? []);
-    const nodes = rawNodes.map((n: {
-      ref_id: string;
-      node_type: string;
-      date_added_to_graph: number;
-      properties?: { name?: string; definition?: string };
-    }) => ({
-      ref_id: n.ref_id,
-      node_type: n.node_type,
-      name: n.properties?.name,
-      definition: n.properties?.definition ?? null,
-      date_added_to_graph: n.date_added_to_graph,
-    }));
+    const nodes = rawNodes
+      .filter((n: { ref_id?: string; node_type?: string; date_added_to_graph?: number; properties?: { name?: string; definition?: string } }) => {
+        if (!n?.ref_id) {
+          console.warn("[Lingo nodes] Dropping item missing ref_id", n);
+          return false;
+        }
+        return true;
+      })
+      .map((n: {
+        ref_id: string;
+        node_type: string;
+        date_added_to_graph: number;
+        properties?: { name?: string; definition?: string };
+      }) => ({
+        ref_id: n.ref_id,
+        node_type: n.node_type,
+        name: n.properties?.name,
+        definition: n.properties?.definition ?? null,
+        date_added_to_graph: n.date_added_to_graph,
+      }));
 
     nodes.sort((a: { date_added_to_graph: number }, b: { date_added_to_graph: number }) => (b.date_added_to_graph ?? 0) - (a.date_added_to_graph ?? 0));
 

--- a/src/app/api/workspaces/[slug]/lingo/nodes/search/route.ts
+++ b/src/app/api/workspaces/[slug]/lingo/nodes/search/route.ts
@@ -73,13 +73,21 @@ export async function GET(
 
     const data = await response.json();
     const rawNodes = Array.isArray(data) ? data : (data?.nodes ?? []);
-    const nodes = rawNodes.map((n: Record<string, unknown>) => ({
-      ref_id: n.ref_id,
-      node_type: n.node_type,
-      name: (n.title ?? n.name ?? "") as string,
-      definition: (n.definition ?? null) as string | null,
-      date_added_to_graph: (n.date_added_to_graph ?? 0) as number,
-    }));
+    const nodes = rawNodes
+      .filter((n: Record<string, unknown>) => {
+        if (!n?.ref_id) {
+          console.warn("[Lingo nodes/search] Dropping item missing ref_id", n);
+          return false;
+        }
+        return true;
+      })
+      .map((n: Record<string, unknown>) => ({
+        ref_id: n.ref_id,
+        node_type: n.node_type,
+        name: (n.title ?? n.name ?? "") as string,
+        definition: (n.definition ?? null) as string | null,
+        date_added_to_graph: (n.date_added_to_graph ?? 0) as number,
+      }));
     return NextResponse.json({ success: true, data: nodes });
   } catch (err) {
     console.error("[Lingo nodes/search] Jarvis fetch failed", err);

--- a/src/app/w/[slug]/learn/lingo/components/AddEdgePanel.tsx
+++ b/src/app/w/[slug]/learn/lingo/components/AddEdgePanel.tsx
@@ -172,7 +172,7 @@ export function AddEdgePanel({
               data-testid="search-results"
             >
               {searchResults.map((result) => (
-                <li key={result.ref_id}>
+                <li key={result.ref_id ?? result.name}>
                   <button
                     className={`w-full text-left px-4 py-2.5 text-sm transition-colors hover:bg-accent/60 ${
                       targetNode?.ref_id === result.ref_id

--- a/src/app/w/[slug]/learn/lingo/components/LingoExplorer.tsx
+++ b/src/app/w/[slug]/learn/lingo/components/LingoExplorer.tsx
@@ -297,7 +297,7 @@ export function LingoExplorer({ workspaceSlug }: LingoExplorerProps) {
             >
               {filteredNodes.map((node) => (
                 <LingoCard
-                  key={node.ref_id}
+                  key={node.ref_id ?? node.name}
                   node={node}
                   onClick={() => handleCardClick(node)}
                 />

--- a/src/app/w/[slug]/learn/lingo/components/LingoExplorer.tsx
+++ b/src/app/w/[slug]/learn/lingo/components/LingoExplorer.tsx
@@ -35,6 +35,7 @@ export function LingoExplorer({ workspaceSlug }: LingoExplorerProps) {
   const [edges, setEdges] = useState<NeighborEdge[]>([]);
   const [breadcrumbs, setBreadcrumbs] = useState<BreadcrumbItem[]>([]);
   const [deletedEdgeIds, setDeletedEdgeIds] = useState<Set<string>>(new Set());
+  const [deletedNodeIds, setDeletedNodeIds] = useState<Set<string>>(new Set());
   const [isAddEdgePanelOpen, setIsAddEdgePanelOpen] = useState(false);
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [isLoadingDetail, setIsLoadingDetail] = useState(false);
@@ -230,6 +231,56 @@ export function LingoExplorer({ workspaceSlug }: LingoExplorerProps) {
     }
   };
 
+  // ── Optimistic node delete ────────────────────────────────────────────────
+
+  const handleDeleteNode = (refId: string) => {
+    // Optimistically hide + navigate back to list immediately
+    setDeletedNodeIds((prev) => new Set([...prev, refId]));
+    setView("list");
+    setSelectedNode(null);
+    setBreadcrumbs([]);
+
+    let undone = false;
+    toast("Node removed", {
+      duration: 5000,
+      action: {
+        label: "Undo",
+        onClick: () => {
+          undone = true;
+          setDeletedNodeIds((prev) => {
+            const next = new Set(prev);
+            next.delete(refId);
+            return next;
+          });
+        },
+      },
+      onDismiss: () => {
+        if (!undone) confirmDeleteNode(refId);
+      },
+      onAutoClose: () => {
+        if (!undone) confirmDeleteNode(refId);
+      },
+    });
+  };
+
+  const confirmDeleteNode = async (refId: string) => {
+    try {
+      const res = await fetch(
+        `/api/workspaces/${workspaceSlug}/lingo/nodes/${encodeURIComponent(refId)}`,
+        { method: "DELETE" },
+      );
+      if (!res.ok) throw new Error("Delete failed");
+    } catch {
+      // Revert optimistic removal
+      setDeletedNodeIds((prev) => {
+        const next = new Set(prev);
+        next.delete(refId);
+        return next;
+      });
+      toast.error("Failed to delete node");
+    }
+  };
+
   // ── Node creation ─────────────────────────────────────────────────────────
 
   const handleNodeCreated = useCallback(
@@ -243,9 +294,9 @@ export function LingoExplorer({ workspaceSlug }: LingoExplorerProps) {
 
   // ── Filtered nodes ────────────────────────────────────────────────────────
 
-  const filteredNodes = nameFilter
-    ? nodes.filter((n) => n.name.toLowerCase().includes(nameFilter.toLowerCase()))
-    : nodes;
+  const filteredNodes = nodes
+    .filter((n) => !deletedNodeIds.has(n.ref_id))
+    .filter((n) => !nameFilter || n.name.toLowerCase().includes(nameFilter.toLowerCase()));
 
   // ── Render ────────────────────────────────────────────────────────────────
 
@@ -366,6 +417,7 @@ export function LingoExplorer({ workspaceSlug }: LingoExplorerProps) {
                 edges={edges}
                 deletedEdgeIds={deletedEdgeIds}
                 onDeleteEdge={handleDeleteEdge}
+                onDeleteNode={handleDeleteNode}
                 onNavigate={handleNavigateNeighbor}
                 onAddEdge={() => setIsAddEdgePanelOpen(true)}
               />

--- a/src/app/w/[slug]/learn/lingo/components/NeighborView.tsx
+++ b/src/app/w/[slug]/learn/lingo/components/NeighborView.tsx
@@ -11,6 +11,7 @@ interface NeighborViewProps {
   edges: NeighborEdge[];
   deletedEdgeIds: Set<string>;
   onDeleteEdge: (edgeRefId: string) => void;
+  onDeleteNode: (refId: string) => void;
   onNavigate: (node: NeighborNode) => void;
   onAddEdge: () => void;
 }
@@ -20,6 +21,7 @@ export function NeighborView({
   edges,
   deletedEdgeIds,
   onDeleteEdge,
+  onDeleteNode,
   onNavigate,
   onAddEdge,
 }: NeighborViewProps) {
@@ -39,16 +41,27 @@ export function NeighborView({
             </p>
           )}
         </div>
-        <Button
-          size="sm"
-          variant="outline"
-          className="shrink-0"
-          onClick={onAddEdge}
-          data-testid="add-connection-button"
-        >
-          <Plus className="w-4 h-4 mr-1.5" />
-          Add connection
-        </Button>
+        <div className="flex items-center gap-2 shrink-0">
+          <button
+            onClick={() => onDeleteNode(node.ref_id)}
+            className="shrink-0 p-1.5 rounded text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
+            aria-label={`Delete node ${node.name}`}
+            data-testid="delete-node-button"
+          >
+            <Trash2 className="w-4 h-4" />
+            <span className="sr-only">Delete node</span>
+          </button>
+          <Button
+            size="sm"
+            variant="outline"
+            className="shrink-0"
+            onClick={onAddEdge}
+            data-testid="add-connection-button"
+          >
+            <Plus className="w-4 h-4 mr-1.5" />
+            Add connection
+          </Button>
+        </div>
       </div>
 
       {/* Connections */}

--- a/src/app/w/[slug]/learn/lingo/components/NeighborView.tsx
+++ b/src/app/w/[slug]/learn/lingo/components/NeighborView.tsx
@@ -23,7 +23,9 @@ export function NeighborView({
   onNavigate,
   onAddEdge,
 }: NeighborViewProps) {
-  const visibleEdges = edges.filter((e) => !deletedEdgeIds.has(e.edge_ref_id));
+  const visibleEdges = edges.filter(
+    (e) => !deletedEdgeIds.has(e.edge_ref_id) && e.neighbor_node?.ref_id,
+  );
 
   return (
     <div className="flex flex-col gap-4" data-testid="neighbor-view">


### PR DESCRIPTION
Generated with Hive: Guard against missing ref_id in Lingo API and components to prevent crashes