### PR TITLE
Persist graph-walk sub-agent traces and link them from agent-logs

### DIFF
--- a/src/__tests__/unit/components/agent-logs/MessageBubble.test.tsx
+++ b/src/__tests__/unit/components/agent-logs/MessageBubble.test.tsx
@@ -64,6 +64,8 @@ vi.mock("lucide-react", () => ({
   ChevronRight: () => React.createElement("span", { "data-testid": "chevron-right" }),
   Copy: () => React.createElement("span", { "data-testid": "icon-copy" }),
   Check: () => React.createElement("span", { "data-testid": "icon-check" }),
+  Flag: () => React.createElement("span", { "data-testid": "icon-flag" }),
+  Waypoints: () => React.createElement("span", { "data-testid": "icon-waypoints" }),
 }));
 
 describe("MessageBubble reasoning rendering", () => {
@@ -181,5 +183,42 @@ describe("MessageBubble timestamp rendering", () => {
     render(React.createElement(MessageBubble, { message }));
 
     expect(screen.queryByTestId("tooltip-content")).toBeNull();
+  });
+});
+
+describe("MessageBubble graph-walk trace link", () => {
+  const graphWalkMessage: ParsedMessage = {
+    role: "assistant",
+    content: "Found 3 File nodes.",
+    graphWalkTrace: { detailConversationId: "gw-conv-1", status: "ready" },
+  };
+
+  it("renders a 'View graph walk trace' link to the sub-conversation when slug is provided", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: graphWalkMessage,
+        workspaceSlug: "hive",
+      }),
+    );
+    const link = screen.getByText("View graph walk trace").closest("a");
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute("href")).toBe(
+      "/w/hive/agent-logs/chat/gw-conv-1?from=canvas",
+    );
+  });
+
+  it("does not render the link when workspaceSlug is absent", () => {
+    render(React.createElement(MessageBubble, { message: graphWalkMessage }));
+    expect(screen.queryByText("View graph walk trace")).toBeNull();
+  });
+
+  it("does not render the link for a normal assistant message", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: { role: "assistant", content: "just text" },
+        workspaceSlug: "hive",
+      }),
+    );
+    expect(screen.queryByText("View graph walk trace")).toBeNull();
   });
 });

--- a/src/__tests__/unit/lib/utils/chat-conversation-log.test.ts
+++ b/src/__tests__/unit/lib/utils/chat-conversation-log.test.ts
@@ -154,6 +154,53 @@ describe("chatMessagesToParsedMessages", () => {
     expect(out[1].timestamp).toBeUndefined();
   });
 
+  it("attaches graphWalkTrace from a graph_walk source row", () => {
+    const stored: StoredChatMessage[] = [
+      {
+        id: "graph-walk-w1",
+        role: "assistant",
+        content: "Found 3 File nodes linked to AuthFeature.",
+        source: {
+          kind: "graph_walk",
+          detailConversationId: "gw-conv-w1",
+          title: "Files linked to AuthFeature",
+          status: "ready",
+        },
+      },
+    ];
+    const out = chatMessagesToParsedMessages(stored);
+    expect(out).toHaveLength(1);
+    expect(out[0].graphWalkTrace).toEqual({
+      detailConversationId: "gw-conv-w1",
+      title: "Files linked to AuthFeature",
+      status: "ready",
+    });
+  });
+
+  it("does not attach graphWalkTrace when detailConversationId is absent", () => {
+    const stored: StoredChatMessage[] = [
+      {
+        role: "assistant",
+        content: "answer",
+        source: { kind: "graph_walk", status: "ready" },
+      },
+    ];
+    expect(chatMessagesToParsedMessages(stored)[0].graphWalkTrace).toBeUndefined();
+  });
+
+  it("graphWalkTrace survives the JSON.stringify → parseAgentLogStats round-trip", () => {
+    const stored: StoredChatMessage[] = [
+      {
+        role: "assistant",
+        content: "answer",
+        source: { kind: "graph_walk", detailConversationId: "gw-conv-x" },
+      },
+    ];
+    const parsed = chatMessagesToParsedMessages(stored);
+    const { conversation } = parseAgentLogStats(JSON.stringify(parsed));
+    expect(conversation[0].graphWalkTrace?.detailConversationId).toBe("gw-conv-x");
+  });
+
   it("produces output the agent-log parser + pairing helpers consume correctly", () => {
     const stored: StoredChatMessage[] = [
       { role: "user", content: "find auth" },

--- a/src/__tests__/unit/services/canvas-graph-walk-worker.test.ts
+++ b/src/__tests__/unit/services/canvas-graph-walk-worker.test.ts
@@ -22,6 +22,7 @@ vi.mock("@/lib/db", () => ({
   db: {
     sharedConversation: {
       findUnique: vi.fn(),
+      upsert: vi.fn(async () => ({})),
     },
     $queryRaw: vi.fn(),
   },
@@ -94,6 +95,8 @@ describe("runGraphWalkSubAgent", () => {
     (db.sharedConversation.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(
       VALID_CONVERSATION,
     );
+    // Default: trace-conversation upsert succeeds
+    (db.sharedConversation.upsert as ReturnType<typeof vi.fn>).mockResolvedValue({});
     // Default: agent writes an answer
     mockAgentWithAnswer("The answer is 42.");
   });
@@ -212,6 +215,48 @@ describe("runGraphWalkSubAgent", () => {
         status: "ready",
       }),
     );
+  });
+
+  // ─── Trace persistence ─────────────────────────────────────────────
+
+  test("persists the tool-call trace to a standalone graph-walk conversation", async () => {
+    await runGraphWalkSubAgent(BASE_ARGS);
+
+    expect(db.sharedConversation.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: `gw-conv-${BASE_ARGS.graphWalkId}` },
+        create: expect.objectContaining({
+          id: `gw-conv-${BASE_ARGS.graphWalkId}`,
+          source: "graph-walk",
+          sourceControlOrgId: BASE_ARGS.orgId,
+          userId: BASE_ARGS.userId,
+          title: BASE_ARGS.title,
+        }),
+      }),
+    );
+  });
+
+  test("passes detailConversationId backlink to fan-out on success", async () => {
+    await runGraphWalkSubAgent(BASE_ARGS);
+
+    expect(fanOutGraphWalkToCanvas).toHaveBeenCalledWith(
+      BASE_ARGS.conversationId,
+      expect.objectContaining({
+        detailConversationId: `gw-conv-${BASE_ARGS.graphWalkId}`,
+      }),
+    );
+  });
+
+  test("trace persist failure is non-fatal → still fans out without backlink", async () => {
+    (db.sharedConversation.upsert as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("db down"),
+    );
+    await runGraphWalkSubAgent(BASE_ARGS);
+
+    const payload = (fanOutGraphWalkToCanvas as ReturnType<typeof vi.fn>).mock
+      .calls[0][1];
+    expect(payload.status).toBe("ready");
+    expect(payload.detailConversationId).toBeUndefined();
   });
 
   // ─── Failure paths ─────────────────────────────────────────────────

--- a/src/app/api/workspaces/[slug]/chat/conversations/[conversationId]/route.ts
+++ b/src/app/api/workspaces/[slug]/chat/conversations/[conversationId]/route.ts
@@ -83,9 +83,12 @@ export async function GET(
       select: conversationSelect,
     });
 
-    // Fallback: an org-canvas conversation for this workspace's parent
-    // org. These are org-scoped (`workspaceId` null) so they miss the
-    // query above — but the Canvas tab links here, so resolve them too.
+    // Fallback: an org-scoped conversation for this workspace's parent
+    // org. These have `workspaceId` null so they miss the query above,
+    // but are still deep-linked from the Canvas tab and its detail view:
+    //   - "org-canvas" — the canvas chat sessions themselves.
+    //   - "graph-walk" — standalone sub-agent tool-call traces
+    //     (`gw-conv-*`), linked from a graph-walk result bubble.
     // Access is already gated by `validateWorkspaceAccess` above, so
     // any caller is an authenticated workspace member — IDOR safety is
     // preserved at that layer. No per-user filter here keeps this
@@ -95,7 +98,7 @@ export async function GET(
         where: {
           id: conversationId,
           sourceControlOrgId: workspace.sourceControlOrgId,
-          source: "org-canvas",
+          source: { in: ["org-canvas", "graph-walk"] },
         },
         select: conversationSelect,
       });

--- a/src/app/w/[slug]/agent-logs/chat/[conversationId]/page.tsx
+++ b/src/app/w/[slug]/agent-logs/chat/[conversationId]/page.tsx
@@ -184,6 +184,7 @@ export default async function ChatDetailPage({ params, searchParams }: ChatDetai
             loading={false}
             error={null}
             variant="page"
+            workspaceSlug={slug}
           />
         )}
       </div>

--- a/src/components/agent-logs/LogDetailContent.tsx
+++ b/src/components/agent-logs/LogDetailContent.tsx
@@ -7,7 +7,7 @@ import { estimateTokens } from "@/lib/utils/token-estimate";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Badge } from "@/components/ui/badge";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { Loader2, User, Bot, Wrench, Code2, ChevronDown, ChevronRight, Copy, Check, Flag } from "lucide-react";
+import { Loader2, User, Bot, Wrench, Code2, ChevronDown, ChevronRight, Copy, Check, Flag, Waypoints } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
 import { cn } from "@/lib/utils";
@@ -29,6 +29,12 @@ export interface LogDetailContentProps {
   error: string | null;
   variant?: "modal" | "page";
   onFlagTurn?: (turnIndex: number) => void;
+  /**
+   * Workspace slug used to build in-app deep links from a message
+   * (e.g. a graph-walk result's "view trace" link into its sub-agent
+   * conversation). Omit to suppress such links.
+   */
+  workspaceSlug?: string;
 }
 
 /** Characters before assistant text is truncated with a "Show more" button */
@@ -303,11 +309,13 @@ export function MessageBubble({
   toolCallIndex,
   consumedResultIds,
   onFlag,
+  workspaceSlug,
 }: {
   message: ParsedMessage;
   toolCallIndex?: Map<string, ToolResultContent>;
   consumedResultIds?: Set<string>;
   onFlag?: () => void;
+  workspaceSlug?: string;
 }) {
   const { timezone } = useUserTimezone();
   const [showToolDetails, setShowToolDetails] = useState(false);
@@ -327,6 +335,19 @@ export function MessageBubble({
   const isUser = role === "user";
   const isTool = role === "tool";
   const isAssistant = role === "assistant";
+
+  // Graph-walk result rows link into their standalone sub-agent trace.
+  const graphWalkTrace = message.graphWalkTrace;
+  const graphWalkTraceLink =
+    graphWalkTrace?.detailConversationId && workspaceSlug ? (
+      <a
+        href={`/w/${workspaceSlug}/agent-logs/chat/${graphWalkTrace.detailConversationId}?from=canvas`}
+        className="mt-2 inline-flex items-center gap-1 text-xs text-primary hover:underline"
+      >
+        <Waypoints className="h-3 w-3" />
+        View graph walk trace
+      </a>
+    ) : null;
 
   // --- System message ---
   if (role === "system") {
@@ -525,6 +546,7 @@ export function MessageBubble({
                   ))}
                 </div>
               )}
+              {graphWalkTraceLink}
             </div>
           </TooltipTrigger>
           <TooltipContent>{new Date(message.timestamp).toLocaleString()}</TooltipContent>
@@ -582,6 +604,7 @@ export function MessageBubble({
               ))}
             </div>
           )}
+          {graphWalkTraceLink}
         </div>
       )}
       {onFlag && isAssistant && (
@@ -766,6 +789,7 @@ export function LogDetailContent({
   error,
   variant = "modal",
   onFlagTurn,
+  workspaceSlug,
 }: LogDetailContentProps) {
   const scrollHeight = variant === "page" ? "h-[calc(100vh-12rem)]" : "h-[400px]";
   const hasContent = conversation !== null || rawContent !== "";
@@ -806,6 +830,7 @@ export function LogDetailContent({
                     toolCallIndex={toolCallIndex}
                     consumedResultIds={consumedResultIds}
                     onFlag={onFlagTurn && msg.role === "assistant" ? () => onFlagTurn(i - 1) : undefined}
+                    workspaceSlug={workspaceSlug}
                   />
                 ))}
               </div>

--- a/src/lib/utils/agent-log-stats.ts
+++ b/src/lib/utils/agent-log-stats.ts
@@ -25,6 +25,18 @@ export interface ParsedMessage {
   tool_calls?: OpenAIToolCall[];
   tool_call_id?: string;
   timestamp?: string | null;
+  /**
+   * Set on a graph-walk result message (fanned out with
+   * `source.kind === "graph_walk"`). Points at the standalone
+   * `SharedConversation` row holding the sub-agent's full tool-call
+   * trace, so the detail view can render a "view trace" drill-in.
+   * Survives the `JSON.stringify` → `parseAgentLogStats` round-trip.
+   */
+  graphWalkTrace?: {
+    detailConversationId: string;
+    title?: string;
+    status?: string;
+  };
 }
 
 export interface AgentLogStats {

--- a/src/lib/utils/chat-conversation-log.ts
+++ b/src/lib/utils/chat-conversation-log.ts
@@ -22,6 +22,18 @@ export interface StoredChatMessage {
   imageData?: string;
   toolCalls?: StoredChatToolCall[];
   timestamp?: string | null;
+  /**
+   * Provenance tag for fanned-out sub-agent rows. For graph-walk
+   * results (`kind === "graph_walk"`) `detailConversationId` points at
+   * the standalone trace conversation so the detail view can link into
+   * it.
+   */
+  source?: {
+    kind?: string;
+    detailConversationId?: string;
+    title?: string;
+    status?: string;
+  };
 }
 
 /**
@@ -95,7 +107,18 @@ export function chatMessagesToParsedMessages(
     if (m.imageData) {
       content = content ? `[image attached]\n${content}` : "[image attached]";
     }
-    out.push({ role: m.role, content, timestamp: m.timestamp ?? null });
+    const parsed: ParsedMessage = { role: m.role, content, timestamp: m.timestamp ?? null };
+    // Graph-walk result rows carry a link down into their standalone
+    // tool-call trace conversation — surface it so the detail view can
+    // render a "view trace" drill-in.
+    if (m.source?.kind === "graph_walk" && m.source.detailConversationId) {
+      parsed.graphWalkTrace = {
+        detailConversationId: m.source.detailConversationId,
+        title: m.source.title,
+        status: m.source.status,
+      };
+    }
+    out.push(parsed);
   }
 
   return out;

--- a/src/services/canvas-graph-walk-fanout.ts
+++ b/src/services/canvas-graph-walk-fanout.ts
@@ -23,7 +23,15 @@ export interface GraphWalkFanOutPayload {
   answer: string;
   /** "ready" when the sub-agent produced an answer; "failed" otherwise. */
   status: "ready" | "failed";
-}
+  /**
+   * Id of the standalone (history-hidden, `source: "graph-walk"`)
+   * SharedConversation row that holds the sub-agent's full tool-call
+   * trace. Stashed on the result bubble's `source` so the UI can
+   * deep-link to "view graph walk trace". Absent when the trace write
+   * failed (non-fatal — the answer bubble still lands).
+   */
+  detailConversationId?: string;
+};
 
 /** Row shape written into SharedConversation.messages. */
 type GraphWalkMessageRow = {
@@ -36,6 +44,7 @@ type GraphWalkMessageRow = {
     graphWalkId: string;
     title: string;
     status: string;
+    detailConversationId?: string;
   };
 };
 
@@ -49,7 +58,7 @@ export async function fanOutGraphWalkToCanvas(
   conversationId: string,
   payload: GraphWalkFanOutPayload,
 ): Promise<void> {
-  const { graphWalkId, title, answer, status } = payload;
+  const { graphWalkId, title, answer, status, detailConversationId } = payload;
 
   try {
     let didAppend = false;
@@ -93,6 +102,7 @@ export async function fanOutGraphWalkToCanvas(
           graphWalkId,
           title,
           status,
+          ...(detailConversationId ? { detailConversationId } : {}),
         },
       };
 

--- a/src/services/canvas-graph-walk-worker.ts
+++ b/src/services/canvas-graph-walk-worker.ts
@@ -8,8 +8,15 @@
  *   - NOT call `dispatch_graph_walk` (stripped — prevents self-redispatch).
  *   - NOT call any other write tools (canvas mutations, proposals, etc.).
  *
- * After the loop completes, fans the answer back into the owning canvas
- * conversation via `fanOutGraphWalkToCanvas`.
+ * After the loop completes, it:
+ *   - Persists the sub-agent's full tool-call trace to a standalone
+ *     `SharedConversation` row (`source: "graph-walk"`, id
+ *     `gw-conv-${graphWalkId}`) via `messagesFromSteps`. That `source`
+ *     keeps the row out of every history list; it exists so the trace
+ *     is reviewable and deep-linkable.
+ *   - Fans the answer back into the owning canvas conversation via
+ *     `fanOutGraphWalkToCanvas`, stashing the trace row's id on the
+ *     result bubble's `source.detailConversationId` as a backlink.
  *
  * Mirrors `canvas-research-worker.ts`:
  *   - Best-effort advisory lock prevents duplicate concurrent runs.
@@ -32,6 +39,7 @@ import {
 import { db } from "@/lib/db";
 import { runCanvasAgent } from "@/lib/ai/runCanvasAgent";
 import { fanOutGraphWalkToCanvas } from "@/services/canvas-graph-walk-fanout";
+import { messagesFromSteps } from "@/services/canvas-turn-persistence";
 import type { DispatchedGraphWalkIntent } from "@/lib/ai/graphWalkDispatchTools";
 
 /**
@@ -50,6 +58,66 @@ const SOFT_BUDGET_MS = 300_000; // 5 min — communicated to the agent
 const HARD_BUDGET_MS = 240_000; // 4 min — forced finalize cutover
 
 const FINALIZE_TOOL = "finalize_graph_walk";
+
+/**
+ * Tool names stripped from the persisted trace. `finalize_graph_walk`
+ * carries the synthesized answer as its input — that text is already the
+ * fan-out bubble's content, so showing it again as a tool row is noise.
+ * The trace we keep is the graph traversal itself (graph_search, etc.).
+ */
+const TRACE_STRIP_TOOLS: ReadonlySet<string> = new Set([FINALIZE_TOOL]);
+
+/**
+ * Persist the sub-agent's full tool-call trace to a standalone
+ * `SharedConversation` row. The row uses `source: "graph-walk"` so it is
+ * invisible to every history-list query (they allow-list `"org-canvas"`
+ * / `"dashboard"` / `"logs-agent"`); it exists purely so the trace is
+ * reviewable and deep-linkable from the parent's result bubble.
+ *
+ * The row id is deterministic (`gw-conv-${graphWalkId}`) and the write is
+ * an upsert, so a worker retry overwrites rather than duplicates.
+ *
+ * Non-fatal: on any failure we log and return `undefined`; the caller
+ * still fans the answer bubble out, just without a backlink.
+ */
+async function persistGraphWalkTrace(args: {
+  graphWalkId: string;
+  title: string;
+  orgId: string;
+  userId: string;
+  steps: Parameters<typeof messagesFromSteps>[0];
+}): Promise<string | undefined> {
+  const { graphWalkId, title, orgId, userId, steps } = args;
+  const id = `gw-conv-${graphWalkId}`;
+  try {
+    const rows = messagesFromSteps(steps, "gw-", TRACE_STRIP_TOOLS);
+    await db.sharedConversation.upsert({
+      where: { id },
+      create: {
+        id,
+        sourceControlOrgId: orgId,
+        userId,
+        source: "graph-walk",
+        title,
+        messages: rows as unknown as never,
+        followUpQuestions: [] as unknown as never,
+        lastMessageAt: new Date(),
+      },
+      update: {
+        messages: rows as unknown as never,
+        lastMessageAt: new Date(),
+      },
+    });
+    return id;
+  } catch (e) {
+    console.error("[canvas-graph-walk] persist trace failed (non-fatal)", {
+      graphWalkId,
+      title,
+      error: e instanceof Error ? e.message : String(e),
+    });
+    return undefined;
+  }
+}
 
 /**
  * Build the per-step budget hook for a single graph-walk run.
@@ -255,7 +323,7 @@ export async function runGraphWalkSubAgent(
 
     // Drive the stream to completion.
     await result.text;
-    await result.steps;
+    const steps = await result.steps;
 
     const answer = graphWalkAnswerSink.answer;
     const status: "ready" | "failed" =
@@ -268,11 +336,22 @@ export async function runGraphWalkSubAgent(
       status,
     });
 
+    // Persist the full tool-call trace to a hidden standalone
+    // conversation, then link it from the fan-out bubble.
+    const detailConversationId = await persistGraphWalkTrace({
+      graphWalkId,
+      title,
+      orgId,
+      userId,
+      steps: steps as Parameters<typeof messagesFromSteps>[0],
+    });
+
     await fanOutGraphWalkToCanvas(conversationId, {
       graphWalkId,
       title,
       answer: answer ?? "",
       status,
+      detailConversationId,
     });
   } catch (e) {
     console.error("[canvas-graph-walk] failed (non-fatal)", {


### PR DESCRIPTION
## Summary

The graph-walk sub-agent previously discarded its step trace — only the synthesized answer was fanned back into the parent canvas conversation, so there was **no way to review the tool calls (`graph_search`, `graph_get`, etc.) the sub-agent made**.

This persists the full tool-call trace to a standalone `SharedConversation` row and surfaces a **"View graph walk trace"** drill-in from the agent-logs canvas detail page.

## How it works

**Worker + fan-out**
- `runGraphWalkSubAgent` now runs the sub-agent's `result.steps` through the existing `messagesFromSteps` and **upserts** a `gw-conv-${graphWalkId}` row with `source: "graph-walk"`. That source keeps it out of every history-list query (they allow-list `org-canvas`/`dashboard`/`logs-agent`). Deterministic id + upsert makes worker retries overwrite rather than duplicate.
- `fanOutGraphWalkToCanvas` stashes `detailConversationId` on the result bubble's `source` as a backlink. Fully non-fatal — a trace-write failure still lands the answer bubble, just without the link.

**Agent-logs detail view** (`agent-logs/chat/<parentId>`)
- Widened the conversation detail API's org-scoped fallback from `source: "org-canvas"` to `source: { in: ["org-canvas", "graph-walk"] }`, so the trace rows resolve for **any workspace member** (access still gated by `validateWorkspaceAccess` + parent-org match).
- Carry `graphWalkTrace` through `StoredChatMessage` -> `ParsedMessage` (survives the `JSON.stringify` -> `parseAgentLogStats` round-trip) and render a "View graph walk trace" link in `LogDetailContent`/`MessageBubble` when a `workspaceSlug` is provided. The link deep-links to `agent-logs/chat/<detailConversationId>?from=canvas`, where the trace renders through the same viewer (expandable calls + args + results + stats bar).

No canvas chat UI changes.

## Tests
- Trace persistence + backlink wiring (`canvas-graph-walk-worker.test.ts`)
- `graphWalkTrace` attachment + parse round-trip (`chat-conversation-log.test.ts`)
- Link rendering / href / absence cases (`MessageBubble.test.tsx`)

## Note
Only turns processed after this ships will have graph-walk result rows carrying `detailConversationId`; older fan-out rows predate the backlink.