### PR TITLE
fix(jarvis-mirror): use PascalCase Hive* Neo4j labels

### DIFF
--- a/src/__tests__/unit/services/jarvis-pr-link-cron.test.ts
+++ b/src/__tests__/unit/services/jarvis-pr-link-cron.test.ts
@@ -35,12 +35,12 @@ function prNode(repo: string, number: number, ref_id: string, dateSec: number) {
 }
 
 function taskNode(taskId: string, ref_id: string) {
-  return { ref_id, node_type: "Hivetask", date_added_to_graph: 0, properties: { task_id: taskId } };
+  return { ref_id, node_type: "HiveTask", date_added_to_graph: 0, properties: { task_id: taskId } };
 }
 
 /**
  * The cron now calls searchLatestByTypes twice per workspace: once for
- * `PullRequest` nodes and once for `Hivetask` nodes (to resolve task ref_ids).
+ * `PullRequest` nodes and once for `HiveTask` nodes (to resolve task ref_ids).
  * Dispatch on the requested node type so each call gets the right payload.
  */
 function mockSearch(
@@ -49,7 +49,7 @@ function mockSearch(
 ) {
   mockedSearch.mockImplementation(async (_cfg: any, nodeTypes: any) => {
     if ("PullRequest" in nodeTypes) return prResult as any;
-    if ("Hivetask" in nodeTypes) return { ok: true, nodes: taskNodes } as any;
+    if ("HiveTask" in nodeTypes) return { ok: true, nodes: taskNodes } as any;
     return { ok: true, nodes: [] } as any;
   });
 }
@@ -117,7 +117,7 @@ describe("runJarvisPrLink", () => {
       timeoutMs: expect.any(Number),
     });
     // task ref_ids are resolved via a full HiveTask pull
-    expect(mockedSearch).toHaveBeenCalledWith(CFG, { Hivetask: 100_000 }, {
+    expect(mockedSearch).toHaveBeenCalledWith(CFG, { HiveTask: 100_000 }, {
       withProperties: true,
       timeoutMs: expect.any(Number),
     });

--- a/src/lib/ai/capabilities.ts
+++ b/src/lib/ai/capabilities.ts
@@ -287,8 +287,8 @@ export const CAPABILITY_REGISTRY: Record<OrgCapability, CapabilityDefinition> =
         "**graph_walker** — fetch KG node-type ontology (`graph_ontology`), " +
         "dereference any URN (`graph_get`), expand 1-hop neighbors (`graph_neighbors`), " +
         "search the swarm knowledge graph (`graph_search`, realm `kg`) — Hive " +
-        "Features/Tasks/ChatMessages now live there as Hivefeature/Hivetask/" +
-        "Hivechatmessage, alongside the code graph. Load when you need to walk the " +
+        "Features/Tasks/ChatMessages now live there as HiveFeature/HiveTask/" +
+        "HiveChatMessage, alongside the code graph. Load when you need to walk the " +
         "knowledge graph or dereference a URN from another tool. (The `pg` realm is disabled.)",
       writeToolNames: [], // read-only
     },

--- a/src/lib/ai/graphWalkerTools.ts
+++ b/src/lib/ai/graphWalkerTools.ts
@@ -77,7 +77,7 @@ const PG_REALM_ENABLED = false;
 /** Shared message returned when a pg-realm operation is attempted while disabled. */
 const PG_DISABLED_MESSAGE =
   "pg realm is disabled — Hive features, tasks, and chat messages now live in " +
-  "the kg realm as Hivefeature / Hivetask / Hivechatmessage nodes. Use " +
+  "the kg realm as HiveFeature / HiveTask / HiveChatMessage nodes. Use " +
   'graph_search with realm: "kg" (and graph_ontology to discover node types).';
 
 // ---------------------------------------------------------------------------
@@ -1013,7 +1013,7 @@ export function buildGraphWalkerTools(
         "returning ranked results with URN, type, title, and realm. " +
         "The kg realm searches Jarvis knowledge-graph nodes — including Hive " +
         "Features, Tasks, and ChatMessages, which are mirrored into the kg as " +
-        "Hivefeature / Hivetask / Hivechatmessage nodes; the canvas realm covers " +
+        "HiveFeature / HiveTask / HiveChatMessage nodes; the canvas realm covers " +
         "canvas nodes. " +
         "The `pg` realm is DISABLED (roadmap/chat data now lives in the kg). " +
         "Scope with `realm`, `type`, or `workspace` to narrow results. " +

--- a/src/lib/constants/prompt.ts
+++ b/src/lib/constants/prompt.ts
@@ -718,7 +718,7 @@ You have four **read-only** tools for graph traversal, focused on the swarm know
 
 ### Where the data lives now
 
-Hive **Features, Tasks, and ChatMessages are mirrored directly into each workspace's knowledge graph (kg realm)** as \`Hivefeature\` / \`Hivetask\` / \`Hivechatmessage\` nodes — alongside the ingested code graph (files, functions, data models, concepts). Search and traverse them there via the \`kg\` realm.
+Hive **Features, Tasks, and ChatMessages are mirrored directly into each workspace's knowledge graph (kg realm)** as \`HiveFeature\` / \`HiveTask\` / \`HiveChatMessage\` nodes — alongside the ingested code graph (files, functions, data models, concepts). Search and traverse them there via the \`kg\` realm.
 
 The \`pg\` realm is **DISABLED**: \`graph_search\` with \`realm: "pg"\` returns nothing, and \`graph_get\` / \`graph_neighbors\` refuse pg URNs. Do not try to reach roadmap/chat data through pg — use the kg realm.
 
@@ -731,18 +731,18 @@ canvas  →  urn:{org}:canvas:{type}:{id}
 kg      →  urn:{org}:kg:{workspace}:{type}:{id}
 \`\`\`
 
-Realms: \`kg\` (the swarm knowledge-graph — Hivefeature/Hivetask/Hivechatmessage plus code concepts, files, functions, data models) and \`canvas\` (canvas nodes). \`pg\` is disabled.
+Realms: \`kg\` (the swarm knowledge-graph — HiveFeature/HiveTask/HiveChatMessage plus code concepts, files, functions, data models) and \`canvas\` (canvas nodes). \`pg\` is disabled.
 
 ### Tools
 
-- **\`graph_ontology({ workspace })\`** — Fetch the list of valid KG node types (with descriptions) for a workspace's knowledge graph. **Call this first** before using \`graph_search\` with \`realm: "kg"\` — the returned \`type\` values are the exact strings to pass as the \`type\` filter in \`graph_search\`. This is how you discover the Hive node types (e.g. \`Hivefeature\`, \`Hivetask\`, \`Hivechatmessage\`) and the code node types. Returns \`{ node_types: [{ type, description }] }\`.
+- **\`graph_ontology({ workspace })\`** — Fetch the list of valid KG node types (with descriptions) for a workspace's knowledge graph. **Call this first** before using \`graph_search\` with \`realm: "kg"\` — the returned \`type\` values are the exact strings to pass as the \`type\` filter in \`graph_search\`. This is how you discover the Hive node types (e.g. \`HiveFeature\`, \`HiveTask\`, \`HiveChatMessage\`) and the code node types. Returns \`{ node_types: [{ type, description }] }\`.
 
 - **\`graph_get({ urn })\`** — Resolve a single URN to its full node content. Use this when you have a specific URN and need the entity's complete data.
 
 - **\`graph_neighbors({ urn, depth?, edge_type?, node_type? })\`** — Return all adjacent URNs reachable in one hop, each with \`edgeType\`, \`direction\`, and a best-effort \`title\` (a human-readable label — e.g. a feature's title, a file's name, a concept's name). Use the \`title\` to decide which neighbor to follow without having to \`graph_get\` every one. kg neighbors also carry \`node_type\` and \`ref_id\`; \`title\` may be absent for a node type that exposes no recognizable label. Filter kg edges/nodes with \`edge_type\` / \`node_type\`.
 
 - **\`graph_search({ query, realm?, type?, workspace?, limit? })\`** — Discover nodes by keyword. Returns \`{ urn, type, title, realm }[]\` ranked results. Scope with \`realm\` and/or \`type\` to narrow results:
-  - \`realm: "kg"\` — searches the swarm knowledge-graph: Hive Features/Tasks/ChatMessages (\`Hivefeature\` / \`Hivetask\` / \`Hivechatmessage\`) plus code nodes (concepts, files, functions, …). **First call \`graph_ontology({ workspace })\` to get valid \`type\` values**, then pass the desired type as the \`type\` filter. Provide \`workspace\` to search one workspace's swarm, or omit it to fan out across all your member workspaces.
+  - \`realm: "kg"\` — searches the swarm knowledge-graph: Hive Features/Tasks/ChatMessages (\`HiveFeature\` / \`HiveTask\` / \`HiveChatMessage\`) plus code nodes (concepts, files, functions, …). **First call \`graph_ontology({ workspace })\` to get valid \`type\` values**, then pass the desired type as the \`type\` filter. Provide \`workspace\` to search one workspace's swarm, or omit it to fan out across all your member workspaces.
   - \`realm: "canvas"\` — searches **authored** canvas nodes by text/label only.
   - Omit \`realm\` to search canvas + kg simultaneously (kg fans out across all your member workspaces).
   - \`realm: "pg"\` is disabled and returns nothing.
@@ -750,12 +750,12 @@ Realms: \`kg\` (the swarm knowledge-graph — Hivefeature/Hivetask/Hivechatmessa
 ### kg realm workflow
 
 1. Call \`graph_ontology({ workspace })\` → get the list of valid node types for the workspace's KG.
-2. Pick the relevant \`type\` values from the returned list (e.g. \`Hivefeature\`, \`Hivetask\`, \`Hivechatmessage\`, \`File\`, \`Function\`).
+2. Pick the relevant \`type\` values from the returned list (e.g. \`HiveFeature\`, \`HiveTask\`, \`HiveChatMessage\`, \`File\`, \`Function\`).
 3. Call \`graph_search({ query, realm: "kg", workspace, type: "<chosen type>" })\` with the exact type string from step 2.
 
 ### Scope reminder
 
-The chain that connects roadmap to code lives entirely in the kg now: a \`Hivefeature\` \`HAS_TASK\` \`Hivetask\`, which \`HAS_MESSAGE\` \`Hivechatmessage\`, and links out to the files/functions that implement it. Walk these with \`graph_neighbors\` (filter with \`node_type\`, e.g. \`["File"]\`). kg traversal talks to the live swarm, so it can fail if the swarm is unconfigured/unreachable — those calls return an \`{ error }\` you should treat as "unavailable", not "empty".
+The chain that connects roadmap to code lives entirely in the kg now: a \`HiveFeature\` \`HAS_TASK\` \`HiveTask\`, which \`HAS_MESSAGE\` \`HiveChatMessage\`, and links out to the files/functions that implement it. Walk these with \`graph_neighbors\` (filter with \`node_type\`, e.g. \`["File"]\`). kg traversal talks to the live swarm, so it can fail if the swarm is unconfigured/unreachable — those calls return an \`{ error }\` you should treat as "unavailable", not "empty".
 
 ### Read-only
 

--- a/src/services/jarvis-mirror/mappers.ts
+++ b/src/services/jarvis-mirror/mappers.ts
@@ -12,9 +12,9 @@
  *
  * NOTE on Neo4j label casing: Jarvis runs `.capitalize()` on every node type
  * (on both schema registration and writes), so the type names below are stored
- * as `Hivefeature` / `Hivetask` / `Hivechatmessage` labels in Neo4j (Neo4j
+ * as `HiveFeature` / `HiveTask` / `HiveChatMessage` labels in Neo4j (Neo4j
  * labels are case-sensitive). Query the graph with the capitalized form, e.g.
- * `MATCH (f:Hivefeature) ...`. The strings here stay PascalCase only so they
+ * `MATCH (f:HiveFeature) ...`. The strings here stay PascalCase only so they
  * read naturally and match the schema-library source.
  */
 
@@ -23,9 +23,9 @@ export const HIVE_TASK = "HiveTask";
 export const HIVE_CHAT_MESSAGE = "HiveChatMessage";
 
 // Jarvis capitalizes node types on write, so a `HiveTask` node is stored (and
-// must be queried) under the Neo4j label `Hivetask` (see the casing note above).
+// must be queried) under the Neo4j label `HiveTask` (see the casing note above).
 // Used by the PR-link cron to read back HiveTask nodes' ref_ids.
-export const HIVE_TASK_LABEL = "Hivetask";
+export const HIVE_TASK_LABEL = "HiveTask";
 
 export const EDGE_HAS_TASK = "HAS_TASK";
 export const EDGE_HAS_MESSAGE = "HAS_MESSAGE";


### PR DESCRIPTION
## Summary
Neo4j labels are case-sensitive. Corrects the label casing assumption from `Hivetask`/`Hivefeature`/`Hivechatmessage` to `HiveTask`/`HiveFeature`/`HiveChatMessage`.

The key functional change is in `src/services/jarvis-mirror/mappers.ts`:
```
export const HIVE_TASK_LABEL = "HiveTask"; // was "Hivetask"
```
This label is used by the PR-link cron to read back `HiveTask` nodes' ref_ids. The remaining changes update prompt/capability documentation text and the cron test to match.

## Tests
- Updated `jarvis-pr-link-cron.test.ts` to assert the `HiveTask` node type / search payload.
- Ran affected unit tests: `jarvis-pr-link-cron`, `jarvis-mirror-mappers`, `lingo/collect`, `kg-adapter`, `graphWalkerTools` — 138 tests pass.

## Note
The prior comments claimed Jarvis runs `.capitalize()` (lowercasing the tail) on node types. This PR assumes Jarvis instead preserves PascalCase. Please confirm the actual Neo4j label casing behavior in Jarvis before merging, since the cron readback depends on it.