### PR TITLE
fix(ai): force Bifrost raw passthrough for Anthropic calls (web_search/code_execution)

### DIFF
--- a/src/__tests__/unit/lib/ai/provider.test.ts
+++ b/src/__tests__/unit/lib/ai/provider.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Real-aieo branch requires USE_MOCKS to be falsy (otherwise getModel
+// short-circuits to the local Anthropic mock).
+vi.mock("@/config/env", () => ({
+  config: { USE_MOCKS: false, MOCK_BASE: "http://localhost:3000" },
+}));
+
+const getModelAieo = vi.fn(() => ({ modelId: "stub" }));
+
+vi.mock("aieo", () => ({
+  getModel: (...args: unknown[]) => getModelAieo(...args),
+  getProviderTool: vi.fn(),
+  getApiKeyForProvider: vi.fn(() => "real-key"),
+}));
+
+import { getModel } from "@/lib/ai/provider";
+
+function lastOpts() {
+  return getModelAieo.mock.calls.at(-1)?.[1] as {
+    headers?: Record<string, string>;
+    baseUrl?: string;
+  };
+}
+
+describe("getModel Bifrost passthrough header", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("adds a claude-code user-agent for Anthropic calls routed through Bifrost", () => {
+    getModel("anthropic", "key", "slug", undefined, {
+      baseUrl: "https://gw.example/anthropic/v1",
+      headers: { "x-macaroon": "tok" },
+    });
+
+    const opts = lastOpts();
+    expect(opts.baseUrl).toBe("https://gw.example/anthropic/v1");
+    expect(opts.headers?.["user-agent"]).toBe("claude-code");
+    // Existing Bifrost headers (cost-tracking macaroon) are preserved.
+    expect(opts.headers?.["x-macaroon"]).toBe("tok");
+  });
+
+  it("does NOT add the user-agent when there is no Bifrost baseUrl", () => {
+    getModel("anthropic", "key", "slug", undefined, {
+      headers: { "x-macaroon": "tok" },
+    });
+
+    expect(lastOpts().headers?.["user-agent"]).toBeUndefined();
+  });
+
+  it("does NOT add the user-agent for non-Anthropic providers", () => {
+    getModel("openai", "key", "slug", undefined, {
+      baseUrl: "https://gw.example/openai/v1",
+    });
+
+    expect(lastOpts().headers?.["user-agent"]).toBeUndefined();
+  });
+
+  it("leaves direct (non-Bifrost) calls untouched", () => {
+    getModel("anthropic", "key");
+    const opts = lastOpts();
+    expect(opts.baseUrl).toBeUndefined();
+    expect(opts.headers).toBeUndefined();
+  });
+});

--- a/src/lib/ai/provider.ts
+++ b/src/lib/ai/provider.ts
@@ -102,13 +102,35 @@ export function getModel(
   // overrides are present, they replace the provider's default
   // baseUrl and add per-request headers (e.g. `x-macaroon`). aieo
   // 0.1.33+ accepts `headers` on GetModelOptions.
+  //
+  // Bifrost raw-passthrough opt-in: when an Anthropic call is routed
+  // through Bifrost (`overrides.baseUrl` set), present a Claude-Code
+  // `user-agent`. Bifrost's `checkAnthropicPassthrough` engages raw
+  // passthrough when the UA matches `claude-cli`/`claude-code`/
+  // `claude-vscode` AND the model is a Claude model — forwarding our
+  // EXACT request body and streaming back Anthropic's RAW response.
+  // This deliberately bypasses Bifrost's request/response conversion
+  // pipeline, which otherwise:
+  //   (a) silently upgrades the `web_search_20250305` tool aieo sends
+  //       to the agentic `web_search_20260209` variant on Opus 4.7+,
+  //       pulling in server-side `code_execution` blocks the AI SDK
+  //       has no handler for ("unavailable tool 'code_execution'"); and
+  //   (b) carries its own streaming-reconstruction bugs for server
+  //       tools.
+  // The AI SDK keeps our value as the UA prefix (it only appends its
+  // own suffix), so the substring match still fires. Cost tracking is
+  // unaffected — Bifrost still runs its governance/macaroon plugins in
+  // passthrough mode and parses usage from the raw response.
+  const headers =
+    overrides?.baseUrl && provider === "anthropic"
+      ? { ...overrides.headers, "user-agent": "claude-code" }
+      : overrides?.headers;
+
   return getModelAieo(provider, {
     apiKey,
     modelName: modelType,
     ...(overrides?.baseUrl ? { baseUrl: overrides.baseUrl } : {}),
-    ...(overrides?.headers && Object.keys(overrides.headers).length > 0
-      ? { headers: overrides.headers }
-      : {}),
+    ...(headers && Object.keys(headers).length > 0 ? { headers } : {}),
   });
 }
 


### PR DESCRIPTION
## Symptom

In prod, `web_search` either returned immediately with `finishReason: "tool-calls"` (nothing executed), or — once the gateway was upgraded — fired a server-side `code_execution` block that errored with:

> Model tried to call unavailable tool 'code_execution'

## Root cause

Prod LLM calls route through our Bifrost gateway. Hive's `@ai-sdk/anthropic` requests hit Bifrost's **conversion pipeline** (the raw-passthrough path only engages for `claude-code` User-Agents, which we don't send). That pipeline:

1. **Silently upgrades the web_search tool version by model.** aieo requests the classic `web_search_20250305`, but Bifrost rewrites it to the agentic `web_search_20260209` for Opus 4.7+ (`IsOpus47Plus` + `WebSearchDynamic`). The agentic variant runs searches **inside Anthropic's code-execution sandbox** (programmatic tool calling), emitting `code_execution` server-tool blocks. aieo only registered `web_search` — not `code_execution` — so the AI SDK has no handler → the error above. This upgrade is hardcoded in Bifrost (Go), not configurable from hive, and exists across versions.
2. Carries its own streaming-reconstruction bugs for Anthropic server tools.

## Fix

Present a `claude-code` `user-agent` on Bifrost-routed **Anthropic** calls in `src/lib/ai/provider.ts`. This engages Bifrost's `checkAnthropicPassthrough`, which forwards our **exact** request body upstream and streams back Anthropic's **raw** response — bypassing the conversion pipeline. Hive speaks native Anthropic anyway, so passthrough is the correct mode here.

- The AI SDK keeps our value as the UA prefix (it only appends its own suffix), so Bifrost's substring match still fires.
- Cost tracking is unaffected: Bifrost still runs its governance/macaroon plugins in passthrough mode and parses usage from the raw response.
- Scoped to `provider === "anthropic"` + `overrides.baseUrl` set (i.e. only Bifrost-routed Anthropic calls). Direct calls and non-Anthropic providers are untouched.

## Tests

New `src/__tests__/unit/lib/ai/provider.test.ts` (4 cases, all passing):
- Bifrost + Anthropic → adds `user-agent: claude-code`, preserves `x-macaroon`
- No Bifrost baseUrl → no header
- Non-Anthropic provider → no header
- Direct (non-Bifrost) call → untouched

## Related

Gateway-side version bump (independent, still a general improvement but no longer strictly required to fix web_search): stakwork/stakgraph#1422.