### PR TITLE
Fix mcpUpdatePrompt to return newly-saved draft value and description

### DIFF
--- a/src/__tests__/unit/lib/mcp/mcpUpdatePrompt.test.ts
+++ b/src/__tests__/unit/lib/mcp/mcpUpdatePrompt.test.ts
@@ -29,9 +29,9 @@ function makeResult(versionNumber: number) {
     prompt: {
       id: "prompt-1",
       name: "MY_PROMPT",
-      value: "Updated content",
-      description: "A description",
-      publishedVersionId: `version-${versionNumber}`,
+      value: "Old published content",
+      description: "Old published desc",
+      publishedVersionId: `version-${versionNumber - 1}`,
       stakworkId: null,
       syncStatus: "OK",
       createdAt: new Date(),
@@ -41,7 +41,8 @@ function makeResult(versionNumber: number) {
       id: `version-${versionNumber}`,
       versionNumber,
       value: "Updated content",
-      published: true,
+      description: "New desc",
+      published: false,
       createdAt: new Date(),
     },
   };
@@ -62,6 +63,19 @@ describe("mcpUpdatePrompt — happy path", () => {
     expect(data.name).toBe("MY_PROMPT");
     expect(data.versionId).toBe("version-2");
     expect(data.versionNumber).toBe(2);
+  });
+
+  it("returns the newly-saved draft value/description, not the stale published content", async () => {
+    const result = await mcpUpdatePrompt(STAKWORK_AUTH, "prompt-1", "Updated content", "New desc");
+
+    expect(result.isError).toBeFalsy();
+    const data = JSON.parse((result.content[0] as { text: string }).text);
+    // Must reflect the draft version, not the published prompt
+    expect(data.value).toBe("Updated content");
+    expect(data.description).toBe("New desc");
+    // Must NOT return stale published content
+    expect(data.value).not.toBe("Old published content");
+    expect(data.description).not.toBe("Old published desc");
   });
 
   it("forwards auth.userId as userId to writePromptThrough", async () => {

--- a/src/lib/mcp/mcpTools.ts
+++ b/src/lib/mcp/mcpTools.ts
@@ -1335,8 +1335,8 @@ export async function mcpUpdatePrompt(
     return mcpOk({
       id: prompt.id,
       name: prompt.name,
-      value: prompt.value,
-      description: prompt.description,
+      value: version.value,
+      description: version.description,
       versionId: version.id,
       versionNumber: version.versionNumber,
     });

--- a/src/services/prompts/prompt-sync.ts
+++ b/src/services/prompts/prompt-sync.ts
@@ -37,6 +37,7 @@ export interface WritePromptThroughResult {
     id: string;
     versionNumber: number;
     value: string;
+    description: string | null;
     published: boolean;
     createdAt: Date;
   };


### PR DESCRIPTION
Generated with Hive: Fix mcpUpdatePrompt to return newly-saved draft value and description