### PR TITLE
jarvis-pr-link: partial linking + failure observability; org-context retrieval plan

### DIFF
--- a/docs/plans/org-context-retrieval.md
+++ b/docs/plans/org-context-retrieval.md
@@ -1,0 +1,202 @@
+# Org-Context Retrieval: Seed → PPR → Package
+
+Status: design, ready to implement. Substrate verified against prod (swarm38) 2026-07-04.
+
+## Problem
+
+Agents do accurate work in the wrong place. Given "add CSV export to the billing
+rollup," research and codegen are fine — but the agent doesn't reliably know
+*which* feature the user means (org jargon), *where* that feature lives
+(repos/dirs/files), or *how similar work was done before* (exemplar PRs). Today
+this is addressed by stuffing concept/repo descriptions into context, which
+degrades as the corpus grows (hundreds of concepts, dozens of repos, redundant
+and dead entries).
+
+The insight from comparing GNN embeddings vs. LLM-with-context: the LLM already
+knows software; what it lacks is the **org-specific delta** — the lexicon (what
+things are called here) and the placement prior (what goes where). Don't train a
+model to understand the org. Build small components that **look things up** for
+a model that already understands software, and make them learn from every merged
+PR.
+
+## Architecture: three steps at query time
+
+```
+user utterance / new task
+        │
+   [1] SEED — match text → graph nodes
+        │     alias/exact match on names (nameIndex fulltext)
+        │     + embedding search (vector index)
+        │     → 2-5 seed nodes (HiveFeature, Concept)
+        │
+   [2] WALK — personalized PageRank from seeds
+        │     jarvis POST /v2/graph/algorithm {algorithm_name: "page_rank",
+        │       sourceNodes: [...], relationshipWeightProperty: "weight"}
+        │     persist=false → stream mode, read-only, local computation
+        │     → scored neighborhood
+        │
+   [3] PACKAGE — filter + format for the consuming agent
+        │     top ~10 Files, ~3 Concepts, ~3 similar past Tasks/PRs
+        │     altitude-filtered per consumer (see below)
+        ▼
+   context block handed to Jamie / planner / Goose
+```
+
+No trained model anywhere in v1. Learning happens **in the graph** (edge
+weights from outcome counting, below), not in model weights. A learned
+re-ranker is a later, optional upgrade that must beat this baseline to ship.
+
+### Why PPR and not embeddings alone
+
+Embedding search finds nodes that *sound like* the query. PPR finds nodes
+*structurally entangled* with the seeds — the config file two repos away, the
+test that always breaks, the migration nobody mentions in prose. It's local
+(computed from the seeds outward, indifferent to total graph size), weightable
+(outcome counters bias the walk), and already deployed in jarvis.
+
+### The pathway it walks (verified in prod)
+
+```
+HiveInitiative -HAS_MILESTONE-> HiveMilestone
+HiveInitiative -HAS_RESEARCH->  HiveResearch
+HiveFeature    -HAS_TASK->      HiveTask
+HiveFeature/Task -HAS_MESSAGE-> HiveChatMessage
+HiveTask       -RESULTED_IN->   PullRequest      ← backfilled 2026-07-04 (~1k+ edges)
+PullRequest    -TOUCHES->       Concept
+PullRequest    -MODIFIES->      File
+Concept        -MODIFIES->      File
+File           -CONTAINS->      Function/Tests, CALLS, HANDLER, ... (stakgraph AST)
+```
+
+All stakgraph nodes carry the `Data_Bank` label and `namespace: "default"`, so
+the bulk-edge and read paths cross the Hive/codegraph boundary.
+
+### Known graph gaps (fill opportunistically, none block v1)
+
+- `AgentSession → HiveTask` — traces are islands; without this, "how it was
+  done" (gotchas, process) can't be retrieved. Emit one edge when a session
+  starts with a task id. Highest-value missing edge.
+- `HiveDecision` / `HiveNote` — canvas islands (0 edges). Link to the
+  feature/task they annotate in the canvas mirror.
+- `HiveResearch` — write-only (only initiatives point at it).
+- Some swarms are missing a whole leg (e.g. stakwork workspace: 0 linked, 345
+  pending — no usable task-mirror or PR ingestion). Per-swarm health check
+  belongs in the mirror cron's output.
+
+## Implementation
+
+### Step 1 — `getOrgContext(query, workspace)` service
+
+New service in hive (`src/services/org-context/`), callable from the task
+creation flow and as an MCP tool for the agents.
+
+1. **Seed.** `GET /graph/search?search=<q>&stakgraph=true` (fulltext) plus the
+   vector index via the same endpoint's hybrid mode. Take top 2–5 among
+   node types `HiveFeature`, `Concept`. An exact alias/name hit outranks any
+   embedding score.
+2. **Walk.** `POST /v2/graph/algorithm` `{algorithm_name: "page_rank",
+   sourceNodes: [<seed ref_ids>], limit: 200}` (persist=false → stream).
+3. **Package.** Filter by node type; drop `status: deprecated/dead` when that
+   field lands (see gitree CONSOLIDATION.md); format:
+
+```
+This appears to concern: <Feature name> — <one-line description>
+Relevant files: <top files with paths>
+Related concept docs: <concept names + ids>
+Similar past work: PR #<n> "<title>" (task: "<task title>") — touched <files>
+```
+
+Exemplar PRs come from the ranked PullRequest nodes; their task titles via
+`RESULTED_IN`. The exemplar is often the highest-value element: an agent shown
+a near-identical past change in the right place rarely works in the wrong one.
+
+**Altitude views** (same corpus, filtered per consumer):
+- Jamie (org-level chat): Features/Initiatives + one-line summaries.
+- Planner: Features + repos + entry-point files + exemplar PRs.
+- Goose/task agents: file paths, functions, concept docs (clues).
+
+### Step 2 — Outcome counters (learning by counting)
+
+Every merged PR reinforces the pathways that produced it. Nightly (or in the
+pr-link cron, which already touches these nodes):
+
+- On `RESULTED_IN` creation, and on PR merge status: increment a `weight`
+  property on the edges along `Task→PR→File` and bump
+  `Feature→(derived)→File` support counts.
+- Recency decay at read time (or periodic decay pass): the walk should prefer
+  recently-reinforced paths. PPR consumes this via
+  `relationshipWeightProperty: "weight"`.
+
+A pattern seen twice stays noise; seen fifty times, it dominates the walk.
+This is the "learns on the job" loop with zero training infrastructure.
+
+### Step 3 — Usage logging (label capture, cheap, start immediately)
+
+New table `org_context_queries`: query text, seed ref_ids, returned ref_ids,
+consuming agent, task id. When the task later has `RESULTED_IN` PRs, join to
+compute *retrieved-vs-actually-touched*. This yields, for free:
+
+- precision@k time series (is retrieval getting better?)
+- ranking labels for the future re-ranker
+- merge candidates for the concept corpus (always co-retrieved, never co-used)
+
+### Step 4 — Evaluation harness (we already have the dataset)
+
+The RESULTED_IN backfill created ~1,000+ labeled examples: **task description →
+files actually touched** (via task→PR→MODIFIES→File). Temporal split (train
+on old, test on new — never random):
+
+- For each held-out task: run Seed→Walk with the task title/description,
+  measure whether the PR's files appear in the top-k. Report precision@10 /
+  recall@10.
+- **Baselines to beat:** (a) BGE embedding similarity only, no walk;
+  (b) unweighted PPR; (c) weighted PPR. Each upgrade must beat the previous
+  on this harness or it doesn't ship.
+
+This harness is buildable *today* and is the single most important piece —
+it converts every future retrieval idea from an argument into a measurement.
+
+### Step 5 — Learned re-ranker (only after Steps 3–4 accumulate data)
+
+Small model over path/candidate features — seed-to-candidate PPR score,
+embedding similarity, recency, outcome counts, node type, same-repo flag.
+Gradient-boosted trees or a 2-layer MLP: trains in minutes, retrainable
+nightly, disposable. Labels from Step 3 logs + Step 4 harness.
+
+Later options, strictly gated on beating the incumbent on the Step 4 harness:
+- **Fine-tuned embedding retriever** (BGE-class, ~30–100M params) on
+  (utterance → touched-location) pairs — fixes jargon grounding ("Falcon" ↔
+  `services/ingest`) better than any generic embedding.
+- **Schema-free GNN** (NBFNet/ULTRA-style relation-structure models) as the
+  walk upgrade. Explicitly NOT a per-type heterogeneous GNN: open-vocabulary
+  node/edge types as text embeddings, so new node kinds (Decisions, Learnings,
+  sandbox gotchas) need no schema or retraining. Only if weighted-PPR+re-ranker
+  plateaus below target.
+
+## What this deliberately avoids
+
+- **No LLM-judged step labeling** for supervision — merge status, task
+  completion, and retrieved-vs-used are the only labels; they can't argue back.
+- **No always-in-context concept dumps** — retrieval-first; corpus size stops
+  mattering. (Concept lifecycle/dedup work is tracked separately in
+  stakgraph `mcp/src/gitree/CONSOLIDATION.md`.)
+- **No parametric model as the memory.** The graph is the memory; models only
+  re-rank what the graph retrieves. Anything learned is rebuildable from the
+  graph + logs in minutes, so nothing drifts unrecoverably.
+
+## Order of work
+
+1. Step 4 eval harness (uses existing data; sets the bar)
+2. Step 1 service + MCP tool, measured against the harness
+3. Step 3 usage logging (ship with Step 1)
+4. Step 2 outcome weights (first measurable ranking upgrade)
+5. `AgentSession → HiveTask` edge + Decision/Note linking (grows the pathway)
+6. Step 5 re-ranker, when logs justify it
+
+## Success metrics
+
+- precision@10 / recall@10 on the Step 4 harness, reported per phase
+- wrong-place rate proxy: tasks whose PR files ⊄ retrieved file set
+- seed hit rate: % of queries where an alias/name match found the right
+  Feature/Concept directly (lexicon health)
+- retrieval latency budget: < 1s end-to-end (seed + walk + package)

--- a/src/__tests__/unit/services/jarvis-pr-link-cron.test.ts
+++ b/src/__tests__/unit/services/jarvis-pr-link-cron.test.ts
@@ -161,6 +161,65 @@ describe("runJarvisPrLink", () => {
     );
   });
 
+  it("writes edges for resolvable PRs on a mixed task but leaves it unmarked (partial linking)", async () => {
+    setupDb({
+      workspaces: [{ id: "w1", slug: "w1", jarvisSyncState: null }],
+      tasks: [
+        {
+          id: "t1",
+          title: "T1",
+          chatMessages: [
+            prArtifact("https://github.com/stakwork/hive/pull/4542"),
+            prArtifact("https://github.com/stakwork/hive/pull/9999"), // never ingested
+          ],
+        },
+      ],
+    });
+    mockSearch(found(prNode("stakwork/hive", 4542, "ref-4542", 1782430995)), [taskNode("t1", "tref-1")]);
+
+    const res = await runJarvisPrLink();
+
+    // The resolvable edge IS written…
+    const edgeArg = mockedAddEdge.mock.calls[0][1];
+    expect(edgeArg).toHaveLength(1);
+    expect(edgeArg[0]).toMatchObject({ source_ref_id: "tref-1", target_ref_id: "ref-4542" });
+    // …but the task is NOT marked, so the missing PR retries next run.
+    expect((mockedDb.task as any).updateMany).not.toHaveBeenCalled();
+    expect(res.results[0]).toMatchObject({ linked: 0, pending: 1 });
+  });
+
+  it("marks a multi-PR task linked when ALL its PRs resolve", async () => {
+    setupDb({
+      workspaces: [{ id: "w1", slug: "w1", jarvisSyncState: null }],
+      tasks: [
+        {
+          id: "t1",
+          title: "T1",
+          chatMessages: [
+            prArtifact("https://github.com/stakwork/hive/pull/4542"),
+            prArtifact("https://github.com/stakwork/hive/pull/4543"),
+          ],
+        },
+      ],
+    });
+    mockSearch(
+      found(
+        prNode("stakwork/hive", 4542, "ref-4542", 1782430995),
+        prNode("stakwork/hive", 4543, "ref-4543", 1782430996),
+      ),
+      [taskNode("t1", "tref-1")],
+    );
+
+    const res = await runJarvisPrLink();
+
+    expect(mockedAddEdge.mock.calls[0][1]).toHaveLength(2);
+    expect((mockedDb.task as any).updateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["t1"] } },
+      data: { jarvisPrLinkedAt: expect.any(Date) },
+    });
+    expect(res.results[0]).toMatchObject({ linked: 1, pending: 0 });
+  });
+
   it("uses an incremental fetch when a high-water exists", async () => {
     setupDb({
       workspaces: [

--- a/src/services/jarvis-pr-link-cron.ts
+++ b/src/services/jarvis-pr-link-cron.ts
@@ -25,6 +25,10 @@
  *    chained run must keep pulling the full set.
  *  - Per-task marker (`Task.jarvisPrLinkedAt`) keeps the scan cheap and is the
  *    retry latch; best-effort per workspace (one failure never aborts others).
+ *  - Partial linking: a task referencing several PRs gets edges for the PRs
+ *    that ARE ingested immediately; it is marked linked only once all of them
+ *    resolved. Re-submitting already-written edges on retry is safe (the
+ *    backend merges on edge_key).
  */
 
 import { db } from "@/lib/db";
@@ -285,10 +289,17 @@ async function linkWorkspace(
   const taskRefMap = taskFetch.map;
 
   // Tasks with no resolvable PR URL are marked unconditionally (no edge to
-  // write). Tasks whose PRs all resolve are queued with their edges so they can
-  // be marked only once those edges actually land.
+  // write). Tasks with at least one resolvable PR get their resolvable edges
+  // written NOW (partial linking); a task is marked linked only once ALL its
+  // PRs resolved and their edges landed — partially-resolved tasks stay
+  // unmarked so the missing PRs retry (edge writes are idempotent on edge_key,
+  // so re-submitting the already-written edges is safe).
   const noEdgeTaskIds: string[] = [];
-  const resolved: { taskId: string; edges: ReturnType<typeof taskPrEdge>[] }[] = [];
+  const resolved: {
+    taskId: string;
+    edges: ReturnType<typeof taskPrEdge>[];
+    complete: boolean;
+  }[] = [];
   let pending = 0;
 
   for (const task of tasks) {
@@ -304,12 +315,23 @@ async function linkWorkspace(
       continue;
     }
     const refIds = refs.map((r) => prMap.get(prNodeKey(r.repo, r.number)));
-    if (refIds.some((id) => !id)) {
-      // At least one PR not ingested yet — retry next run, don't mark.
+    const resolvedIds = refIds.filter((id): id is string => !!id);
+    if (resolvedIds.length === 0) {
+      // No PR ingested yet — retry next run, don't mark.
       pending++;
       continue;
     }
-    resolved.push({ taskId: task.id, edges: refIds.map((id) => taskPrEdge(taskRefId, id!)) });
+    const complete = resolvedIds.length === refIds.length;
+    if (!complete) {
+      // Some PRs still unresolved — write what we have, but the task stays
+      // unmarked (and counts as pending) so the rest retries next run.
+      pending++;
+    }
+    resolved.push({
+      taskId: task.id,
+      edges: resolvedIds.map((id) => taskPrEdge(taskRefId, id)),
+      complete,
+    });
   }
 
   const linkedTaskIds: string[] = [...noEdgeTaskIds];
@@ -339,7 +361,7 @@ async function linkWorkspace(
     return true;
   };
 
-  for (const { taskId, edges: taskEdges } of resolved) {
+  for (const { taskId, edges: taskEdges, complete } of resolved) {
     if (Date.now() >= deadline) {
       budgetHit = true;
       break;
@@ -348,7 +370,9 @@ async function linkWorkspace(
       if (!(await flush())) break; // endpointMissing — stop writing
     }
     batchEdges.push(...taskEdges);
-    batchTaskIds.push(taskId);
+    // Only fully-resolved tasks are marked once their edges land; partial
+    // tasks contribute edges but stay unmarked so missing PRs retry.
+    if (complete) batchTaskIds.push(taskId);
   }
   if (!endpointMissing) await flush();
 
@@ -421,6 +445,11 @@ export async function runJarvisPrLink(
         logger.warn(`[JARVIS PR LINK] ${ws.slug}: ${result.errors.length} errors`, LOG, {
           errors: result.errors.slice(0, 5),
         });
+      }
+      // Quiet skips (missing endpoint, no config) were invisible in logs and
+      // masked a swarm that 404'd every run for weeks — always surface them.
+      if (result.skipped) {
+        logger.warn(`[JARVIS PR LINK] ${ws.slug}: skipped — ${result.skipped}`, LOG);
       }
       results.push(result);
     } catch (error) {

--- a/src/services/swarm/api/nodes.ts
+++ b/src/services/swarm/api/nodes.ts
@@ -36,9 +36,8 @@ async function jarvisRequest({
   data?: unknown;
   timeoutMs?: number;
 }): Promise<JarvisApiResponse> {
+  const url = `${config.jarvisUrl.replace(/\/$/, "")}${endpoint.startsWith("/") ? "" : "/"}${endpoint}`;
   try {
-    const url = `${config.jarvisUrl.replace(/\/$/, "")}${endpoint.startsWith("/") ? "" : "/"}${endpoint}`;
-
     const headers: Record<string, string> = {
       "x-api-token": config.apiKey,
       "Content-Type": "application/json",
@@ -53,7 +52,9 @@ async function jarvisRequest({
 
     if (!response.ok) {
       const responseText = await response.text();
-      console.error("[Jarvis Nodes] Request failed:", response.status, responseText);
+      // Include method + URL: a bare status is undebuggable across 17
+      // workspaces × N endpoints (a quiet 404 hid a dead swarm for weeks).
+      console.error("[Jarvis Nodes] Request failed:", method, url, response.status, responseText);
       return {
         ok: false,
         status: response.status,
@@ -75,7 +76,7 @@ async function jarvisRequest({
       body,
     };
   } catch (error) {
-    console.error("[Jarvis Nodes] Request error:", error);
+    console.error("[Jarvis Nodes] Request error:", method, url, error);
     return {
       ok: false,
       status: 500,
@@ -209,12 +210,26 @@ async function executeBulkEdgeRequest(
   }
 
   const body = result.body as
-    | { status?: string; status_messages?: string[] }
+    | { status?: string; status_messages?: string[]; edges?: unknown[] }
     | undefined;
 
   const errors = (body?.status_messages ?? []).filter((m) =>
     m.toLowerCase().startsWith("error"),
   );
+
+  // Silent-no-op detector: jarvis's bulk endpoints report every written OR
+  // already-existing edge in `edges`, so a healthy response accounts for the
+  // full submission even on idempotent re-runs. A shortfall with no ERROR
+  // messages means endpoints silently failed to match (this exact mode — a
+  // label-pinned MATCH finding no node — once returned "Success" while
+  // writing nothing, and cost weeks). Warn loudly; don't fail the call, since
+  // older backends may not return `edges` at all.
+  if (errors.length === 0 && Array.isArray(body?.edges) && body!.edges!.length < edgeList.length) {
+    console.warn(
+      `[Jarvis Nodes] edges/bulk: submitted ${edgeList.length} edges but backend reported ` +
+        `${body!.edges!.length} — possible silent no-op (unmatched ref_ids?)`,
+    );
+  }
 
   // Success means "no real errors" — NOT status === "success". Jarvis returns
   // status "Warning" whenever status_messages is non-empty, which includes


### PR DESCRIPTION
## What

Two small hardening fixes for the jarvis PR-link cron, plus the design doc for the org-context retrieval system.

### Partial linking (`jarvis-pr-link-cron.ts`)
A task referencing several PRs was all-or-nothing: one un-ingested PR (closed-unmerged, gitree-skip-filtered) blocked **all** of the task's edges forever. Now the resolvable PRs get their `RESULTED_IN` edges written immediately; the task is marked linked only once all its PRs resolve, so the missing ones keep retrying. Re-submitting already-written edges is safe — the backend merges on `edge_key`.

### Failure observability (`nodes.ts`, cron summary)
Debugging this cron in prod today was blind archaeology because failures were anonymous:
- `jarvisRequest` failures now log **method + URL** (a bare `404 page not found` across 17 workspaces hid a dead swarm for weeks).
- Quiet workspace skips (`endpoint missing (404)`, `no jarvis config`) are now surfaced in the cron summary log — previously visible only in the response JSON nobody reads.
- `edges/bulk` responses are checked for **silent no-ops**: if the backend reports fewer edges than submitted with no errors, we warn. This exact mode (label-pinned MATCH finding no node → `"Success"` with zero writes) consumed the original backfill of 79 tasks.

### Retrieval plan (`docs/plans/org-context-retrieval.md`)
The seed → personalized-PageRank → package architecture for giving agents org context (jargon grounding + "what goes where"), with the eval harness built from the freshly-backfilled `Task→RESULTED_IN→PR→File` pairs, outcome-weighted walks (learning by counting), and a strictly-gated upgrade ladder (re-ranker → fine-tuned retriever → schema-free GNN).

## Tests
- Two new unit tests: mixed-PR task writes resolvable edges but stays unmarked; fully-resolved multi-PR task links and is marked.
- All 69 tests in the two touched suites pass; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)