### PR TITLE
feat: fetch org shared conversations via API_TOKEN

### DIFF
--- a/src/app/api/org/[githubLogin]/chat/shared/[shareId]/route.ts
+++ b/src/app/api/org/[githubLogin]/chat/shared/[shareId]/route.ts
@@ -1,7 +1,8 @@
 import { authOptions } from "@/lib/auth/nextauth";
+import { validateApiToken } from "@/lib/auth/api-token";
 import { db } from "@/lib/db";
 import { getServerSession } from "next-auth/next";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * GET a single org-scoped shared conversation. Mirrors the
@@ -15,17 +16,27 @@ import { NextResponse } from "next/server";
  * viewer page at `/org/[githubLogin]/chat/shared/[shareId]/page.tsx`
  * fetches directly from Prisma; this route exposes the same data to
  * the client.
+ *
+ * External systems can also fetch via the `x-api-token` header
+ * (`API_TOKEN`). A valid token is treated as a trusted service
+ * credential and bypasses the per-user org-membership check; the row
+ * is still verified to belong to the requested org.
  */
 export async function GET(
-  _request: Request,
+  request: NextRequest,
   { params }: { params: Promise<{ githubLogin: string; shareId: string }> },
 ) {
-  const session = await getServerSession(authOptions);
-  if (!session?.user || !(session.user as { id?: string }).id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const isApiToken = validateApiToken(request);
+
+  let userId: string | null = null;
+  if (!isApiToken) {
+    const session = await getServerSession(authOptions);
+    if (!session?.user || !(session.user as { id?: string }).id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    userId = (session.user as { id: string }).id;
   }
 
-  const userId = (session.user as { id: string }).id;
   const { githubLogin, shareId } = await params;
 
   try {
@@ -42,16 +53,19 @@ export async function GET(
     }
 
     // Verify caller has access to this org via SourceControlToken,
-    // matching the share POST's auth check.
-    const token = await db.sourceControlToken.findFirst({
-      where: { userId, sourceControlOrgId: org.id },
-    });
+    // matching the share POST's auth check. Skipped for trusted
+    // API_TOKEN callers (the token itself is the authority).
+    if (!isApiToken) {
+      const token = await db.sourceControlToken.findFirst({
+        where: { userId: userId!, sourceControlOrgId: org.id },
+      });
 
-    if (!token) {
-      return NextResponse.json(
-        { error: "Access denied. You must be an organization member." },
-        { status: 403 },
-      );
+      if (!token) {
+        return NextResponse.json(
+          { error: "Access denied. You must be an organization member." },
+          { status: 403 },
+        );
+      }
     }
 
     const sharedConversation = await db.sharedConversation.findUnique({


### PR DESCRIPTION
## Summary
Adds `x-api-token` (`API_TOKEN`) support to the org-scoped shared conversation GET route so external/trusted systems can fetch a `SharedConversation` without a NextAuth session.

- Route: `GET /api/org/[githubLogin]/chat/shared/[shareId]`
- A valid `API_TOKEN` is treated as a trusted service credential and bypasses the per-user `SourceControlToken` org-membership check.
- The row is still verified to belong to the requested org (`sourceControlOrgId` match → 404 otherwise), so a token cannot read conversations from a different org via the wrong `githubLogin`.
- Session + org-membership flow is unchanged for browser callers.

Uses `validateApiToken` from `src/lib/auth/api-token.ts`, mirroring the trusted-token pattern in `ask/sync`. `requireAuthOrApiToken` was not used because it requires a `workspaceId` to resolve an acting workspace-owner (org routes have no workspace) and derives its session from middleware context rather than `getServerSession`; a read on an org-scoped resource needs no acting-user identity.

## Usage
```
GET /api/org/<githubLogin>/chat/shared/<shareId>
x-api-token: <API_TOKEN>
```

## Test plan
- [ ] Request with valid `x-api-token` returns the conversation
- [ ] Request with valid token but mismatched org returns 404
- [ ] Request without token/session returns 401
- [ ] Existing session-based access unchanged