### PR TITLE
Disable pg realm in graph_walker, focus on kg

### DIFF
--- a/src/__tests__/unit/lib/ai/graphWalkerTools.test.ts
+++ b/src/__tests__/unit/lib/ai/graphWalkerTools.test.ts
@@ -212,15 +212,14 @@ describe("buildGraphWalkerTools", () => {
       expect(mockResolveCanvasNode).not.toHaveBeenCalled();
     });
 
-    it("calls resolvePgNode for pg realm and returns node", async () => {
+    it("pg realm is DISABLED: returns a disabled note without calling resolvePgNode", async () => {
       mockParseUrn.mockReturnValue({
         realm: "pg",
         org: "myorg",
         type: "feature",
         id: "feat-1",
       });
-      const fakeNode = { id: "feat-1", title: "My Feature" };
-      mockResolvePgNode.mockResolvedValue(fakeNode);
+      mockResolvePgNode.mockResolvedValue({ id: "feat-1", title: "My Feature" });
 
       const tools = getTools();
       const result = await tools.graph_get.execute(
@@ -228,25 +227,10 @@ describe("buildGraphWalkerTools", () => {
         {} as never,
       );
 
-      expect(mockResolvePgNode).toHaveBeenCalledWith("urn:myorg:pg:feature:feat-1");
-      expect(result).toEqual(fakeNode);
-    });
-
-    it("returns access denied error when resolvePgNode returns null", async () => {
-      mockParseUrn.mockReturnValue({
-        realm: "pg",
-        org: "myorg",
-        type: "feature",
-        id: "feat-missing",
-      });
-      mockResolvePgNode.mockResolvedValue(null);
-
-      const tools = getTools();
-      const result = await tools.graph_get.execute(
-        { urn: "urn:myorg:pg:feature:feat-missing" },
-        {} as never,
-      );
-      expect(result).toEqual({ error: "not found or access denied" });
+      // pg is gated off — the resolver is never consulted and the caller is
+      // told to use the kg realm instead.
+      expect(mockResolvePgNode).not.toHaveBeenCalled();
+      expect(result).toMatchObject({ error: expect.stringContaining("pg realm is disabled") });
     });
 
     it("calls resolveCanvasNode for canvas realm and returns node", async () => {
@@ -374,50 +358,16 @@ describe("buildGraphWalkerTools", () => {
       expect(result).toEqual({ error: "invalid URN" });
     });
 
-    it("pg arm delegates entirely to pgNeighbors and passes through result", async () => {
+    it("pg realm is DISABLED: returns a disabled note without calling pgNeighbors", async () => {
       mockParseUrn.mockReturnValue({
         realm: "pg",
         org: "myorg",
         type: "feature",
         id: "feat-1",
       });
-      const fakeNeighbors = [
+      mockPgNeighbors.mockResolvedValue([
         { urn: "urn:myorg:pg:initiative:init-1", edgeType: "initiative", direction: "forward" },
-      ];
-      mockPgNeighbors.mockResolvedValue(fakeNeighbors);
-
-      const tools = getTools();
-      const result = await tools.graph_neighbors.execute(
-        { urn: "urn:myorg:pg:feature:feat-1" },
-        {} as never,
-      );
-
-      expect(mockPgNeighbors).toHaveBeenCalledWith(
-        "urn:myorg:pg:feature:feat-1",
-        { userId: USER_ID, orgId: ORG_ID },
-      );
-      expect(result).toEqual({ neighbors: fakeNeighbors });
-    });
-
-    it("pg arm attaches a human-readable title to each neighbor (batched per type)", async () => {
-      // Real-ish URN parser so attachPgTitles groups neighbors by type/id.
-      mockParseUrn.mockImplementation((urn: string) => {
-        const [, org, realm, type, ...idParts] = urn.split(":");
-        if (realm === "kg") {
-          const [workspace, kgType, ...rest] = [type, ...idParts];
-          return { realm, org, workspace, type: kgType, id: rest.join(":") };
-        }
-        return { realm, org, type, id: idParts.join(":") };
-      });
-
-      mockPgNeighbors.mockResolvedValue([
-        { urn: "urn:myorg:pg:initiative:init-1", edgeType: "BELONGS_TO_INITIATIVE", direction: "forward" },
-        { urn: "urn:myorg:pg:milestone:ms-1", edgeType: "BELONGS_TO_MILESTONE", direction: "forward" },
-        // opaque-external neighbor — no pg recipe, must pass through untouched
-        { urn: "stakwork:workflow:42", edgeType: "REFERENCES_WORKFLOW", direction: "forward" },
       ]);
-      dbInitiative.findMany.mockResolvedValue([{ id: "init-1", name: "Canvas Chat" }]);
-      dbMilestone.findMany.mockResolvedValue([{ id: "ms-1", name: "Planner Agent & Tooling" }]);
 
       const tools = getTools();
       const result = await tools.graph_neighbors.execute(
@@ -425,71 +375,8 @@ describe("buildGraphWalkerTools", () => {
         {} as never,
       );
 
-      // Batched: one query per distinct neighbor type
-      expect(dbInitiative.findMany).toHaveBeenCalledWith({
-        where: { id: { in: ["init-1"] } },
-        select: { id: true, name: true },
-      });
-      const neighbors = (result as { neighbors: Array<{ urn: string; title?: string }> }).neighbors;
-      expect(neighbors.find((n) => n.urn.includes("init-1"))?.title).toBe("Canvas Chat");
-      expect(neighbors.find((n) => n.urn.includes("ms-1"))?.title).toBe(
-        "Planner Agent & Tooling",
-      );
-      // opaque-external neighbor stays untouched (no title)
-      expect(neighbors.find((n) => n.urn === "stakwork:workflow:42")?.title).toBeUndefined();
-    });
-
-    it("pg arm labels cross-realm kg neighbors (implemented-by concepts) via a batched by-refs call", async () => {
-      // Real-ish parser so both pg and kg URNs resolve to {realm,type,id,workspace}.
-      mockParseUrn.mockImplementation((urn: string) => {
-        const [, org, realm, type, ...idParts] = urn.split(":");
-        if (realm === "kg") {
-          const [workspace, kgType, ...rest] = [type, ...idParts];
-          return { realm, org, workspace, type: kgType, id: rest.join(":") };
-        }
-        return { realm, org, type, id: idParts.join(":") };
-      });
-
-      // A pg feature whose neighbors include pg siblings AND kg concepts that
-      // arrived through the Postgres UrnEdge bridge (no title from pgNeighbors).
-      mockPgNeighbors.mockResolvedValue([
-        { urn: "urn:myorg:pg:milestone:ms-1", edgeType: "BELONGS_TO_MILESTONE", direction: "forward" },
-        { urn: "urn:myorg:kg:my-ws:concept:c1", edgeType: "implemented-by", direction: "forward" },
-        { urn: "urn:myorg:kg:my-ws:concept:c2", edgeType: "implemented-by", direction: "forward" },
-      ]);
-      dbMilestone.findMany.mockResolvedValue([{ id: "ms-1", name: "Canvas Workflow" }]);
-
-      mockResolveKgSeam.mockResolvedValue({
-        workspace: "my-ws",
-        swarmUrl: "https://jarvis.example.com",
-        jarvisUrl: "https://jarvis.example.com",
-        swarmApiKey: "key-123",
-      });
-      mockKgGetNodesByRefs.mockResolvedValue(
-        new Map([
-          ["c1", "Integration Tests"],
-          ["c2", "Org Canvas"],
-        ]),
-      );
-
-      const tools = getTools();
-      const result = await tools.graph_neighbors.execute(
-        { urn: "urn:myorg:pg:feature:feat-1" },
-        {} as never,
-      );
-
-      // One batched call covering both concept ref_ids
-      expect(mockKgGetNodesByRefs).toHaveBeenCalledTimes(1);
-      expect(mockKgGetNodesByRefs).toHaveBeenCalledWith(
-        "https://jarvis.example.com",
-        "key-123",
-        expect.arrayContaining(["c1", "c2"]),
-      );
-
-      const neighbors = (result as { neighbors: Array<{ urn: string; title?: string }> }).neighbors;
-      expect(neighbors.find((n) => n.urn.includes("ms-1"))?.title).toBe("Canvas Workflow");
-      expect(neighbors.find((n) => n.urn.includes("concept:c1"))?.title).toBe("Integration Tests");
-      expect(neighbors.find((n) => n.urn.includes("concept:c2"))?.title).toBe("Org Canvas");
+      expect(mockPgNeighbors).not.toHaveBeenCalled();
+      expect(result).toMatchObject({ error: expect.stringContaining("pg realm is disabled") });
     });
 
     it("kg arm maps the derived node name onto each neighbor's title", async () => {
@@ -845,8 +732,8 @@ describe("buildGraphWalkerTools", () => {
       dbQueryRaw.mockResolvedValue([]);
     });
 
-    it("searches pg + canvas when no realm specified", async () => {
-      // pg returns a feature
+    it("searches canvas + kg (fan-out) when no realm specified; pg is skipped", async () => {
+      // pg is disabled — even though a feature exists, the pg arm must not run.
       dbFeature.findMany.mockResolvedValue([{ id: "feat-1", title: "Auth system" }]);
       // canvas returns a node
       dbCanvas.findMany.mockResolvedValue([
@@ -860,6 +747,19 @@ describe("buildGraphWalkerTools", () => {
         nodes: [{ id: "n1", type: "text", text: "Auth system design" }],
         edges: [],
       });
+      // kg fan-out: one member workspace with a reachable swarm.
+      dbWorkspace.findMany.mockResolvedValue([{ id: "ws-1", slug: "workspace-one" }]);
+      mockGetSwarmAccessByWorkspaceId.mockResolvedValue({
+        success: true,
+        data: { swarmUrl: "https://jarvis1.example.com", swarmName: "swarm-one", swarmApiKey: "key-1" },
+      });
+      mockKgSearch.mockResolvedValue([
+        { ref_id: "hf-1", node_type: "HiveFeature", name: "Auth system" },
+      ]);
+      mockFormatUrn.mockImplementation(
+        (p: { realm: string; org: string; workspace?: string; type: string; id: string }) =>
+          `urn:${p.org}:${p.realm}:${p.workspace ? p.workspace + ":" : ""}${p.type}:${p.id}`,
+      );
 
       const tools = getTools();
       const result = await tools.graph_search.execute(
@@ -867,14 +767,15 @@ describe("buildGraphWalkerTools", () => {
         {} as never,
       );
 
-      expect(result).toHaveProperty("results");
+      // pg arm never runs
+      expect(dbFeature.findMany).not.toHaveBeenCalled();
       const results = (result as { results: Array<{ realm: string }> }).results;
-      // Should have both pg and canvas results
-      expect(results.some((r) => r.realm === "pg")).toBe(true);
+      expect(results.some((r) => r.realm === "pg")).toBe(false);
       expect(results.some((r) => r.realm === "canvas")).toBe(true);
+      expect(results.some((r) => r.realm === "kg")).toBe(true);
     });
 
-    it("only searches pg when realm='pg'", async () => {
+    it("returns nothing for realm='pg' (disabled) and never queries Postgres", async () => {
       dbFeature.findMany.mockResolvedValue([
         { id: "feat-2", title: "Search feature" },
       ]);
@@ -885,9 +786,11 @@ describe("buildGraphWalkerTools", () => {
         {} as never,
       );
 
+      // pg disabled: no arms run, empty results.
+      expect(dbFeature.findMany).not.toHaveBeenCalled();
       expect(dbCanvas.findMany).not.toHaveBeenCalled();
       const results = (result as { results: Array<{ realm: string }> }).results;
-      expect(results.every((r) => r.realm === "pg")).toBe(true);
+      expect(results).toEqual([]);
     });
 
     it("only searches canvas when realm='canvas'", async () => {
@@ -998,47 +901,6 @@ describe("buildGraphWalkerTools", () => {
       expect(results[0]).toMatchObject({ title: "utils.ts", realm: "kg" });
     });
 
-    it("pg results include correct urn, type, title, realm fields", async () => {
-      dbFeature.findMany.mockResolvedValue([{ id: "feat-3", title: "Feature Alpha" }]);
-
-      const tools = getTools();
-      const result = await tools.graph_search.execute(
-        { query: "Alpha", realm: "pg" },
-        {} as never,
-      );
-
-      const results = (
-        result as {
-          results: Array<{ urn: string; type: string; title: string; realm: string }>;
-        }
-      ).results;
-
-      expect(mockFormatUrn).toHaveBeenCalledWith(
-        expect.objectContaining({ realm: "pg", type: "feature", id: "feat-3" }),
-      );
-      expect(results[0]).toMatchObject({
-        type: "feature",
-        title: "Feature Alpha",
-        realm: "pg",
-      });
-    });
-
-    it("pg URNs embed the org githubLogin, not the cuid", async () => {
-      dbFeature.findMany.mockResolvedValue([{ id: "feat-9", title: "X" }]);
-
-      const tools = getTools();
-      await tools.graph_search.execute({ query: "X", realm: "pg" }, {} as never);
-
-      // org segment must be the githubLogin so URNs round-trip through graph_get
-      expect(mockFormatUrn).toHaveBeenCalledWith(
-        expect.objectContaining({ org: "myorg", type: "feature", id: "feat-9" }),
-      );
-      expect(dbSourceControlOrg.findUnique).toHaveBeenCalledWith({
-        where: { id: ORG_ID },
-        select: { githubLogin: true },
-      });
-    });
-
     it("returns { results: [] } when the org cannot be resolved", async () => {
       dbSourceControlOrg.findUnique.mockResolvedValue(null);
       dbFeature.findMany.mockResolvedValue([{ id: "feat-1", title: "Auth" }]);
@@ -1054,8 +916,12 @@ describe("buildGraphWalkerTools", () => {
       expect(dbFeature.findMany).not.toHaveBeenCalled();
     });
 
-    it("matches features on title and plan columns (brief/requirements/architecture)", async () => {
+    it("pg-realm entities (features/tasks/etc.) are never queried in Postgres", async () => {
+      // pg is disabled — regardless of realm/type, none of the pg-backed
+      // Prisma models are touched. Roadmap/chat discovery flows through kg now
+      // (HiveFeature / HiveTask / HiveChatMessage).
       dbFeature.findMany.mockResolvedValue([{ id: "feat-7", title: "Billing" }]);
+      dbTask.findMany.mockResolvedValue([{ id: "task-1", title: "Fix login" }]);
 
       const tools = getTools();
       await tools.graph_search.execute(
@@ -1063,257 +929,7 @@ describe("buildGraphWalkerTools", () => {
         {} as never,
       );
 
-      expect(dbFeature.findMany).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: expect.objectContaining({
-            deleted: false,
-            workspace: { sourceControlOrgId: ORG_ID },
-            OR: [
-              { title: { contains: "webhook", mode: "insensitive" } },
-              { brief: { contains: "webhook", mode: "insensitive" } },
-              { requirements: { contains: "webhook", mode: "insensitive" } },
-              { architecture: { contains: "webhook", mode: "insensitive" } },
-            ],
-          }),
-        }),
-      );
-    });
-
-    it("searches tasks in the pg arm", async () => {
-      dbTask.findMany.mockResolvedValue([
-        { id: "task-1", title: "Fix login bug" },
-      ]);
-
-      const tools = getTools();
-      const result = await tools.graph_search.execute(
-        { query: "login", realm: "pg" },
-        {} as never,
-      );
-
-      // Tasks scoped to the org via workspace, excluding deleted/archived
-      expect(dbTask.findMany).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: expect.objectContaining({
-            deleted: false,
-            archived: false,
-            workspace: { sourceControlOrgId: ORG_ID, deleted: false },
-            OR: [
-              { title: { contains: "login", mode: "insensitive" } },
-              { description: { contains: "login", mode: "insensitive" } },
-            ],
-          }),
-        }),
-      );
-      expect(mockFormatUrn).toHaveBeenCalledWith(
-        expect.objectContaining({ realm: "pg", type: "task", id: "task-1" }),
-      );
-      const results = (
-        result as { results: Array<{ type: string; title: string }> }
-      ).results;
-      expect(results).toContainEqual(
-        expect.objectContaining({ type: "task", title: "Fix login bug", realm: "pg" }),
-      );
-    });
-
-    it("searches workspaces in the pg arm (name/description/mission)", async () => {
-      dbWorkspace.findMany.mockResolvedValue([
-        { id: "ws-1", name: "Core Platform" },
-      ]);
-
-      const tools = getTools();
-      const result = await tools.graph_search.execute(
-        { query: "platform", realm: "pg", type: "workspace" },
-        {} as never,
-      );
-
-      expect(dbWorkspace.findMany).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: expect.objectContaining({
-            sourceControlOrgId: ORG_ID,
-            deleted: false,
-            OR: [
-              { name: { contains: "platform", mode: "insensitive" } },
-              { description: { contains: "platform", mode: "insensitive" } },
-              { mission: { contains: "platform", mode: "insensitive" } },
-            ],
-          }),
-        }),
-      );
-      expect(mockFormatUrn).toHaveBeenCalledWith(
-        expect.objectContaining({ realm: "pg", type: "workspace", id: "ws-1" }),
-      );
-      const results = (
-        result as { results: Array<{ type: string; title: string }> }
-      ).results;
-      expect(results).toContainEqual(
-        expect.objectContaining({ type: "workspace", title: "Core Platform", realm: "pg" }),
-      );
-    });
-
-    it("searches repositories in the pg arm (name/description/URL)", async () => {
-      dbRepository.findMany.mockResolvedValue([
-        { id: "repo-1", name: "hive" },
-      ]);
-
-      const tools = getTools();
-      const result = await tools.graph_search.execute(
-        { query: "hive", realm: "pg", type: "repository" },
-        {} as never,
-      );
-
-      expect(dbRepository.findMany).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: expect.objectContaining({
-            workspace: { sourceControlOrgId: ORG_ID, deleted: false },
-            OR: [
-              { name: { contains: "hive", mode: "insensitive" } },
-              { description: { contains: "hive", mode: "insensitive" } },
-              { repositoryUrl: { contains: "hive", mode: "insensitive" } },
-            ],
-          }),
-        }),
-      );
-      expect(mockFormatUrn).toHaveBeenCalledWith(
-        expect.objectContaining({ realm: "pg", type: "repository", id: "repo-1" }),
-      );
-      const results = (
-        result as { results: Array<{ type: string; title: string }> }
-      ).results;
-      expect(results).toContainEqual(
-        expect.objectContaining({ type: "repository", title: "hive", realm: "pg" }),
-      );
-    });
-
-    it("searches research docs in the pg arm (title/topic/summary/content)", async () => {
-      dbResearch.findMany.mockResolvedValue([
-        { id: "res-1", title: "OAuth deep-dive", topic: "oauth" },
-      ]);
-
-      const tools = getTools();
-      const result = await tools.graph_search.execute(
-        { query: "oauth", realm: "pg", type: "research" },
-        {} as never,
-      );
-
-      expect(dbResearch.findMany).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: expect.objectContaining({
-            orgId: ORG_ID,
-            OR: [
-              { title: { contains: "oauth", mode: "insensitive" } },
-              { topic: { contains: "oauth", mode: "insensitive" } },
-              { summary: { contains: "oauth", mode: "insensitive" } },
-              { content: { contains: "oauth", mode: "insensitive" } },
-            ],
-          }),
-        }),
-      );
-      expect(mockFormatUrn).toHaveBeenCalledWith(
-        expect.objectContaining({ realm: "pg", type: "research", id: "res-1" }),
-      );
-      const results = (
-        result as { results: Array<{ type: string; title: string }> }
-      ).results;
-      expect(results).toContainEqual(
-        expect.objectContaining({ type: "research", title: "OAuth deep-dive", realm: "pg" }),
-      );
-    });
-
-    it("falls back to topic when a research title is empty", async () => {
-      dbResearch.findMany.mockResolvedValue([
-        { id: "res-2", title: "", topic: "rate limiting" },
-      ]);
-
-      const tools = getTools();
-      const result = await tools.graph_search.execute(
-        { query: "rate", realm: "pg", type: "research" },
-        {} as never,
-      );
-
-      const results = (
-        result as { results: Array<{ title: string }> }
-      ).results;
-      expect(results).toContainEqual(
-        expect.objectContaining({ title: "rate limiting" }),
-      );
-    });
-
-    it("searches connection docs in the pg arm (name/summary/architecture)", async () => {
-      dbConnection.findMany.mockResolvedValue([
-        { id: "conn-1", name: "Sphinx ↔ Hive" },
-      ]);
-
-      const tools = getTools();
-      const result = await tools.graph_search.execute(
-        { query: "sphinx", realm: "pg", type: "connection" },
-        {} as never,
-      );
-
-      expect(dbConnection.findMany).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: expect.objectContaining({
-            orgId: ORG_ID,
-            OR: [
-              { name: { contains: "sphinx", mode: "insensitive" } },
-              { summary: { contains: "sphinx", mode: "insensitive" } },
-              { architecture: { contains: "sphinx", mode: "insensitive" } },
-            ],
-          }),
-        }),
-      );
-      expect(mockFormatUrn).toHaveBeenCalledWith(
-        expect.objectContaining({ realm: "pg", type: "connection", id: "conn-1" }),
-      );
-      const results = (
-        result as { results: Array<{ type: string; title: string }> }
-      ).results;
-      expect(results).toContainEqual(
-        expect.objectContaining({ type: "connection", title: "Sphinx ↔ Hive", realm: "pg" }),
-      );
-    });
-
-    it("searches conversations in the pg arm via raw query", async () => {
-      dbQueryRaw.mockResolvedValue([
-        { id: "convo-1", title: "Roadmap chat" },
-        { id: "convo-2", title: null },
-      ]);
-
-      const tools = getTools();
-      const result = await tools.graph_search.execute(
-        { query: "roadmap", realm: "pg" },
-        {} as never,
-      );
-
-      expect(dbQueryRaw).toHaveBeenCalled();
-      expect(mockFormatUrn).toHaveBeenCalledWith(
-        expect.objectContaining({
-          realm: "pg",
-          type: "conversation",
-          id: "convo-1",
-        }),
-      );
-      const results = (
-        result as { results: Array<{ type: string; title: string }> }
-      ).results;
-      expect(results).toContainEqual(
-        expect.objectContaining({ type: "conversation", title: "Roadmap chat" }),
-      );
-      // Null titles fall back to a placeholder
-      expect(results).toContainEqual(
-        expect.objectContaining({
-          type: "conversation",
-          title: "(untitled conversation)",
-        }),
-      );
-    });
-
-    it("does not search conversations or tasks when type filters them out", async () => {
-      const tools = getTools();
-      await tools.graph_search.execute(
-        { query: "x", realm: "pg", type: "feature" },
-        {} as never,
-      );
-
+      expect(dbFeature.findMany).not.toHaveBeenCalled();
       expect(dbTask.findMany).not.toHaveBeenCalled();
       expect(dbWorkspace.findMany).not.toHaveBeenCalled();
       expect(dbRepository.findMany).not.toHaveBeenCalled();

--- a/src/lib/ai/capabilities.ts
+++ b/src/lib/ai/capabilities.ts
@@ -286,8 +286,10 @@ export const CAPABILITY_REGISTRY: Record<OrgCapability, CapabilityDefinition> =
       menuBlurb:
         "**graph_walker** — fetch KG node-type ontology (`graph_ontology`), " +
         "dereference any URN (`graph_get`), expand 1-hop neighbors (`graph_neighbors`), " +
-        "search across pg/canvas/kg realms (`graph_search`). Load when you need to " +
-        "walk the cross-realm graph or dereference a URN from another tool.",
+        "search the swarm knowledge graph (`graph_search`, realm `kg`) — Hive " +
+        "Features/Tasks/ChatMessages now live there as HiveFeature/HiveTask/" +
+        "HiveChatMessage, alongside the code graph. Load when you need to walk the " +
+        "knowledge graph or dereference a URN from another tool. (The `pg` realm is disabled.)",
       writeToolNames: [], // read-only
     },
   };
@@ -341,9 +343,14 @@ function buildLearnCapabilityTool(resolved: readonly OrgCapability[]): ToolSet {
         loadable.join(", ") +
         ". Call this FIRST whenever the user wants to: draw / diagram / " +
         "annotate / re-lay-out the canvas (`whiteboard`), create a saved " +
-        "research writeup (`research`), or document a system integration " +
-        "(`connections`). Returns the full rules for that capability; " +
-        "don't call the capability's tools until you've loaded them.",
+        "research writeup (`research`), document a system integration " +
+        "(`connections`), or search / walk / traverse the knowledge graph or " +
+        "dereference a URN (`graph_walker` — this covers ANY use of " +
+        "`graph_search`, `graph_ontology`, `graph_get`, or `graph_neighbors`). " +
+        "You MUST load a capability before calling any of its tools; if you " +
+        "find yourself about to call one of those tools without having loaded " +
+        "its capability this turn, call `learn_capability` first. Returns the " +
+        "full rules for that capability.",
       inputSchema: z.object({
         capability: z
           .enum(loadable as [OrgCapability, ...OrgCapability[]])
@@ -416,11 +423,11 @@ export function composeCapabilityPromptSuffix(
 
 ## More capabilities (load on demand)
 
-These advanced capabilities are available but their detailed rules are NOT loaded yet. Before using any of their tools, call \`learn_capability(<name>)\` to load the instructions:
+These advanced capabilities are available but their detailed rules are NOT loaded yet. Before using ANY of their tools, you MUST call \`learn_capability(<name>)\` first to load the instructions — do not call a capability's tools until you have loaded it this session:
 
 ${menu}
 
-Only load a capability when the user's request actually calls for it; for the common "propose a feature, then send it to its planner" flow you don't need any of these.`
+Only load a capability when the user's request actually calls for it; for the common "propose a feature, then send it to its planner" flow you don't need any of these. But whenever the user asks you to search, walk, or traverse the graph / knowledge graph, or to look up an entity by URN, that REQUIRES the \`graph_walker\` capability — call \`learn_capability("graph_walker")\` before using \`graph_search\` / \`graph_ontology\` / \`graph_get\` / \`graph_neighbors\`.`
   );
 }
 

--- a/src/lib/ai/capabilities.ts
+++ b/src/lib/ai/capabilities.ts
@@ -287,8 +287,8 @@ export const CAPABILITY_REGISTRY: Record<OrgCapability, CapabilityDefinition> =
         "**graph_walker** — fetch KG node-type ontology (`graph_ontology`), " +
         "dereference any URN (`graph_get`), expand 1-hop neighbors (`graph_neighbors`), " +
         "search the swarm knowledge graph (`graph_search`, realm `kg`) — Hive " +
-        "Features/Tasks/ChatMessages now live there as HiveFeature/HiveTask/" +
-        "HiveChatMessage, alongside the code graph. Load when you need to walk the " +
+        "Features/Tasks/ChatMessages now live there as Hivefeature/Hivetask/" +
+        "Hivechatmessage, alongside the code graph. Load when you need to walk the " +
         "knowledge graph or dereference a URN from another tool. (The `pg` realm is disabled.)",
       writeToolNames: [], // read-only
     },

--- a/src/lib/ai/graphWalkerTools.ts
+++ b/src/lib/ai/graphWalkerTools.ts
@@ -4,10 +4,20 @@
  * Exposes three agent tools:
  *   - `graph_get`       — resolve a single URN to its full node content
  *   - `graph_neighbors` — return all adjacent URNs reachable in one hop
- *   - `graph_search`    — keyword search across pg, canvas, and kg realms
+ *   - `graph_search`    — keyword search across canvas and kg realms
  *
- * All three realms are live: pg (Postgres roadmap), canvas (canvas nodes), and
- * kg (the swarm knowledge graph, served by Jarvis v2 over HTTP).
+ * The primary realm is `kg` (the swarm knowledge graph, served by Jarvis v2 over
+ * HTTP); `canvas` (canvas nodes) is also live.
+ *
+ * ## pg realm is DISABLED (see PG_REALM_ENABLED)
+ *
+ * Hive Features, Tasks, and ChatMessages are now mirrored directly into each
+ * workspace's knowledge graph (kg realm) as `HiveFeature` / `HiveTask` /
+ * `HiveChatMessage` nodes — see `src/services/jarvis-mirror`. The pg-realm
+ * search/resolve code below is retained for reference but gated off behind
+ * `PG_REALM_ENABLED`, so all roadmap + conversation discovery now flows through
+ * the kg realm. Flip `PG_REALM_ENABLED` back to `true` to re-enable the
+ * Postgres-backed roadmap traversal.
  *
  * All tools are read-only — no node creation, edge writes, or swarm mutations.
  */
@@ -49,6 +59,26 @@ async function urnOrgMatchesContext(
   });
   return row?.id === orgId;
 }
+
+// ---------------------------------------------------------------------------
+// Feature gate
+// ---------------------------------------------------------------------------
+
+/**
+ * When `false`, the pg realm is inert: `graph_search` skips its pg arms (and
+ * default no-realm search falls through to canvas + kg), and `graph_get` /
+ * `graph_neighbors` refuse to resolve pg URNs. Hive Features, Tasks, and
+ * ChatMessages now live in the kg realm (HiveFeature / HiveTask /
+ * HiveChatMessage) via the jarvis-mirror sync, so pg is no longer the source of
+ * truth for roadmap discovery. Flip to `true` to re-enable Postgres traversal.
+ */
+const PG_REALM_ENABLED = false;
+
+/** Shared message returned when a pg-realm operation is attempted while disabled. */
+const PG_DISABLED_MESSAGE =
+  "pg realm is disabled — Hive features, tasks, and chat messages now live in " +
+  "the kg realm as HiveFeature / HiveTask / HiveChatMessage nodes. Use " +
+  'graph_search with realm: "kg" (and graph_ontology to discover node types).';
 
 // ---------------------------------------------------------------------------
 // Internal types
@@ -804,8 +834,9 @@ export function buildGraphWalkerTools(
     graph_get: tool({
       description:
         "Resolve a single URN to its full node content. " +
-        "Routes by realm: `pg` and `canvas` URNs are resolved locally; " +
+        "Routes by realm: `canvas` URNs are resolved locally; " +
         "`kg` URNs are resolved live from the swarm knowledge graph (Jarvis). " +
+        "The `pg` realm is DISABLED (its entities now live in the kg). " +
         "Use this when you have a specific URN and need the entity's data.",
       inputSchema: z.object({
         urn: z.string().describe(
@@ -824,6 +855,7 @@ export function buildGraphWalkerTools(
 
         switch (parsed.realm) {
           case "pg": {
+            if (!PG_REALM_ENABLED) return { error: PG_DISABLED_MESSAGE };
             const node = await resolvePgNode(urn);
             return node ?? { error: "not found or access denied" };
           }
@@ -846,9 +878,9 @@ export function buildGraphWalkerTools(
       description:
         "Return all adjacent URNs reachable in one hop from the given node, " +
         "with edgeType and direction. " +
-        "For `pg` URNs, delegates to the full pgNeighbors registry (FK traversal + UrnEdge). " +
         "For `canvas` URNs, unions structural canvas edges with UrnEdge cross-realm edges. " +
-        "For `kg` URNs, calls Jarvis v2 with optional edge_type / node_type filters (kg-specific, ignored by other realms).",
+        "For `kg` URNs, calls Jarvis v2 with optional edge_type / node_type filters (kg-specific, ignored by other realms). " +
+        "The `pg` realm is DISABLED (its entities now live in the kg).",
       inputSchema: z.object({
         urn: z.string().describe("Canonical URN of the node to expand."),
         depth: z
@@ -886,6 +918,7 @@ export function buildGraphWalkerTools(
 
         switch (parsed.realm) {
           case "pg": {
+            if (!PG_REALM_ENABLED) return { error: PG_DISABLED_MESSAGE };
             const ctx: PgNeighborContext = { userId, orgId };
             const results = await pgNeighbors(urn, ctx);
             // pg-native neighbors get labels from Postgres; cross-realm kg
@@ -976,13 +1009,16 @@ export function buildGraphWalkerTools(
 
     graph_search: tool({
       description:
-        "Search for nodes by keyword across pg, canvas, and kg realms, " +
+        "Search for nodes by keyword across the canvas and kg realms, " +
         "returning ranked results with URN, type, title, and realm. " +
-        "The pg realm covers features, initiatives, milestones, tasks, and " +
-        "org-canvas chat conversations; the canvas realm covers canvas nodes; " +
-        "the kg realm searches Jarvis knowledge-graph nodes. " +
+        "The kg realm searches Jarvis knowledge-graph nodes — including Hive " +
+        "Features, Tasks, and ChatMessages, which are mirrored into the kg as " +
+        "HiveFeature / HiveTask / HiveChatMessage nodes; the canvas realm covers " +
+        "canvas nodes. " +
+        "The `pg` realm is DISABLED (roadmap/chat data now lives in the kg). " +
         "Scope with `realm`, `type`, or `workspace` to narrow results. " +
-        "Default (no realm) searches pg + canvas. " +
+        "Default (no realm) searches canvas + kg (kg fanned out across all " +
+        "member workspaces). " +
         "For kg: provide `workspace` to search one workspace, or omit to fan-out across all member workspaces.",
       inputSchema: z.object({
         query: z.string().min(1).describe("Keyword(s) to search for."),
@@ -990,7 +1026,8 @@ export function buildGraphWalkerTools(
           .enum(["pg", "canvas", "kg"])
           .optional()
           .describe(
-            "Limit search to a specific realm. Omit to search pg + canvas.",
+            "Limit search to a specific realm. Omit to search canvas + kg. " +
+              "`pg` is DISABLED and returns nothing — use `kg` instead.",
           ),
         workspace: z
           .string()
@@ -1000,7 +1037,9 @@ export function buildGraphWalkerTools(
           .string()
           .optional()
           .describe(
-            "Filter by node type (e.g. 'feature', 'initiative', 'milestone', 'task', 'conversation', 'node').",
+            "Filter by node type. For kg use the exact type from graph_ontology " +
+              "(e.g. 'HiveFeature', 'HiveTask', 'HiveChatMessage', 'File', 'Function'); " +
+              "for canvas use 'node' / 'text'.",
           ),
         limit: z
           .number()
@@ -1036,14 +1075,20 @@ export function buildGraphWalkerTools(
         if (!orgRow) return { results: [] };
         const urnOrg = orgRow.githubLogin;
 
-        if (!realm || realm === "pg") {
+        // pg realm is disabled (see PG_REALM_ENABLED) — features/tasks/chat are
+        // discovered through the kg realm now. When re-enabled, pg re-joins the
+        // default (no-realm) fan-out alongside canvas.
+        if (PG_REALM_ENABLED && (!realm || realm === "pg")) {
           arms.push(searchPg(query, { orgId, urnOrg, type, limit }));
           arms.push(searchConversations(query, { orgId, urnOrg, type, limit }));
         }
         if (!realm || realm === "canvas") {
           arms.push(searchCanvas(query, { orgId, urnOrg, type, limit }));
         }
-        if (realm === "kg") {
+        // kg runs on an explicit realm:"kg" request, and — now that pg is
+        // disabled — also on the default no-realm search (fan-out across the
+        // user's member workspaces when no `workspace` is given).
+        if (realm === "kg" || !realm) {
           arms.push(
             searchKg(query, { orgId, urnOrg, userId, workspace, type, limit }),
           );

--- a/src/lib/ai/graphWalkerTools.ts
+++ b/src/lib/ai/graphWalkerTools.ts
@@ -77,7 +77,7 @@ const PG_REALM_ENABLED = false;
 /** Shared message returned when a pg-realm operation is attempted while disabled. */
 const PG_DISABLED_MESSAGE =
   "pg realm is disabled — Hive features, tasks, and chat messages now live in " +
-  "the kg realm as HiveFeature / HiveTask / HiveChatMessage nodes. Use " +
+  "the kg realm as Hivefeature / Hivetask / Hivechatmessage nodes. Use " +
   'graph_search with realm: "kg" (and graph_ontology to discover node types).';
 
 // ---------------------------------------------------------------------------
@@ -1013,7 +1013,7 @@ export function buildGraphWalkerTools(
         "returning ranked results with URN, type, title, and realm. " +
         "The kg realm searches Jarvis knowledge-graph nodes — including Hive " +
         "Features, Tasks, and ChatMessages, which are mirrored into the kg as " +
-        "HiveFeature / HiveTask / HiveChatMessage nodes; the canvas realm covers " +
+        "Hivefeature / Hivetask / Hivechatmessage nodes; the canvas realm covers " +
         "canvas nodes. " +
         "The `pg` realm is DISABLED (roadmap/chat data now lives in the kg). " +
         "Scope with `realm`, `type`, or `workspace` to narrow results. " +
@@ -1038,7 +1038,7 @@ export function buildGraphWalkerTools(
           .optional()
           .describe(
             "Filter by node type. For kg use the exact type from graph_ontology " +
-              "(e.g. 'HiveFeature', 'HiveTask', 'HiveChatMessage', 'File', 'Function'); " +
+              "(e.g. 'hivefeature', 'hivetask', 'hivechatmessage', 'File', 'Function'); " +
               "for canvas use 'node' / 'text'.",
           ),
         limit: z

--- a/src/lib/constants/prompt.ts
+++ b/src/lib/constants/prompt.ts
@@ -714,44 +714,48 @@ export function getGraphWalkerCapabilitySnippet(): string {
 
 ## Graph Walker Tools
 
-You have four **read-only** tools for cross-realm graph traversal. These tools never create, modify, or delete nodes or edges.
+You have four **read-only** tools for graph traversal, focused on the swarm knowledge graph (kg). These tools never create, modify, or delete nodes or edges.
+
+### Where the data lives now
+
+Hive **Features, Tasks, and ChatMessages are mirrored directly into each workspace's knowledge graph (kg realm)** as \`HiveFeature\` / \`HiveTask\` / \`HiveChatMessage\` nodes — alongside the ingested code graph (files, functions, data models, concepts). Search and traverse them there via the \`kg\` realm.
+
+The \`pg\` realm is **DISABLED**: \`graph_search\` with \`realm: "pg"\` returns nothing, and \`graph_get\` / \`graph_neighbors\` refuse pg URNs. Do not try to reach roadmap/chat data through pg — use the kg realm.
 
 ### URN format
 
 URNs follow a variable-arity canonical format. Never construct URN strings by hand — use \`formatUrn\` from the URN utilities:
 
 \`\`\`
-pg / canvas  →  urn:{org}:{realm}:{type}:{id}
-kg           →  urn:{org}:kg:{workspace}:{type}:{id}
+canvas  →  urn:{org}:canvas:{type}:{id}
+kg      →  urn:{org}:kg:{workspace}:{type}:{id}
 \`\`\`
 
-Realms: \`pg\` (Postgres roadmap entities), \`canvas\` (canvas nodes), \`kg\` (the swarm code knowledge-graph — concepts, files, functions, data models).
+Realms: \`kg\` (the swarm knowledge-graph — HiveFeature/HiveTask/HiveChatMessage plus code concepts, files, functions, data models) and \`canvas\` (canvas nodes). \`pg\` is disabled.
 
 ### Tools
 
-- **\`graph_ontology({ workspace })\`** — Fetch the list of valid KG node types (with descriptions) for a workspace's knowledge graph. **Call this first** before using \`graph_search\` with \`realm: "kg"\` — the returned \`type\` values are the exact strings to pass as the \`type\` filter in \`graph_search\`. This avoids guessing type names blind. Returns \`{ node_types: [{ type, description }] }\`.
+- **\`graph_ontology({ workspace })\`** — Fetch the list of valid KG node types (with descriptions) for a workspace's knowledge graph. **Call this first** before using \`graph_search\` with \`realm: "kg"\` — the returned \`type\` values are the exact strings to pass as the \`type\` filter in \`graph_search\`. This is how you discover the Hive node types (e.g. \`HiveFeature\`, \`HiveTask\`, \`HiveChatMessage\`) and the code node types. Returns \`{ node_types: [{ type, description }] }\`.
 
 - **\`graph_get({ urn })\`** — Resolve a single URN to its full node content. Use this when you have a specific URN and need the entity's complete data.
 
-- **\`graph_neighbors({ urn, depth? })\`** — Return all adjacent URNs reachable in one hop, each with \`edgeType\`, \`direction\`, and a best-effort \`title\` (a human-readable label — e.g. a feature's title, a file's name, a concept's name). Use the \`title\` to decide which neighbor to follow without having to \`graph_get\` every one. kg neighbors also carry \`node_type\` and \`ref_id\`; \`title\` may be absent for a node type that exposes no recognizable label.
+- **\`graph_neighbors({ urn, depth?, edge_type?, node_type? })\`** — Return all adjacent URNs reachable in one hop, each with \`edgeType\`, \`direction\`, and a best-effort \`title\` (a human-readable label — e.g. a feature's title, a file's name, a concept's name). Use the \`title\` to decide which neighbor to follow without having to \`graph_get\` every one. kg neighbors also carry \`node_type\` and \`ref_id\`; \`title\` may be absent for a node type that exposes no recognizable label. Filter kg edges/nodes with \`edge_type\` / \`node_type\`.
 
 - **\`graph_search({ query, realm?, type?, workspace?, limit? })\`** — Discover nodes by keyword. Returns \`{ urn, type, title, realm }[]\` ranked results. Scope with \`realm\` and/or \`type\` to narrow results:
-  - \`realm: "pg"\` — searches features, initiatives, milestones, tasks, workspaces, and repositories by title/name (features also match on their brief/requirements/architecture plan content; tasks also match on description; workspaces also match on description/mission; repositories also match on description/URL), plus research docs (title/topic/summary/content), connection docs (name/summary/architecture), and org-canvas chat conversations (title + message content)
-  - \`realm: "canvas"\` — searches **authored** canvas nodes by text/label only. Projected/live cards (workspace/initiative/feature/milestone/repository/research) are NOT in this arm — find those via their pg types instead.
-  - \`realm: "kg"\` — searches the swarm code knowledge-graph (concepts, files, functions, …). **First call \`graph_ontology({ workspace })\` to get valid \`type\` values**, then pass the desired type as the \`type\` filter. Provide \`workspace\` to search one workspace's swarm, or omit it to fan out across all your member workspaces.
-  - Omit \`realm\` to search pg and canvas simultaneously (kg is searched only when explicitly requested with \`realm: "kg"\`)
-  - Narrow pg results with \`type\`: \`"feature"\`, \`"initiative"\`, \`"milestone"\`, \`"task"\`, \`"workspace"\`, \`"repository"\`, \`"research"\`, \`"connection"\`, or \`"conversation"\`
-  - From a \`workspace\` URN, \`graph_neighbors\` walks \`HAS_MEMBER\` → workspace members, and each member's \`IS_USER\` → the underlying user
+  - \`realm: "kg"\` — searches the swarm knowledge-graph: Hive Features/Tasks/ChatMessages (\`HiveFeature\` / \`HiveTask\` / \`HiveChatMessage\`) plus code nodes (concepts, files, functions, …). **First call \`graph_ontology({ workspace })\` to get valid \`type\` values**, then pass the desired type as the \`type\` filter. Provide \`workspace\` to search one workspace's swarm, or omit it to fan out across all your member workspaces.
+  - \`realm: "canvas"\` — searches **authored** canvas nodes by text/label only.
+  - Omit \`realm\` to search canvas + kg simultaneously (kg fans out across all your member workspaces).
+  - \`realm: "pg"\` is disabled and returns nothing.
 
 ### kg realm workflow
 
 1. Call \`graph_ontology({ workspace })\` → get the list of valid node types for the workspace's KG.
-2. Pick the relevant \`type\` values from the returned list.
+2. Pick the relevant \`type\` values from the returned list (e.g. \`HiveFeature\`, \`HiveTask\`, \`HiveChatMessage\`, \`File\`, \`Function\`).
 3. Call \`graph_search({ query, realm: "kg", workspace, type: "<chosen type>" })\` with the exact type string from step 2.
 
 ### Scope reminder
 
-All three realms are live (pg, canvas, kg). The chain that connects roadmap to code: a \`pg:feature\` links to \`kg:concept\` nodes (edge type \`implemented-by\`, surfaced by \`graph_neighbors\`), and from a \`kg:concept\` you can walk to the files/functions that implement it (filter with \`node_type\`, e.g. \`["File"]\`). kg traversal talks to the live swarm, so it can fail if the swarm is unconfigured/unreachable — those calls return an \`{ error }\` you should treat as "unavailable", not "empty". Default \`graph_search\` (no realm) searches pg + canvas; request \`realm: "kg"\` to search the code graph.
+The chain that connects roadmap to code lives entirely in the kg now: a \`HiveFeature\` \`HAS_TASK\` \`HiveTask\`, which \`HAS_MESSAGE\` \`HiveChatMessage\`, and links out to the files/functions that implement it. Walk these with \`graph_neighbors\` (filter with \`node_type\`, e.g. \`["File"]\`). kg traversal talks to the live swarm, so it can fail if the swarm is unconfigured/unreachable — those calls return an \`{ error }\` you should treat as "unavailable", not "empty".
 
 ### Read-only
 

--- a/src/lib/constants/prompt.ts
+++ b/src/lib/constants/prompt.ts
@@ -718,7 +718,7 @@ You have four **read-only** tools for graph traversal, focused on the swarm know
 
 ### Where the data lives now
 
-Hive **Features, Tasks, and ChatMessages are mirrored directly into each workspace's knowledge graph (kg realm)** as \`HiveFeature\` / \`HiveTask\` / \`HiveChatMessage\` nodes — alongside the ingested code graph (files, functions, data models, concepts). Search and traverse them there via the \`kg\` realm.
+Hive **Features, Tasks, and ChatMessages are mirrored directly into each workspace's knowledge graph (kg realm)** as \`Hivefeature\` / \`Hivetask\` / \`Hivechatmessage\` nodes — alongside the ingested code graph (files, functions, data models, concepts). Search and traverse them there via the \`kg\` realm.
 
 The \`pg\` realm is **DISABLED**: \`graph_search\` with \`realm: "pg"\` returns nothing, and \`graph_get\` / \`graph_neighbors\` refuse pg URNs. Do not try to reach roadmap/chat data through pg — use the kg realm.
 
@@ -731,18 +731,18 @@ canvas  →  urn:{org}:canvas:{type}:{id}
 kg      →  urn:{org}:kg:{workspace}:{type}:{id}
 \`\`\`
 
-Realms: \`kg\` (the swarm knowledge-graph — HiveFeature/HiveTask/HiveChatMessage plus code concepts, files, functions, data models) and \`canvas\` (canvas nodes). \`pg\` is disabled.
+Realms: \`kg\` (the swarm knowledge-graph — Hivefeature/Hivetask/Hivechatmessage plus code concepts, files, functions, data models) and \`canvas\` (canvas nodes). \`pg\` is disabled.
 
 ### Tools
 
-- **\`graph_ontology({ workspace })\`** — Fetch the list of valid KG node types (with descriptions) for a workspace's knowledge graph. **Call this first** before using \`graph_search\` with \`realm: "kg"\` — the returned \`type\` values are the exact strings to pass as the \`type\` filter in \`graph_search\`. This is how you discover the Hive node types (e.g. \`HiveFeature\`, \`HiveTask\`, \`HiveChatMessage\`) and the code node types. Returns \`{ node_types: [{ type, description }] }\`.
+- **\`graph_ontology({ workspace })\`** — Fetch the list of valid KG node types (with descriptions) for a workspace's knowledge graph. **Call this first** before using \`graph_search\` with \`realm: "kg"\` — the returned \`type\` values are the exact strings to pass as the \`type\` filter in \`graph_search\`. This is how you discover the Hive node types (e.g. \`Hivefeature\`, \`Hivetask\`, \`Hivechatmessage\`) and the code node types. Returns \`{ node_types: [{ type, description }] }\`.
 
 - **\`graph_get({ urn })\`** — Resolve a single URN to its full node content. Use this when you have a specific URN and need the entity's complete data.
 
 - **\`graph_neighbors({ urn, depth?, edge_type?, node_type? })\`** — Return all adjacent URNs reachable in one hop, each with \`edgeType\`, \`direction\`, and a best-effort \`title\` (a human-readable label — e.g. a feature's title, a file's name, a concept's name). Use the \`title\` to decide which neighbor to follow without having to \`graph_get\` every one. kg neighbors also carry \`node_type\` and \`ref_id\`; \`title\` may be absent for a node type that exposes no recognizable label. Filter kg edges/nodes with \`edge_type\` / \`node_type\`.
 
 - **\`graph_search({ query, realm?, type?, workspace?, limit? })\`** — Discover nodes by keyword. Returns \`{ urn, type, title, realm }[]\` ranked results. Scope with \`realm\` and/or \`type\` to narrow results:
-  - \`realm: "kg"\` — searches the swarm knowledge-graph: Hive Features/Tasks/ChatMessages (\`HiveFeature\` / \`HiveTask\` / \`HiveChatMessage\`) plus code nodes (concepts, files, functions, …). **First call \`graph_ontology({ workspace })\` to get valid \`type\` values**, then pass the desired type as the \`type\` filter. Provide \`workspace\` to search one workspace's swarm, or omit it to fan out across all your member workspaces.
+  - \`realm: "kg"\` — searches the swarm knowledge-graph: Hive Features/Tasks/ChatMessages (\`Hivefeature\` / \`Hivetask\` / \`Hivechatmessage\`) plus code nodes (concepts, files, functions, …). **First call \`graph_ontology({ workspace })\` to get valid \`type\` values**, then pass the desired type as the \`type\` filter. Provide \`workspace\` to search one workspace's swarm, or omit it to fan out across all your member workspaces.
   - \`realm: "canvas"\` — searches **authored** canvas nodes by text/label only.
   - Omit \`realm\` to search canvas + kg simultaneously (kg fans out across all your member workspaces).
   - \`realm: "pg"\` is disabled and returns nothing.
@@ -750,12 +750,12 @@ Realms: \`kg\` (the swarm knowledge-graph — HiveFeature/HiveTask/HiveChatMessa
 ### kg realm workflow
 
 1. Call \`graph_ontology({ workspace })\` → get the list of valid node types for the workspace's KG.
-2. Pick the relevant \`type\` values from the returned list (e.g. \`HiveFeature\`, \`HiveTask\`, \`HiveChatMessage\`, \`File\`, \`Function\`).
+2. Pick the relevant \`type\` values from the returned list (e.g. \`Hivefeature\`, \`Hivetask\`, \`Hivechatmessage\`, \`File\`, \`Function\`).
 3. Call \`graph_search({ query, realm: "kg", workspace, type: "<chosen type>" })\` with the exact type string from step 2.
 
 ### Scope reminder
 
-The chain that connects roadmap to code lives entirely in the kg now: a \`HiveFeature\` \`HAS_TASK\` \`HiveTask\`, which \`HAS_MESSAGE\` \`HiveChatMessage\`, and links out to the files/functions that implement it. Walk these with \`graph_neighbors\` (filter with \`node_type\`, e.g. \`["File"]\`). kg traversal talks to the live swarm, so it can fail if the swarm is unconfigured/unreachable — those calls return an \`{ error }\` you should treat as "unavailable", not "empty".
+The chain that connects roadmap to code lives entirely in the kg now: a \`Hivefeature\` \`HAS_TASK\` \`Hivetask\`, which \`HAS_MESSAGE\` \`Hivechatmessage\`, and links out to the files/functions that implement it. Walk these with \`graph_neighbors\` (filter with \`node_type\`, e.g. \`["File"]\`). kg traversal talks to the live swarm, so it can fail if the swarm is unconfigured/unreachable — those calls return an \`{ error }\` you should treat as "unavailable", not "empty".
 
 ### Read-only
 


### PR DESCRIPTION
## Summary

Hive **Features, Tasks, and ChatMessages** are now mirrored directly into each workspace's knowledge graph (kg realm) as `HiveFeature` / `HiveTask` / `HiveChatMessage` nodes (see `src/services/jarvis-mirror`). That makes the Postgres (`pg`) realm redundant for roadmap/chat discovery in the `graph_walker` tools, so this PR **disables the pg realm** and points the agent at the `kg` realm instead.

Per request, the pg code is **disabled, not deleted** — it's gated behind a flag and can be re-enabled.

## Changes

**`src/lib/ai/graphWalkerTools.ts`**
- Added `PG_REALM_ENABLED = false` gate (+ shared `PG_DISABLED_MESSAGE`). The pg search/resolve code is retained but inert; flip to `true` to restore.
- `graph_get` / `graph_neighbors`: the `pg` case short-circuits with a disabled note instead of calling `resolvePgNode` / `pgNeighbors`.
- `graph_search`: pg arms are skipped; default (no-realm) search now fans out to **canvas + kg** (kg across all member workspaces). `realm:"pg"` returns `[]`.
- Tool descriptions updated to lead with `kg` and the `Hive*` node types.

**`src/lib/constants/prompt.ts`**
- Rewrote `getGraphWalkerCapabilitySnippet()`: leads with "Hive Features/Tasks/ChatMessages now live in the kg realm as HiveFeature/HiveTask/HiveChatMessage", marks `pg` DISABLED, and documents the kg-only traversal chain (`HAS_TASK` → `HAS_MESSAGE` → files/functions).

**`src/lib/ai/capabilities.ts`**
- Updated the `graph_walker` menu blurb.
- Strengthened the **capability-loading nudge**: `learn_capability`'s description and the "More capabilities" menu now explicitly require calling `learn_capability("graph_walker")` before using any of `graph_search` / `graph_ontology` / `graph_get` / `graph_neighbors` (previously graph_walker wasn't named in the trigger lists, which likely caused the agent to skip loading it).

**Tests**
- Updated `graphWalkerTools.test.ts` to assert the disabled pg behavior.

## Testing
- `graphWalkerTools.test.ts`: 32 passed
- Full AI unit suite: 330 passed
- Source files typecheck clean