### PR TITLE
logs-agent: cross-workspace scope redirect + task-attached transcript merge

### DIFF
--- a/src/app/api/workspaces/[slug]/logs-agent/route.ts
+++ b/src/app/api/workspaces/[slug]/logs-agent/route.ts
@@ -55,6 +55,13 @@ export async function POST(
       SWARM_NOT_ACTIVE: { msg: "Swarm not configured or not active", status: 400 },
       SWARM_NOT_CONFIGURED: { msg: "Swarm not configured or not active", status: 400 },
       SWARM_NAME_MISSING: { msg: "Swarm name not found", status: 400 },
+      SCOPE_WRONG_WORKSPACE: {
+        msg:
+          error.type === "SCOPE_WRONG_WORKSPACE"
+            ? error.message
+            : "Scoped task/feature belongs to another workspace",
+        status: 400,
+      },
       AGENT_REQUEST_FAILED: {
         msg: "Failed to send request to logs agent",
         status:

--- a/src/lib/ai/askTools.ts
+++ b/src/lib/ai/askTools.ts
@@ -543,6 +543,9 @@ function buildWorkspaceTools(
           }
 
           const { error } = result;
+          if (error.type === "SCOPE_WRONG_WORKSPACE") {
+            return error.message;
+          }
           if (error.type === "TIMEOUT") {
             return "The Logs Agent timed out before returning a result. Please try again or narrow your query to a specific feature or task.";
           }

--- a/src/lib/ai/askToolsMulti.ts
+++ b/src/lib/ai/askToolsMulti.ts
@@ -495,6 +495,9 @@ export function askToolsMulti(
           }
 
           const { error } = result;
+          if (error.type === "SCOPE_WRONG_WORKSPACE") {
+            return error.message;
+          }
           if (error.type === "TIMEOUT") {
             return `The Logs Agent timed out before returning a result for ${ws.slug}. Please try again or narrow your query to a specific feature or task.`;
           }

--- a/src/services/logs-agent.ts
+++ b/src/services/logs-agent.ts
@@ -36,6 +36,7 @@ export type RunLogsAgentError =
   | { type: "SWARM_NOT_ACTIVE" }
   | { type: "SWARM_NOT_CONFIGURED" }
   | { type: "SWARM_NAME_MISSING" }
+  | { type: "SCOPE_WRONG_WORKSPACE"; message: string }
   | { type: "AGENT_REQUEST_FAILED"; statusCode: number; message: string }
   | { type: "NO_REQUEST_ID" }
   | { type: "AGENT_FAILED"; message: string }
@@ -188,6 +189,95 @@ export async function runLogsAgent(
       })
     : [];
 
+  // Scoped ids that exist but live in another workspace match nothing here
+  // (the runs query is workspace-fenced). Detect that and redirect the caller
+  // instead of dispatching an agent that can never reach the requested logs.
+  if (hasScope && rawRuns.length === 0) {
+    const [scopedTasks, scopedFeatures] = await Promise.all([
+      rawTaskIds.length > 0
+        ? db.task.findMany({
+            where: { id: { in: rawTaskIds } },
+            select: { id: true, workspace: { select: { slug: true } } },
+          })
+        : Promise.resolve([]),
+      rawFeatureIds.length > 0
+        ? db.feature.findMany({
+            where: { id: { in: rawFeatureIds } },
+            select: { id: true, workspace: { select: { slug: true } } },
+          })
+        : Promise.resolve([]),
+    ]);
+    const misrouted = [
+      ...scopedTasks
+        .filter((t) => t.workspace.slug !== slug)
+        .map((t) => ({ kind: "task", id: t.id, slug: t.workspace.slug })),
+      ...scopedFeatures
+        .filter((f) => f.workspace.slug !== slug)
+        .map((f) => ({ kind: "feature", id: f.id, slug: f.workspace.slug })),
+    ];
+    if (misrouted.length > 0) {
+      const details = misrouted
+        .map((m) => `${m.kind} ${m.id} belongs to workspace "${m.slug}"`)
+        .join("; ");
+      logger.info("[LogsAgent] scope redirected to other workspace", `workspace=${slug}`, {
+        misrouted,
+      });
+      return {
+        success: false,
+        error: {
+          type: "SCOPE_WRONG_WORKSPACE",
+          message: `Scope error: ${details}, not "${slug}". Its runs and agent transcripts are not reachable from this workspace — invoke that workspace's logs_agent tool with the same scope instead.`,
+        },
+      };
+    }
+  }
+
+  // Agent transcripts are not always linked to a StakworkRun — some pipelines
+  // report them attached directly to the task or feature (stakworkRunId null).
+  // Fetch those and merge them into the matched runs' agentLogs so the swarm's
+  // fetch_agent_log tool can reach them.
+  const mergeTaskIds = new Set(rawTaskIds);
+  const mergeFeatureIds = new Set(rawFeatureIds);
+  for (const r of rawRuns) {
+    if (r.taskId) mergeTaskIds.add(r.taskId);
+    if (r.featureId) mergeFeatureIds.add(r.featureId);
+  }
+  const orphanLogs =
+    workspaceRow && (mergeTaskIds.size > 0 || mergeFeatureIds.size > 0)
+      ? await db.agentLog.findMany({
+          where: {
+            workspaceId: workspaceRow.id,
+            stakworkRunId: null,
+            OR: [
+              ...(mergeTaskIds.size > 0
+                ? [{ taskId: { in: [...mergeTaskIds] } }]
+                : []),
+              ...(mergeFeatureIds.size > 0
+                ? [{ featureId: { in: [...mergeFeatureIds] } }]
+                : []),
+            ],
+          },
+          orderBy: { createdAt: "desc" },
+          take: 50,
+          select: { id: true, agent: true, taskId: true, featureId: true },
+        })
+      : [];
+
+  const mergedRuns = rawRuns.map((r) => ({ ...r, agentLogs: [...r.agentLogs] }));
+  for (const log of orphanLogs) {
+    // Runs are ordered createdAt desc, so this attaches to the most recent match
+    const run = mergedRuns.find(
+      (r) =>
+        (log.taskId !== null && r.taskId === log.taskId) ||
+        (log.featureId !== null && r.featureId === log.featureId),
+    );
+    if (!run) continue;
+    // fetch_agent_log matches by agent name case-insensitively — skip collisions
+    const agentLower = log.agent.toLowerCase();
+    if (run.agentLogs.some((l) => l.agent.toLowerCase() === agentLower)) continue;
+    run.agentLogs.push({ id: log.id, agent: log.agent });
+  }
+
   // Log scope resolution
   logger.info(
     "[LogsAgent] StakworkRun scope resolved",
@@ -199,7 +289,8 @@ export async function runLogsAgent(
       matchedRunCount: rawRuns.length,
       matchedProjectIds: rawRuns.map((r) => r.projectId),
       matchedAgentLogCount: rawRuns.reduce((n, r) => n + r.agentLogs.length, 0),
-      sample: rawRuns.slice(0, 5).map((r) => ({
+      mergedOrphanLogCount: orphanLogs.length,
+      sample: mergedRuns.slice(0, 5).map((r) => ({
         projectId: r.projectId,
         type: r.type,
         status: r.status,
@@ -219,7 +310,7 @@ export async function runLogsAgent(
 
   const SIGNED_URL_EXPIRY_SECONDS = 3600;
 
-  const stakworkRuns = rawRuns.map((run) => ({
+  const stakworkRuns = mergedRuns.map((run) => ({
     projectId: run.projectId as number,
     type: run.type,
     status: run.status,


### PR DESCRIPTION
## Problem

A dashboard-chat (canvas agent) investigation of a task's agent transcript failed in a cascade:

1. The canvas agent called `hive__logs_agent` scoped to a taskId that actually belongs to the **stakwork** workspace. The runs query is workspace-fenced, so it silently matched **zero runs** (`matchedRunCount: 0` in prod logs).
2. With zero runs, `stakworkRuns` is omitted from the swarm request, so the swarm agent was dispatched **without** `fetch_agent_log`/`fetch_workflow_run` tools — no legitimate path to the transcript.
3. The swarm agent fell back to curling the private Vercel blob URL directly (always 403s) and grepping prod logs, then confidently misdiagnosed the transcript as "never persisted" (it exists).

Separately: even a correctly-routed call would have missed this transcript, because the AgentLog was written with `task_id` but no `stakwork_run_id` (`stakworkRunId: null`), and the snapshot only surfaces transcripts through the `StakworkRun → agentLogs` relation.

## Fixes (Hive-only, no swarm deploy needed)

**1. Cross-workspace scope redirect** — when a scoped call matches zero runs, look up the scoped task/feature ids without the workspace filter. If they live in another workspace, return a new `SCOPE_WRONG_WORKSPACE` error immediately:

> Scope error: task cmr63… belongs to workspace "stakwork", not "hive". Its runs and agent transcripts are not reachable from this workspace — invoke that workspace's logs_agent tool with the same scope instead.

Surfaced verbatim through the `logs_agent` tool in `askTools`/`askToolsMulti` (so the calling LLM can self-correct in one step) and as a 400 from `POST /api/workspaces/[slug]/logs-agent`. Scoped ids that belong to this workspace but simply have no runs still dispatch normally — pod/Quickwit/CloudWatch queries are unaffected.

**2. Task/feature-attached transcript merge** — also query `AgentLog` rows with `stakworkRunId: null` attached to the scoped ids or to the tasks/features of matched runs (capped at 50), and merge them into the most recent matching run's `agentLogs` list (skipping agent-name collisions, since the swarm matches by name case-insensitively). They ship as signed URLs like any run-attached log, so the swarm's existing `fetch_agent_log` reaches them unchanged.

The `[LogsAgent] StakworkRun scope resolved` log now includes `mergedOrphanLogCount` for observability.

## Testing

- `npx vitest run` on the logs-agent route + askTools suites: 70/70 pass
- `tsc --noEmit`: no new errors in touched files (pre-existing test-file and stale-Prisma-client errors unchanged, verified against master)
- eslint: 0 errors

## Follow-ups (not in this PR)

- stakgraph extension to deliver task-attached transcripts when *zero* runs match (needs a new `agentLogs` field in the `/logs/agent` body)
- `list_agent_logs` / `read_agent_log` tiered tools in askTools for cheap metadata/slice access without the swarm round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)