### PR TITLE
feat: expose settings.prompts as _metadata for API_TOKEN callers

### DIFF
--- a/src/app/api/org/[githubLogin]/chat/shared/[shareId]/route.ts
+++ b/src/app/api/org/[githubLogin]/chat/shared/[shareId]/route.ts
@@ -75,6 +75,9 @@ export async function GET(
         sourceControlOrgId: true,
         title: true,
         messages: true,
+        // Only needed to expose `settings.prompts` to trusted
+        // API_TOKEN callers (see response below).
+        ...(isApiToken ? { settings: true } : {}),
       },
     });
 
@@ -94,11 +97,27 @@ export async function GET(
       );
     }
 
+    // Trusted API_TOKEN callers (e.g. external eval clients) get the
+    // prompt-version resolutions used for this conversation's turns,
+    // stored at `settings.prompts` keyed by prompt name. Returned as
+    // `_metadata.prompts` (unflattened) and never exposed to browser
+    // callers.
+    let metadata: { prompts: unknown } | undefined;
+    if (isApiToken) {
+      const settings = (sharedConversation.settings ?? {}) as {
+        prompts?: unknown;
+      };
+      if (settings.prompts != null) {
+        metadata = { prompts: settings.prompts };
+      }
+    }
+
     return NextResponse.json(
       {
         id: sharedConversation.id,
         title: sharedConversation.title,
         messages: sharedConversation.messages,
+        ...(metadata ? { _metadata: metadata } : {}),
       },
       { status: 200 },
     );


### PR DESCRIPTION
## Summary
Builds on #4602. External eval clients fetching an org shared conversation via `API_TOKEN` now receive the prompt-version resolutions used for the conversation's turns as `_metadata.prompts`.

- Route: `GET /api/org/[githubLogin]/chat/shared/[shareId]`
- Source data: `SharedConversation.settings.prompts` — a map keyed by prompt name, each value a `PromptResolution` (`{ prompt_id, prompt_version_id, resolution }`), written every turn by `ask/quick` → `persistOrgCanvasPromptResolutions`.
- Returned **unflattened** (the raw `settings.prompts` map) as `_metadata.prompts`.
- **API_TOKEN-only**: `settings` is only selected from the DB and surfaced when the caller authenticated via `x-api-token`. Browser/session callers see no change to the response.

## Response shape (API_TOKEN caller)
```jsonc
{
  "id": "...",
  "title": "...",
  "messages": [ /* ... */ ],
  "_metadata": {
    "prompts": {
      "CANVAS_AGENT_SYSTEM_PROMPT": {
        "prompt_id": 123,
        "prompt_version_id": 456,
        "resolution": { /* ... */ }
      }
    }
  }
}
```
`_metadata` is omitted entirely when `settings.prompts` is absent.

## Test plan
- [x] API_TOKEN request returns `_metadata.prompts` matching `settings.prompts`
- [x] API_TOKEN request on a conversation without `settings.prompts` omits `_metadata`
- [x] Session/browser request never includes `_metadata` (and doesn't select `settings`)
- [x] Cross-org / unauthenticated behavior unchanged