### PR TITLE
Record canvas chat system-prompt version on conversation settings

### DIFF
--- a/src/app/api/ask/quick/route.ts
+++ b/src/app/api/ask/quick/route.ts
@@ -35,6 +35,7 @@ import {
   hasConcepts,
   persistOrgCanvasPromptCache,
   fetchOrgCanvasConversationMessages,
+  persistOrgCanvasPromptResolutions,
 } from "@/services/org-canvas-conversation";
 import {
   emitFollowUpQuestions,
@@ -474,6 +475,7 @@ export async function POST(request: NextRequest) {
         assembledPrefix,
         cacheableConcepts,
         cacheHit,
+        promptResolutions,
       } = await runCanvasAgent({
           userId,
           orgId: orgId && isMultiWorkspace ? orgId : undefined,
@@ -589,6 +591,23 @@ export async function POST(request: NextRequest) {
           } catch (err) {
             console.error(
               "❌ [quick-ask] Failed to persist prompt cache:",
+              err,
+            );
+          }
+        });
+      }
+
+      // Record which Prompt-Manager prompt versions produced this turn
+      // onto `settings.prompts`. Unlike the concept cache (miss-only),
+      // the prompt is resolved every turn, so persist every turn (latest
+      // wins). Best-effort + off the response path via `after()`.
+      if (cacheRowId && Object.keys(promptResolutions).length > 0) {
+        after(async () => {
+          try {
+            await persistOrgCanvasPromptResolutions(cacheRowId, promptResolutions);
+          } catch (err) {
+            console.error(
+              "❌ [quick-ask] Failed to persist prompt resolutions:",
               err,
             );
           }

--- a/src/lib/ai/canvas-system-prompt.ts
+++ b/src/lib/ai/canvas-system-prompt.ts
@@ -83,12 +83,18 @@ interface CanvasPromptCacheStore {
   inFlight?: Promise<CanvasSystemPromptResult>;
 }
 
-const DEFAULT_RESULT: CanvasSystemPromptResult = {
-  value: DEFAULT_CANVAS_SYSTEM_PROMPT,
-  name: PROMPT_NAME,
-  promptId: null,
-  promptVersionId: null,
-};
+// Built lazily (not a module-level const) so importing this module does
+// NOT eagerly read `DEFAULT_CANVAS_SYSTEM_PROMPT` — tests that mock
+// `@/lib/constants/prompt` without that export would otherwise crash at
+// import time.
+function defaultResult(): CanvasSystemPromptResult {
+  return {
+    value: DEFAULT_CANVAS_SYSTEM_PROMPT,
+    name: PROMPT_NAME,
+    promptId: null,
+    promptVersionId: null,
+  };
+}
 
 // Anchor the cache on globalThis so it survives module re-evaluation
 // within a single (warm) serverless instance / dev process.
@@ -104,11 +110,11 @@ export async function getCanvasSystemPrompt(): Promise<CanvasSystemPromptResult>
   // and we can't reach the real Stakwork API, so use the in-repo copy.
   // (Not cached — it's a constant.)
   if (isDevelopmentMode()) {
-    return DEFAULT_RESULT;
+    return defaultResult();
   }
 
   if (!config.STAKWORK_API_KEY || !config.STAKWORK_BASE_URL) {
-    return DEFAULT_RESULT;
+    return defaultResult();
   }
 
   // Fresh cache hit.
@@ -147,10 +153,10 @@ async function fetchAndCache(): Promise<CanvasSystemPromptResult> {
     // outage.
     console.error("getCanvasSystemPrompt: falling back to default:", error);
     cacheStore.entry = {
-      result: DEFAULT_RESULT,
+      result: defaultResult(),
       expiresAt: Date.now() + FALLBACK_TTL_MS,
     };
-    return DEFAULT_RESULT;
+    return defaultResult();
   } finally {
     clearTimeout(timer);
   }

--- a/src/lib/ai/canvas-system-prompt.ts
+++ b/src/lib/ai/canvas-system-prompt.ts
@@ -32,7 +32,8 @@ import { DEFAULT_CANVAS_SYSTEM_PROMPT } from "@/lib/constants/prompt";
  * also memoized to dedupe concurrent turns (no thundering herd).
  */
 
-const PROMPT_NAME = "CANVAS_AGENT_SYSTEM_PROMPT";
+export const CANVAS_SYSTEM_PROMPT_NAME = "CANVAS_AGENT_SYSTEM_PROMPT";
+const PROMPT_NAME = CANVAS_SYSTEM_PROMPT_NAME;
 // Covers all 3 sequential Stakwork calls (search → detail → version).
 const TIMEOUT_MS = 15_000;
 // Cache a successful resolution for 5 min. Cache a fallback (Stakwork
@@ -58,15 +59,36 @@ interface StakworkPromptVersionDetail {
   value: string;
 }
 
-interface CanvasPromptCacheEntry {
+/**
+ * The resolved canvas system prompt plus the Prompt-Manager coordinates
+ * it came from. `promptId` / `promptVersionId` are null whenever the
+ * value is the in-repo `DEFAULT_CANVAS_SYSTEM_PROMPT` (dev/mock mode,
+ * missing config, Stakwork outage, or a prompt with no published
+ * version) — i.e. when there is no Prompt-Manager version to attribute.
+ */
+export interface CanvasSystemPromptResult {
   value: string;
+  name: string;
+  promptId: number | null;
+  promptVersionId: number | null;
+}
+
+interface CanvasPromptCacheEntry {
+  result: CanvasSystemPromptResult;
   expiresAt: number;
 }
 
 interface CanvasPromptCacheStore {
   entry?: CanvasPromptCacheEntry;
-  inFlight?: Promise<string>;
+  inFlight?: Promise<CanvasSystemPromptResult>;
 }
+
+const DEFAULT_RESULT: CanvasSystemPromptResult = {
+  value: DEFAULT_CANVAS_SYSTEM_PROMPT,
+  name: PROMPT_NAME,
+  promptId: null,
+  promptVersionId: null,
+};
 
 // Anchor the cache on globalThis so it survives module re-evaluation
 // within a single (warm) serverless instance / dev process.
@@ -77,22 +99,22 @@ const cacheStore: CanvasPromptCacheStore =
   globalForCanvasPrompt.__canvasSystemPromptCache ??
   (globalForCanvasPrompt.__canvasSystemPromptCache = {});
 
-export async function getCanvasSystemPrompt(): Promise<string> {
+export async function getCanvasSystemPrompt(): Promise<CanvasSystemPromptResult> {
   // Dev/mock mode: the in-memory mock store has no CANVAS_AGENT_SYSTEM_PROMPT
   // and we can't reach the real Stakwork API, so use the in-repo copy.
   // (Not cached — it's a constant.)
   if (isDevelopmentMode()) {
-    return DEFAULT_CANVAS_SYSTEM_PROMPT;
+    return DEFAULT_RESULT;
   }
 
   if (!config.STAKWORK_API_KEY || !config.STAKWORK_BASE_URL) {
-    return DEFAULT_CANVAS_SYSTEM_PROMPT;
+    return DEFAULT_RESULT;
   }
 
   // Fresh cache hit.
   const cached = cacheStore.entry;
   if (cached && cached.expiresAt > Date.now()) {
-    return cached.value;
+    return cached.result;
   }
 
   // Dedupe concurrent refreshes: the first caller starts the fetch and
@@ -110,14 +132,14 @@ export async function getCanvasSystemPrompt(): Promise<string> {
   }
 }
 
-async function fetchAndCache(): Promise<string> {
+async function fetchAndCache(): Promise<CanvasSystemPromptResult> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
 
   try {
-    const value = await resolvePublishedPrompt(controller.signal);
-    cacheStore.entry = { value, expiresAt: Date.now() + SUCCESS_TTL_MS };
-    return value;
+    const result = await resolvePublishedPrompt(controller.signal);
+    cacheStore.entry = { result, expiresAt: Date.now() + SUCCESS_TTL_MS };
+    return result;
   } catch (error) {
     // Timeout (AbortError), network failure, bad JSON, missing prompt —
     // all collapse to the in-repo default, cached briefly to avoid
@@ -125,16 +147,18 @@ async function fetchAndCache(): Promise<string> {
     // outage.
     console.error("getCanvasSystemPrompt: falling back to default:", error);
     cacheStore.entry = {
-      value: DEFAULT_CANVAS_SYSTEM_PROMPT,
+      result: DEFAULT_RESULT,
       expiresAt: Date.now() + FALLBACK_TTL_MS,
     };
-    return DEFAULT_CANVAS_SYSTEM_PROMPT;
+    return DEFAULT_RESULT;
   } finally {
     clearTimeout(timer);
   }
 }
 
-async function resolvePublishedPrompt(signal: AbortSignal): Promise<string> {
+async function resolvePublishedPrompt(
+  signal: AbortSignal,
+): Promise<CanvasSystemPromptResult> {
   const headers = {
     Authorization: `Token token=${config.STAKWORK_API_KEY}`,
     "Content-Type": "application/json",
@@ -173,13 +197,25 @@ async function resolvePublishedPrompt(signal: AbortSignal): Promise<string> {
       const versionJson = await versionRes.json();
       const version: StakworkPromptVersionDetail | undefined = versionJson?.data;
       if (version?.value) {
-        return version.value;
+        return {
+          value: version.value,
+          name: PROMPT_NAME,
+          promptId: match.id,
+          promptVersionId: detail.published_version_id,
+        };
       }
     }
   }
 
+  // Unpublished prompt: we know the prompt id but there's no version to
+  // attribute, so leave `promptVersionId` null.
   if (detail.value) {
-    return detail.value;
+    return {
+      value: detail.value,
+      name: PROMPT_NAME,
+      promptId: match.id,
+      promptVersionId: null,
+    };
   }
 
   throw new Error("prompt has no usable value");

--- a/src/lib/ai/runCanvasAgent.ts
+++ b/src/lib/ai/runCanvasAgent.ts
@@ -367,6 +367,17 @@ export interface RunCanvasAgentResult {
    * signal for the caller to persist `cacheableConcepts`.
    */
   cacheHit: boolean;
+  /**
+   * Prompt-Manager coordinates of the system prompts resolved this turn,
+   * keyed by prompt name (e.g. `CANVAS_AGENT_SYSTEM_PROMPT`). The caller
+   * persists this onto `SharedConversation.settings.prompts`. Empty when
+   * every prompt resolved to its in-repo default (dev/mock, missing
+   * config, Stakwork outage) — there is no version to attribute then.
+   */
+  promptResolutions: Record<
+    string,
+    { prompt_id: number; prompt_version_id: number | null }
+  >;
 }
 
 // ---------------------------------------------------------------------------
@@ -589,6 +600,16 @@ export async function runCanvasAgent(
   // and the rollout flag's per-slug allow-list semantics.
   let primaryWorkspaceId: string | undefined;
   let primaryUserId: string | undefined;
+  // Prompt-Manager coordinates of the system prompts resolved this turn,
+  // keyed by prompt name (e.g. CANVAS_AGENT_SYSTEM_PROMPT). Populated in
+  // the multi-workspace (org-canvas) branch; the caller persists it onto
+  // `SharedConversation.settings.prompts` so each conversation records
+  // which prompt versions produced its turns. Empty when the prompt
+  // resolved to the in-repo default (no version to attribute).
+  const promptResolutions: Record<
+    string,
+    { prompt_id: number; prompt_version_id: number | null }
+  > = {};
   // Per-call web_search capture, used by `update_research`'s execute
   // closure to linkify Anthropic `<cite index="N-M">` tags. Empty
   // (and unused) when no org-tool branch is built.
@@ -670,6 +691,15 @@ export async function runCanvasAgent(
     // Manager (published CANVAS_AGENT_SYSTEM_PROMPT). Bounded by a 10s
     // deadline and always falls back to the in-repo default.
     const canvasSystemPrompt = await getCanvasSystemPrompt();
+    // Record the Prompt-Manager version only when it actually came from
+    // the manager (default-fallback has a null promptId — nothing to
+    // attribute).
+    if (canvasSystemPrompt.promptId != null) {
+      promptResolutions[canvasSystemPrompt.name] = {
+        prompt_id: canvasSystemPrompt.promptId,
+        prompt_version_id: canvasSystemPrompt.promptVersionId,
+      };
+    }
 
     // Always rebuilt fresh (cheap string work) so the scope hint reflects
     // the user's CURRENT canvas/selection, even on a concept-cache hit.
@@ -680,7 +710,7 @@ export async function runCanvasAgent(
       orgId,
       buildScopeHint(scope, linkedWorkspaces),
       orgPromptSuffix,
-      canvasSystemPrompt,
+      canvasSystemPrompt.value,
       userTimezone,
     );
     cacheHit = multiCacheHit;
@@ -971,6 +1001,7 @@ export async function runCanvasAgent(
     assembledPrefix: prefixMessages,
     cacheableConcepts,
     cacheHit,
+    promptResolutions,
   };
 }
 

--- a/src/services/org-canvas-conversation.ts
+++ b/src/services/org-canvas-conversation.ts
@@ -260,3 +260,30 @@ export async function persistOrgCanvasPromptCache(
     WHERE id = ${rowId}
   `;
 }
+
+/**
+ * Record which Prompt-Manager prompt versions produced this
+ * conversation's turns, at `settings.prompts` keyed by prompt name:
+ * `{ prompts: { CANVAS_AGENT_SYSTEM_PROMPT: { prompt_id, prompt_version_id } } }`.
+ *
+ * Conversation-level + latest-wins: the jsonb `||` merge replaces the
+ * whole `prompts` key each turn, so it reflects the versions used by the
+ * most recent turn (good enough — prompt versions change rarely and the
+ * canvas chat is single-owner). Race-free against the client autosave's
+ * concurrent `settings` writes for the same reason `persistOrgCanvasPromptCache`
+ * is: both sides merge into the blob rather than overwriting it. No-op
+ * when `resolutions` is empty (every prompt fell back to its in-repo
+ * default, so there's nothing to attribute). Caller has validated `rowId`.
+ */
+export async function persistOrgCanvasPromptResolutions(
+  rowId: string,
+  resolutions: Record<string, { prompt_id: number; prompt_version_id: number | null }>,
+): Promise<void> {
+  if (Object.keys(resolutions).length === 0) return;
+  const patch = JSON.stringify({ prompts: resolutions });
+  await db.$executeRaw`
+    UPDATE shared_conversations
+    SET settings = COALESCE(settings, '{}'::jsonb) || ${patch}::jsonb
+    WHERE id = ${rowId}
+  `;
+}


### PR DESCRIPTION
## What

Capture which Stakwork Prompt-Manager version produced an org-canvas conversation's turns, and persist it on the conversation. New stored data (no schema migration — rides on the existing `SharedConversation.settings` JSON column):

```jsonc
"settings": {
  "prompts": {
    "CANVAS_AGENT_SYSTEM_PROMPT": { "prompt_id": 123, "prompt_version_id": 456 }
  }
}
```

## Why

The canvas-chat system prompt (`CANVAS_AGENT_SYSTEM_PROMPT`) is resolved from the Prompt Manager per turn (5-min in-memory cache). We want a per-conversation record of which prompt version was actually in effect, for attribution/debugging.

## How

- **`canvas-system-prompt.ts`** — `getCanvasSystemPrompt()` now returns `{ value, name, promptId, promptVersionId }` instead of a bare string. The value is unchanged; it just carries the resolved Prompt-Manager coordinates alongside (cached together so attribution survives a cache hit).
- **`runCanvasAgent.ts`** — collects a `promptResolutions` map (keyed by prompt name) and adds it to the return. Only records an entry when it came from the manager (default fallback contributes nothing).
- **`org-canvas-conversation.ts`** — new `persistOrgCanvasPromptResolutions(rowId, resolutions)` merges `{ prompts: ... }` into `settings` via the same jsonb `||` merge as `persistOrgCanvasPromptCache` (race-free against the client autosave's concurrent `settings` writes).
- **`/api/ask/quick/route.ts`** — persists the map every turn in an `after()` block (off the response path, best-effort), latest-wins.

## Semantics / edge cases

- **Conversation-level, latest-wins** — `settings.prompts` reflects the version that produced the most recent turn.
- `prompt_version_id` is `null` for an unpublished prompt (id known, no published version).
- The key is **omitted entirely** when the prompt falls back to the in-repo default (dev/mock, missing config, or Stakwork outage) — nothing real to attribute.
- The server-driven autoturn path is intentionally out of scope; only the user-driven `/api/ask/quick` send path stamps this.

## Testing

- `tsc --noEmit` clean on all touched files.
- Existing `canvas-agent-autoturn` unit tests pass (also exercises `runCanvasAgent`'s return shape).