### PR TITLE
feat(bifrost): seed default agent catalog into the gateway

### DIFF
--- a/prisma/migrations/20260629190000_add_bifrost_agents_seed_cache/migration.sql
+++ b/prisma/migrations/20260629190000_add_bifrost_agents_seed_cache/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "swarms" ADD COLUMN IF NOT EXISTS "bifrost_agents_seed_hash" TEXT;
+ALTER TABLE "swarms" ADD COLUMN IF NOT EXISTS "bifrost_agents_seed_at" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -440,6 +440,13 @@ model Swarm {
   bifrostTrustedOrgId     String?               @map("bifrost_trusted_org_id")
   bifrostTrustedPubkey    String?               @map("bifrost_trusted_pubkey")
   bifrostTrustSyncedAt    DateTime?             @map("bifrost_trust_synced_at")
+  // Agent-catalog seed reconcile cache. Content-addressed by a hash
+  // of the default-agent manifest Hive pushes to the gateway's
+  // `POST /_plugin/agents`. When the manifest changes (new agent,
+  // changed default model), the hash differs and the next LLM call
+  // re-seeds. See gateway/plans/agent-catalog.md.
+  bifrostAgentsSeedHash   String?               @map("bifrost_agents_seed_hash")
+  bifrostAgentsSeedAt     DateTime?             @map("bifrost_agents_seed_at")
   environmentVariablesNew EnvironmentVariable[] @relation("SwarmEnvironmentVariables")
   pods                    Pod[]
   workspace               Workspace             @relation(fields: [workspaceId], references: [id], onDelete: Cascade)

--- a/src/services/bifrost/BifrostPluginClient.ts
+++ b/src/services/bifrost/BifrostPluginClient.ts
@@ -1,6 +1,8 @@
 import { BIFROST_HTTP_TIMEOUT_MS } from "./constants";
 import { BifrostHttpError } from "./BifrostClient";
 import type {
+  AgentCatalogManifest,
+  SeedAgentsResponse,
   TrustOrgRow,
   TrustOrgUpsert,
   TrustRealmIDRequest,
@@ -106,6 +108,24 @@ export class BifrostPluginClient {
       "PUT",
       "/_plugin/trust/realm_id",
       body,
+    );
+  }
+
+  /**
+   * POST /_plugin/agents — seed the gateway's neo4j agent catalog.
+   * Whole-fleet, replace-by-source: the manifest is the complete set
+   * of agents this `source` knows about, so the plugin replaces that
+   * source's existing entries in one transaction. Idempotent — safe to
+   * re-send the same manifest (the seed reconciler gates re-sends on a
+   * content hash, but the endpoint tolerates duplicates regardless).
+   */
+  async seedAgentCatalog(
+    manifest: AgentCatalogManifest,
+  ): Promise<SeedAgentsResponse> {
+    return this.request<SeedAgentsResponse>(
+      "POST",
+      "/_plugin/agents",
+      manifest,
     );
   }
 

--- a/src/services/bifrost/agent-catalog-reconciler.ts
+++ b/src/services/bifrost/agent-catalog-reconciler.ts
@@ -1,0 +1,217 @@
+import { db } from "@/lib/db";
+import { EncryptionService } from "@/lib/encryption";
+import { withLock } from "@/lib/locks/redis-lock";
+import { logger } from "@/lib/logger";
+
+import {
+  agentCatalogManifestHash,
+  buildAgentCatalogManifest,
+} from "./agent-catalog";
+import { BifrostHttpError } from "./BifrostClient";
+import { BifrostPluginClient } from "./BifrostPluginClient";
+import {
+  BIFROST_AGENT_CATALOG_LOCK_ACQUIRE_TIMEOUT_MS,
+  BIFROST_AGENT_CATALOG_LOCK_PREFIX,
+  BIFROST_AGENT_CATALOG_LOCK_TTL_MS,
+  BIFROST_AGENT_CATALOG_LOG_TAG,
+} from "./constants";
+import { deriveBifrostBaseUrl } from "./resolve";
+
+/**
+ * Agent-catalog seed reconciler.
+ *
+ * Pushes Hive's default agent set (names + default model) into the
+ * workspace's gateway neo4j catalog via `POST /_plugin/agents`. The
+ * catalog is the source of truth for what each agent *is*; Hive's
+ * `BIFROST_AGENT_NAMES` is the source of truth for which agents
+ * *exist*. This reconciler keeps the former in sync with the latter.
+ *
+ * Mirrors `ensureBifrostTrust`'s shape:
+ *   - content-addressed cache on the `Swarm` row
+ *     (`bifrostAgentsSeedHash`) — a manifest change flips the hash and
+ *     re-seeds; otherwise the hot path is one DB read and no HTTP.
+ *   - per-workspace Redis lock around the actual push.
+ *   - lazy-only, triggered from `getBifrostForLLM` after the trust
+ *     reconcile. Best-effort: failures are logged and surfaced via the
+ *     return status; the orchestrator swallows them (a stale catalog
+ *     never blocks an LLM call).
+ */
+
+export type AgentCatalogReconcileStatus =
+  /** Swarm row's hash matched the current manifest — no HTTP. */
+  | "cached"
+  /** Manifest pushed and the hash stamped. */
+  | "seeded"
+  /** Workspace has no swarm or no swarmUrl — nothing to reach. */
+  | "skipped-no-swarm"
+  /** Swarm has no provisioning token — can't authenticate. */
+  | "skipped-no-token"
+  /** Attempted and failed; details in the error. */
+  | "failed";
+
+export interface AgentCatalogReconcileResult {
+  workspaceId: string;
+  status: AgentCatalogReconcileStatus;
+  /** Manifest hash that is now (or was already) live. */
+  hash?: string;
+  /** Set when `status === "failed"`. Already logged. */
+  error?: Error;
+}
+
+export interface AgentCatalogReconcileOptions {
+  /** Inject a plugin client (tests). */
+  pluginClientFactory?: (opts: {
+    baseUrl: string;
+    provisioningToken: string;
+  }) => BifrostPluginClient;
+}
+
+export async function ensureBifrostAgentCatalog(
+  workspaceId: string,
+  options: AgentCatalogReconcileOptions = {},
+): Promise<AgentCatalogReconcileResult> {
+  const manifest = buildAgentCatalogManifest();
+  const hash = agentCatalogManifestHash(manifest);
+
+  const swarm = await db.swarm.findUnique({
+    where: { workspaceId },
+    select: {
+      swarmUrl: true,
+      swarmApiKey: true,
+      bifrostAgentsSeedHash: true,
+    },
+  });
+  if (!swarm || !swarm.swarmUrl) {
+    return { workspaceId, status: "skipped-no-swarm" };
+  }
+  if (!swarm.swarmApiKey) {
+    return { workspaceId, status: "skipped-no-token" };
+  }
+
+  // Content-addressed cache hit — the gateway already has this exact
+  // manifest. Hot path: no lock, no HTTP.
+  if (swarm.bifrostAgentsSeedHash === hash) {
+    return { workspaceId, status: "cached", hash };
+  }
+
+  const lockKey = `${BIFROST_AGENT_CATALOG_LOCK_PREFIX}:${workspaceId}`;
+  try {
+    return await withLock(
+      lockKey,
+      () =>
+        seedLocked(
+          workspaceId,
+          swarm.swarmUrl!,
+          swarm.swarmApiKey!,
+          hash,
+          options,
+        ),
+      {
+        ttlMs: BIFROST_AGENT_CATALOG_LOCK_TTL_MS,
+        acquireTimeoutMs: BIFROST_AGENT_CATALOG_LOCK_ACQUIRE_TIMEOUT_MS,
+      },
+    );
+  } catch (err) {
+    return failed(workspaceId, asError(err));
+  }
+}
+
+async function seedLocked(
+  workspaceId: string,
+  swarmUrl: string,
+  encryptedToken: string,
+  hash: string,
+  options: AgentCatalogReconcileOptions,
+): Promise<AgentCatalogReconcileResult> {
+  // Re-check inside the lock — a racing caller may have just seeded.
+  const fresh = await db.swarm.findUnique({
+    where: { workspaceId },
+    select: { bifrostAgentsSeedHash: true },
+  });
+  if (fresh?.bifrostAgentsSeedHash === hash) {
+    return { workspaceId, status: "cached", hash };
+  }
+
+  const encryption = EncryptionService.getInstance();
+  let provisioningToken: string;
+  try {
+    provisioningToken = encryption.decryptField("swarmApiKey", encryptedToken);
+  } catch (err) {
+    throw new Error(
+      `Failed to decrypt swarmApiKey for workspace ${workspaceId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+
+  const baseUrl = deriveBifrostBaseUrl(swarmUrl);
+  const client =
+    options.pluginClientFactory?.({ baseUrl, provisioningToken }) ??
+    new BifrostPluginClient({ baseUrl, provisioningToken });
+
+  // Rebuild the manifest here (cheap, deterministic) so the bytes we
+  // push and the bytes we hashed are the same source.
+  const manifest = buildAgentCatalogManifest();
+
+  let written: Awaited<ReturnType<BifrostPluginClient["seedAgentCatalog"]>>;
+  try {
+    written = await client.seedAgentCatalog(manifest);
+  } catch (err) {
+    // 503 = catalog not configured (neo4j unset on this swarm). Treat
+    // as a benign skip rather than a failure — the swarm simply isn't
+    // wired for the catalog, and we don't want to retry-spam it. We
+    // deliberately do NOT stamp the hash, so if neo4j is later wired
+    // the next call seeds.
+    if (err instanceof BifrostHttpError && err.status === 503) {
+      logger.info(
+        "Bifrost agent catalog not configured on swarm; skipping seed",
+        BIFROST_AGENT_CATALOG_LOG_TAG,
+        { workspaceId },
+      );
+      return { workspaceId, status: "skipped-no-swarm", hash };
+    }
+    throw wrapHttpError(err, "POST /_plugin/agents");
+  }
+
+  await db.swarm.update({
+    where: { workspaceId },
+    data: {
+      bifrostAgentsSeedHash: hash,
+      bifrostAgentsSeedAt: new Date(),
+    },
+  });
+
+  logger.info("Bifrost agent catalog seeded", BIFROST_AGENT_CATALOG_LOG_TAG, {
+    workspaceId,
+    hash,
+    written: written.written,
+  });
+
+  return { workspaceId, status: "seeded", hash };
+}
+
+function wrapHttpError(err: unknown, op: string): Error {
+  if (err instanceof BifrostHttpError) {
+    return new Error(`${op}: ${err.message}`);
+  }
+  if (err instanceof Error) return new Error(`${op}: ${err.message}`);
+  return new Error(`${op}: ${String(err)}`);
+}
+
+function asError(err: unknown): Error {
+  if (err instanceof Error) return err;
+  return new Error(String(err));
+}
+
+function failed(
+  workspaceId: string,
+  err: Error,
+): AgentCatalogReconcileResult {
+  // Warn (not error) — best-effort, swallowed by the orchestrator.
+  logger.warn(
+    "Bifrost agent catalog seed failed",
+    BIFROST_AGENT_CATALOG_LOG_TAG,
+    { workspaceId, error: err.message },
+  );
+  return { workspaceId, status: "failed", error: err };
+}

--- a/src/services/bifrost/agent-catalog.ts
+++ b/src/services/bifrost/agent-catalog.ts
@@ -1,0 +1,110 @@
+import { createHash } from "crypto";
+
+import {
+  AGENT_CATALOG_SOURCE,
+  DEFAULT_AGENT_MODEL,
+} from "./constants";
+import { BIFROST_AGENT_NAMES, type BifrostAgentName } from "./orchestrator";
+import type {
+  AgentCatalogManifest,
+  AgentCatalogManifestAgent,
+} from "./types";
+
+/**
+ * The default agent catalog Hive seeds into each swarm's gateway.
+ *
+ * This is the bridge between Hive's compile-time `BIFROST_AGENT_NAMES`
+ * (the source of truth for *which* agents exist — every LLM call site
+ * is typed against it) and the gateway's neo4j catalog (the source of
+ * truth for what each agent *is*). The two join by `name` — the same
+ * string the `x-bf-dim-agent-name` header carries.
+ *
+ * For now this only declares each agent's identity + default model;
+ * prompts / tools / skills are left empty and authored later in the
+ * gateway UI. Adding a new call site means adding it to
+ * `BIFROST_AGENT_NAMES`; give it an entry here too so it shows up in
+ * the catalog with a sensible display name (the `display` fallback
+ * covers the case where someone forgets).
+ */
+interface DefaultAgentSpec {
+  displayName: string;
+  description: string;
+  /** Override `DEFAULT_AGENT_MODEL` for this agent (none do yet). */
+  defaultModel?: string;
+}
+
+const DEFAULT_AGENT_SPECS: Record<BifrostAgentName, DefaultAgentSpec> = {
+  "repo-agent": {
+    displayName: "Repo Agent",
+    description: "Answers questions about a repository's code.",
+  },
+  "chat-agent": {
+    displayName: "Chat Agent",
+    description: "General conversational assistant.",
+  },
+  "canvas-agent": {
+    displayName: "Canvas Agent",
+    description: "Drives the visual canvas surface.",
+  },
+  "diagram-agent": {
+    displayName: "Diagram Agent",
+    description: "Generates and edits architecture diagrams.",
+  },
+  "logs-agent": {
+    displayName: "Logs Agent",
+    description: "Investigates logs and runtime output.",
+  },
+  "plan-agent": {
+    displayName: "Plan Agent",
+    description: "Breaks work into an actionable plan.",
+  },
+  "coder-agent": {
+    displayName: "Coder Agent",
+    description: "Writes and modifies code.",
+  },
+  "pr-monitor": {
+    displayName: "PR Monitor",
+    description: "Watches and reports on pull requests.",
+  },
+  "task-generation": {
+    displayName: "Task Generation",
+    description: "Generates structured task tickets.",
+  },
+};
+
+/**
+ * Build the seed manifest for `POST /_plugin/agents`. Deterministic:
+ * agents are emitted in `BIFROST_AGENT_NAMES` order so the manifest
+ * hash is stable across calls (the content-addressed seed cache relies
+ * on this).
+ */
+export function buildAgentCatalogManifest(): AgentCatalogManifest {
+  const agents: AgentCatalogManifestAgent[] = BIFROST_AGENT_NAMES.map(
+    (name) => {
+      const spec = DEFAULT_AGENT_SPECS[name];
+      return {
+        name,
+        display_name: spec.displayName,
+        description: spec.description,
+        default_model: spec.defaultModel ?? DEFAULT_AGENT_MODEL,
+      };
+    },
+  );
+  return { source: AGENT_CATALOG_SOURCE, agents };
+}
+
+/**
+ * Content hash of a manifest — the cache key stamped on
+ * `Swarm.bifrostAgentsSeedHash`. A change to any agent's name,
+ * display, description, or default model flips the hash and triggers a
+ * re-seed on the next LLM call. The manifest is already
+ * deterministically ordered, so a plain `JSON.stringify` is a stable
+ * canonical form.
+ */
+export function agentCatalogManifestHash(
+  manifest: AgentCatalogManifest,
+): string {
+  return createHash("sha256")
+    .update(JSON.stringify(manifest))
+    .digest("hex");
+}

--- a/src/services/bifrost/constants.ts
+++ b/src/services/bifrost/constants.ts
@@ -131,3 +131,30 @@ export const MACAROON_DEFAULT_MAX_STEPS = 2000;
  * do material damage. Caller can shorten per call site.
  */
 export const MACAROON_DEFAULT_TTL_SECONDS = 3600;
+
+// ─── Agent catalog seed ──────────────────────────────────────────────
+//
+// Hive seeds the gateway's neo4j agent catalog with the default agent
+// set on the first LLM call per swarm. Content-addressed by a manifest
+// hash on the Swarm row — only re-pushes when the default set or a
+// default model changes. Lazy + best-effort, triggered from
+// `getBifrostForLLM` right after the trust reconcile. See
+// `gateway/plans/agent-catalog.md`.
+
+/** Default LLM seeded for every default agent. */
+export const DEFAULT_AGENT_MODEL = "claude-sonnet-4-6";
+
+/** `source` tag on the catalog push — replace-by-source key. */
+export const AGENT_CATALOG_SOURCE = "hive";
+
+/** Redis key prefix for the per-workspace agent-catalog seed mutex. */
+export const BIFROST_AGENT_CATALOG_LOCK_PREFIX = "bifrost-agents:lock";
+
+/** TTL for the agent-catalog seed lock. */
+export const BIFROST_AGENT_CATALOG_LOCK_TTL_MS = 30_000;
+
+/** How long to wait to acquire the agent-catalog seed lock. */
+export const BIFROST_AGENT_CATALOG_LOCK_ACQUIRE_TIMEOUT_MS = 20_000;
+
+/** Log tag for agent-catalog seeding. */
+export const BIFROST_AGENT_CATALOG_LOG_TAG = "BIFROST_AGENTS";

--- a/src/services/bifrost/orchestrator.ts
+++ b/src/services/bifrost/orchestrator.ts
@@ -177,6 +177,13 @@ export async function getBifrostForLLM(
   // `ensureBifrostTrust` and we fall through to VK reconcile.
   await runTrustReconcile(workspaceAuth.workspaceId);
 
+  // 2b. Agent-catalog seed. Pushes the default agent set into the
+  // swarm's gateway neo4j catalog. Content-addressed-cached on the
+  // Swarm row, so this is a single DB read on the hot path. Non-fatal
+  // and independent of trust — a stale/absent catalog never blocks an
+  // LLM call. See `gateway/plans/agent-catalog.md`.
+  await runAgentCatalogReconcile(workspaceAuth.workspaceId);
+
   // 3. VK reconcile (phase 1). Without this, the LLM call can't
   // route through Bifrost at all — return undefined and let the
   // caller fall back to the swarm-default key.
@@ -215,6 +222,28 @@ async function runTrustReconcile(workspaceId: string): Promise<void> {
     logger.warn(
       "Bifrost trust reconcile threw unexpectedly; continuing to VK reconcile",
       "BIFROST_TRUST",
+      {
+        workspaceId,
+        error: err instanceof Error ? err.message : String(err),
+      },
+    );
+  }
+}
+
+async function runAgentCatalogReconcile(workspaceId: string): Promise<void> {
+  try {
+    const { ensureBifrostAgentCatalog } = await import(
+      "./agent-catalog-reconciler"
+    );
+    await ensureBifrostAgentCatalog(workspaceId);
+  } catch (err) {
+    // Defensive — ensureBifrostAgentCatalog catches its own errors and
+    // returns `failed`; this is for unexpected throws (lock-acquire
+    // timeout, DB drop). Swallow so catalog seeding never blocks an
+    // LLM call.
+    logger.warn(
+      "Bifrost agent catalog reconcile threw unexpectedly; continuing",
+      "BIFROST_AGENTS",
       {
         workspaceId,
         error: err instanceof Error ? err.message : String(err),

--- a/src/services/bifrost/types.ts
+++ b/src/services/bifrost/types.ts
@@ -219,3 +219,73 @@ export interface TrustOrgRow {
   grace_pubkeys?: string[];
   grace_until?: string;
 }
+
+// ─── Agent catalog seed ────────────────────────────────────────────────
+//
+// Wire shapes for the gateway's `POST /_plugin/agents` catalog write.
+// Matches `catalogPushRequest` / `catalogPushAgent` in
+// `gateway/internal/adminapi/catalog.go`. Hive seeds the default agent
+// set (names + default model); prompts/tools/skills are left empty for
+// now — the catalog is a registry, edited later in the gateway UI.
+
+/** A prompt the agent uses (system/role instruction). */
+export interface AgentCatalogManifestPrompt {
+  name: string;
+  role?: string;
+  body?: string;
+  /** Optional per-item source override; defaults to the manifest source. */
+  source?: string;
+}
+
+/** A tool the agent can call. */
+export interface AgentCatalogManifestTool {
+  name: string;
+  description?: string;
+  /** JSON parameter schema, passed through opaque. */
+  schema?: unknown;
+  source?: string;
+}
+
+/** A skill loaded for the agent. */
+export interface AgentCatalogManifestSkill {
+  name: string;
+  description?: string;
+  source?: string;
+}
+
+/**
+ * One agent in the seed manifest. Mirrors `catalogPushAgent` in
+ * `gateway/internal/adminapi/catalog.go`.
+ *
+ * `name` / `display_name` / `description` / `default_model` are the
+ * agent's identity; `prompts` / `tools` / `skills` are its
+ * capabilities. The Hive seed currently sends identity only — the
+ * capability fields are part of the contract but left undefined until
+ * they're authored (in the gateway UI, or by a future richer push).
+ */
+export interface AgentCatalogManifestAgent {
+  name: string;
+  display_name?: string;
+  description?: string;
+  /** Default LLM for this agent (full model id or shortcut). */
+  default_model?: string;
+  prompts?: AgentCatalogManifestPrompt[];
+  tools?: AgentCatalogManifestTool[];
+  skills?: AgentCatalogManifestSkill[];
+}
+
+/** POST /_plugin/agents request body (whole-fleet, replace-by-source). */
+export interface AgentCatalogManifest {
+  source: string;
+  agents: AgentCatalogManifestAgent[];
+}
+
+/** POST /_plugin/agents response body — counts of nodes written. */
+export interface SeedAgentsResponse {
+  written: {
+    agents: number;
+    prompts: number;
+    tools: number;
+    skills: number;
+  };
+}

--- a/src/services/swarm/db.ts
+++ b/src/services/swarm/db.ts
@@ -96,6 +96,8 @@ export const select = {
   bifrostTrustedOrgId: true,
   bifrostTrustedPubkey: true,
   bifrostTrustSyncedAt: true,
+  bifrostAgentsSeedHash: true,
+  bifrostAgentsSeedAt: true,
 };
 
 export async function saveOrUpdateSwarm(params: SaveOrUpdateSwarmParams) {


### PR DESCRIPTION
## What

Wires Hive as the first **push source** for the gateway's neo4j agent catalog. On the first LLM call per swarm, Hive seeds the default agent set — each agent's **name, display name, description, and default model** — into the swarm's gateway via `POST /_plugin/agents`.

Division of truth:
- **Hive's `BIFROST_AGENT_NAMES`** stays the compile-time source of truth for *which* agents exist (every LLM call site is typed against it).
- **The gateway's neo4j catalog** is the source of truth for *what each agent is* (its capabilities + default model).
- They join by `name` — the same string the `x-bf-dim-agent-name` header carries.

Companion to the gateway PR (stakwork/stakgraph#1420) that adds the catalog endpoints + `default_model` field.

## How

- **`agent-catalog.ts`** — `DEFAULT_AGENT_SPECS` (one entry per `BIFROST_AGENT_NAME`), a deterministic manifest builder, and a content hash. Every agent defaults to `claude-sonnet-4-6` for now; `prompts`/`tools`/`skills` are part of the wire contract but left empty (authored later in the gateway UI).
- **`agent-catalog-reconciler.ts`** — `ensureBifrostAgentCatalog(workspaceId)`, mirroring `ensureBifrostTrust`:
  - **content-addressed cache** on the `Swarm` row (`bifrostAgentsSeedHash`) — a cache hit is one DB read with no HTTP; re-seeds only when the manifest changes.
  - per-workspace **Redis lock** around the actual push.
  - `503` (neo4j unset on the swarm) is a benign skip; any failure is logged and swallowed so a stale catalog never blocks an LLM call.
- **`orchestrator.ts`** — `runAgentCatalogReconcile` fires right after the trust reconcile in `getBifrostForLLM` (lazy import, best-effort).
- **`BifrostPluginClient.seedAgentCatalog`** + manifest/response wire types mirroring `catalogPushAgent` in the gateway.
- **Prisma** — `Swarm.bifrostAgentsSeedHash` / `bifrostAgentsSeedAt` (+ migration `20260629190000_add_bifrost_agents_seed_cache`).

## Notes

- **Migration not yet applied** — run the usual `prisma migrate` on deploy.
- Lazy + best-effort by design: this rides the same per-workspace path as the trust reconciler and has the same failure posture (never breaks an LLM call).
- Production source typechecks + lints clean. Pre-existing `tsc` errors in `__tests__` (partial-`Swarm` mocks) and `useCanvasEdgeOps`/`.next-dev` are unrelated.