### PR TITLE
fix(ai): coerce tool-call input to an object in message sanitizer

### DIFF
--- a/src/__tests__/unit/lib/ai/message-sanitizer.test.ts
+++ b/src/__tests__/unit/lib/ai/message-sanitizer.test.ts
@@ -128,3 +128,126 @@ describe("sanitizeAndCompleteToolCalls — missing output repair", () => {
     expect(part.output).toEqual({ type: "json", value: "hello" });
   });
 });
+
+function assistantToolCallPart(msg: ModelMessage) {
+  const content = msg.content as Array<Record<string, unknown>>;
+  return content.find((c) => c.type === "tool-call") as { input?: unknown; toolCallId?: string };
+}
+
+describe("sanitizeAndCompleteToolCalls — tool-call input normalization", () => {
+  test("parses a valid JSON-string input into an object", async () => {
+    const messages: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "c1",
+            toolName: "propose_feature",
+            input: '{"proposalId":"p1","title":"X"}',
+          } as never,
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "c1",
+            toolName: "propose_feature",
+            output: { type: "json", value: { ok: true } },
+          } as never,
+        ],
+      },
+    ];
+
+    const out = await sanitizeAndCompleteToolCalls(messages, "http://swarm", "key");
+    const part = assistantToolCallPart(out.find((m) => m.role === "assistant")!);
+    expect(part.input).toEqual({ proposalId: "p1", title: "X" });
+  });
+
+  test("coerces an unparseable string input to an empty object", async () => {
+    const messages: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "c2",
+            toolName: "propose_feature",
+            input: '{ "dependsOnFeatureIds": cmr2i71ez, }', // invalid JSON (unquoted value)
+          } as never,
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "c2",
+            toolName: "propose_feature",
+            output: { type: "json", value: { error: "x" } },
+          } as never,
+        ],
+      },
+    ];
+
+    const out = await sanitizeAndCompleteToolCalls(messages, "http://swarm", "key");
+    const part = assistantToolCallPart(out.find((m) => m.role === "assistant")!);
+    expect(part.input).toEqual({});
+  });
+
+  test("normalizes the input even when the result was a backfilled placeholder", async () => {
+    // Mirrors the real corruption: a tool-call with an unparseable string
+    // input AND a missing result. The orphan-repair path creates a placeholder
+    // result (keeping the call), so its string input must still be normalized
+    // to an object or Anthropic 400s.
+    const messages: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "orphan-1",
+            toolName: "propose_feature",
+            input: "{ malformed",
+          } as never,
+        ],
+      },
+    ];
+
+    const out = await sanitizeAndCompleteToolCalls(messages, "http://swarm", "key");
+    const assistant = out.find((m) => m.role === "assistant")!;
+    const part = assistantToolCallPart(assistant);
+    expect(part.input).toEqual({});
+    // and the orphan got a result so the pair is complete
+    expect(out.some((m) => m.role === "tool")).toBe(true);
+  });
+
+  test("leaves a well-formed object input untouched (same reference)", async () => {
+    const input = { a: 1, b: { c: 2 } };
+    const messages: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "tool-call", toolCallId: "c3", toolName: "read_canvas", input } as never,
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "c3",
+            toolName: "read_canvas",
+            output: { type: "json", value: {} },
+          } as never,
+        ],
+      },
+    ];
+
+    const out = await sanitizeAndCompleteToolCalls(messages, "http://swarm", "key");
+    const part = assistantToolCallPart(out.find((m) => m.role === "assistant")!);
+    expect(part.input).toEqual(input);
+  });
+});

--- a/src/lib/ai/message-sanitizer.ts
+++ b/src/lib/ai/message-sanitizer.ts
@@ -2,6 +2,38 @@ import { ModelMessage } from "ai";
 import { swarmFetch } from "./concepts";
 
 /**
+ * Coerce a tool-call `input` into a plain object.
+ *
+ * When a tool-call is streamed with malformed args, its `input` can end up a
+ * raw string (unparsed JSON) rather than an object. The AI SDK's ModelMessage
+ * Zod schema tolerates this, so `streamText` proceeds — but the Anthropic API
+ * rejects it with `tool_use.input: Input should be an object` (HTTP 400),
+ * killing the whole turn. We normalize every persisted tool-call's input to a
+ * guaranteed object: parse a JSON string when possible, otherwise fall back to
+ * `{}` (these calls are typically already paired with an error result, so the
+ * exact args no longer matter — what matters is the request being well-formed).
+ */
+function normalizeToolInput(input: unknown): Record<string, unknown> {
+  if (input !== null && typeof input === "object" && !Array.isArray(input)) {
+    return input as Record<string, unknown>;
+  }
+  if (typeof input === "string") {
+    const trimmed = input.trim();
+    if (trimmed !== "") {
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+          return parsed as Record<string, unknown>;
+        }
+      } catch {
+        // not valid JSON — fall through to empty object
+      }
+    }
+  }
+  return {};
+}
+
+/**
  * Intelligently sanitize messages to ensure every tool-call has a corresponding tool-result.
  * For incomplete tool-calls (like learn_concept), this function will execute them to get results.
  * This prevents API errors when tool calls fail or don't complete properly during streaming.
@@ -188,14 +220,32 @@ export async function sanitizeAndCompleteToolCalls(
       const hasToolCalls = msg.content.some((item: any) => item.type === "tool-call");
 
       if (hasToolCalls) {
-        // Filter out tool-calls without results (that we couldn't execute)
-        const filteredContent = msg.content.filter((item) => {
-          const toolCall = item as any;
-          if (toolCall.type === "tool-call") {
-            return toolCallIdsWithResults.has(toolCall.toolCallId);
-          }
-          return true; // Keep non-tool-call content
-        });
+        // Filter out tool-calls without results (that we couldn't execute),
+        // then normalize the input of every surviving tool-call to a plain
+        // object. A tool-call with a string/null input passes the AI SDK's
+        // schema but is rejected by the Anthropic API
+        // (`tool_use.input: Input should be an object`, HTTP 400).
+        const filteredContent = msg.content
+          .filter((item) => {
+            const toolCall = item as any;
+            if (toolCall.type === "tool-call") {
+              return toolCallIdsWithResults.has(toolCall.toolCallId);
+            }
+            return true; // Keep non-tool-call content
+          })
+          .map((item) => {
+            const toolCall = item as any;
+            if (toolCall.type === "tool-call") {
+              const normalizedInput = normalizeToolInput(toolCall.input);
+              if (normalizedInput !== toolCall.input) {
+                console.log(
+                  `🔧 [message-sanitizer] Normalizing non-object input for tool: ${toolCall.toolName}`,
+                );
+                return { ...toolCall, input: normalizedInput };
+              }
+            }
+            return item;
+          });
 
         // Only include this message if it has content after filtering
         if (filteredContent.length > 0) {


### PR DESCRIPTION
Follow-up to #4626.

## Problem

After the missing-output tool-result is repaired, the **assistant** side of the same corruption still kills the turn:

```
messages.59.content.1.tool_use.input: Input should be an object   (HTTP 400)
→ AI_NoOutputGeneratedError
```

A `propose_feature` call was emitted with malformed JSON args (unquoted value), so its `input` stayed a **raw string** instead of an object. The AI SDK's `ModelMessage` Zod schema tolerates a string input, so `streamText` proceeds — but the Anthropic API requires `tool_use.input` to be an object and 400s.

The orphan-repair path makes it worse: it pairs the bad call with a placeholder result, so the call is now **kept** (not filtered) and reaches the API with its string input intact.

## Fix

`sanitizeAndCompleteToolCalls` now normalizes every surviving tool-call's `input` to a plain object:
- already an object → left as-is (same reference)
- JSON string → parsed into an object when valid
- unparseable / empty / null / array → `{}`

These calls are typically already paired with an error result, so the exact args no longer matter — only that the request is well-formed.

## Tests

Extends `message-sanitizer.test.ts` (now 8 tests total): valid JSON-string parse, unparseable-string fallback to `{}`, the orphan + placeholder-result path, and well-formed object input left untouched.

## Related

- #4626 handled the missing `output` on the tool-**result** side.
- This handles the string `input` on the tool-**call** side. Together they fully un-stick a conversation corrupted by a malformed tool-call.
- Upstream follow-up still stands: prevent persisting a tool-call with unparseable args in the first place.