### PR TITLE
Decouple prompt agent names from the publish lifecycle

### DIFF
--- a/src/__tests__/integration/api/workflow-prompts-hive.test.ts
+++ b/src/__tests__/integration/api/workflow-prompts-hive.test.ts
@@ -5,7 +5,7 @@
 import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
 import { NextRequest } from "next/server";
 import { GET, POST } from "@/app/api/workflow/prompts/route";
-import { GET as GET_BY_ID, PUT, DELETE } from "@/app/api/workflow/prompts/[id]/route";
+import { GET as GET_BY_ID, PUT, PATCH, DELETE } from "@/app/api/workflow/prompts/[id]/route";
 import { GET as GET_VERSIONS, } from "@/app/api/workflow/prompts/[id]/versions/route";
 import { GET as GET_VERSION_BY_ID } from "@/app/api/workflow/prompts/[id]/versions/[versionId]/route";
 import { POST as PUBLISH } from "@/app/api/workflow/prompts/[id]/versions/[versionId]/publish/route";
@@ -917,6 +917,96 @@ describe("Hive-native Prompt CRUD + Write-through Sync", () => {
       expect(sentBody.agent_names).toBeUndefined();
       expect(sentBody.prompt.agentNames).toBeUndefined();
       expect(sentBody.prompt.agent_names).toBeUndefined();
+    });
+  });
+
+  // ─── PATCH agentNames (decoupled from version/publish lifecycle) ──────────────
+
+  describe("PATCH agentNames (no new version, no publish)", () => {
+    test("PATCH updates agentNames without creating a new version", async () => {
+      authAs(testUser);
+      stakworkOkCreate(210);
+
+      const createRes = await POST(
+        makeReq("http://localhost/api/workflow/prompts", "POST", {
+          name: "AGENT_NAMES_PATCH",
+          value: "v1",
+          agentNames: ["repo-agent"],
+        }),
+      );
+      const created = (await createRes.json()).data;
+      createdPromptIds.push(created.id);
+
+      const fetchCallsBefore = mockFetch.mock.calls.length;
+
+      authAs(testUser);
+      const patchRes = await PATCH(
+        makeReq(`http://localhost/api/workflow/prompts/${created.id}`, "PATCH", {
+          agentNames: ["repo-agent", "chat-agent"],
+        }),
+        { params: Promise.resolve({ id: created.id }) },
+      );
+      expect(patchRes.status).toBe(200);
+      const patchData = (await patchRes.json()).data;
+      expect(patchData.agent_names).toEqual(["repo-agent", "chat-agent"]);
+
+      const prompt = await db.prompt.findUnique({
+        where: { id: created.id },
+        include: { versions: true },
+      });
+      // No new version created — still just the initial published version.
+      expect(prompt!.versions).toHaveLength(1);
+      expect(prompt!.agentNames).toEqual(["repo-agent", "chat-agent"]);
+      // Published pointer unchanged (still the original published version).
+      expect(prompt!.publishedVersionId).toBe(created.published_version_id);
+      // No Stakwork push for a metadata-only PATCH.
+      expect(mockFetch.mock.calls.length).toBe(fetchCallsBefore);
+    });
+
+    test("PATCH validates agent names and rejects unknown ones with 400", async () => {
+      authAs(testUser);
+      stakworkOkCreate(211);
+
+      const createRes = await POST(
+        makeReq("http://localhost/api/workflow/prompts", "POST", {
+          name: "AGENT_NAMES_PATCH_INVALID",
+          value: "v1",
+        }),
+      );
+      const created = (await createRes.json()).data;
+      createdPromptIds.push(created.id);
+
+      authAs(testUser);
+      const patchRes = await PATCH(
+        makeReq(`http://localhost/api/workflow/prompts/${created.id}`, "PATCH", {
+          agentNames: ["not-a-real-agent"],
+        }),
+        { params: Promise.resolve({ id: created.id }) },
+      );
+      expect(patchRes.status).toBe(400);
+      const body = await patchRes.json();
+      expect(body.error).toMatch(/Invalid agent name/);
+    });
+
+    test("PATCH returns 400 when agentNames is omitted", async () => {
+      authAs(testUser);
+      stakworkOkCreate(212);
+
+      const createRes = await POST(
+        makeReq("http://localhost/api/workflow/prompts", "POST", {
+          name: "AGENT_NAMES_PATCH_MISSING",
+          value: "v1",
+        }),
+      );
+      const created = (await createRes.json()).data;
+      createdPromptIds.push(created.id);
+
+      authAs(testUser);
+      const patchRes = await PATCH(
+        makeReq(`http://localhost/api/workflow/prompts/${created.id}`, "PATCH", {}),
+        { params: Promise.resolve({ id: created.id }) },
+      );
+      expect(patchRes.status).toBe(400);
     });
   });
 

--- a/src/app/api/workflow/prompts/[id]/route.ts
+++ b/src/app/api/workflow/prompts/[id]/route.ts
@@ -218,6 +218,72 @@ export async function PUT(
   }
 }
 
+// ─── PATCH /api/workflow/prompts/[id] ────────────────────────────────────────
+// Lightweight update for Prompt-level metadata that is NOT versioned (agent
+// names). Unlike PUT, this never creates a new draft version and never touches
+// the publish lifecycle — it writes directly to the Prompt row.
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const devMode = isDevelopmentMode();
+    const authResult = await getAuthenticatedUserId(devMode);
+    if (authResult instanceof NextResponse) return authResult;
+    const { userId } = authResult;
+
+    const denied = await requireWriteAccess(userId, devMode);
+    if (denied) return denied;
+
+    const { id } = await params;
+    if (!id) {
+      return NextResponse.json({ error: "Prompt ID is required" }, { status: 400 });
+    }
+
+    const body = await request.json();
+    const { agentNames } = body as { agentNames?: unknown };
+
+    if (agentNames === undefined) {
+      return NextResponse.json({ error: "agentNames is required" }, { status: 400 });
+    }
+
+    const normalizedAgentNames = normalizeAgentNames(agentNames);
+    if (!Array.isArray(normalizedAgentNames)) {
+      return NextResponse.json({ error: normalizedAgentNames.error }, { status: 400 });
+    }
+
+    const existing = await db.prompt.findUnique({ where: { id } });
+    if (!existing) {
+      return NextResponse.json({ error: "Prompt not found" }, { status: 404 });
+    }
+
+    await db.prompt.update({
+      where: { id },
+      data: { agentNames: normalizedAgentNames },
+    });
+
+    // Refetch with versions (ordered desc) so the response shape matches GET/PUT.
+    const updated = await db.prompt.findUnique({
+      where: { id },
+      include: {
+        versions: {
+          select: { id: true, versionNumber: true, value: true },
+          orderBy: { versionNumber: "desc" },
+        },
+      },
+    });
+    if (!updated) {
+      return NextResponse.json({ error: "Prompt not found after update" }, { status: 404 });
+    }
+
+    return NextResponse.json({ success: true, data: shapePromptDetail(updated) });
+  } catch (err: unknown) {
+    console.error("Error updating prompt agent names:", err);
+    return NextResponse.json({ error: "Failed to update agent names" }, { status: 500 });
+  }
+}
+
 // ─── DELETE /api/workflow/prompts/[id] ───────────────────────────────────────
 
 export async function DELETE(

--- a/src/components/prompts/index.tsx
+++ b/src/components/prompts/index.tsx
@@ -669,7 +669,6 @@ export function PromptsPanel({ workflowId, variant = "panel", onNavigateToWorkfl
         body: JSON.stringify({
           value: formValue.trim(),
           description: formDescription.trim(),
-          agentNames: formAgentNames,
         }),
       });
 
@@ -692,6 +691,38 @@ export function PromptsPanel({ workflowId, variant = "panel", onNavigateToWorkfl
       setError(err instanceof Error ? err.message : "Failed to update prompt");
     } finally {
       setIsSaving(false);
+    }
+  };
+
+  // Agent names are Prompt-level metadata (not versioned) and are saved
+  // independently of the draft/publish lifecycle. Autosave via PATCH.
+  const [isSavingAgentNames, setIsSavingAgentNames] = useState(false);
+
+  const handleSaveAgentNames = async (names: string[]) => {
+    if (!selectedPrompt) return;
+
+    const previous = selectedPrompt.agent_names ?? [];
+    // Optimistic update
+    setFormAgentNames(names);
+    setSelectedPrompt({ ...selectedPrompt, agent_names: names });
+    setIsSavingAgentNames(true);
+    try {
+      const response = await fetch(`/api/workflow/prompts/${selectedPrompt.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentNames: names }),
+      });
+      if (!response.ok) {
+        throw new Error("Failed to update agent names");
+      }
+    } catch (err) {
+      console.error("Error updating agent names:", err);
+      // Revert on failure
+      setFormAgentNames(previous);
+      setSelectedPrompt((prev) => (prev ? { ...prev, agent_names: previous } : prev));
+      setError(err instanceof Error ? err.message : "Failed to update agent names");
+    } finally {
+      setIsSavingAgentNames(false);
     }
   };
 
@@ -1191,32 +1222,15 @@ export function PromptsPanel({ workflowId, variant = "panel", onNavigateToWorkfl
                 <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
                   Agent Names
                 </label>
-                {isEditing ? (
-                  <div className="mt-1">
-                    <AgentNamesEditor
-                      agentNames={formAgentNames}
-                      onChange={setFormAgentNames}
-                      disabled={isSaving}
-                    />
-                  </div>
-                ) : (
-                  <div className="mt-1">
-                    {(selectedPrompt.agent_names ?? []).length === 0 ? (
-                      <p className="text-xs text-muted-foreground italic">No agents assigned.</p>
-                    ) : (
-                      <div className="flex flex-wrap gap-2">
-                        {(selectedPrompt.agent_names ?? []).map((name) => (
-                          <span
-                            key={name}
-                            className="inline-flex items-center rounded-full bg-muted px-3 py-1 text-xs font-medium"
-                          >
-                            {name}
-                          </span>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                )}
+                {/* Agent names are Prompt-level metadata — edited inline and saved
+                    immediately, independent of the draft/publish lifecycle. */}
+                <div className="mt-1">
+                  <AgentNamesEditor
+                    agentNames={selectedPrompt.agent_names ?? []}
+                    onChange={handleSaveAgentNames}
+                    disabled={isSavingAgentNames}
+                  />
+                </div>
               </div>
 
               <div>


### PR DESCRIPTION
## Problem

On the `/w/[slug]/prompts` page, adding/removing an **agent name** forced the prompt into an unpublished-draft state, so you had to **publish** to apply the change. That's confusing because agent names aren't versioned — they're stored on the `Prompt` row (`Prompt.agentNames`), stable across versions.

The friction was entirely in the write path: the UI only saved agent names by bundling them into `PUT /api/workflow/prompts/[id]`, which always creates a new unpublished draft version.

## Fix

- **API:** new `PATCH /api/workflow/prompts/[id]` that updates **only** `agentNames` directly on the `Prompt` row — no new version, no change to `publishedVersionId`, no Stakwork version push. Reuses existing `normalizeAgentNames` validation (trim, dedupe, reject unknown agents -> 400).
- **UI:** the `AgentNamesEditor` in the detail view is now always interactive (no longer gated behind Edit) and autosaves each add/remove via `PATCH` with optimistic update + revert-on-error.
- Removed `agentNames` from the version-creating `PUT` call. Managing agents and editing/publishing the prompt value are now fully separate flows. Create flow (`POST`) is unchanged.

## Tests

- Added integration tests: PATCH updates agent names **without** creating a version or a Stakwork push; rejects unknown agents (400); requires `agentNames` (400).
- `workflow-prompts-hive.test.ts`: 41/41 pass. Prompts UI unit tests: 28/28 pass. No new type errors.