### PR TITLE
fix(ai): repair tool-results with missing output in message sanitizer

### DIFF
--- a/src/__tests__/unit/lib/ai/message-sanitizer.test.ts
+++ b/src/__tests__/unit/lib/ai/message-sanitizer.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for sanitizeAndCompleteToolCalls (message-sanitizer).
+ *
+ * Focus: a persisted tool-result whose `output` field is missing/nullish
+ * (produced when a tool-call's args fail to parse) must be repaired into a
+ * valid `{ type: "json", value: ... }` shape. Otherwise it poisons the
+ * entire conversation — every subsequent turn throws AI_InvalidPromptError
+ * ("messages do not match the ModelMessage[] schema").
+ */
+
+import { describe, test, expect, vi } from "vitest";
+import type { ModelMessage } from "ai";
+
+// swarmFetch is only reached for orphaned tool-CALLS (no matching result);
+// none of these cases exercise it, but the import must resolve.
+vi.mock("@/lib/ai/concepts", () => ({ swarmFetch: vi.fn() }));
+
+import { sanitizeAndCompleteToolCalls } from "@/lib/ai/message-sanitizer";
+
+function toolResultPart(msg: ModelMessage) {
+  const content = msg.content as Array<Record<string, unknown>>;
+  return content[0];
+}
+
+describe("sanitizeAndCompleteToolCalls — missing output repair", () => {
+  test("backfills a tool-result whose output is entirely missing", async () => {
+    // Mirrors the real corruption: an assistant tool-call paired with a
+    // tool-result that has NO `output` key.
+    const messages: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "propose_feature",
+            input: "{ malformed json",
+          } as never,
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-1",
+            toolName: "propose_feature",
+            // no `output`
+          } as never,
+        ],
+      },
+    ];
+
+    const out = await sanitizeAndCompleteToolCalls(messages, "http://swarm", "key");
+
+    const toolMsg = out.find((m) => m.role === "tool")!;
+    const part = toolResultPart(toolMsg) as { output?: { type: string; value: unknown } };
+    expect(part.output).toBeDefined();
+    expect(part.output?.type).toBe("json");
+    expect(part.output?.value).toMatchObject({ error: expect.any(String) });
+  });
+
+  test("backfills a tool-result whose output is null", async () => {
+    const messages: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "tool-call", toolCallId: "c2", toolName: "read_canvas", input: {} } as never,
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          { type: "tool-result", toolCallId: "c2", toolName: "read_canvas", output: null } as never,
+        ],
+      },
+    ];
+
+    const out = await sanitizeAndCompleteToolCalls(messages, "http://swarm", "key");
+    const part = toolResultPart(out.find((m) => m.role === "tool")!) as {
+      output?: { type: string };
+    };
+    expect(part.output?.type).toBe("json");
+  });
+
+  test("leaves a well-formed { type, value } output untouched", async () => {
+    const good = { type: "json", value: { ok: true } };
+    const messages: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "tool-call", toolCallId: "c3", toolName: "read_canvas", input: {} } as never,
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          { type: "tool-result", toolCallId: "c3", toolName: "read_canvas", output: good } as never,
+        ],
+      },
+    ];
+
+    const out = await sanitizeAndCompleteToolCalls(messages, "http://swarm", "key");
+    const part = toolResultPart(out.find((m) => m.role === "tool")!) as { output?: unknown };
+    expect(part.output).toEqual(good);
+  });
+
+  test("wraps a raw string output into { type: json, value }", async () => {
+    const messages: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "tool-call", toolCallId: "c4", toolName: "read_canvas", input: {} } as never,
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          { type: "tool-result", toolCallId: "c4", toolName: "read_canvas", output: "hello" } as never,
+        ],
+      },
+    ];
+
+    const out = await sanitizeAndCompleteToolCalls(messages, "http://swarm", "key");
+    const part = toolResultPart(out.find((m) => m.role === "tool")!) as {
+      output?: { type: string; value: unknown };
+    };
+    expect(part.output).toEqual({ type: "json", value: "hello" });
+  });
+});

--- a/src/lib/ai/message-sanitizer.ts
+++ b/src/lib/ai/message-sanitizer.ts
@@ -242,7 +242,28 @@ export async function sanitizeAndCompleteToolCalls(
       if (Array.isArray(msg.content)) {
         const normalizedContent = msg.content.map((item) => {
           const toolResult = item as any;
-          if (toolResult.type === "tool-result" && toolResult.output !== undefined) {
+          if (toolResult.type === "tool-result") {
+            // Missing/nullish output — a malformed tool-result. This happens
+            // when a tool-call's args fail to parse (e.g. invalid JSON), so the
+            // call errors before any result is recorded, yet a tool-result
+            // placeholder still gets persisted with no `output`. The AI SDK's
+            // ModelMessage schema REQUIRES `output` to be a structured object,
+            // so a single such message poisons the ENTIRE conversation: every
+            // subsequent turn throws AI_InvalidPromptError ("messages do not
+            // match the ModelMessage[] schema"). Coerce it to a valid error
+            // result so already-corrupted histories self-heal.
+            if (toolResult.output === undefined || toolResult.output === null) {
+              console.log(
+                `🔧 [message-sanitizer] Backfilling missing output for tool: ${toolResult.toolName}`,
+              );
+              return {
+                ...toolResult,
+                output: {
+                  type: "json",
+                  value: { error: "Tool result was not recorded." },
+                },
+              };
+            }
             // Check if output is a raw string or primitive instead of object format
             if (
               typeof toolResult.output === "string" ||


### PR DESCRIPTION
## Problem

Jamie (the canvas agent) could get **permanently stuck** on a conversation: every turn failed with

```
AI_InvalidPromptError: Invalid prompt: The messages do not match the ModelMessage[] schema.
```

The schema validation pointed at a `tool`-role message whose `tool-result` part had **no `output` field** (`expected object … received undefined` at `path: ["output"]`).

### Root cause

When a tool-call is emitted with malformed JSON args (e.g. an unquoted value), the args never parse to an object, the call errors, and a tool-result placeholder gets persisted with no `output`:

```json
{"role":"tool","content":[{"type":"tool-result","toolCallId":"...","toolName":"propose_feature"}]}
```

Once that lands in stored history, it's re-sent on every subsequent turn — and the AI SDK's `ModelMessage` schema requires `output` to be a structured object, so **every future turn dies**.

`sanitizeAndCompleteToolCalls` normalizes wrongly-shaped outputs, but its guard was `toolResult.output !== undefined`, so a *missing* output was skipped and passed straight through.

## Fix

In `message-sanitizer.ts`, a `tool-result` with `output === undefined || null` is now coerced into a valid `{ type: "json", value: { error: "Tool result was not recorded." } }`. Corrupted histories **self-heal** at the single chokepoint before the LLM call, and this guards against any future source producing such a message.

## Tests

Adds `message-sanitizer.test.ts` (4 tests, passing): missing output, null output, well-formed output left untouched, raw-string output wrapped.

## Follow-up (not in this PR)

This is defense-in-depth at read time. The upstream bug — persisting a tool-result with no `output` when tool-call args fail to parse — still exists at the write/persistence layer and is worth tracking down separately.