### PR TITLE
fix(jarvis): treat edge-bulk 'Warning' as success so the mirror cursor advances

### DIFF
--- a/src/__tests__/unit/services/swarm/api/nodes.test.ts
+++ b/src/__tests__/unit/services/swarm/api/nodes.test.ts
@@ -424,7 +424,7 @@ describe("addEdgeBulk", () => {
       expect(result.errors).toHaveLength(0);
     });
 
-    test("returns success:true with Warning status when no error messages", async () => {
+    test("returns success:true with Warning status when no error messages (dups skipped)", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 200,
@@ -436,8 +436,11 @@ describe("addEdgeBulk", () => {
 
       const result = await addEdgeBulk(config, edgeList);
 
-      expect(result.success).toBe(false); // Warning is not "success"
-      expect(result.errors).toHaveLength(0); // no "error" prefixed messages
+      // Jarvis returns "Warning" for benign notices like skipped duplicate
+      // edges on re-runs. Success must key off the absence of real errors, not
+      // status === "success", or the mirror cursor freezes on the second pass.
+      expect(result.success).toBe(true);
+      expect(result.errors).toHaveLength(0);
     });
   });
 
@@ -458,7 +461,7 @@ describe("addEdgeBulk", () => {
 
       const result = await addEdgeBulk(config, edgeList);
 
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false); // real errors present → not success
       expect(result.errors).toEqual([
         "Error: invalid ref_id for item 2",
         "error: missing source node",

--- a/src/services/swarm/api/nodes.ts
+++ b/src/services/swarm/api/nodes.ts
@@ -216,8 +216,17 @@ async function executeBulkEdgeRequest(
     m.toLowerCase().startsWith("error"),
   );
 
+  // Success means "no real errors" — NOT status === "success". Jarvis returns
+  // status "Warning" whenever status_messages is non-empty, which includes
+  // benign notices like duplicate edges being skipped on re-runs
+  // (skipped_dup). Treating "Warning" as failure caused the jarvis-mirror
+  // cursor (advanced only when nodes AND edges succeed) to freeze for any
+  // entity type that writes edges: on the second pass every edge is a dup →
+  // "Warning" → edgesOk=false → cursor never advances (tasks/chat stuck while
+  // edge-less features advanced fine). Mirror `addNodeBulk`, which already
+  // keys success off the error count.
   return {
-    success: body?.status?.toLowerCase() === "success",
+    success: errors.length === 0,
     errors,
   };
 }


### PR DESCRIPTION
## The bug behind tasks & chat being permanently stuck

The `jarvis-mirror` advances its per-entity keyset cursor only when **both** the node bulk *and* the edge bulk succeed (`if (nodesOk && edgesOk)`). `executeBulkEdgeRequest` computed:

```ts
success: body?.status?.toLowerCase() === "success"
```

But jarvis-backend sets `status = "Warning" if status_messages else "Success"` — and `status_messages` is non-empty for **benign** notices, most importantly **duplicate edges skipped on a re-run** (`skipped_dup`). So on the second pass over any already-synced batch, every edge is a dup → jarvis returns `"Warning"` → `success=false`.

Critically, those dup notices are **not** `"error"`-prefixed, so `errors` stays empty. Result: `edgesOk=false` with **zero errors reported** → the cursor never advances, counts stay flat, and nothing shows up in `errorSamples`.

### Why only tasks & chat
- **Features** write no edges → gated on `nodesOk` only → advanced fine (caught up).
- **Tasks & chat** write edges (`HAS_TASK`, `HAS_MESSAGE`) → `edgesOk` perpetually `false` after the first batch exists → frozen (`HiveTask` stuck at 1000, `HiveChatMessage` stuck at 500) despite thousands of un-synced live rows and jarvis returning `200 OK`.

This exactly matched the observed signature: `200 OK`, `errorSamples: 0`, counts not moving.

## Fix

Key success off the absence of **real** (error-prefixed) messages — same semantics `addNodeBulk` already uses (`success: errors.length === 0`). "Warning" from skipped dups is now correctly treated as success, so the cursor advances and tasks/chat drain.

Applies to both `addEdgeBulk` and `addEdgeByRefBulk` (shared `executeBulkEdgeRequest`).

## Tests
Updated the two edge-bulk tests that encoded the old status-based behavior; 71 tests pass across the nodes + mirror-cron suites.