### PR TITLE
Generated with Hive: Extend eval-capture routes to support AgentLog and SharedConversation with agent override and IDOR checks

### DIFF
--- a/src/__tests__/integration/api/agent-logs-eval-capture.test.ts
+++ b/src/__tests__/integration/api/agent-logs-eval-capture.test.ts
@@ -1,0 +1,536 @@
+/**
+ * Integration tests for:
+ *   POST /api/workspaces/[slug]/agent-logs/[logId]/eval/capture
+ *   POST /api/workspaces/[slug]/agent-logs/[logId]/flag-as-eval
+ *
+ * Covers:
+ * — Existing AgentLog-based capture paths are unchanged
+ * — SharedConversation-backed capture succeeds (previously 404)
+ * — Cross-workspace IDOR is denied for both AgentLog and SharedConversation
+ * — Org-scoped canvas conversation (workspaceId null) is resolved via org fallback
+ * — Explicit agent override in eval/capture
+ * — flag-as-eval IDOR check now resolves SharedConversation
+ */
+
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { db } from "@/lib/db";
+import {
+  createAuthenticatedPostRequest,
+  createPostRequest,
+  generateUniqueId,
+} from "@/__tests__/support/helpers";
+import {
+  createTestUser,
+  createTestWorkspace,
+  createTestMembership,
+  createTestSwarm,
+} from "@/__tests__/support/factories";
+import * as nodesService from "@/services/swarm/api/nodes";
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/services/swarm/api/nodes");
+
+// blob-fetch is used by the AgentLog branch only
+vi.mock("@/lib/utils/blob-fetch", () => ({
+  fetchBlobContent: vi.fn().mockResolvedValue(
+    JSON.stringify({
+      messages: [
+        { role: "user", content: "Hello" },
+        { role: "assistant", content: "Hi there" },
+      ],
+    }),
+  ),
+}));
+
+// Route imports (after mocks)
+import { POST as capturePost } from "@/app/api/workspaces/[slug]/agent-logs/[logId]/eval/capture/route";
+import { POST as flagPost } from "@/app/api/workspaces/[slug]/agent-logs/[logId]/flag-as-eval/route";
+
+// ── Cleanup tracking ──────────────────────────────────────────────────────────
+
+const createdUserIds: string[] = [];
+const createdWorkspaceIds: string[] = [];
+const createdAgentLogIds: string[] = [];
+const createdConversationIds: string[] = [];
+const createdOrgIds: string[] = [];
+
+// Unique installation id counter (avoids unique-constraint conflicts)
+let _installationId = 8_900_000;
+function nextInstallationId() { return _installationId++; }
+
+// ── Factory helpers ───────────────────────────────────────────────────────────
+
+async function createFixtures(orgId?: string) {
+  const user = await createTestUser({
+    email: `ec-int-${Date.now()}-${Math.random()}@example.com`,
+  });
+  createdUserIds.push(user.id);
+
+  const workspace = await createTestWorkspace({
+    slug: `ec-int-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    ownerId: user.id,
+    sourceControlOrgId: orgId ?? null,
+  });
+  createdWorkspaceIds.push(workspace.id);
+
+  await createTestMembership({ workspaceId: workspace.id, userId: user.id, role: "OWNER" });
+  await createTestSwarm({ workspaceId: workspace.id, swarmApiKey: "test-swarm-key" });
+
+  return { user, workspace };
+}
+
+async function createAgentLog(workspaceId: string, overrides: Record<string, unknown> = {}) {
+  const log = await db.agentLog.create({
+    data: {
+      workspaceId,
+      blobUrl: "https://store.private.blob.vercel-storage.com/test-log.json",
+      agent: "coding-agent-cmr3abc",
+      source: "repo_agent",
+      repos: [],
+      config: {
+        model: "claude-3-5-sonnet",
+        source: "repo_agent",
+        systemOverride: "You are a coding agent.",
+      },
+      ...overrides,
+    } as Parameters<typeof db.agentLog.create>[0]["data"],
+  });
+  createdAgentLogIds.push(log.id);
+  return log;
+}
+
+const CANVAS_MESSAGES = [
+  { id: "m1", role: "user", content: "Canvas question" },
+  { id: "m2", role: "assistant", content: "Canvas answer" },
+];
+
+async function createOrgCanvasConversation(
+  sourceControlOrgId: string,
+  userId: string,
+  workspaceId: string | null = null,
+) {
+  const conv = await db.sharedConversation.create({
+    data: {
+      sourceControlOrgId,
+      userId,
+      workspaceId,
+      messages: CANVAS_MESSAGES as unknown as Parameters<typeof db.sharedConversation.create>[0]["data"]["messages"],
+      source: "org-canvas",
+      followUpQuestions: [],
+      title: "Test canvas conversation",
+    },
+  });
+  createdConversationIds.push(conv.id);
+  return conv;
+}
+
+async function createWorkspaceConversation(workspaceId: string, userId: string) {
+  const conv = await db.sharedConversation.create({
+    data: {
+      workspaceId,
+      userId,
+      messages: CANVAS_MESSAGES as unknown as Parameters<typeof db.sharedConversation.create>[0]["data"]["messages"],
+      source: "canvas",
+      followUpQuestions: [],
+      title: "Workspace canvas conversation",
+    },
+  });
+  createdConversationIds.push(conv.id);
+  return conv;
+}
+
+// ── Request builders ──────────────────────────────────────────────────────────
+
+function makeCaptureRequest(
+  slug: string,
+  logId: string,
+  body: Record<string, unknown>,
+  user: { id: string; email: string; name?: string },
+) {
+  return createAuthenticatedPostRequest(
+    `http://localhost/api/workspaces/${slug}/agent-logs/${logId}/eval/capture`,
+    user,
+    body,
+  );
+}
+
+function makeFlagRequest(
+  slug: string,
+  logId: string,
+  body: Record<string, unknown>,
+  user: { id: string; email: string; name?: string },
+) {
+  return createAuthenticatedPostRequest(
+    `http://localhost/api/workspaces/${slug}/agent-logs/${logId}/flag-as-eval`,
+    user,
+    body,
+  );
+}
+
+const VALID_CAPTURE_BODY = {
+  evalSetId: "existing-evalset-ref-123",
+  requirement: "Never return an empty response",
+  reason: "Testing",
+};
+
+const VALID_FLAG_BODY = {
+  evalSetId: "existing-evalset-ref-123",
+  requirementName: "Never return an empty response",
+  requirementDescription: "Agent should always reply",
+  positiveCases: ["Good output"],
+  negativeCases: ["Empty output"],
+  agent: "repo-agent",
+  environment: "test-env",
+  source: "repo_agent",
+};
+
+// ── Setup / teardown ──────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  process.env.USE_MOCKS = "false";
+  process.env.NODE_ENV = "test";
+
+  // Default: nodes succeed
+  vi.mocked(nodesService.addNode)
+    .mockResolvedValueOnce({ success: true, ref_id: "req-ref-1" })
+    .mockResolvedValueOnce({ success: true, ref_id: "trigger-ref-1" })
+    .mockResolvedValueOnce({ success: true, ref_id: "hive-agent-ref-1" });
+  vi.mocked(nodesService.addEdge).mockResolvedValue({ success: true });
+});
+
+afterEach(async () => {
+  if (createdConversationIds.length > 0) {
+    await db.sharedConversation.deleteMany({ where: { id: { in: createdConversationIds } } });
+    createdConversationIds.length = 0;
+  }
+  if (createdAgentLogIds.length > 0) {
+    await db.agentLog.deleteMany({ where: { id: { in: createdAgentLogIds } } });
+    createdAgentLogIds.length = 0;
+  }
+  if (createdWorkspaceIds.length > 0) {
+    await db.workspaceMember.deleteMany({ where: { workspaceId: { in: createdWorkspaceIds } } });
+    await db.swarm.deleteMany({ where: { workspaceId: { in: createdWorkspaceIds } } });
+    await db.workspace.deleteMany({ where: { id: { in: createdWorkspaceIds } } });
+    createdWorkspaceIds.length = 0;
+  }
+  if (createdUserIds.length > 0) {
+    await db.user.deleteMany({ where: { id: { in: createdUserIds } } });
+    createdUserIds.length = 0;
+  }
+  if (createdOrgIds.length > 0) {
+    await db.sourceControlOrg.deleteMany({ where: { id: { in: createdOrgIds } } }).catch(() => {});
+    createdOrgIds.length = 0;
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// eval/capture
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("POST .../agent-logs/[logId]/eval/capture", () => {
+  describe("AgentLog branch (existing behavior unchanged)", () => {
+    test("succeeds for a valid AgentLog id and returns evalSetRef/requirementRef/triggerRef", async () => {
+      const { user, workspace } = await createFixtures();
+      const log = await createAgentLog(workspace.id);
+
+      const req = makeCaptureRequest(workspace.slug, log.id, VALID_CAPTURE_BODY, user);
+      const res = await capturePost(req, {
+        params: Promise.resolve({ slug: workspace.slug, logId: log.id }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+      expect(body.data.evalSetRef).toBe(VALID_CAPTURE_BODY.evalSetId);
+      expect(body.data.requirementRef).toBeTruthy();
+      expect(body.data.triggerRef).toBeTruthy();
+    });
+
+    test("returns 404 when AgentLog id does not exist (and no SharedConversation either)", async () => {
+      const { user, workspace } = await createFixtures();
+
+      const req = makeCaptureRequest(workspace.slug, "nonexistent-id-xyz", VALID_CAPTURE_BODY, user);
+      const res = await capturePost(req, {
+        params: Promise.resolve({ slug: workspace.slug, logId: "nonexistent-id-xyz" }),
+      });
+
+      expect(res.status).toBe(404);
+    });
+
+    test("returns 403 when AgentLog belongs to a different workspace (IDOR)", async () => {
+      const { user: user1, workspace: ws1 } = await createFixtures();
+      const { workspace: ws2 } = await createFixtures();
+
+      // Log belongs to ws2 but request comes in on ws1
+      const log = await createAgentLog(ws2.id);
+
+      const req = makeCaptureRequest(ws1.slug, log.id, VALID_CAPTURE_BODY, user1);
+      const res = await capturePost(req, {
+        params: Promise.resolve({ slug: ws1.slug, logId: log.id }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(nodesService.addNode).not.toHaveBeenCalled();
+    });
+
+    test("agent auto-derived from agentLog.agent field", async () => {
+      const { user, workspace } = await createFixtures();
+      const log = await createAgentLog(workspace.id, { agent: "plan-agent-cmr3abc" });
+
+      const req = makeCaptureRequest(workspace.slug, log.id, VALID_CAPTURE_BODY, user);
+      await capturePost(req, {
+        params: Promise.resolve({ slug: workspace.slug, logId: log.id }),
+      });
+
+      const triggerCall = vi.mocked(nodesService.addNode).mock.calls.find(
+        ([, n]) => n.node_type === "EvalTrigger",
+      );
+      expect(triggerCall?.[1].node_data.agent).toBe("plan-agent");
+    });
+
+    test("explicit agent override in body overrides auto-derived agent", async () => {
+      const { user, workspace } = await createFixtures();
+      const log = await createAgentLog(workspace.id, { agent: "coding-agent-cmr3abc" });
+
+      const req = makeCaptureRequest(workspace.slug, log.id, {
+        ...VALID_CAPTURE_BODY,
+        agent: "canvas-agent",
+      }, user);
+      await capturePost(req, {
+        params: Promise.resolve({ slug: workspace.slug, logId: log.id }),
+      });
+
+      const triggerCall = vi.mocked(nodesService.addNode).mock.calls.find(
+        ([, n]) => n.node_type === "EvalTrigger",
+      );
+      expect(triggerCall?.[1].node_data.agent).toBe("canvas-agent");
+    });
+
+    test("invalid agent override is ignored (auto-derivation applies)", async () => {
+      const { user, workspace } = await createFixtures();
+      const log = await createAgentLog(workspace.id, { agent: "coding-agent-cmr3abc" });
+
+      const req = makeCaptureRequest(workspace.slug, log.id, {
+        ...VALID_CAPTURE_BODY,
+        agent: "totally-unknown-bot",
+      }, user);
+      await capturePost(req, {
+        params: Promise.resolve({ slug: workspace.slug, logId: log.id }),
+      });
+
+      const triggerCall = vi.mocked(nodesService.addNode).mock.calls.find(
+        ([, n]) => n.node_type === "EvalTrigger",
+      );
+      // Falls back to parsed canonical name
+      expect(triggerCall?.[1].node_data.agent).toBe("coding-agent");
+    });
+  });
+
+  describe("SharedConversation branch (new)", () => {
+    test("succeeds for workspace-scoped conversation id", async () => {
+      const { user, workspace } = await createFixtures();
+      const conv = await createWorkspaceConversation(workspace.id, user.id);
+
+      const req = makeCaptureRequest(workspace.slug, conv.id, VALID_CAPTURE_BODY, user);
+      const res = await capturePost(req, {
+        params: Promise.resolve({ slug: workspace.slug, logId: conv.id }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+      expect(body.data.agentName).toBe("canvas-agent"); // default for canvas_chat
+    });
+
+    test("succeeds for org-scoped canvas conversation (workspaceId null) via org fallback", async () => {
+      const orgId = generateUniqueId("org");
+      // Org must exist in SourceControlOrg table
+      await db.sourceControlOrg.create({ data: { id: orgId, name: `org-${orgId}`, githubLogin: `org-${orgId}`, githubInstallationId: nextInstallationId() } });
+      createdOrgIds.push(orgId);
+
+      const { user, workspace } = await createFixtures(orgId);
+      const conv = await createOrgCanvasConversation(orgId, user.id, null);
+
+      const req = makeCaptureRequest(workspace.slug, conv.id, VALID_CAPTURE_BODY, user);
+      const res = await capturePost(req, {
+        params: Promise.resolve({ slug: workspace.slug, logId: conv.id }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+      // canvas-agent is the default for org-canvas
+      expect(body.data.agentName).toBe("canvas-agent");
+
+      // Cleanup handled in afterEach via createdOrgIds
+    });
+
+    test("returns 403 for org-canvas conversation belonging to a different org (IDOR)", async () => {
+      const orgId1 = generateUniqueId("org1");
+      const orgId2 = generateUniqueId("org2");
+
+      await db.sourceControlOrg.create({ data: { id: orgId1, name: `org-${orgId1}`, githubLogin: `org-${orgId1}`, githubInstallationId: nextInstallationId() } });
+      await db.sourceControlOrg.create({ data: { id: orgId2, name: `org-${orgId2}`, githubLogin: `org-${orgId2}`, githubInstallationId: nextInstallationId() } });
+      createdOrgIds.push(orgId1, orgId2);
+
+      const { user: user1, workspace: ws1 } = await createFixtures(orgId1);
+      const { user: user2 } = await createFixtures(orgId2);
+
+      // Conversation belongs to org2
+      const conv = await createOrgCanvasConversation(orgId2, user2.id, null);
+
+      // Request comes in on ws1 (which is linked to org1)
+      const req = makeCaptureRequest(ws1.slug, conv.id, VALID_CAPTURE_BODY, user1);
+      const res = await capturePost(req, {
+        params: Promise.resolve({ slug: ws1.slug, logId: conv.id }),
+      });
+
+      // Should be 404 (not in org1's canvas conversations)
+      expect([403, 404]).toContain(res.status);
+      expect(nodesService.addNode).not.toHaveBeenCalled();
+
+      // Cleanup handled in afterEach via createdOrgIds
+    });
+
+    test("prompt_snapshot for conversation contains messages from stored messages", async () => {
+      const { user, workspace } = await createFixtures();
+      const conv = await createWorkspaceConversation(workspace.id, user.id);
+
+      const req = makeCaptureRequest(workspace.slug, conv.id, VALID_CAPTURE_BODY, user);
+      await capturePost(req, {
+        params: Promise.resolve({ slug: workspace.slug, logId: conv.id }),
+      });
+
+      const triggerCall = vi.mocked(nodesService.addNode).mock.calls.find(
+        ([, n]) => n.node_type === "EvalTrigger",
+      );
+      expect(triggerCall).toBeDefined();
+      const parsed = JSON.parse(triggerCall![1].node_data.body);
+      const snapshot = JSON.parse(parsed.prompt_snapshot);
+      // Messages from CANVAS_MESSAGES
+      expect(snapshot.request_params.messages.length).toBeGreaterThan(0);
+    });
+
+    test("conversation branch: explicit agent override works", async () => {
+      const { user, workspace } = await createFixtures();
+      const conv = await createWorkspaceConversation(workspace.id, user.id);
+
+      const req = makeCaptureRequest(workspace.slug, conv.id, {
+        ...VALID_CAPTURE_BODY,
+        agent: "repo-agent",
+      }, user);
+      await capturePost(req, {
+        params: Promise.resolve({ slug: workspace.slug, logId: conv.id }),
+      });
+
+      const triggerCall = vi.mocked(nodesService.addNode).mock.calls.find(
+        ([, n]) => n.node_type === "EvalTrigger",
+      );
+      expect(triggerCall?.[1].node_data.agent).toBe("repo-agent");
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// flag-as-eval
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("POST .../agent-logs/[logId]/flag-as-eval", () => {
+  describe("AgentLog branch (existing behavior unchanged)", () => {
+    test("succeeds for a valid AgentLog id", async () => {
+      const { user, workspace } = await createFixtures();
+      const log = await createAgentLog(workspace.id);
+
+      // lookupAgentSessionByLogUrl needs a mock since it makes an HTTP call
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false, // session not found → no EVALUATED edge
+        json: async () => ({}),
+      } as Response);
+
+      const req = makeFlagRequest(workspace.slug, log.id, VALID_FLAG_BODY, user);
+      const res = await flagPost(req, {
+        params: Promise.resolve({ slug: workspace.slug, logId: log.id }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+    });
+
+    test("returns 404 when AgentLog does not exist (and no SharedConversation)", async () => {
+      const { user, workspace } = await createFixtures();
+
+      const req = makeFlagRequest(workspace.slug, "nonexistent-xyz", VALID_FLAG_BODY, user);
+      const res = await flagPost(req, {
+        params: Promise.resolve({ slug: workspace.slug, logId: "nonexistent-xyz" }),
+      });
+
+      expect(res.status).toBe(404);
+    });
+
+    test("returns 403 when AgentLog belongs to a different workspace (IDOR)", async () => {
+      const { user: user1, workspace: ws1 } = await createFixtures();
+      const { workspace: ws2 } = await createFixtures();
+
+      const log = await createAgentLog(ws2.id);
+
+      const req = makeFlagRequest(ws1.slug, log.id, VALID_FLAG_BODY, user1);
+      const res = await flagPost(req, {
+        params: Promise.resolve({ slug: ws1.slug, logId: log.id }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(nodesService.addNode).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("SharedConversation branch (new)", () => {
+    test("succeeds for a workspace-scoped SharedConversation id", async () => {
+      const { user, workspace } = await createFixtures();
+      const conv = await createWorkspaceConversation(workspace.id, user.id);
+
+      const req = makeFlagRequest(workspace.slug, conv.id, VALID_FLAG_BODY, user);
+      const res = await flagPost(req, {
+        params: Promise.resolve({ slug: workspace.slug, logId: conv.id }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+    });
+
+    test("denies access to a SharedConversation owned by a different workspace (IDOR)", async () => {
+      const { user: user1, workspace: ws1 } = await createFixtures();
+      const { user: user2, workspace: ws2 } = await createFixtures();
+
+      // Conversation belongs to ws2
+      const conv = await createWorkspaceConversation(ws2.id, user2.id);
+
+      const req = makeFlagRequest(ws1.slug, conv.id, VALID_FLAG_BODY, user1);
+      const res = await flagPost(req, {
+        params: Promise.resolve({ slug: ws1.slug, logId: conv.id }),
+      });
+
+      // The workspace-scoped query won't find ws2's conversation → 404
+      // (resolver uses scoped lookup, not fetch-then-check)
+      expect([403, 404]).toContain(res.status);
+      expect(nodesService.addNode).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Validation", () => {
+    test("returns 400 when required fields are missing", async () => {
+      const { user, workspace } = await createFixtures();
+      const log = await createAgentLog(workspace.id);
+
+      const req = makeFlagRequest(workspace.slug, log.id, { evalSetId: "x" }, user);
+      const res = await flagPost(req, {
+        params: Promise.resolve({ slug: workspace.slug, logId: log.id }),
+      });
+
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/src/__tests__/unit/api/agent-logs-eval-capture.test.ts
+++ b/src/__tests__/unit/api/agent-logs-eval-capture.test.ts
@@ -8,27 +8,13 @@ vi.mock("@/lib/middleware/utils", () => ({
   requireAuth: vi.fn(() => ({ id: "user-1" })),
 }));
 
-vi.mock("@/lib/db", () => ({
-  db: {
-    agentLog: {
-      findUnique: vi.fn(),
-    },
-    workspace: {
-      findUnique: vi.fn(),
-    },
-  },
-}));
-
 vi.mock("@/lib/helpers/swarm-access", () => ({
   getWorkspaceSwarmAccess: vi.fn(),
 }));
 
-vi.mock("@/lib/utils/blob-fetch", () => ({
-  fetchBlobContent: vi.fn(),
-}));
-
-vi.mock("@/lib/utils/agent-log-stats", () => ({
-  parseAgentLogStats: vi.fn(),
+// The route now delegates IDOR + transcript resolution to resolveCaptureSource.
+vi.mock("@/lib/eval-capture/resolve-capture-source", () => ({
+  resolveCaptureSource: vi.fn(),
 }));
 
 vi.mock("@/lib/utils/swarm", () => ({
@@ -45,10 +31,8 @@ vi.mock("@/lib/logger", () => ({
 }));
 
 import { POST } from "@/app/api/workspaces/[slug]/agent-logs/[logId]/eval/capture/route";
-import { db } from "@/lib/db";
 import { getWorkspaceSwarmAccess } from "@/lib/helpers/swarm-access";
-import { fetchBlobContent } from "@/lib/utils/blob-fetch";
-import { parseAgentLogStats } from "@/lib/utils/agent-log-stats";
+import { resolveCaptureSource } from "@/lib/eval-capture/resolve-capture-source";
 import { addNode, addEdge } from "@/services/swarm/api/nodes";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -84,23 +68,40 @@ const BASE_CONFIG = {
   mcpServers: [],
 };
 
-const BASE_AGENT_LOG = {
-  workspaceId: "ws-1",
-  blobUrl: "https://store.private.blob.vercel-storage.com/test-log.json",
-  agentName: "coding-agent",
-  source: "github",
-  metadata: null,
-  config: BASE_CONFIG, // DB column is the canonical source of truth
-};
-
-const BASE_WORKSPACE = { slug: "test-ws" };
-
 const SAMPLE_MESSAGES = [
   { role: "user", content: "Hello" },
   { role: "assistant", content: "Hi there" },
   { role: "user", content: "Do this task" },
   { role: "assistant", content: "Done" },
 ];
+
+/** Default resolveCaptureSource result for the AgentLog branch */
+function makeAgentLogCapture(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    kind: "agent_log" as const,
+    workspaceId: "ws-1",
+    blobUrl: "https://store.private.blob.vercel-storage.com/test-log.json",
+    agent: overrides.agent ?? null,
+    source: overrides.source ?? "github",
+    metadata: overrides.metadata ?? null,
+    config: overrides.config ?? BASE_CONFIG,
+    conversation: (overrides.conversation as typeof SAMPLE_MESSAGES) ?? SAMPLE_MESSAGES,
+    effectiveConfig: (overrides.effectiveConfig as Record<string, unknown> | undefined) ?? BASE_CONFIG,
+    ...overrides,
+  };
+}
+
+/** Default resolveCaptureSource result for the Conversation branch */
+function makeConversationCapture(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    kind: "conversation" as const,
+    workspaceId: "ws-1",
+    conversationId: "conv-abc",
+    source: (overrides.source as string | null) ?? "org-canvas",
+    conversation: (overrides.conversation as typeof SAMPLE_MESSAGES) ?? SAMPLE_MESSAGES,
+    ...overrides,
+  };
+}
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
@@ -109,19 +110,12 @@ describe("POST /api/workspaces/[slug]/agent-logs/[logId]/eval/capture", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    // Disable mock delegation so the live path runs in tests
     origUseMocks = process.env.USE_MOCKS;
     process.env.USE_MOCKS = "false";
 
     (getWorkspaceSwarmAccess as Mock).mockResolvedValue(SWARM_SUCCESS);
-    (db.agentLog.findUnique as Mock).mockResolvedValue(BASE_AGENT_LOG);
-    (db.workspace.findUnique as Mock).mockResolvedValue(BASE_WORKSPACE);
-    (fetchBlobContent as Mock).mockResolvedValue("{}");
-    // blob-parsed config is undefined by default — DB column is the canonical source
-    (parseAgentLogStats as Mock).mockReturnValue({
-      conversation: SAMPLE_MESSAGES,
-      config: undefined,
-    });
+    // Default: AgentLog found and owned
+    (resolveCaptureSource as Mock).mockResolvedValue(makeAgentLogCapture());
     (addNode as Mock).mockImplementation((_cfg, node) => {
       const type = node.node_type;
       return Promise.resolve({ success: true, ref_id: `ref-${type}` });
@@ -162,30 +156,28 @@ describe("POST /api/workspaces/[slug]/agent-logs/[logId]/eval/capture", () => {
 
   // ── IDOR guard ──────────────────────────────────────────────────────────
 
-  test("returns 404 when agent log does not exist", async () => {
-    (db.agentLog.findUnique as Mock).mockResolvedValue(null);
+  test("returns 404 when resolveCaptureSource returns null (record not found)", async () => {
+    (resolveCaptureSource as Mock).mockResolvedValue(null);
     const res = await POST(
       makeRequest({ evalSetId: "eval-set-1", requirement: "Test" }),
       makeParams(),
     );
     expect(res.status).toBe(404);
-    // Blob fetch must NOT have been called
-    expect(fetchBlobContent).not.toHaveBeenCalled();
+    // Jarvis must NOT have been called
+    expect(addNode).not.toHaveBeenCalled();
   });
 
-  test("returns 403 when log belongs to a different workspace", async () => {
-    (db.workspace.findUnique as Mock).mockResolvedValue({ slug: "other-workspace" });
+  test("returns 403 when resolveCaptureSource returns { denied: true }", async () => {
+    (resolveCaptureSource as Mock).mockResolvedValue({ denied: true });
     const res = await POST(
       makeRequest({ evalSetId: "eval-set-1", requirement: "Test" }),
       makeParams("test-ws", "log-1"),
     );
     expect(res.status).toBe(403);
-    // Both blob fetch and Jarvis must NOT be called before IDOR check passes
-    expect(fetchBlobContent).not.toHaveBeenCalled();
     expect(addNode).not.toHaveBeenCalled();
   });
 
-  // ── prompt_snapshot builder ──────────────────────────────────────────────
+  // ── prompt_snapshot builder (AgentLog branch) ────────────────────────────
 
   test("builds prompt_snapshot with full conversation when turnIndex is undefined", async () => {
     await POST(
@@ -226,10 +218,11 @@ describe("POST /api/workspaces/[slug]/agent-logs/[logId]/eval/capture", () => {
   });
 
   test("uses config.resolvedRequestUrl when present", async () => {
-    (db.agentLog.findUnique as Mock).mockResolvedValue({
-      ...BASE_AGENT_LOG,
-      config: { ...BASE_CONFIG, resolvedRequestUrl: "https://api.anthropic.com/v1/messages" },
-    });
+    (resolveCaptureSource as Mock).mockResolvedValue(
+      makeAgentLogCapture({
+        effectiveConfig: { ...BASE_CONFIG, resolvedRequestUrl: "https://api.anthropic.com/v1/messages" },
+      }),
+    );
 
     await POST(
       makeRequest({ evalSetId: "eval-set-1", requirement: "URL test" }),
@@ -248,8 +241,6 @@ describe("POST /api/workspaces/[slug]/agent-logs/[logId]/eval/capture", () => {
   });
 
   test("falls back to empty string for url when resolvedRequestUrl is absent", async () => {
-    // BASE_AGENT_LOG.config = BASE_CONFIG which has no resolvedRequestUrl — default mock is sufficient
-
     await POST(
       makeRequest({ evalSetId: "eval-set-1", requirement: "No URL" }),
       makeParams(),
@@ -270,6 +261,10 @@ describe("POST /api/workspaces/[slug]/agent-logs/[logId]/eval/capture", () => {
 
   test("uses agentLog.source as change_type (DB column takes priority)", async () => {
     // agentLog.source = "github", config.source = "repo_agent"
+    (resolveCaptureSource as Mock).mockResolvedValue(
+      makeAgentLogCapture({ source: "github" }),
+    );
+
     await POST(
       makeRequest({ evalSetId: "eval-set-1", requirement: "change_type test" }),
       makeParams(),
@@ -285,10 +280,9 @@ describe("POST /api/workspaces/[slug]/agent-logs/[logId]/eval/capture", () => {
   // ── source discriminator ─────────────────────────────────────────────────
 
   test('sets source to "repo_agent" when agentLog.source is "repo_agent"', async () => {
-    (db.agentLog.findUnique as Mock).mockResolvedValue({
-      ...BASE_AGENT_LOG,
-      source: "repo_agent",
-    });
+    (resolveCaptureSource as Mock).mockResolvedValue(
+      makeAgentLogCapture({ source: "repo_agent" }),
+    );
 
     await POST(
       makeRequest({ evalSetId: "eval-set-1", requirement: "source repo_agent" }),
@@ -303,11 +297,12 @@ describe("POST /api/workspaces/[slug]/agent-logs/[logId]/eval/capture", () => {
   });
 
   test('sets source to "provider_direct" when agentLog.source is null and resolvedRequestUrl matches Anthropic', async () => {
-    (db.agentLog.findUnique as Mock).mockResolvedValue({
-      ...BASE_AGENT_LOG,
-      source: null,
-      config: { ...BASE_CONFIG, resolvedRequestUrl: "https://api.anthropic.com/v1/messages" },
-    });
+    (resolveCaptureSource as Mock).mockResolvedValue(
+      makeAgentLogCapture({
+        source: null,
+        effectiveConfig: { ...BASE_CONFIG, resolvedRequestUrl: "https://api.anthropic.com/v1/messages" },
+      }),
+    );
 
     await POST(
       makeRequest({ evalSetId: "eval-set-1", requirement: "source provider_direct" }),
@@ -322,10 +317,9 @@ describe("POST /api/workspaces/[slug]/agent-logs/[logId]/eval/capture", () => {
   });
 
   test('sets source to "jamie_agent" when agentLog.source is "canvas_chat"', async () => {
-    (db.agentLog.findUnique as Mock).mockResolvedValue({
-      ...BASE_AGENT_LOG,
-      source: "canvas_chat",
-    });
+    (resolveCaptureSource as Mock).mockResolvedValue(
+      makeAgentLogCapture({ source: "canvas_chat" }),
+    );
 
     await POST(
       makeRequest({ evalSetId: "eval-set-1", requirement: "source jamie_agent" }),
@@ -340,11 +334,9 @@ describe("POST /api/workspaces/[slug]/agent-logs/[logId]/eval/capture", () => {
   });
 
   test('falls back to "repo_agent" source when agentLog.source is unknown and no matching resolvedRequestUrl', async () => {
-    (db.agentLog.findUnique as Mock).mockResolvedValue({
-      ...BASE_AGENT_LOG,
-      source: "github",
-      // config: BASE_CONFIG (default) — no resolvedRequestUrl
-    });
+    (resolveCaptureSource as Mock).mockResolvedValue(
+      makeAgentLogCapture({ source: "github" }),
+    );
 
     await POST(
       makeRequest({ evalSetId: "eval-set-1", requirement: "source fallback" }),
@@ -359,10 +351,9 @@ describe("POST /api/workspaces/[slug]/agent-logs/[logId]/eval/capture", () => {
   });
 
   test("falls back to config.source when agentLog.source is null", async () => {
-    (db.agentLog.findUnique as Mock).mockResolvedValue({
-      ...BASE_AGENT_LOG,
-      source: null,
-    });
+    (resolveCaptureSource as Mock).mockResolvedValue(
+      makeAgentLogCapture({ source: null }),
+    );
 
     await POST(
       makeRequest({ evalSetId: "eval-set-1", requirement: "fallback test" }),
@@ -373,15 +364,17 @@ describe("POST /api/workspaces/[slug]/agent-logs/[logId]/eval/capture", () => {
       ([, node]) => node.node_type === "EvalTrigger",
     );
     expect(triggerCall).toBeDefined();
+    // effectiveConfig.source = "repo_agent"
     expect(triggerCall[1].node_data.change_type).toBe("repo_agent");
   });
 
   test("falls back to swarm_agent when both agentLog.source and config.source are null", async () => {
-    (db.agentLog.findUnique as Mock).mockResolvedValue({
-      ...BASE_AGENT_LOG,
-      source: null,
-      config: { model: "gpt-4", temperature: 0 }, // no source
-    });
+    (resolveCaptureSource as Mock).mockResolvedValue(
+      makeAgentLogCapture({
+        source: null,
+        effectiveConfig: { model: "gpt-4", temperature: 0 }, // no source
+      }),
+    );
 
     await POST(
       makeRequest({ evalSetId: "eval-set-1", requirement: "fallback all" }),
@@ -432,10 +425,9 @@ describe("POST /api/workspaces/[slug]/agent-logs/[logId]/eval/capture", () => {
       { name: "prompt-a", resolution: { value: "v1" } },
       { name: "prompt-b", resolution: { value: "v2" } },
     ];
-    (db.agentLog.findUnique as Mock).mockResolvedValue({
-      ...BASE_AGENT_LOG,
-      metadata: { prompts },
-    });
+    (resolveCaptureSource as Mock).mockResolvedValue(
+      makeAgentLogCapture({ metadata: { prompts } }),
+    );
 
     await POST(
       makeRequest({ evalSetId: "eval-set-1", requirement: "prompts test" }),
@@ -453,10 +445,9 @@ describe("POST /api/workspaces/[slug]/agent-logs/[logId]/eval/capture", () => {
   });
 
   test("omits prompts field when metadata.prompts is absent", async () => {
-    (db.agentLog.findUnique as Mock).mockResolvedValue({
-      ...BASE_AGENT_LOG,
-      metadata: null,
-    });
+    (resolveCaptureSource as Mock).mockResolvedValue(
+      makeAgentLogCapture({ metadata: null }),
+    );
 
     await POST(
       makeRequest({ evalSetId: "eval-set-1", requirement: "no prompts" }),
@@ -473,10 +464,9 @@ describe("POST /api/workspaces/[slug]/agent-logs/[logId]/eval/capture", () => {
   // ── agent auto-detection from AgentLog.agent ────────────────────────────
 
   test("parses canonical agent from agentLog.agent cuid-suffixed value", async () => {
-    (db.agentLog.findUnique as Mock).mockResolvedValue({
-      ...BASE_AGENT_LOG,
-      agent: "coding-agent-cmr3lw4o5abc",
-    });
+    (resolveCaptureSource as Mock).mockResolvedValue(
+      makeAgentLogCapture({ agent: "coding-agent-cmr3lw4o5abc" }),
+    );
 
     await POST(
       makeRequest({ evalSetId: "eval-set-1", requirement: "Agent parse test" }),
@@ -491,10 +481,9 @@ describe("POST /api/workspaces/[slug]/agent-logs/[logId]/eval/capture", () => {
   });
 
   test("parses wfe-agent from agentLog.agent", async () => {
-    (db.agentLog.findUnique as Mock).mockResolvedValue({
-      ...BASE_AGENT_LOG,
-      agent: "wfe-agent-cmr3abc123xyz",
-    });
+    (resolveCaptureSource as Mock).mockResolvedValue(
+      makeAgentLogCapture({ agent: "wfe-agent-cmr3abc123xyz" }),
+    );
 
     await POST(
       makeRequest({ evalSetId: "eval-set-1", requirement: "WFE agent test" }),
@@ -509,11 +498,12 @@ describe("POST /api/workspaces/[slug]/agent-logs/[logId]/eval/capture", () => {
   });
 
   test("falls back to resolveHiveAgentName when agentLog.agent is not parseable", async () => {
-    (db.agentLog.findUnique as Mock).mockResolvedValue({
-      ...BASE_AGENT_LOG,
-      agent: "unknown-bot-xyz",
-      source: "canvas_chat", // jamie_agent source → canvas-agent default
-    });
+    (resolveCaptureSource as Mock).mockResolvedValue(
+      makeAgentLogCapture({
+        agent: "unknown-bot-xyz",
+        source: "canvas_chat", // jamie_agent source → canvas-agent default
+      }),
+    );
 
     await POST(
       makeRequest({ evalSetId: "eval-set-1", requirement: "Fallback agent test" }),
@@ -528,11 +518,9 @@ describe("POST /api/workspaces/[slug]/agent-logs/[logId]/eval/capture", () => {
   });
 
   test("falls back to source-bucket default when agentLog.agent is null", async () => {
-    (db.agentLog.findUnique as Mock).mockResolvedValue({
-      ...BASE_AGENT_LOG,
-      agent: null,
-      source: "repo_agent",
-    });
+    (resolveCaptureSource as Mock).mockResolvedValue(
+      makeAgentLogCapture({ agent: null, source: "repo_agent" }),
+    );
 
     await POST(
       makeRequest({ evalSetId: "eval-set-1", requirement: "Null agent test" }),
@@ -546,13 +534,164 @@ describe("POST /api/workspaces/[slug]/agent-logs/[logId]/eval/capture", () => {
     expect(triggerCall[1].node_data.agent).toBe("repo-agent");
   });
 
+  // ── Optional agent override ───────────────────────────────────────────────
+
+  test("uses explicit agent override when it is a valid catalog name (AgentLog branch)", async () => {
+    (resolveCaptureSource as Mock).mockResolvedValue(
+      makeAgentLogCapture({ agent: "coding-agent-cmr3abc", source: "repo_agent" }),
+    );
+
+    await POST(
+      makeRequest({ evalSetId: "eval-set-1", requirement: "Agent override", agent: "plan-agent" }),
+      makeParams(),
+    );
+
+    const triggerCall = (addNode as Mock).mock.calls.find(
+      ([, node]) => node.node_type === "EvalTrigger",
+    );
+    expect(triggerCall).toBeDefined();
+    expect(triggerCall[1].node_data.agent).toBe("plan-agent");
+  });
+
+  test("ignores agent override when it is not in CAPTURE_AGENT_NAMES (uses auto-derived)", async () => {
+    (resolveCaptureSource as Mock).mockResolvedValue(
+      makeAgentLogCapture({ agent: "coding-agent-cmr3abc", source: "repo_agent" }),
+    );
+
+    await POST(
+      makeRequest({
+        evalSetId: "eval-set-1",
+        requirement: "Invalid override",
+        agent: "totally-unknown-bot",
+      }),
+      makeParams(),
+    );
+
+    const triggerCall = (addNode as Mock).mock.calls.find(
+      ([, node]) => node.node_type === "EvalTrigger",
+    );
+    expect(triggerCall).toBeDefined();
+    // Falls back to parsed agent from agentLog.agent
+    expect(triggerCall[1].node_data.agent).toBe("coding-agent");
+  });
+
+  // ── Conversation branch ────────────────────────────────────────────────────
+
+  test("succeeds for conversation branch with canvas_chat defaults to canvas-agent", async () => {
+    (resolveCaptureSource as Mock).mockResolvedValue(makeConversationCapture());
+
+    const res = await POST(
+      makeRequest({ evalSetId: "eval-set-1", requirement: "Canvas capture" }),
+      makeParams("test-ws", "conv-abc"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+
+    const triggerCall = (addNode as Mock).mock.calls.find(
+      ([, node]) => node.node_type === "EvalTrigger",
+    );
+    expect(triggerCall).toBeDefined();
+    expect(triggerCall[1].node_data.agent).toBe("canvas-agent");
+    expect(triggerCall[1].node_data.source).toBe("jamie_agent");
+  });
+
+  test("conversation branch: environment is set to conversationId", async () => {
+    (resolveCaptureSource as Mock).mockResolvedValue(
+      makeConversationCapture({ conversationId: "conv-xyz" }),
+    );
+
+    await POST(
+      makeRequest({ evalSetId: "eval-set-1", requirement: "Conversation env" }),
+      makeParams("test-ws", "conv-xyz"),
+    );
+
+    const triggerCall = (addNode as Mock).mock.calls.find(
+      ([, node]) => node.node_type === "EvalTrigger",
+    );
+    expect(triggerCall).toBeDefined();
+    expect(triggerCall[1].node_data.environment).toBe("conv-xyz");
+  });
+
+  test("conversation branch: prompt_snapshot contains messages from conversation", async () => {
+    const convMessages = [
+      { role: "user", content: "Canvas question" },
+      { role: "assistant", content: "Canvas answer" },
+    ];
+    (resolveCaptureSource as Mock).mockResolvedValue(
+      makeConversationCapture({ conversation: convMessages }),
+    );
+
+    await POST(
+      makeRequest({ evalSetId: "eval-set-1", requirement: "Conv snapshot" }),
+      makeParams("test-ws", "conv-abc"),
+    );
+
+    const triggerCall = (addNode as Mock).mock.calls.find(
+      ([, node]) => node.node_type === "EvalTrigger",
+    );
+    expect(triggerCall).toBeDefined();
+    const parsed = JSON.parse(triggerCall[1].node_data.body);
+    const snapshot = JSON.parse(parsed.prompt_snapshot);
+    expect(snapshot.request_params.messages).toEqual(convMessages);
+  });
+
+  test("conversation branch: slices to turnIndex + 1 when turnIndex provided", async () => {
+    (resolveCaptureSource as Mock).mockResolvedValue(makeConversationCapture());
+
+    await POST(
+      makeRequest({ evalSetId: "eval-set-1", requirement: "Conv turn", turnIndex: 1 }),
+      makeParams("test-ws", "conv-abc"),
+    );
+
+    const triggerCall = (addNode as Mock).mock.calls.find(
+      ([, node]) => node.node_type === "EvalTrigger",
+    );
+    expect(triggerCall).toBeDefined();
+    const parsed = JSON.parse(triggerCall[1].node_data.body);
+    const snapshot = JSON.parse(parsed.prompt_snapshot);
+    // SAMPLE_MESSAGES has 4 items; turnIndex=1 → slice(0, 2)
+    expect(snapshot.request_params.messages).toHaveLength(2);
+  });
+
+  test("conversation branch: explicit agent override is respected", async () => {
+    (resolveCaptureSource as Mock).mockResolvedValue(makeConversationCapture());
+
+    await POST(
+      makeRequest({
+        evalSetId: "eval-set-1",
+        requirement: "Conv agent override",
+        agent: "repo-agent",
+      }),
+      makeParams("test-ws", "conv-abc"),
+    );
+
+    const triggerCall = (addNode as Mock).mock.calls.find(
+      ([, node]) => node.node_type === "EvalTrigger",
+    );
+    expect(triggerCall).toBeDefined();
+    expect(triggerCall[1].node_data.agent).toBe("repo-agent");
+  });
+
+  test("conversation branch: IDOR denied returns 403 without Jarvis calls", async () => {
+    (resolveCaptureSource as Mock).mockResolvedValue({ denied: true });
+
+    const res = await POST(
+      makeRequest({ evalSetId: "eval-set-1", requirement: "IDOR conv" }),
+      makeParams("test-ws", "conv-other-ws"),
+    );
+
+    expect(res.status).toBe(403);
+    expect(addNode).not.toHaveBeenCalled();
+  });
+
   // ── HiveAgent upsert + ATTRIBUTED_TO edge (non-fatal) ────────────────────
 
   test("upserts HiveAgent node after EvalTrigger creation", async () => {
-    (db.agentLog.findUnique as Mock).mockResolvedValue({
-      ...BASE_AGENT_LOG,
-      agent: "coding-agent-cmr3lw4o5abc",
-    });
+    (resolveCaptureSource as Mock).mockResolvedValue(
+      makeAgentLogCapture({ agent: "coding-agent-cmr3lw4o5abc" }),
+    );
 
     await POST(
       makeRequest({ evalSetId: "eval-set-1", requirement: "HiveAgent upsert" }),
@@ -569,10 +708,9 @@ describe("POST /api/workspaces/[slug]/agent-logs/[logId]/eval/capture", () => {
   });
 
   test("upserts HiveAgent node with correct spec for wfe-agent", async () => {
-    (db.agentLog.findUnique as Mock).mockResolvedValue({
-      ...BASE_AGENT_LOG,
-      agent: "wfe-agent-cmr3abc",
-    });
+    (resolveCaptureSource as Mock).mockResolvedValue(
+      makeAgentLogCapture({ agent: "wfe-agent-cmr3abc" }),
+    );
 
     await POST(
       makeRequest({ evalSetId: "eval-set-1", requirement: "WFE HiveAgent test" }),
@@ -659,10 +797,9 @@ describe("POST /api/workspaces/[slug]/agent-logs/[logId]/eval/capture", () => {
   // ── agentName in response ────────────────────────────────────────────────
 
   test("response includes agentName in data", async () => {
-    (db.agentLog.findUnique as Mock).mockResolvedValue({
-      ...BASE_AGENT_LOG,
-      agent: "plan-agent-cmr3xyz",
-    });
+    (resolveCaptureSource as Mock).mockResolvedValue(
+      makeAgentLogCapture({ agent: "plan-agent-cmr3xyz" }),
+    );
 
     const res = await POST(
       makeRequest({ evalSetId: "eval-set-1", requirement: "Response agentName test" }),
@@ -706,10 +843,9 @@ describe("POST /api/workspaces/[slug]/agent-logs/[logId]/eval/capture", () => {
       providerConfig: { timeout: 30 },
       repos: ["repo-1"],
     };
-    (db.agentLog.findUnique as Mock).mockResolvedValue({
-      ...BASE_AGENT_LOG,
-      config: fullConfig,
-    });
+    (resolveCaptureSource as Mock).mockResolvedValue(
+      makeAgentLogCapture({ effectiveConfig: fullConfig }),
+    );
 
     await POST(
       makeRequest({ evalSetId: "eval-set-1", requirement: "Full harness fields" }),
@@ -745,10 +881,9 @@ describe("POST /api/workspaces/[slug]/agent-logs/[logId]/eval/capture", () => {
       { role: "assistant", content: "Hi there" },
       { role: "user", content: "Do this task" },
     ];
-    (parseAgentLogStats as Mock).mockReturnValue({
-      conversation: messagesWithSystem,
-      config: undefined,
-    });
+    (resolveCaptureSource as Mock).mockResolvedValue(
+      makeAgentLogCapture({ conversation: messagesWithSystem }),
+    );
 
     await POST(
       makeRequest({ evalSetId: "eval-set-1", requirement: "System preserved", turnIndex: 2 }),
@@ -769,14 +904,15 @@ describe("POST /api/workspaces/[slug]/agent-logs/[logId]/eval/capture", () => {
   });
 
   test("Test C: PromptResolution map in metadata.prompts is normalised to flat array", async () => {
-    (db.agentLog.findUnique as Mock).mockResolvedValue({
-      ...BASE_AGENT_LOG,
-      metadata: {
-        prompts: {
-          MY_PROMPT: { prompt_id: 1, prompt_version_id: 2, resolution: {} },
+    (resolveCaptureSource as Mock).mockResolvedValue(
+      makeAgentLogCapture({
+        metadata: {
+          prompts: {
+            MY_PROMPT: { prompt_id: 1, prompt_version_id: 2, resolution: {} },
+          },
         },
-      },
-    });
+      }),
+    );
 
     await POST(
       makeRequest({ evalSetId: "eval-set-1", requirement: "PromptResolution map" }),
@@ -793,14 +929,19 @@ describe("POST /api/workspaces/[slug]/agent-logs/[logId]/eval/capture", () => {
   });
 
   test("PromptResolution map with resolution.value is normalised to include resolution string", async () => {
-    (db.agentLog.findUnique as Mock).mockResolvedValue({
-      ...BASE_AGENT_LOG,
-      metadata: {
-        prompts: {
-          MY_PROMPT: { prompt_id: 1, prompt_version_id: 2, resolution: { value: "You are a coding agent." } },
+    (resolveCaptureSource as Mock).mockResolvedValue(
+      makeAgentLogCapture({
+        metadata: {
+          prompts: {
+            MY_PROMPT: {
+              prompt_id: 1,
+              prompt_version_id: 2,
+              resolution: { value: "You are a coding agent." },
+            },
+          },
         },
-      },
-    });
+      }),
+    );
 
     await POST(
       makeRequest({ evalSetId: "eval-set-1", requirement: "resolution passthrough" }),
@@ -823,14 +964,19 @@ describe("POST /api/workspaces/[slug]/agent-logs/[logId]/eval/capture", () => {
   });
 
   test("PromptResolution map with object resolution.value is flattened to string", async () => {
-    (db.agentLog.findUnique as Mock).mockResolvedValue({
-      ...BASE_AGENT_LOG,
-      metadata: {
-        prompts: {
-          JSON_PROMPT: { prompt_id: 3, prompt_version_id: 4, resolution: { value: { key: "val" } } },
+    (resolveCaptureSource as Mock).mockResolvedValue(
+      makeAgentLogCapture({
+        metadata: {
+          prompts: {
+            JSON_PROMPT: {
+              prompt_id: 3,
+              prompt_version_id: 4,
+              resolution: { value: { key: "val" } },
+            },
+          },
         },
-      },
-    });
+      }),
+    );
 
     await POST(
       makeRequest({ evalSetId: "eval-set-1", requirement: "json resolution" }),
@@ -848,11 +994,10 @@ describe("POST /api/workspaces/[slug]/agent-logs/[logId]/eval/capture", () => {
   // ── fallback: DB config null → blob-parsed config ───────────────────────
 
   test("falls back to blob-parsed config for request_params when DB config column is null", async () => {
-    (db.agentLog.findUnique as Mock).mockResolvedValue({ ...BASE_AGENT_LOG, config: null });
-    (parseAgentLogStats as Mock).mockReturnValue({
-      conversation: SAMPLE_MESSAGES,
-      config: BASE_CONFIG,
-    });
+    // effectiveConfig = undefined simulates DB config null + blob-parsed config result
+    (resolveCaptureSource as Mock).mockResolvedValue(
+      makeAgentLogCapture({ effectiveConfig: BASE_CONFIG }),
+    );
 
     await POST(makeRequest({ evalSetId: "eval-set-1", requirement: "fallback" }), makeParams());
 
@@ -872,7 +1017,11 @@ describe("POST /api/workspaces/[slug]/agent-logs/[logId]/eval/capture", () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       json: async () => ({
         success: true,
-        data: { evalSetRef: "eval-set-1", requirementRef: "mock-req-ref", triggerRef: "mock-trigger-ref" },
+        data: {
+          evalSetRef: "eval-set-1",
+          requirementRef: "mock-req-ref",
+          triggerRef: "mock-trigger-ref",
+        },
       }),
     } as Response);
 

--- a/src/__tests__/unit/lib/eval-capture/resolve-capture-source.test.ts
+++ b/src/__tests__/unit/lib/eval-capture/resolve-capture-source.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Unit tests for resolveCaptureSource
+ *
+ * Covers:
+ * - AgentLog found and owned by workspace → returns agent_log kind
+ * - AgentLog found but belongs to a different workspace → returns { denied: true }
+ * - No AgentLog; SharedConversation found via workspaceId → returns conversation kind
+ * - No AgentLog; SharedConversation found via org fallback (workspaceId null) → returns conversation kind
+ * - No AgentLog; SharedConversation found but wrong workspaceId → returns { denied: true }
+ * - Neither record found → returns null
+ * - Workspace itself not found → returns null
+ */
+
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    workspace: { findFirst: vi.fn() },
+    agentLog: { findUnique: vi.fn() },
+    sharedConversation: { findFirst: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/utils/blob-fetch", () => ({
+  fetchBlobContent: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/agent-log-stats", () => ({
+  parseAgentLogStats: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/chat-conversation-log", () => ({
+  chatMessagesToParsedMessages: vi.fn((msgs) => msgs), // pass-through for simplicity
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { resolveCaptureSource } from "@/lib/eval-capture/resolve-capture-source";
+import { db } from "@/lib/db";
+import { fetchBlobContent } from "@/lib/utils/blob-fetch";
+import { parseAgentLogStats } from "@/lib/utils/agent-log-stats";
+import type { Mock } from "vitest";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const WORKSPACE_ID = "ws-111";
+const ORG_ID = "org-222";
+const SLUG = "test-ws";
+const LOG_ID = "log-abc";
+const CONV_ID = "conv-xyz";
+
+const WORKSPACE = { id: WORKSPACE_ID, sourceControlOrgId: ORG_ID };
+
+const AGENT_LOG = {
+  workspaceId: WORKSPACE_ID,
+  blobUrl: "https://store.private.blob.vercel-storage.com/log.json",
+  agent: "coding-agent-cmr123",
+  source: "repo_agent",
+  metadata: null,
+  config: { model: "claude-3" },
+};
+
+const CONVERSATION_MSG = { role: "user", content: "hello" };
+
+const CONVERSATION_WS = {
+  id: CONV_ID,
+  workspaceId: WORKSPACE_ID,
+  sourceControlOrgId: null,
+  source: "canvas",
+  messages: [CONVERSATION_MSG],
+};
+
+const CONVERSATION_ORG = {
+  id: CONV_ID,
+  workspaceId: null, // org-scoped
+  sourceControlOrgId: ORG_ID,
+  source: "org-canvas",
+  messages: [CONVERSATION_MSG],
+};
+
+const PARSED_MESSAGES = [{ role: "user", content: "hello" }];
+const PARSED_CONFIG = { model: "claude-3" };
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  (db.workspace.findFirst as Mock).mockResolvedValue(WORKSPACE);
+  (db.agentLog.findUnique as Mock).mockResolvedValue(null);
+  (db.sharedConversation.findFirst as Mock).mockResolvedValue(null);
+  (fetchBlobContent as Mock).mockResolvedValue("{}");
+  (parseAgentLogStats as Mock).mockReturnValue({
+    conversation: PARSED_MESSAGES,
+    config: PARSED_CONFIG,
+  });
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("resolveCaptureSource", () => {
+  describe("workspace not found", () => {
+    test("returns null when workspace does not exist", async () => {
+      (db.workspace.findFirst as Mock).mockResolvedValue(null);
+
+      const result = await resolveCaptureSource(SLUG, LOG_ID);
+
+      expect(result).toBeNull();
+      expect(db.agentLog.findUnique).not.toHaveBeenCalled();
+      expect(db.sharedConversation.findFirst).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("AgentLog branch", () => {
+    test("returns agent_log kind when AgentLog is found and owned by workspace", async () => {
+      (db.agentLog.findUnique as Mock).mockResolvedValue(AGENT_LOG);
+
+      const result = await resolveCaptureSource(SLUG, LOG_ID);
+
+      expect(result).not.toBeNull();
+      expect(result).not.toEqual({ denied: true });
+      if (!result || "denied" in result) throw new Error("expected CaptureSource");
+      expect(result.kind).toBe("agent_log");
+      expect(result.workspaceId).toBe(WORKSPACE_ID);
+      expect(result.agent).toBe(AGENT_LOG.agent);
+      expect(result.source).toBe(AGENT_LOG.source);
+      expect(result.conversation).toEqual(PARSED_MESSAGES);
+      // effectiveConfig should come from DB config
+      expect(result.effectiveConfig).toEqual(AGENT_LOG.config);
+    });
+
+    test("fetches and parses blob content for AgentLog", async () => {
+      (db.agentLog.findUnique as Mock).mockResolvedValue(AGENT_LOG);
+
+      await resolveCaptureSource(SLUG, LOG_ID);
+
+      expect(fetchBlobContent).toHaveBeenCalledWith(AGENT_LOG.blobUrl);
+      expect(parseAgentLogStats).toHaveBeenCalled();
+    });
+
+    test("returns { denied: true } when AgentLog belongs to a different workspace", async () => {
+      (db.agentLog.findUnique as Mock).mockResolvedValue({
+        ...AGENT_LOG,
+        workspaceId: "other-ws-999",
+      });
+
+      const result = await resolveCaptureSource(SLUG, LOG_ID);
+
+      expect(result).toEqual({ denied: true });
+      // No blob fetch should occur
+      expect(fetchBlobContent).not.toHaveBeenCalled();
+    });
+
+    test("does NOT fall through to SharedConversation when AgentLog is found (even if it's denied)", async () => {
+      (db.agentLog.findUnique as Mock).mockResolvedValue({
+        ...AGENT_LOG,
+        workspaceId: "different-ws",
+      });
+
+      await resolveCaptureSource(SLUG, LOG_ID);
+
+      expect(db.sharedConversation.findFirst).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("SharedConversation branch", () => {
+    test("returns conversation kind when found via workspaceId", async () => {
+      (db.agentLog.findUnique as Mock).mockResolvedValue(null);
+      (db.sharedConversation.findFirst as Mock).mockResolvedValue(CONVERSATION_WS);
+
+      const result = await resolveCaptureSource(SLUG, CONV_ID);
+
+      expect(result).not.toBeNull();
+      if (!result || "denied" in result) throw new Error("expected CaptureSource");
+      expect(result.kind).toBe("conversation");
+      expect(result.workspaceId).toBe(WORKSPACE_ID);
+      expect(result.conversationId).toBe(CONV_ID);
+      expect(result.source).toBe("canvas");
+    });
+
+    test("does NOT fetch blob for conversation branch", async () => {
+      (db.sharedConversation.findFirst as Mock).mockResolvedValue(CONVERSATION_WS);
+
+      await resolveCaptureSource(SLUG, CONV_ID);
+
+      expect(fetchBlobContent).not.toHaveBeenCalled();
+    });
+
+    test("returns conversation kind via org fallback when workspaceId is null", async () => {
+      (db.agentLog.findUnique as Mock).mockResolvedValue(null);
+
+      // Primary lookup returns null; org fallback returns the conversation
+      (db.sharedConversation.findFirst as Mock)
+        .mockResolvedValueOnce(null)          // primary (workspaceId match) → miss
+        .mockResolvedValueOnce(CONVERSATION_ORG); // org fallback → hit
+
+      const result = await resolveCaptureSource(SLUG, CONV_ID);
+
+      expect(result).not.toBeNull();
+      if (!result || "denied" in result) throw new Error("expected CaptureSource");
+      expect(result.kind).toBe("conversation");
+      // workspaceId comes from the resolved workspace, not the conversation row
+      expect(result.workspaceId).toBe(WORKSPACE_ID);
+      expect(result.source).toBe("org-canvas");
+
+      // Org-fallback query must include source filter
+      const calls = (db.sharedConversation.findFirst as Mock).mock.calls;
+      expect(calls).toHaveLength(2);
+      expect(calls[1][0].where.source).toEqual({ in: ["org-canvas", "graph-walk"] });
+      expect(calls[1][0].where.sourceControlOrgId).toBe(ORG_ID);
+    });
+
+    test("skips org fallback when workspace has no sourceControlOrgId", async () => {
+      (db.workspace.findFirst as Mock).mockResolvedValue({ id: WORKSPACE_ID, sourceControlOrgId: null });
+      (db.sharedConversation.findFirst as Mock).mockResolvedValueOnce(null); // primary miss
+
+      const result = await resolveCaptureSource(SLUG, CONV_ID);
+
+      expect(result).toBeNull();
+      // Only one call (primary); no org fallback
+      expect(db.sharedConversation.findFirst).toHaveBeenCalledTimes(1);
+    });
+
+    test("returns { denied: true } when conversation has non-null workspaceId that doesn't match", async () => {
+      (db.sharedConversation.findFirst as Mock).mockResolvedValueOnce({
+        ...CONVERSATION_WS,
+        workspaceId: "wrong-ws-999",
+      });
+
+      const result = await resolveCaptureSource(SLUG, CONV_ID);
+
+      expect(result).toEqual({ denied: true });
+    });
+
+    test("returns null when neither AgentLog nor SharedConversation is found", async () => {
+      (db.agentLog.findUnique as Mock).mockResolvedValue(null);
+      (db.sharedConversation.findFirst as Mock).mockResolvedValue(null);
+
+      const result = await resolveCaptureSource(SLUG, "nonexistent-id");
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/src/app/api/workspaces/[slug]/agent-logs/[logId]/eval/capture/route.ts
+++ b/src/app/api/workspaces/[slug]/agent-logs/[logId]/eval/capture/route.ts
@@ -1,15 +1,16 @@
-import { randomUUID } from "crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { getMiddlewareContext, requireAuth } from "@/lib/middleware/utils";
 import { getJarvisUrl } from "@/lib/utils/swarm";
 import { getWorkspaceSwarmAccess } from "@/lib/helpers/swarm-access";
-import { addNode, addEdge } from "@/services/swarm/api/nodes";
-import { db } from "@/lib/db";
-import { fetchBlobContent } from "@/lib/utils/blob-fetch";
-import { parseAgentLogStats } from "@/lib/utils/agent-log-stats";
 import { deriveEvalTriggerSource } from "@/lib/utils/eval-source";
-import { parseCanonicalAgent, resolveHiveAgentName, getCaptureAgentSpec } from "@/lib/utils/hive-agent";
+import {
+  parseCanonicalAgent,
+  resolveHiveAgentName,
+  isCaptureAgentName,
+} from "@/lib/utils/hive-agent";
 import { mapPromptResolutions, type PromptResolution } from "@/types/evals";
+import { resolveCaptureSource } from "@/lib/eval-capture/resolve-capture-source";
+import { createEvalNodes } from "@/lib/eval-capture/create-eval-nodes";
 import { logger } from "@/lib/logger";
 
 export const runtime = "nodejs";
@@ -45,43 +46,18 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       return handleSwarmAccessError(swarmAccessResult.error);
     }
 
-    // 3. IDOR guard — verify log belongs to this workspace (before any blob/Jarvis calls)
-    const agentLog = await db.agentLog.findUnique({
-      where: { id: logId },
-      select: {
-        workspaceId: true,
-        blobUrl: true,
-        agent: true,
-        source: true,
-        metadata: true,
-        config: true,
-      },
-    });
-
-    if (!agentLog) {
-      return NextResponse.json({ error: "Agent log not found" }, { status: 404 });
-    }
-
-    const logWorkspace = await db.workspace.findUnique({
-      where: { id: agentLog.workspaceId },
-      select: { slug: true },
-    });
-
-    if (!logWorkspace || logWorkspace.slug !== slug) {
-      return NextResponse.json({ error: "Access denied" }, { status: 403 });
-    }
-
-    // 4. Validate body
+    // 3. Validate body early (before IDOR check — no side-effects yet)
     const body = await request.json().catch(() => null);
     if (!body) {
       return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
     }
 
-    const { evalSetId, requirement, reason, turnIndex } = body as {
+    const { evalSetId, requirement, reason, turnIndex, agent: agentOverride } = body as {
       evalSetId?: string;
       requirement?: string;
       reason?: string;
       turnIndex?: number;
+      agent?: string;
     };
 
     if (!evalSetId?.trim()) {
@@ -92,7 +68,18 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       return NextResponse.json({ error: "requirement is required" }, { status: 400 });
     }
 
-    // 5. USE_MOCKS → delegate to mock endpoint
+    // 4. IDOR + transcript resolution (AgentLog OR SharedConversation)
+    //    Must run before USE_MOCKS delegation and any external call.
+    const captured = await resolveCaptureSource(slug, logId);
+
+    if (captured === null) {
+      return NextResponse.json({ error: "Agent log not found" }, { status: 404 });
+    }
+    if ("denied" in captured) {
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
+    }
+
+    // 5. USE_MOCKS → delegate to mock endpoint (id-agnostic, preserved for both branches)
     if (process.env.USE_MOCKS === "true") {
       logger.info("[AgentEvalCapture] USE_MOCKS=true, routing to mock endpoint");
       const mockRes = await fetch(
@@ -106,75 +93,6 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       return NextResponse.json(await mockRes.json());
     }
 
-    // 6. Fetch blob and parse conversation + config (blob still needed for conversation)
-    const blobContent = await fetchBlobContent(agentLog.blobUrl);
-    const { conversation, config: blobConfig } = parseAgentLogStats(blobContent);
-
-    // Prefer DB column (canonical); fall back to blob-parsed config for legacy rows
-    const effectiveConfig =
-      agentLog.config && typeof agentLog.config === "object"
-        ? (agentLog.config as Record<string, unknown>)
-        : (blobConfig as Record<string, unknown> | undefined);
-
-    // 7. Slice conversation
-    const slicedConversation =
-      turnIndex != null ? conversation.slice(0, turnIndex + 1) : conversation;
-
-    // 8. Build prompt_snapshot
-    const promptSnapshot = JSON.stringify({
-      url: (effectiveConfig as { resolvedRequestUrl?: string } | undefined)?.resolvedRequestUrl ?? "",
-      method: "post",
-      request_params: {
-        // Full harness config spread
-        ...(effectiveConfig
-          ? {
-              systemOverride: effectiveConfig.systemOverride,
-              toolsConfig: effectiveConfig.toolsConfig,
-              tools: effectiveConfig.tools,
-              schema: effectiveConfig.schema,
-              providerConfig: effectiveConfig.providerConfig,
-              baseUrl: effectiveConfig.baseUrl,
-              mcpServers: effectiveConfig.mcpServers,
-              model: effectiveConfig.model,
-              provider: effectiveConfig.provider,
-              temperature: effectiveConfig.temperature,
-              source: effectiveConfig.source,
-              repos: effectiveConfig.repos,
-            }
-          : {}),
-        messages: slicedConversation, // role:"system" at index 0 is preserved by slice(0, n+1)
-      },
-    });
-
-    // 9. Extract metadata.prompts (handles both flat array and PromptResolution map shapes)
-    const metadata =
-      agentLog.metadata != null && typeof agentLog.metadata === "object"
-        ? (agentLog.metadata as Record<string, unknown>)
-        : {};
-    const rawPrompts = metadata.prompts;
-    const metadataPrompts: unknown[] = Array.isArray(rawPrompts)
-      ? (rawPrompts as unknown[])
-      : (mapPromptResolutions(
-          rawPrompts as Record<string, PromptResolution> | null | undefined,
-        ) ?? []);
-
-    // 10. Resolve change_type
-    const changeType = agentLog.source ?? (effectiveConfig?.source as string | undefined) ?? "swarm_agent";
-
-    // 10a. Derive EvalTrigger source discriminator
-    const evalTriggerSource = deriveEvalTriggerSource(
-      agentLog.source,
-      (effectiveConfig as { resolvedRequestUrl?: string } | undefined)?.resolvedRequestUrl,
-    );
-
-    // 10b. Resolve canonical agent name: parse from AgentLog.agent (primary),
-    //      fall back to source-bucket default.
-    const parsedAgent = parseCanonicalAgent(agentLog.agent ?? "");
-    const resolvedAgent =
-      parsedAgent ??
-      resolveHiveAgentName(evalTriggerSource);
-    logger.info(`[AgentEvalCapture] Resolved agent: ${resolvedAgent} (parsed=${parsedAgent ?? "none"}, source=${evalTriggerSource})`);
-
     const { swarmName, swarmApiKey } = swarmAccessResult.data;
     const jarvisUrl = getJarvisUrl(swarmName);
     const nodeConfig = { jarvisUrl, apiKey: swarmApiKey };
@@ -182,106 +100,142 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     const evalSetRef = evalSetId.trim();
     logger.info(`[AgentEvalCapture] Using EvalSet ref_id: ${evalSetRef}`);
 
-    // 11. Create EvalRequirement node
-    const reqResult = await addNode(nodeConfig, {
-      node_type: "EvalRequirement",
-      node_data: {
-        id: randomUUID(),
-        name: requirement.trim(),
-      },
-    });
+    // 6. Branch: build prompt_snapshot, resolve agent, etc.
+    let promptSnapshot: string;
+    let changeType: string;
+    let evalTriggerSource: ReturnType<typeof deriveEvalTriggerSource>;
+    let resolvedAgent: string;
+    let metadataPrompts: string[] = [];
+    let environment: string;
 
-    if (!reqResult.success || !reqResult.ref_id) {
-      logger.error("[AgentEvalCapture] Failed to create EvalRequirement", reqResult.error);
-      return NextResponse.json({ error: "Failed to create requirement" }, { status: 502 });
-    }
-    const requirementRef = reqResult.ref_id;
-    logger.info(`[AgentEvalCapture] EvalRequirement created, ref_id: ${requirementRef}`);
+    if (captured.kind === "agent_log") {
+      // ── AgentLog branch (identical to previous behaviour) ──────────────────
+      const { conversation, effectiveConfig, agent, source, metadata } = captured;
 
-    // 12. Create EvalTrigger node
-    const scopeKey = turnIndex != null ? `turn:${turnIndex}` : "session:full";
+      // Slice conversation
+      const slicedConversation =
+        turnIndex != null ? conversation.slice(0, turnIndex + 1) : conversation;
 
-    const triggerResult = await addNode(nodeConfig, {
-      node_type: "EvalTrigger",
-      node_data: {
-        id: randomUUID(),
-        agent: resolvedAgent,
-        environment: logId,
-        change_type: changeType,
-        source: evalTriggerSource,
-        start_point: scopeKey,
-        end_point: scopeKey,
-        body: JSON.stringify({
-          prompt_snapshot: promptSnapshot,
-          output_snapshot: null,
-          tool_call_trace: null,
-          feedback_note: reason ?? null,
-        }),
-        ...(metadataPrompts.length > 0
-          ? { prompts: metadataPrompts.map((p) => JSON.stringify(p)) }
-          : {}),
-      },
-    });
-
-    if (!triggerResult.success || !triggerResult.ref_id) {
-      logger.error("[AgentEvalCapture] Failed to create EvalTrigger", triggerResult.error);
-      return NextResponse.json({ error: "Failed to create trigger" }, { status: 502 });
-    }
-    const triggerRef = triggerResult.ref_id;
-    logger.info(`[AgentEvalCapture] EvalTrigger created, ref_id: ${triggerRef}`);
-
-    // 13. Upsert HiveAgent node + ATTRIBUTED_TO edge (non-fatal)
-    try {
-      const agentSpec = getCaptureAgentSpec(resolvedAgent);
-      const hiveAgentResult = await addNode(nodeConfig, {
-        node_type: "HiveAgent",
-        node_data: {
-          name: resolvedAgent,
-          display_name: agentSpec.displayName,
-          description: agentSpec.description,
+      // Build prompt_snapshot
+      promptSnapshot = JSON.stringify({
+        url: (effectiveConfig as { resolvedRequestUrl?: string } | undefined)?.resolvedRequestUrl ?? "",
+        method: "post",
+        request_params: {
+          ...(effectiveConfig
+            ? {
+                systemOverride: effectiveConfig.systemOverride,
+                toolsConfig: effectiveConfig.toolsConfig,
+                tools: effectiveConfig.tools,
+                schema: effectiveConfig.schema,
+                providerConfig: effectiveConfig.providerConfig,
+                baseUrl: effectiveConfig.baseUrl,
+                mcpServers: effectiveConfig.mcpServers,
+                model: effectiveConfig.model,
+                provider: effectiveConfig.provider,
+                temperature: effectiveConfig.temperature,
+                source: effectiveConfig.source,
+                repos: effectiveConfig.repos,
+              }
+            : {}),
+          messages: slicedConversation,
         },
       });
-      logger.info(
-        `[AgentEvalCapture] HiveAgent upsert: success=${hiveAgentResult.success} alreadyExists=${hiveAgentResult.alreadyExists ?? false} ref_id=${hiveAgentResult.ref_id ?? "n/a"}`,
+
+      // Extract metadata.prompts
+      const metaObj =
+        metadata != null && typeof metadata === "object"
+          ? (metadata as Record<string, unknown>)
+          : {};
+      const rawPrompts = metaObj.prompts;
+      const promptsArr: unknown[] = Array.isArray(rawPrompts)
+        ? (rawPrompts as unknown[])
+        : (mapPromptResolutions(
+            rawPrompts as Record<string, PromptResolution> | null | undefined,
+          ) ?? []);
+      metadataPrompts = promptsArr.map((p) => JSON.stringify(p));
+
+      changeType = source ?? (effectiveConfig?.source as string | undefined) ?? "swarm_agent";
+
+      evalTriggerSource = deriveEvalTriggerSource(
+        source,
+        (effectiveConfig as { resolvedRequestUrl?: string } | undefined)?.resolvedRequestUrl,
       );
 
-      if (hiveAgentResult.success) {
-        const attrEdgeResult = await addEdge(nodeConfig, {
-          edge: { edge_type: "ATTRIBUTED_TO" },
-          source: { ref_id: triggerRef },
-          target: { node_type: "HiveAgent", node_data: { name: resolvedAgent } },
-        });
-        logger.info(`[AgentEvalCapture] ATTRIBUTED_TO edge: success=${attrEdgeResult.success}`);
-        if (!attrEdgeResult.success) {
-          logger.warn(`[AgentEvalCapture] ATTRIBUTED_TO edge failed (non-fatal): ${attrEdgeResult.error}`);
-        }
+      // Agent override takes priority when it's a valid catalog name; otherwise
+      // parse from AgentLog.agent (primary), fall back to source-bucket default.
+      if (agentOverride != null && isCaptureAgentName(agentOverride)) {
+        resolvedAgent = agentOverride;
       } else {
-        logger.warn(`[AgentEvalCapture] HiveAgent upsert failed (non-fatal): ${hiveAgentResult.error}`);
+        const parsedAgent = parseCanonicalAgent(agent ?? "");
+        resolvedAgent = parsedAgent ?? resolveHiveAgentName(evalTriggerSource);
       }
-    } catch (err) {
-      logger.warn(`[AgentEvalCapture] HiveAgent/ATTRIBUTED_TO step threw (non-fatal): ${String(err)}`);
+
+      environment = logId;
+    } else {
+      // ── SharedConversation branch ───────────────────────────────────────────
+      const { conversation, source, conversationId } = captured;
+
+      // For conversations no blob or config exists; snapshot is just the messages
+      const slicedConversation =
+        turnIndex != null ? conversation.slice(0, turnIndex + 1) : conversation;
+
+      promptSnapshot = JSON.stringify({
+        url: "",
+        method: "post",
+        request_params: {
+          messages: slicedConversation,
+        },
+      });
+
+      changeType = source ?? "canvas_chat";
+
+      // canvas_chat → jamie_agent → canvas-agent default
+      evalTriggerSource = deriveEvalTriggerSource("canvas_chat", undefined);
+
+      // Agent override takes priority; otherwise default to canvas-agent
+      if (agentOverride != null && isCaptureAgentName(agentOverride)) {
+        resolvedAgent = agentOverride;
+      } else {
+        resolvedAgent = resolveHiveAgentName(evalTriggerSource);
+      }
+
+      environment = conversationId;
     }
 
-    // EvalSet -[HAS_REQUIREMENT]-> EvalRequirement
-    await addEdge(nodeConfig, {
-      edge: { edge_type: "HAS_REQUIREMENT" },
-      source: { ref_id: evalSetRef },
-      target: { ref_id: requirementRef },
-    });
-    logger.info("[AgentEvalCapture] HAS_REQUIREMENT edge created");
+    logger.info(
+      `[AgentEvalCapture] Resolved agent: ${resolvedAgent} (source=${evalTriggerSource}, kind=${captured.kind})`,
+    );
 
-    // EvalRequirement -[HAS_TRIGGER]-> EvalTrigger
-    await addEdge(nodeConfig, {
-      edge: { edge_type: "HAS_TRIGGER" },
-      source: { ref_id: requirementRef },
-      target: { ref_id: triggerRef },
-    });
-    logger.info("[AgentEvalCapture] HAS_TRIGGER edge created");
+    const scopeKey = turnIndex != null ? `turn:${turnIndex}` : "session:full";
 
-    // 15. Return success
+    // 7. Create eval nodes + edges via shared helper
+    const result = await createEvalNodes({
+      nodeConfig,
+      evalSetRef,
+      requirement,
+      reason,
+      promptSnapshot,
+      changeType,
+      evalTriggerSource,
+      resolvedAgent,
+      scopeKey,
+      environment,
+      metadataPrompts,
+    });
+
+    if ("error" in result) {
+      return NextResponse.json({ error: result.error }, { status: result.status });
+    }
+
+    // 8. Return success
     return NextResponse.json({
       success: true,
-      data: { evalSetRef, requirementRef, triggerRef, agentName: resolvedAgent },
+      data: {
+        evalSetRef,
+        requirementRef: result.requirementRef,
+        triggerRef: result.triggerRef,
+        agentName: result.agentName,
+      },
     });
   } catch (error) {
     logger.error("[AgentEvalCapture] Unexpected error", String(error));

--- a/src/app/api/workspaces/[slug]/agent-logs/[logId]/flag-as-eval/route.ts
+++ b/src/app/api/workspaces/[slug]/agent-logs/[logId]/flag-as-eval/route.ts
@@ -5,8 +5,8 @@ import { getJarvisUrl } from "@/lib/utils/swarm";
 import { getWorkspaceSwarmAccess } from "@/lib/helpers/swarm-access";
 import { addNode, addEdge } from "@/services/swarm/api/nodes";
 import { lookupAgentSessionByLogUrl } from "@/lib/utils/agent-session-lookup";
-import { db } from "@/lib/db";
 import { isEvalTriggerSource, type EvalTriggerSource } from "@/lib/utils/eval-source";
+import { resolveCaptureSource } from "@/lib/eval-capture/resolve-capture-source";
 import { logger } from "@/lib/logger";
 
 type RouteParams = { params: Promise<{ slug: string; logId: string }> };
@@ -36,25 +36,6 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     if (!swarmAccessResult.success) {
       logger.warn("[FlagAsEval] Swarm access denied", swarmAccessResult.error.type);
       return handleSwarmAccessError(swarmAccessResult.error);
-    }
-
-    // IDOR guard — verify the log belongs to this workspace
-    const agentLog = await db.agentLog.findUnique({
-      where: { id: logId },
-      select: { workspaceId: true, blobUrl: true },
-    });
-
-    if (!agentLog) {
-      return NextResponse.json({ error: "Agent log not found" }, { status: 404 });
-    }
-
-    const logWorkspace = await db.workspace.findUnique({
-      where: { id: agentLog.workspaceId },
-      select: { slug: true },
-    });
-
-    if (!logWorkspace || logWorkspace.slug !== slug) {
-      return NextResponse.json({ error: "Access denied" }, { status: 403 });
     }
 
     // Parse and validate request body
@@ -95,7 +76,17 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       );
     }
 
-    // USE_MOCKS branch
+    // IDOR guard — verify the log (AgentLog OR SharedConversation) belongs to this workspace
+    const captured = await resolveCaptureSource(slug, logId);
+
+    if (captured === null) {
+      return NextResponse.json({ error: "Agent log not found" }, { status: 404 });
+    }
+    if ("denied" in captured) {
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
+    }
+
+    // USE_MOCKS branch (after IDOR check — mock routes are id-agnostic)
     if (process.env.USE_MOCKS === "true") {
       logger.info("[FlagAsEval] USE_MOCKS=true, routing to mock endpoint");
       const mockResponse = await fetch(
@@ -168,17 +159,21 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       target: { ref_id: triggerRefId },
     });
 
-    // 5. Optional: look up AgentSession by log URL and create EVALUATED edge
+    // 5. Optional: look up AgentSession by log URL (only available for AgentLog branch)
     let sessionRefId: string | undefined;
-    const foundSession = await lookupAgentSessionByLogUrl(config, agentLog.blobUrl);
-    if (foundSession) {
-      sessionRefId = foundSession;
-      await addEdge(config, {
-        edge: { edge_type: "EVALUATED" },
-        source: { ref_id: triggerRefId },
-        target: { ref_id: sessionRefId },
-      });
+    if (captured.kind === "agent_log") {
+      const foundSession = await lookupAgentSessionByLogUrl(config, captured.blobUrl);
+      if (foundSession) {
+        sessionRefId = foundSession;
+        await addEdge(config, {
+          edge: { edge_type: "EVALUATED" },
+          source: { ref_id: triggerRefId },
+          target: { ref_id: sessionRefId },
+        });
+      }
     }
+
+    logger.info(`[FlagAsEval] resolved source=${captured.kind} logId=${logId}`);
 
     return NextResponse.json({
       success: true,

--- a/src/lib/eval-capture/create-eval-nodes.ts
+++ b/src/lib/eval-capture/create-eval-nodes.ts
@@ -1,0 +1,153 @@
+/**
+ * Shared eval-node/edge creation logic for all eval-capture routes.
+ *
+ * Extracts EvalRequirement, EvalTrigger, HiveAgent upsert, and
+ * HAS_REQUIREMENT / HAS_TRIGGER / ATTRIBUTED_TO / EVALUATED edge wiring
+ * so both routes and both record-type branches call the same code.
+ */
+import { randomUUID } from "crypto";
+import { addNode, addEdge } from "@/services/swarm/api/nodes";
+import { getCaptureAgentSpec } from "@/lib/utils/hive-agent";
+import { logger } from "@/lib/logger";
+import type { JarvisConnectionConfig } from "@/types/jarvis";
+import type { EvalTriggerSource } from "@/lib/utils/eval-source";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface CreateEvalNodesOptions {
+  nodeConfig: JarvisConnectionConfig;
+  evalSetRef: string;
+  requirement: string;
+  reason?: string | null;
+  /** Sliced conversation already turned into a JSON-serialisable prompt snapshot */
+  promptSnapshot: string;
+  changeType: string;
+  evalTriggerSource: EvalTriggerSource;
+  resolvedAgent: string;
+  scopeKey: string;
+  environment: string;
+  /** Array of individually JSON-stringified prompt resolution strings */
+  metadataPrompts?: string[];
+}
+
+export interface CreateEvalNodesResult {
+  requirementRef: string;
+  triggerRef: string;
+  agentName: string;
+}
+
+// ── Implementation ────────────────────────────────────────────────────────────
+
+export async function createEvalNodes(
+  options: CreateEvalNodesOptions,
+): Promise<CreateEvalNodesResult | { error: string; status: number }> {
+  const {
+    nodeConfig,
+    evalSetRef,
+    requirement,
+    reason,
+    promptSnapshot,
+    changeType,
+    evalTriggerSource,
+    resolvedAgent,
+    scopeKey,
+    environment,
+    metadataPrompts = [],
+  } = options;
+
+  // 1. Create EvalRequirement node
+  const reqResult = await addNode(nodeConfig, {
+    node_type: "EvalRequirement",
+    node_data: {
+      id: randomUUID(),
+      name: requirement.trim(),
+    },
+  });
+
+  if (!reqResult.success || !reqResult.ref_id) {
+    logger.error("[AgentEvalCapture] Failed to create EvalRequirement", reqResult.error);
+    return { error: "Failed to create requirement", status: 502 };
+  }
+  const requirementRef = reqResult.ref_id;
+  logger.info(`[AgentEvalCapture] EvalRequirement created, ref_id: ${requirementRef}`);
+
+  // 2. Create EvalTrigger node
+  const triggerResult = await addNode(nodeConfig, {
+    node_type: "EvalTrigger",
+    node_data: {
+      id: randomUUID(),
+      agent: resolvedAgent,
+      environment,
+      change_type: changeType,
+      source: evalTriggerSource,
+      start_point: scopeKey,
+      end_point: scopeKey,
+      body: JSON.stringify({
+        prompt_snapshot: promptSnapshot,
+        output_snapshot: null,
+        tool_call_trace: null,
+        feedback_note: reason ?? null,
+      }),
+      ...(metadataPrompts.length > 0
+        ? { prompts: metadataPrompts }
+        : {}),
+    },
+  });
+
+  if (!triggerResult.success || !triggerResult.ref_id) {
+    logger.error("[AgentEvalCapture] Failed to create EvalTrigger", triggerResult.error);
+    return { error: "Failed to create trigger", status: 502 };
+  }
+  const triggerRef = triggerResult.ref_id;
+  logger.info(`[AgentEvalCapture] EvalTrigger created, ref_id: ${triggerRef}`);
+
+  // 3. Upsert HiveAgent node + ATTRIBUTED_TO edge (non-fatal)
+  try {
+    const agentSpec = getCaptureAgentSpec(resolvedAgent);
+    const hiveAgentResult = await addNode(nodeConfig, {
+      node_type: "HiveAgent",
+      node_data: {
+        name: resolvedAgent,
+        display_name: agentSpec.displayName,
+        description: agentSpec.description,
+      },
+    });
+    logger.info(
+      `[AgentEvalCapture] HiveAgent upsert: success=${hiveAgentResult.success} alreadyExists=${hiveAgentResult.alreadyExists ?? false} ref_id=${hiveAgentResult.ref_id ?? "n/a"}`,
+    );
+
+    if (hiveAgentResult.success) {
+      const attrEdgeResult = await addEdge(nodeConfig, {
+        edge: { edge_type: "ATTRIBUTED_TO" },
+        source: { ref_id: triggerRef },
+        target: { node_type: "HiveAgent", node_data: { name: resolvedAgent } },
+      });
+      logger.info(`[AgentEvalCapture] ATTRIBUTED_TO edge: success=${attrEdgeResult.success}`);
+      if (!attrEdgeResult.success) {
+        logger.warn(`[AgentEvalCapture] ATTRIBUTED_TO edge failed (non-fatal): ${attrEdgeResult.error}`);
+      }
+    } else {
+      logger.warn(`[AgentEvalCapture] HiveAgent upsert failed (non-fatal): ${hiveAgentResult.error}`);
+    }
+  } catch (err) {
+    logger.warn(`[AgentEvalCapture] HiveAgent/ATTRIBUTED_TO step threw (non-fatal): ${String(err)}`);
+  }
+
+  // 4. EvalSet -[HAS_REQUIREMENT]-> EvalRequirement
+  await addEdge(nodeConfig, {
+    edge: { edge_type: "HAS_REQUIREMENT" },
+    source: { ref_id: evalSetRef },
+    target: { ref_id: requirementRef },
+  });
+  logger.info("[AgentEvalCapture] HAS_REQUIREMENT edge created");
+
+  // 5. EvalRequirement -[HAS_TRIGGER]-> EvalTrigger
+  await addEdge(nodeConfig, {
+    edge: { edge_type: "HAS_TRIGGER" },
+    source: { ref_id: requirementRef },
+    target: { ref_id: triggerRef },
+  });
+  logger.info("[AgentEvalCapture] HAS_TRIGGER edge created");
+
+  return { requirementRef, triggerRef, agentName: resolvedAgent };
+}

--- a/src/lib/eval-capture/resolve-capture-source.ts
+++ b/src/lib/eval-capture/resolve-capture-source.ts
@@ -1,0 +1,157 @@
+/**
+ * Shared transcript resolver for eval-capture routes.
+ *
+ * Tries AgentLog first (existing path); if not found, falls back to
+ * SharedConversation mirroring the exact ownership check used in the
+ * GET /api/workspaces/[slug]/chat/conversations/[conversationId] route.
+ *
+ * IDOR: ownership is verified here, before any blob fetch, Jarvis write,
+ * or mock delegation.
+ */
+import { db } from "@/lib/db";
+import { fetchBlobContent } from "@/lib/utils/blob-fetch";
+import { parseAgentLogStats } from "@/lib/utils/agent-log-stats";
+import { chatMessagesToParsedMessages } from "@/lib/utils/chat-conversation-log";
+import type { ParsedMessage } from "@/lib/utils/agent-log-stats";
+import { logger } from "@/lib/logger";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type CaptureSource =
+  | {
+      kind: "agent_log";
+      workspaceId: string;
+      blobUrl: string;
+      agent: string | null;
+      source: string | null;
+      metadata: unknown;
+      config: unknown;
+      conversation: ParsedMessage[];
+      effectiveConfig: Record<string, unknown> | undefined;
+    }
+  | {
+      kind: "conversation";
+      workspaceId: string;
+      conversationId: string;
+      source: string | null;
+      conversation: ParsedMessage[];
+    };
+
+// ── Resolver ──────────────────────────────────────────────────────────────────
+
+/**
+ * @param slug       - Workspace slug from the route params.
+ * @param id         - The logId / conversationId from the route params.
+ * @returns CaptureSource discriminated union, or null if the record is not
+ *          found, or a 403-style object if found but not owned by the workspace.
+ */
+export async function resolveCaptureSource(
+  slug: string,
+  id: string,
+): Promise<CaptureSource | { denied: true } | null> {
+  // ── 1. Fetch workspace (needed for IDOR checks) ────────────────────────────
+  const workspace = await db.workspace.findFirst({
+    where: { slug, deleted: false },
+    select: { id: true, sourceControlOrgId: true },
+  });
+
+  if (!workspace) return null;
+
+  // ── 2. Try AgentLog first ─────────────────────────────────────────────────
+  const agentLog = await db.agentLog.findUnique({
+    where: { id },
+    select: {
+      workspaceId: true,
+      blobUrl: true,
+      agent: true,
+      source: true,
+      metadata: true,
+      config: true,
+    },
+  });
+
+  if (agentLog) {
+    // IDOR: verify this log belongs to the requested workspace
+    if (agentLog.workspaceId !== workspace.id) {
+      logger.warn(
+        `[AgentEvalCapture] IDOR: agentLog ${id} belongs to workspace ${agentLog.workspaceId}, not ${workspace.id}`,
+      );
+      return { denied: true };
+    }
+
+    // Fetch and parse blob content
+    const blobContent = await fetchBlobContent(agentLog.blobUrl);
+    const { conversation, config: blobConfig } = parseAgentLogStats(blobContent);
+
+    // Prefer DB column (canonical); fall back to blob-parsed config for legacy rows
+    const effectiveConfig =
+      agentLog.config && typeof agentLog.config === "object"
+        ? (agentLog.config as Record<string, unknown>)
+        : (blobConfig as Record<string, unknown> | undefined);
+
+    logger.info(`[AgentEvalCapture] resolved source=agent_log trigger=${agentLog.source ?? "unknown"}`);
+
+    return {
+      kind: "agent_log",
+      workspaceId: agentLog.workspaceId,
+      blobUrl: agentLog.blobUrl,
+      agent: agentLog.agent,
+      source: agentLog.source,
+      metadata: agentLog.metadata,
+      config: agentLog.config,
+      conversation,
+      effectiveConfig,
+    };
+  }
+
+  // ── 3. Fall back to SharedConversation ────────────────────────────────────
+  //
+  // Mirrors the exact ownership fallback in:
+  //   GET /api/workspaces/[slug]/chat/conversations/[conversationId]/route.ts
+  //
+  // Primary: match by workspaceId
+  let conversation = await db.sharedConversation.findFirst({
+    where: { id, workspaceId: workspace.id },
+    select: { id: true, workspaceId: true, sourceControlOrgId: true, source: true, messages: true },
+  });
+
+  // Fallback: org-scoped canvas/graph-walk sessions (workspaceId is null for these)
+  if (!conversation && workspace.sourceControlOrgId) {
+    conversation = await db.sharedConversation.findFirst({
+      where: {
+        id,
+        sourceControlOrgId: workspace.sourceControlOrgId,
+        source: { in: ["org-canvas", "graph-walk"] },
+      },
+      select: { id: true, workspaceId: true, sourceControlOrgId: true, source: true, messages: true },
+    });
+  }
+
+  if (!conversation) {
+    return null;
+  }
+
+  // IDOR: if workspaceId is set, it must match; org-fallback is already scoped
+  // by org ownership, which was gated by getWorkspaceSwarmAccess above.
+  if (conversation.workspaceId !== null && conversation.workspaceId !== workspace.id) {
+    logger.warn(
+      `[AgentEvalCapture] IDOR: conversation ${id} belongs to workspace ${conversation.workspaceId}, not ${workspace.id}`,
+    );
+    return { denied: true };
+  }
+
+  const rawMessages = Array.isArray(conversation.messages) ? conversation.messages : [];
+  const parsedMessages = chatMessagesToParsedMessages(
+    rawMessages as unknown as Parameters<typeof chatMessagesToParsedMessages>[0],
+  );
+
+  logger.info(`[AgentEvalCapture] resolved source=conversation trigger=canvas_chat`);
+
+  return {
+    kind: "conversation",
+    workspaceId: workspace.id,
+    conversationId: conversation.id,
+    source: conversation.source,
+    conversation: parsedMessages,
+  };
+}


### PR DESCRIPTION
Extend eval-capture routes to support AgentLog and SharedConversation with agent override and IDOR checks