### PR TITLE
feat(jarvis-mirror): scope cron run to a single workspace via ?workspace=

### DIFF
--- a/src/__tests__/unit/services/jarvis-mirror-cron.test.ts
+++ b/src/__tests__/unit/services/jarvis-mirror-cron.test.ts
@@ -94,6 +94,21 @@ describe("runJarvisMirror", () => {
     expect((mockedDb.workspace as any).update).not.toHaveBeenCalled();
   });
 
+  it("scopes the workspace query when opts.workspace is provided", async () => {
+    setupDb({ workspaces: [{ id: "w1", slug: "hive", jarvisSyncState: null }] });
+    await runJarvisMirror({ workspace: "hive" });
+    const where = (mockedDb.workspace as any).findMany.mock.calls[0][0].where;
+    expect(where.OR).toEqual([{ slug: "hive" }, { id: "hive" }]);
+    expect(where.deleted).toBe(false);
+  });
+
+  it("does not add a workspace scope when opts.workspace is omitted", async () => {
+    setupDb({ workspaces: [] });
+    await runJarvisMirror();
+    const where = (mockedDb.workspace as any).findMany.mock.calls[0][0].where;
+    expect(where.OR).toBeUndefined();
+  });
+
   it("reports capped=true and anyCapped when a batch fills maxPerType", async () => {
     const features = Array.from({ length: 2 }, (_, i) => ({
       id: `f${i}`,

--- a/src/app/api/cron/jarvis-mirror/route.ts
+++ b/src/app/api/cron/jarvis-mirror/route.ts
@@ -21,9 +21,15 @@ export async function GET(request: NextRequest) {
 
   const depth = Number(request.nextUrl.searchParams.get("d") ?? "0") || 0;
 
-  logger.info(`[JARVIS MIRROR] cron invoked (depth=${depth})`, "JARVIS_MIRROR");
+  // Optional `?workspace=<slug|id>` scopes the run to one workspace (debugging).
+  const workspace = request.nextUrl.searchParams.get("workspace") ?? undefined;
 
-  const result = await runJarvisMirror();
+  logger.info(
+    `[JARVIS MIRROR] cron invoked (depth=${depth}${workspace ? `, workspace=${workspace}` : ""})`,
+    "JARVIS_MIRROR",
+  );
+
+  const result = await runJarvisMirror({ workspace });
 
   // Self-chain to drain a backlog quickly: if a batch was capped, immediately
   // trigger another run that resumes from the advanced cursors.

--- a/src/services/jarvis-mirror-cron.ts
+++ b/src/services/jarvis-mirror-cron.ts
@@ -257,7 +257,7 @@ async function mirrorWorkspace(
  * Returns `anyCapped` so the caller can self-chain to drain a backlog.
  */
 export async function runJarvisMirror(
-  opts: { maxPerType?: number } = {},
+  opts: { maxPerType?: number; workspace?: string } = {},
 ): Promise<MirrorRunResult> {
   const maxPerType = opts.maxPerType ?? DEFAULT_MAX_PER_TYPE;
 
@@ -266,8 +266,16 @@ export async function runJarvisMirror(
     return { processed: 0, anyCapped: false, results: [] };
   }
 
+  // Optional single-workspace scope (by slug or id) for targeted debugging.
+  // Keeps a slow/unreachable swarm's noise out of the run while iterating.
+  const scope = opts.workspace?.trim();
+
   const workspaces = await db.workspace.findMany({
-    where: { deleted: false, swarm: { isNot: null } },
+    where: {
+      deleted: false,
+      swarm: { isNot: null },
+      ...(scope ? { OR: [{ slug: scope }, { id: scope }] } : {}),
+    },
     select: { id: true, slug: true, jarvisSyncState: true },
   });
 


### PR DESCRIPTION
## Why

Debugging the jarvis-mirror requires triggering it for one swarm and tailing that swarm's jarvis logs. Today the cron always loops all workspaces, so a targeted run is impossible and other (slow/unreachable) swarms' 30s timeouts pollute the logs and eat the route budget.

## What

- `runJarvisMirror({ workspace })` accepts a slug **or** id; when set, the workspace query is filtered to that one (`OR: [{slug}, {id}]`).
- `GET /api/cron/jarvis-mirror?workspace=<slug|id>` threads it through, and logs `workspace=` in the `cron invoked` line.
- No behavior change when the param is absent (still runs all workspaces).
- The self-chain preserves the param automatically (it rebuilds the URL from `request.url`).

## Usage

```bash
curl -sS "https://<hive-host>/api/cron/jarvis-mirror?workspace=hive" \
  -H "Authorization: Bearer $CRON_SECRET" | jq
```

## Tests
Added two unit tests (scope applied when provided; absent otherwise). Full cron suite green (15 tests).

## Context
Being used to debug why `hive`'s `task`/`chat` cursors are stuck (features are caught up: 1737 PG ≈ 1741 graph; tasks 1000/3569 with 3069 live rows past the frozen cursor; chat 500/28096). This lets us watch a hive-only run against jarvis to see the exact task/edge error.