### PR TITLE
Fix jarvis bulk node writes: /v2/nodes -> /node/bulk

### DIFF
--- a/src/__tests__/unit/services/swarm/api/nodes.test.ts
+++ b/src/__tests__/unit/services/swarm/api/nodes.test.ts
@@ -981,7 +981,7 @@ describe("addNodeBulk", () => {
     { node_type: "HiveTask", node_data: { task_id: "t2", name: "Task 2" } },
   ];
 
-  test("calls POST /v2/nodes with node array as body (not wrapped in node_list)", async () => {
+  test("calls POST /node/bulk with nodes wrapped in node_list", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       status: 200,
@@ -992,11 +992,11 @@ describe("addNodeBulk", () => {
 
     expect(result).toEqual({ success: true, errors: [] });
     expect(mockFetch).toHaveBeenCalledWith(
-      "https://test-swarm.sphinx.chat:8444/v2/nodes",
+      "https://test-swarm.sphinx.chat:8444/node/bulk",
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({ "x-api-token": "test-api-key" }),
-        body: JSON.stringify(nodes),
+        body: JSON.stringify({ node_list: nodes }),
       }),
     );
   });
@@ -1011,7 +1011,9 @@ describe("addNodeBulk", () => {
     await addNodeBulk(config, nodes, { reprocess: true });
 
     const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body as string);
-    expect(sentBody).toEqual(nodes.map((n) => ({ ...n, reprocess: true })));
+    expect(sentBody).toEqual({
+      node_list: nodes.map((n) => ({ ...n, reprocess: true })),
+    });
   });
 
   test("returns success:true even when status is Warning (some nodes already existed)", async () => {

--- a/src/services/swarm/api/nodes.ts
+++ b/src/services/swarm/api/nodes.ts
@@ -267,6 +267,14 @@ export async function addEdgeByRefBulk(
  * place. Jarvis processes the list sequentially in one Neo4j session, so this
  * collapses many round-trips into one HTTP call. Errors are returned, never
  * thrown. Callers should chunk large lists (see BULK_CHUNK in the mirror cron).
+ *
+ * NOTE: this must target `/node/bulk`, NOT `/v2/nodes`. The swarm's boltwall
+ * gateway reserves `POST /v2/nodes` for its *single-node* handler (`addNodeV2`),
+ * which destructures `{ node_type, node_data }` off the body and 400s on an
+ * array. `/node/bulk` has no explicit boltwall route, so it falls through the
+ * catch-all proxy to jarvis-backend's `create_or_merge_node_bulk` (which reads
+ * `node_list`). A prior "v2 migration" pointed this at `/v2/nodes` and silently
+ * broke every bulk write with `400 node_type and node_data are required`.
  */
 export async function addNodeBulk(
   config: JarvisConnectionConfig,
@@ -281,9 +289,9 @@ export async function addNodeBulk(
 
   const result = await jarvisRequest({
     config,
-    endpoint: "/v2/nodes",
+    endpoint: "/node/bulk",
     method: "POST",
-    data: nodeList,
+    data: { node_list: nodeList },
   });
 
   if (!result.ok) {


### PR DESCRIPTION
## Follow-up to #4650

#4650 was squash-merged with only the timeout commit; the actual bulk-node endpoint fix didn't make it into master. This PR carries just that fix.

## Problem

`addNodeBulk` writes **nothing** to any workspace's knowledge graph — every bulk node write fails with:

```
400 {"success":false,"message":"node_type and node_data are required"}
```

The v2 migration (#4636) changed `addNodeBulk` from `POST /node/bulk` (body `{ node_list }`) to `POST /v2/nodes` (raw array). But hive talks to jarvis through the **boltwall gateway**, and boltwall reserves the exact path `POST /v2/nodes` for its *single-node* handler `addNodeV2`, which destructures `{ node_type, node_data }` off the body and 400s on an array (`jarvis-boltwall/index.ts:299`).

This broke both callers of `addNodeBulk`:
- `jarvis-mirror-cron.ts` (mirrors Features/Tasks/ChatMessages)
- `app/api/lingo/extraction/upsert/route.ts` (lingo term upserts)

## Fix

Point `addNodeBulk` back at `/node/bulk` with `{ node_list }`. That path has no explicit boltwall route, so it falls through boltwall's catch-all proxy to jarvis-backend's `create_or_merge_node_bulk` (which reads `node_list`) — the same path that worked before the migration.

## Scope — surgical, node-bulk only

Only the bulk **node** path is reverted. The rest of #4636 is intentionally kept:

| Function | endpoint | status |
|---|---|---|
| `addNode` (single) | `/v2/nodes` | kept — boltwall `addNodeV2` is built for single nodes |
| `addNodeBulk` | **`/node/bulk`** | reverted — boltwall has no v2 bulk-node route |
| `addEdgeBulk` / `addEdgeByRefBulk` | `/v2/edges/bulk` | kept — proxies through cleanly (confirmed 200 OK) |
| `deleteEdge` / `deleteNode` / `updateNode` | `/v2/*` | kept |

## Tests
`addNodeBulk` unit tests updated to assert `/node/bulk` + `node_list` body. 80 tests pass across nodes / lingo-upsert / mirror-cron suites.

## Durable follow-up (separate repo)
Long-term, add a `POST /v2/nodes/bulk` route to boltwall so hive can stay fully on v2; then flip `addNodeBulk` back over. Bulk admin upserts should bypass `addNodeV2`'s per-node L402/payment/owner-ref logic regardless.