### PR TITLE
Refactor sidebar to use allowlist for Stak Toolkit and Evals link visibility for stakwork and hive workspaces

### DIFF
--- a/src/__tests__/unit/components/Sidebar.test.tsx
+++ b/src/__tests__/unit/components/Sidebar.test.tsx
@@ -1380,6 +1380,54 @@ describe('Sidebar - Evals link visibility under Protect', () => {
     });
   });
 
+  it('shows Evals under Protect for hive workspace in production mode', async () => {
+    const user = userEvent.setup();
+
+    vi.mocked(useWorkspaceModule.useWorkspace).mockReturnValue({
+      workspace: { id: 'ws-2', name: 'Hive', slug: 'hive', poolState: 'COMPLETE' },
+      slug: 'hive',
+      loading: false,
+      error: null,
+      waitingForInputCount: 0,
+      refreshTaskNotifications: vi.fn(),
+    } as any);
+
+    vi.mocked(runtimeModule.isDevelopmentMode).mockReturnValue(false);
+
+    render(<Sidebar user={mockUser} />);
+
+    const protectButtons = screen.getAllByTestId('nav-protect');
+    await user.click(protectButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('nav-evals').length).toBeGreaterThan(0);
+    });
+  });
+
+  it('hides Evals under Protect for arbitrary workspace (acme) in production mode', async () => {
+    const user = userEvent.setup();
+
+    vi.mocked(useWorkspaceModule.useWorkspace).mockReturnValue({
+      workspace: { id: 'ws-3', name: 'Acme', slug: 'acme', poolState: 'COMPLETE' },
+      slug: 'acme',
+      loading: false,
+      error: null,
+      waitingForInputCount: 0,
+      refreshTaskNotifications: vi.fn(),
+    } as any);
+
+    vi.mocked(runtimeModule.isDevelopmentMode).mockReturnValue(false);
+
+    render(<Sidebar user={mockUser} />);
+
+    const protectButtons = screen.getAllByTestId('nav-protect');
+    await user.click(protectButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.queryAllByTestId('nav-evals')).toHaveLength(0);
+    });
+  });
+
   it('shows Evals under Protect in dev mode for any workspace', async () => {
     const user = userEvent.setup();
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -425,6 +425,8 @@ function SidebarContent({
   );
 }
 
+const STAK_TOOLKIT_SLUGS = ["stakwork", "hive"];
+
 export function Sidebar({ user }: SidebarProps) {
   const { slug: workspaceSlug, workspace, waitingForInputCount, refreshTaskNotifications, isPublicViewer } = useWorkspace();
   const { canAdmin } = useWorkspaceAccess();
@@ -454,7 +456,8 @@ export function Sidebar({ user }: SidebarProps) {
 
   // Create Stak Toolkit items if in stakwork workspace or dev mode
   const devMode = isDevelopmentMode();
-  const stakToolkitItems: NavigationItem[] = (workspaceSlug === "stakwork" || devMode) ? [
+  const showStakTools = STAK_TOOLKIT_SLUGS.includes(workspaceSlug ?? "") || devMode;
+  const stakToolkitItems: NavigationItem[] = showStakTools ? [
     {
       icon: Workflow,
       label: "Stak Toolkit",
@@ -505,7 +508,7 @@ export function Sidebar({ user }: SidebarProps) {
         };
       }
       // Filter Evals child from Protect for non-stakwork workspaces
-      if (item.label === "Protect" && item.children && !(workspaceSlug === "stakwork" || devMode)) {
+      if (item.label === "Protect" && item.children && !showStakTools) {
         return {
           ...item,
           children: item.children.filter((child) => child.label !== "Evals"),


### PR DESCRIPTION
Generated with Hive: Refactor sidebar to use allowlist for Stak Toolkit and Evals link visibility for stakwork and hive workspaces