### PR TITLE
Fix jarvis-mirror bulk writes (endpoint regression + timeout)

### DIFF
--- a/src/services/swarm/api/nodes.ts
+++ b/src/services/swarm/api/nodes.ts
@@ -17,9 +17,11 @@ interface JarvisApiResponse {
 // Cap each request so a single unreachable/hung swarm can't dominate the cron's
 // 300 s budget. undici's default *connect* timeout is 10 s and there's no
 // request timeout at all, so a swarm that accepts the connection then stalls
-// could block far longer — this bounds the whole round-trip. Writes are small
-// and should be fast; heavy reads (e.g. the PR backfill) override via `timeoutMs`.
-const REQUEST_TIMEOUT_MS = 7_000;
+// could block far longer — this bounds the whole round-trip. 7 s proved too
+// tight for bulk writes: a 100-node Neo4j upsert legitimately takes longer than
+// that, so healthy swarms were timing out mid-batch and the mirror cursor could
+// never advance. Heavy reads (e.g. the PR backfill) still override via `timeoutMs`.
+const REQUEST_TIMEOUT_MS = 30_000;
 
 async function jarvisRequest({
   config,


### PR DESCRIPTION
Fixes the `jarvis-mirror` cron, which was writing **nothing** to every workspace's knowledge graph (`feature=0 task=0 chat=0`). Two distinct bugs:

## 1. Bulk node writes hit the wrong gateway route (primary regression)

Commit #4636 ("Migrate node and edge write functions to v2") changed `addNodeBulk` from `POST /node/bulk` (body `{ node_list }`) to `POST /v2/nodes` (raw array).

But the swarm's **boltwall gateway** reserves the exact path `POST /v2/nodes` for its *single-node* handler `addNodeV2`, which destructures `{ node_type, node_data }` off the body and returns:

```
400 {"success":false,"message":"node_type and node_data are required"}
```

...when handed an array. So every bulk node write failed, the mirror cursor never advanced, and no features/tasks/chat reached the graph.

**Fix:** point `addNodeBulk` back at `/node/bulk` with `{ node_list }`. That path has no explicit boltwall route, so it falls through boltwall's catch-all proxy to jarvis-backend's `create_or_merge_node_bulk`. 

Not affected:
- **Bulk edges** — `/v2/edges/bulk` is a distinct path that already proxies through cleanly (confirmed `200 OK` in jarvis logs).
- **Single `addNode`** — `/v2/nodes` is correct there; `addNodeV2` is purpose-built for single nodes.

## 2. Bulk-write request timeout too short

`REQUEST_TIMEOUT_MS` was 7s. A 100-node Neo4j bulk upsert legitimately takes longer, so healthy swarms timed out mid-batch (`TimeoutError`). Since the cron only advances its keyset cursor on a fully successful push, a workspace would freeze after its first batch. Raised the default to 30s (heavy reads still override via `timeoutMs`).

## Tests
Updated `addNodeBulk` unit tests to assert `/node/bulk` + `node_list` body. Full suite for the touched files passes (69 tests).

## Known follow-ups (not in this PR)
- `413 Data is too large` on large workspaces (e.g. ganamos-6) — payload size; lower `BULK_CHUNK` from 100.
- `Not a valid node_data` on stakwork — HiveFeature nodes with oversized free-text titles rejected by schema validation.
- Per-workspace budget is only checked between entity types; with the 30s timeout a dead swarm can burn more of the shared budget. Consider a per-chunk `overBudget()` check.