### PR TITLE
Document canonical Feature->Task->PR->File graph-walker flow

### DIFF
--- a/src/lib/constants/prompt.ts
+++ b/src/lib/constants/prompt.ts
@@ -719,7 +719,7 @@ export function getGraphWalkDispatchSnippet(): string {
 ### When to dispatch vs. use inline graph_walker tools
 
 - **Use \`dispatch_graph_walk\`** (background sub-agent) when the graph task is:
-  - Multi-hop traversals (e.g. "find all Files linked to this Feature through Tasks and Messages")
+  - Multi-hop traversals (e.g. "find all Files this Feature touched, via its Tasks and PullRequests")
   - Large ontology scans across many node types
   - Expected to take more than a few seconds
   - Something you want to happen off the critical path while you continue the current turn
@@ -775,9 +775,24 @@ Realms: \`kg\` (the swarm knowledge-graph — HiveFeature/HiveTask/HiveChatMessa
 2. Pick the relevant \`type\` values from the returned list (e.g. \`HiveFeature\`, \`HiveTask\`, \`HiveChatMessage\`, \`File\`, \`Function\`).
 3. Call \`graph_search({ query, realm: "kg", workspace, type: "<chosen type>" })\` with the exact type string from step 2.
 
-### Scope reminder
+### Canonical flow: roadmap → code (find where to focus)
 
-The chain that connects roadmap to code lives entirely in the kg now: a \`HiveFeature\` \`HAS_TASK\` \`HiveTask\`, which \`HAS_MESSAGE\` \`HiveChatMessage\`, and links out to the files/functions that implement it. Walk these with \`graph_neighbors\` (filter with \`node_type\`, e.g. \`["File"]\`). kg traversal talks to the live swarm, so it can fail if the swarm is unconfigured/unreachable — those calls return an \`{ error }\` you should treat as "unavailable", not "empty".
+The chain that connects roadmap to code lives entirely in the kg. The canonical walk — and the fastest way to learn **where in the codebase a feature is implemented** — is:
+
+\`\`\`
+HiveFeature  --HAS_TASK-->  HiveTask  --RESULTED_IN-->  PullRequest  -->  File
+\`\`\`
+
+**Use it when starting a NEW feature:** first \`graph_search\` (realm \`kg\`, type \`HiveFeature\`) for similar existing features, then walk this chain on them to see which Tasks were done, which PullRequests those Tasks produced, and which Files those PRs changed. Those Files are your worked examples — they tell you where to focus first.
+
+Walk it hop-by-hop with \`graph_neighbors\`, filtering by \`node_type\` at each step:
+1. From a \`HiveFeature\` → \`node_type: ["HiveTask"]\` (edge \`HAS_TASK\`) — the tasks.
+2. From a \`HiveTask\` → \`node_type: ["PullRequest"]\` (edge \`RESULTED_IN\`) — the PRs that implemented it.
+3. From a \`PullRequest\` → \`node_type: ["File"]\` — the files it changed. (A \`PullRequest\` node also carries a \`files\` property you can read via \`graph_get\`.)
+
+Also available: \`HiveFeature\` / \`HiveTask\` \`HAS_MESSAGE\` \`HiveChatMessage\` for the conversation history behind a task.
+
+kg traversal talks to the live swarm, so it can fail if the swarm is unconfigured/unreachable — those calls return an \`{ error }\` you should treat as "unavailable", not "empty".
 
 ### Read-only
 


### PR DESCRIPTION
## What

Updates the `graph_walker` capability prompt (`getGraphWalkerCapabilitySnippet` in `src/lib/constants/prompt.ts`) to explicitly teach the canonical roadmap-to-code traversal:

```
HiveFeature --HAS_TASK--> HiveTask --RESULTED_IN--> PullRequest --> File
```

## Why

The prompt previously only documented `HiveFeature -> HiveTask -> HiveChatMessage` and never mentioned `PullRequest` nodes, even though they exist in the KG and are the link between tasks and the files that implement them. Without this, the walker had no guidance to follow the Feature -> Task -> PR -> File path — the fastest way to find worked examples for where to focus when starting a new feature.

## Changes

- Replaced the vague "Scope reminder" with a "Canonical flow: roadmap -> code" section that:
  - Diagrams the full chain with the real edge type names (`HAS_TASK`, `RESULTED_IN`) verified from `src/services/jarvis-mirror/mappers.ts`.
  - States the purpose: when starting a new feature, search similar existing features and walk this chain to find the PRs and files they touched.
  - Gives hop-by-hop `graph_neighbors` filters (`node_type: ["HiveTask"]` -> `["PullRequest"]` -> `["File"]`), plus the `PullRequest.files` property as an alternative via `graph_get`.
- Fixed a stale `dispatch_graph_walk` example that routed Files "through Tasks and Messages" (Files come via PullRequests).

## Notes

The `PullRequest -> File` edge type is ingested by stakgraph, not defined in Hive; the prompt sidesteps this by filtering neighbors on `node_type: ["File"]` rather than an edge type.