### PR TITLE
Fix run-evals route to support cuid version IDs and validate prompt ownership

### DIFF
--- a/prisma/migrations/20260705203054_alter_stakwork_run_prompt_version_id_string/migration.sql
+++ b/prisma/migrations/20260705203054_alter_stakwork_run_prompt_version_id_string/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "stakwork_runs" ALTER COLUMN "prompt_version_id" SET DATA TYPE TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1039,7 +1039,7 @@ model StakworkRun {
   createdAt   DateTime             @default(now()) @map("created_at")
   updatedAt   DateTime             @updatedAt @map("updated_at")
   autoAccept      Boolean              @default(false) @map("auto_accept")
-  promptVersionId Int?                 @map("prompt_version_id")
+  promptVersionId String?              @map("prompt_version_id")
   evalSetId       String?              @map("eval_set_id")
   userId          String?              @map("user_id")
   agentLogs       AgentLog[]

--- a/src/__tests__/integration/api/stakwork/prompt-eval-webhook.test.ts
+++ b/src/__tests__/integration/api/stakwork/prompt-eval-webhook.test.ts
@@ -73,9 +73,9 @@ async function createWorkspace(ownerId: string) {
 
 async function createPromptEvalRun(
   workspaceId: string,
-  opts: { promptVersionId?: number; projectId?: number; autoAccept?: boolean } = {}
+  opts: { promptVersionId?: string; projectId?: number; autoAccept?: boolean } = {}
 ) {
-  const { promptVersionId = 55, projectId = Math.floor(Math.random() * 100000) + 1, autoAccept = false } = opts;
+  const { promptVersionId = "ckversionid55abc0000", projectId = Math.floor(Math.random() * 100000) + 1, autoAccept = false } = opts;
   return db.stakworkRun.create({
     data: {
       type: "PROMPT_EVAL",
@@ -113,7 +113,7 @@ describe("processStakworkRunWebhook — PROMPT_EVAL branch", () => {
   });
 
   it("stores the rich eval result verbatim in StakworkRun.result", async () => {
-    const run = await createPromptEvalRun(workspace.id, { promptVersionId: 55 });
+    const run = await createPromptEvalRun(workspace.id, { promptVersionId: "ckversionid55abc0000" });
 
     await processStakworkRunWebhook(
       { result: RICH_EVAL_RESULT, project_status: "complete", project_id: run.projectId! },
@@ -128,7 +128,7 @@ describe("processStakworkRunWebhook — PROMPT_EVAL branch", () => {
   });
 
   it("fires PROMPT_EVAL_RESULT Pusher event with runId, promptVersionId, and full result", async () => {
-    const run = await createPromptEvalRun(workspace.id, { promptVersionId: 55 });
+    const run = await createPromptEvalRun(workspace.id, { promptVersionId: "ckversionid55abc0000" });
 
     await processStakworkRunWebhook(
       { result: RICH_EVAL_RESULT, project_status: "complete", project_id: run.projectId! },
@@ -140,14 +140,14 @@ describe("processStakworkRunWebhook — PROMPT_EVAL branch", () => {
       "prompt-eval-result",
       {
         runId: run.id,
-        promptVersionId: 55,
+        promptVersionId: "ckversionid55abc0000",
         result: RICH_EVAL_RESULT,
       }
     );
   });
 
   it("skips auto-accept for PROMPT_EVAL runs even when autoAccept is true", async () => {
-    const run = await createPromptEvalRun(workspace.id, { promptVersionId: 55, autoAccept: true });
+    const run = await createPromptEvalRun(workspace.id, { promptVersionId: "ckversionid55abc0000", autoAccept: true });
 
     await processStakworkRunWebhook(
       { result: RICH_EVAL_RESULT, project_status: "complete", project_id: run.projectId! },
@@ -166,7 +166,7 @@ describe("processStakworkRunWebhook — PROMPT_EVAL branch", () => {
   });
 
   it("does not trigger a fast-track chain (no new StakworkRun rows)", async () => {
-    const run = await createPromptEvalRun(workspace.id, { promptVersionId: 55 });
+    const run = await createPromptEvalRun(workspace.id, { promptVersionId: "ckversionid55abc0000" });
     const runsBefore = await db.stakworkRun.count({ where: { workspaceId: workspace.id } });
 
     await processStakworkRunWebhook(
@@ -180,12 +180,12 @@ describe("processStakworkRunWebhook — PROMPT_EVAL branch", () => {
 
   it("does not return wrong run when project_id is absent and multiple runs exist", async () => {
     // Create two runs in the same workspace — no project_id supplied to webhook
-    const run1 = await createPromptEvalRun(workspace.id, { promptVersionId: 10 });
+    const run1 = await createPromptEvalRun(workspace.id, { promptVersionId: "ckversionid10abc0000" });
     const run2 = await db.stakworkRun.create({
       data: {
         type: "PROMPT_EVAL",
         workspaceId: workspace.id,
-        promptVersionId: 20,
+        promptVersionId: "ckversionid20abc0000",
         evalSetId: "eval-set-other",
         status: WorkflowStatus.PENDING,
         webhookUrl: `https://example.com/api/webhook/stakwork/response?type=PROMPT_EVAL&workspace_id=${workspace.id}`,
@@ -216,7 +216,7 @@ describe("processStakworkRunWebhook — PROMPT_EVAL branch", () => {
       data: {
         type: "PROMPT_EVAL",
         workspaceId: workspace.id,
-        promptVersionId: 66,
+        promptVersionId: "ckversionid66abc0000",
         evalSetId: "eval-set-completed",
         status: WorkflowStatus.COMPLETED,
         webhookUrl: `https://example.com/api/webhook/stakwork/response?type=PROMPT_EVAL&workspace_id=${workspace.id}`,

--- a/src/__tests__/integration/api/workspaces/prompts/prompt-eval-run.test.ts
+++ b/src/__tests__/integration/api/workspaces/prompts/prompt-eval-run.test.ts
@@ -18,6 +18,27 @@ import {
 } from "@/__tests__/support/helpers/api-assertions";
 import { db } from "@/lib/db";
 
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Create a Prompt + PromptVersion and return their cuid string ids. */
+async function createTestPromptVersion(opts: { name?: string } = {}) {
+  const uniqueSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const prompt = await db.prompt.create({
+    data: {
+      name: `TEST_PROMPT_${uniqueSuffix.toUpperCase().replace(/[^A-Z0-9]/g, "_")}`,
+      value: "test prompt value",
+    },
+  });
+  const version = await db.promptVersion.create({
+    data: {
+      promptId: prompt.id,
+      versionNumber: 1,
+      value: "test version value",
+    },
+  });
+  return { promptId: prompt.id, versionId: version.id };
+}
+
 describe("Prompt Eval Run API — Integration Tests", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -37,18 +58,56 @@ describe("Prompt Eval Run API — Integration Tests", () => {
     test("returns 401 when unauthenticated", async () => {
       const owner = await createTestUser();
       const workspace = await createTestWorkspace({ ownerId: owner.id });
+      const { promptId, versionId } = await createTestPromptVersion();
 
-      const request = createGetRequest(
-        `http://localhost:3000/api/workspaces/${workspace.slug}/prompts/1/versions/42/run-evals`,
-      ) as any; // createGetRequest returns GET; route handler only checks auth headers
-
-      // Use a plain GET request without auth headers to trigger 401
       const unauthRequest = createGetRequest(
-        `http://localhost:3000/api/workspaces/${workspace.slug}/prompts/1/versions/42/run-evals`,
+        `http://localhost:3000/api/workspaces/${workspace.slug}/prompts/${promptId}/versions/${versionId}/run-evals`,
       );
-      // POST handler requires auth
-      const response = await runEvalsPost(unauthRequest as any, makeParams(workspace.slug, "1", "42"));
+      const response = await runEvalsPost(unauthRequest as any, makeParams(workspace.slug, promptId, versionId));
       await expectUnauthorized(response);
+    });
+
+    test("returns 404 when versionId does not belong to promptId", async () => {
+      const owner = await createTestUser();
+      const workspace = await createTestWorkspace({ ownerId: owner.id });
+      await createTestMembership({ workspaceId: workspace.id, userId: owner.id, role: "OWNER" });
+      await createTestSwarm({ workspaceId: workspace.id, swarmApiKey: "test-key", swarmUrl: "https://test.swarm.url" });
+
+      process.env.STAKWORK_EVAL_SET_RUNNER_WORKFLOW_ID = "999";
+
+      // Create two prompts with their own versions — use versionId from one under the other's promptId
+      const { promptId: promptIdA } = await createTestPromptVersion();
+      const { versionId: versionIdB } = await createTestPromptVersion();
+
+      const request = createAuthenticatedPostRequest(
+        `http://localhost:3000/api/workspaces/${workspace.slug}/prompts/${promptIdA}/versions/${versionIdB}/run-evals`,
+        owner,
+        { evalSetId: "eval-set-abc", promptName: "my-prompt" },
+      );
+
+      const response = await runEvalsPost(request, makeParams(workspace.slug, promptIdA, versionIdB));
+      expect(response.status).toBe(404);
+    });
+
+    test("returns 404 when versionId does not exist at all", async () => {
+      const owner = await createTestUser();
+      const workspace = await createTestWorkspace({ ownerId: owner.id });
+      await createTestMembership({ workspaceId: workspace.id, userId: owner.id, role: "OWNER" });
+      await createTestSwarm({ workspaceId: workspace.id, swarmApiKey: "test-key", swarmUrl: "https://test.swarm.url" });
+
+      process.env.STAKWORK_EVAL_SET_RUNNER_WORKFLOW_ID = "999";
+
+      const { promptId } = await createTestPromptVersion();
+      const nonExistentVersionId = "cuid-does-not-exist-123456";
+
+      const request = createAuthenticatedPostRequest(
+        `http://localhost:3000/api/workspaces/${workspace.slug}/prompts/${promptId}/versions/${nonExistentVersionId}/run-evals`,
+        owner,
+        { evalSetId: "eval-set-abc", promptName: "my-prompt" },
+      );
+
+      const response = await runEvalsPost(request, makeParams(workspace.slug, promptId, nonExistentVersionId));
+      expect(response.status).toBe(404);
     });
 
     test("returns 400 when evalSetId is missing", async () => {
@@ -59,13 +118,15 @@ describe("Prompt Eval Run API — Integration Tests", () => {
 
       process.env.STAKWORK_EVAL_SET_RUNNER_WORKFLOW_ID = "999";
 
+      const { promptId, versionId } = await createTestPromptVersion();
+
       const request = createAuthenticatedPostRequest(
-        `http://localhost:3000/api/workspaces/${workspace.slug}/prompts/1/versions/42/run-evals`,
+        `http://localhost:3000/api/workspaces/${workspace.slug}/prompts/${promptId}/versions/${versionId}/run-evals`,
         owner,
         { promptName: "my-prompt" },
       );
 
-      const response = await runEvalsPost(request, makeParams(workspace.slug, "1", "42"));
+      const response = await runEvalsPost(request, makeParams(workspace.slug, promptId, versionId));
       await expectError(response, "evalSetId and promptName are required", 400);
     });
 
@@ -77,13 +138,15 @@ describe("Prompt Eval Run API — Integration Tests", () => {
 
       process.env.STAKWORK_EVAL_SET_RUNNER_WORKFLOW_ID = "999";
 
+      const { promptId, versionId } = await createTestPromptVersion();
+
       const request = createAuthenticatedPostRequest(
-        `http://localhost:3000/api/workspaces/${workspace.slug}/prompts/1/versions/42/run-evals`,
+        `http://localhost:3000/api/workspaces/${workspace.slug}/prompts/${promptId}/versions/${versionId}/run-evals`,
         owner,
         { evalSetId: "eval-set-abc" },
       );
 
-      const response = await runEvalsPost(request, makeParams(workspace.slug, "1", "42"));
+      const response = await runEvalsPost(request, makeParams(workspace.slug, promptId, versionId));
       await expectError(response, "evalSetId and promptName are required", 400);
     });
 
@@ -94,17 +157,19 @@ describe("Prompt Eval Run API — Integration Tests", () => {
       await createTestSwarm({ workspaceId: workspace.id, swarmApiKey: "test-key", swarmUrl: "https://test.swarm.url" });
 
       // env var intentionally not set
+      const { promptId, versionId } = await createTestPromptVersion();
+
       const request = createAuthenticatedPostRequest(
-        `http://localhost:3000/api/workspaces/${workspace.slug}/prompts/1/versions/42/run-evals`,
+        `http://localhost:3000/api/workspaces/${workspace.slug}/prompts/${promptId}/versions/${versionId}/run-evals`,
         owner,
         { evalSetId: "eval-set-abc", promptName: "my-prompt" },
       );
 
-      const response = await runEvalsPost(request, makeParams(workspace.slug, "1", "42"));
+      const response = await runEvalsPost(request, makeParams(workspace.slug, promptId, versionId));
       await expectError(response, "STAKWORK_EVAL_SET_RUNNER_WORKFLOW_ID", 400);
     });
 
-    test("creates StakworkRun and returns success when Stakwork responds 200", async () => {
+    test("creates StakworkRun with cuid string versionId and returns success when Stakwork responds 200", async () => {
       const owner = await createTestUser();
       const workspace = await createTestWorkspace({ ownerId: owner.id });
       await createTestMembership({ workspaceId: workspace.id, userId: owner.id, role: "OWNER" });
@@ -117,31 +182,34 @@ describe("Prompt Eval Run API — Integration Tests", () => {
         json: async () => ({ data: { project_id: 12345 } }),
       } as any);
 
+      const { promptId, versionId } = await createTestPromptVersion();
+
       const request = createAuthenticatedPostRequest(
-        `http://localhost:3000/api/workspaces/${workspace.slug}/prompts/1/versions/42/run-evals`,
+        `http://localhost:3000/api/workspaces/${workspace.slug}/prompts/${promptId}/versions/${versionId}/run-evals`,
         owner,
         { evalSetId: "eval-set-abc", promptName: "my-prompt" },
       );
 
-      const response = await runEvalsPost(request, makeParams(workspace.slug, "1", "42"));
+      const response = await runEvalsPost(request, makeParams(workspace.slug, promptId, versionId));
       expect(response.status).toBe(200);
       const data = await response.json();
       expect(data.success).toBe(true);
       expect(data.runId).toBeTruthy();
       expect(data.projectId).toBe(12345);
 
-      // Verify DB record was created
+      // Verify DB record was created with the cuid string (not a number)
       const run = await db.stakworkRun.findUnique({ where: { id: data.runId } });
       expect(run).not.toBeNull();
       expect(run?.type).toBe("PROMPT_EVAL");
-      expect(run?.promptVersionId).toBe(42);
+      expect(run?.promptVersionId).toBe(versionId); // cuid string
       expect(run?.evalSetId).toBe("eval-set-abc");
       expect(run?.workspaceId).toBe(workspace.id);
 
-      // Verify Stakwork payload uses webhookUrl (not resultWebhookUrl)
+      // Verify Stakwork payload uses cuid string versionId
       const fetchCallArgs = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       const fetchBody = JSON.parse(fetchCallArgs[1].body as string);
       const vars = fetchBody.workflow_params.set_var.attributes.vars;
+      expect(vars.prompt_overrides[0].prompt_version_id).toBe(versionId); // cuid string
       expect(vars.webhookUrl).toContain(`/api/webhook/stakwork/response?type=PROMPT_EVAL&workspace_id=${workspace.id}`);
       expect(vars.resultWebhookUrl).toBeUndefined();
     });
@@ -160,13 +228,15 @@ describe("Prompt Eval Run API — Integration Tests", () => {
         text: async () => "Internal Server Error",
       } as any);
 
+      const { promptId, versionId } = await createTestPromptVersion();
+
       const request = createAuthenticatedPostRequest(
-        `http://localhost:3000/api/workspaces/${workspace.slug}/prompts/1/versions/42/run-evals`,
+        `http://localhost:3000/api/workspaces/${workspace.slug}/prompts/${promptId}/versions/${versionId}/run-evals`,
         owner,
         { evalSetId: "eval-set-abc", promptName: "my-prompt" },
       );
 
-      const response = await runEvalsPost(request, makeParams(workspace.slug, "1", "42"));
+      const response = await runEvalsPost(request, makeParams(workspace.slug, promptId, versionId));
       expect(response.status).toBe(502);
     });
   });
@@ -178,26 +248,65 @@ describe("Prompt Eval Run API — Integration Tests", () => {
     test("returns 401 when unauthenticated", async () => {
       const owner = await createTestUser();
       const workspace = await createTestWorkspace({ ownerId: owner.id });
+      const { promptId, versionId } = await createTestPromptVersion();
 
       const request = createGetRequest(
-        `http://localhost:3000/api/workspaces/${workspace.slug}/prompts/1/versions/42/run-evals`,
+        `http://localhost:3000/api/workspaces/${workspace.slug}/prompts/${promptId}/versions/${versionId}/run-evals`,
       );
-      const response = await runEvalsGet(request, makeParams(workspace.slug, "1", "42"));
+      const response = await runEvalsGet(request, makeParams(workspace.slug, promptId, versionId));
       await expectUnauthorized(response);
     });
 
-    test("returns 200 with data: null when no run exists", async () => {
+    test("returns 404 when versionId does not belong to promptId", async () => {
       const owner = await createTestUser();
       const workspace = await createTestWorkspace({ ownerId: owner.id });
       await createTestMembership({ workspaceId: workspace.id, userId: owner.id, role: "OWNER" });
       await createTestSwarm({ workspaceId: workspace.id, swarmApiKey: "test-key", swarmUrl: "https://test.swarm.url" });
 
+      const { promptId: promptIdA } = await createTestPromptVersion();
+      const { versionId: versionIdB } = await createTestPromptVersion();
+
       const request = createAuthenticatedGetRequest(
-        `http://localhost:3000/api/workspaces/${workspace.slug}/prompts/1/versions/99/run-evals`,
+        `http://localhost:3000/api/workspaces/${workspace.slug}/prompts/${promptIdA}/versions/${versionIdB}/run-evals`,
         owner,
       );
 
-      const response = await runEvalsGet(request, makeParams(workspace.slug, "1", "99"));
+      const response = await runEvalsGet(request, makeParams(workspace.slug, promptIdA, versionIdB));
+      expect(response.status).toBe(404);
+    });
+
+    test("returns 404 when versionId does not exist at all", async () => {
+      const owner = await createTestUser();
+      const workspace = await createTestWorkspace({ ownerId: owner.id });
+      await createTestMembership({ workspaceId: workspace.id, userId: owner.id, role: "OWNER" });
+      await createTestSwarm({ workspaceId: workspace.id, swarmApiKey: "test-key", swarmUrl: "https://test.swarm.url" });
+
+      const { promptId } = await createTestPromptVersion();
+      const nonExistentVersionId = "cuid-does-not-exist-999999";
+
+      const request = createAuthenticatedGetRequest(
+        `http://localhost:3000/api/workspaces/${workspace.slug}/prompts/${promptId}/versions/${nonExistentVersionId}/run-evals`,
+        owner,
+      );
+
+      const response = await runEvalsGet(request, makeParams(workspace.slug, promptId, nonExistentVersionId));
+      expect(response.status).toBe(404);
+    });
+
+    test("returns 200 with data: null when no run exists for a valid version", async () => {
+      const owner = await createTestUser();
+      const workspace = await createTestWorkspace({ ownerId: owner.id });
+      await createTestMembership({ workspaceId: workspace.id, userId: owner.id, role: "OWNER" });
+      await createTestSwarm({ workspaceId: workspace.id, swarmApiKey: "test-key", swarmUrl: "https://test.swarm.url" });
+
+      const { promptId, versionId } = await createTestPromptVersion();
+
+      const request = createAuthenticatedGetRequest(
+        `http://localhost:3000/api/workspaces/${workspace.slug}/prompts/${promptId}/versions/${versionId}/run-evals`,
+        owner,
+      );
+
+      const response = await runEvalsGet(request, makeParams(workspace.slug, promptId, versionId));
       expect(response.status).toBe(200);
       const data = await response.json();
       expect(data.success).toBe(true);
@@ -210,12 +319,14 @@ describe("Prompt Eval Run API — Integration Tests", () => {
       await createTestMembership({ workspaceId: workspace.id, userId: owner.id, role: "OWNER" });
       await createTestSwarm({ workspaceId: workspace.id, swarmApiKey: "test-key", swarmUrl: "https://test.swarm.url" });
 
-      // Create two runs for the same promptVersionId — older first
+      const { promptId, versionId } = await createTestPromptVersion();
+
+      // Create two runs for the same cuid versionId — older first
       const older = await db.stakworkRun.create({
         data: {
           type: "PROMPT_EVAL",
           workspaceId: workspace.id,
-          promptVersionId: 88,
+          promptVersionId: versionId,
           evalSetId: "eval-set-older",
           status: "COMPLETED",
           result: JSON.stringify({ pass: 3, fail: 2, total: 5 }),
@@ -230,7 +341,7 @@ describe("Prompt Eval Run API — Integration Tests", () => {
         data: {
           type: "PROMPT_EVAL",
           workspaceId: workspace.id,
-          promptVersionId: 88,
+          promptVersionId: versionId,
           evalSetId: "eval-set-newer",
           status: "IN_PROGRESS",
           result: null,
@@ -239,11 +350,11 @@ describe("Prompt Eval Run API — Integration Tests", () => {
       });
 
       const request = createAuthenticatedGetRequest(
-        `http://localhost:3000/api/workspaces/${workspace.slug}/prompts/1/versions/88/run-evals`,
+        `http://localhost:3000/api/workspaces/${workspace.slug}/prompts/${promptId}/versions/${versionId}/run-evals`,
         owner,
       );
 
-      const response = await runEvalsGet(request, makeParams(workspace.slug, "1", "88"));
+      const response = await runEvalsGet(request, makeParams(workspace.slug, promptId, versionId));
       expect(response.status).toBe(200);
       const data = await response.json();
       expect(data.success).toBe(true);
@@ -259,18 +370,20 @@ describe("Prompt Eval Run API — Integration Tests", () => {
       expect(data.history[1].id).toBe(older.id);
     });
 
-    test("returns the latest PROMPT_EVAL run for the correct promptVersionId", async () => {
+    test("returns the latest PROMPT_EVAL run for the correct cuid versionId", async () => {
       const owner = await createTestUser();
       const workspace = await createTestWorkspace({ ownerId: owner.id });
       await createTestMembership({ workspaceId: workspace.id, userId: owner.id, role: "OWNER" });
       await createTestSwarm({ workspaceId: workspace.id, swarmApiKey: "test-key", swarmUrl: "https://test.swarm.url" });
 
-      // Create a PROMPT_EVAL run in DB directly
+      const { promptId, versionId } = await createTestPromptVersion();
+
+      // Create a PROMPT_EVAL run in DB directly using cuid versionId
       const run = await db.stakworkRun.create({
         data: {
           type: "PROMPT_EVAL",
           workspaceId: workspace.id,
-          promptVersionId: 77,
+          promptVersionId: versionId,
           evalSetId: "eval-set-xyz",
           status: "COMPLETED",
           result: JSON.stringify({ pass: 5, fail: 1, total: 6 }),
@@ -279,19 +392,54 @@ describe("Prompt Eval Run API — Integration Tests", () => {
       });
 
       const request = createAuthenticatedGetRequest(
-        `http://localhost:3000/api/workspaces/${workspace.slug}/prompts/1/versions/77/run-evals`,
+        `http://localhost:3000/api/workspaces/${workspace.slug}/prompts/${promptId}/versions/${versionId}/run-evals`,
         owner,
       );
 
-      const response = await runEvalsGet(request, makeParams(workspace.slug, "1", "77"));
+      const response = await runEvalsGet(request, makeParams(workspace.slug, promptId, versionId));
       expect(response.status).toBe(200);
       const data = await response.json();
       expect(data.success).toBe(true);
       expect(data.data).not.toBeNull();
       expect(data.data.id).toBe(run.id);
-      expect(data.data.promptVersionId).toBe(77);
+      expect(data.data.promptVersionId).toBe(versionId); // cuid string
       expect(data.data.evalSetId).toBe("eval-set-xyz");
       expect(data.data.status).toBe("COMPLETED");
+    });
+
+    test("does not return runs for a different versionId in the same workspace", async () => {
+      const owner = await createTestUser();
+      const workspace = await createTestWorkspace({ ownerId: owner.id });
+      await createTestMembership({ workspaceId: workspace.id, userId: owner.id, role: "OWNER" });
+      await createTestSwarm({ workspaceId: workspace.id, swarmApiKey: "test-key", swarmUrl: "https://test.swarm.url" });
+
+      const { promptId, versionId } = await createTestPromptVersion();
+      const { versionId: otherVersionId } = await createTestPromptVersion();
+
+      // Create a run for a different version
+      await db.stakworkRun.create({
+        data: {
+          type: "PROMPT_EVAL",
+          workspaceId: workspace.id,
+          promptVersionId: otherVersionId,
+          evalSetId: "eval-set-other",
+          status: "COMPLETED",
+          result: JSON.stringify({ pass: 5, fail: 0, total: 5 }),
+          webhookUrl: "https://example.com/webhook",
+        },
+      });
+
+      const request = createAuthenticatedGetRequest(
+        `http://localhost:3000/api/workspaces/${workspace.slug}/prompts/${promptId}/versions/${versionId}/run-evals`,
+        owner,
+      );
+
+      const response = await runEvalsGet(request, makeParams(workspace.slug, promptId, versionId));
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      // The queried version has no runs — should return null, not the other version's run
+      expect(data.data).toBeNull();
+      expect(data.history).toHaveLength(0);
     });
   });
 });

--- a/src/__tests__/unit/components/prompts/VersionRowEvalBadge.test.tsx
+++ b/src/__tests__/unit/components/prompts/VersionRowEvalBadge.test.tsx
@@ -42,19 +42,19 @@ const mockPrompt = {
   value: "some value",
   description: "desc",
   usage_notation: "{{PROMPT:TEST_PROMPT}}",
-  current_version_id: 3,
+  current_version_id: "ckcurrentversionid0001",
   published_version_id: null,
   version_count: 3,
   usages: [],
 };
 
 const mockVersions = [
-  { id: 1, version_number: 1, created_at: "2024-01-01T00:00:00Z", whodunnit: null },
-  { id: 2, version_number: 2, created_at: "2024-01-02T00:00:00Z", whodunnit: null },
+  { id: "ckversion0000000001", version_number: 1, created_at: "2024-01-01T00:00:00Z", whodunnit: null },
+  { id: "ckversion0000000002", version_number: 2, created_at: "2024-01-02T00:00:00Z", whodunnit: null },
 ];
 
 /** Helper: build a fetch mock that routes requests appropriately */
-function buildFetch(evalRunsByVersionId: Record<number, object | null> = {}) {
+function buildFetch(evalRunsByVersionId: Record<string, object | null> = {}) {
   return vi.fn((url: unknown) => {
     const u = String(url);
 
@@ -69,7 +69,7 @@ function buildFetch(evalRunsByVersionId: Record<number, object | null> = {}) {
       });
     }
     // Prompt detail
-    if (u.match(/\/api\/workflow\/prompts\/\d+$/) && !u.includes("/versions")) {
+    if (u.match(/\/api\/workflow\/prompts\/[^/]+$/) && !u.includes("/versions")) {
       return Promise.resolve({
         ok: true,
         json: async () => ({ success: true, data: mockPrompt }),
@@ -83,9 +83,9 @@ function buildFetch(evalRunsByVersionId: Record<number, object | null> = {}) {
       });
     }
     // Eval run GET — /versions/[id]/run-evals
-    const evalRunMatch = u.match(/\/versions\/(\d+)\/run-evals/);
+    const evalRunMatch = u.match(/\/versions\/([^/]+)\/run-evals/);
     if (evalRunMatch) {
-      const vId = parseInt(evalRunMatch[1], 10);
+      const vId = evalRunMatch[1];
       const run = evalRunsByVersionId[vId] ?? null;
       return Promise.resolve({
         ok: true,
@@ -93,7 +93,7 @@ function buildFetch(evalRunsByVersionId: Record<number, object | null> = {}) {
       });
     }
     // Version content
-    if (u.match(/\/versions\/\d+$/)) {
+    if (u.match(/\/versions\/[^/]+$/)) {
       return Promise.resolve({
         ok: true,
         json: async () => ({ success: true, data: { value: "version content", description: "" } }),
@@ -134,8 +134,8 @@ describe("Version row eval run UI", () => {
 
   it("shows Loader2 spinner when status is IN_PROGRESS", async () => {
     global.fetch = buildFetch({
-      // version id=1's eval run is IN_PROGRESS
-      1: { id: "run-abc", status: "IN_PROGRESS", result: null, evalSetId: "es-1" },
+      // version id ckversion0000000001's eval run is IN_PROGRESS
+      "ckversion0000000001": { id: "run-abc", status: "IN_PROGRESS", result: null, evalSetId: "es-1" },
     });
 
     render(<PromptsPanel workspaceSlug="test-workspace" />);
@@ -153,7 +153,7 @@ describe("Version row eval run UI", () => {
 
   it("shows green badge '8/10 pass' when all pass (fail === 0)", async () => {
     global.fetch = buildFetch({
-      1: { id: "run-1", status: "COMPLETED", result: '{"pass":8,"fail":0,"total":10}', evalSetId: "es-1" },
+      "ckversion0000000001": { id: "run-1", status: "COMPLETED", result: '{"pass":8,"fail":0,"total":10}', evalSetId: "es-1" },
     });
 
     render(<PromptsPanel workspaceSlug="test-workspace" />);
@@ -169,7 +169,7 @@ describe("Version row eval run UI", () => {
 
   it("shows red badge '7/10 pass' when some fail", async () => {
     global.fetch = buildFetch({
-      1: { id: "run-2", status: "COMPLETED", result: '{"pass":7,"fail":3,"total":10}', evalSetId: "es-1" },
+      "ckversion0000000001": { id: "run-2", status: "COMPLETED", result: '{"pass":7,"fail":3,"total":10}', evalSetId: "es-1" },
     });
 
     render(<PromptsPanel workspaceSlug="test-workspace" />);
@@ -193,11 +193,11 @@ describe("Version row eval run UI", () => {
     // Wait for version list to render so Pusher effect has fired
     await waitFor(() => expect(screen.getByText("v1")).toBeInTheDocument());
 
-    // Simulate Pusher event with the real DB id (3 = current_version_id)
+    // Simulate Pusher event with the real DB id (ckcurrentversionid0001 = current_version_id)
     expect(capturedPusherHandler).not.toBeNull();
     capturedPusherHandler!({
       runId: "r1",
-      promptVersionId: 3, // matches mockPrompt.current_version_id
+      promptVersionId: "ckcurrentversionid0001", // matches mockPrompt.current_version_id
       result: { pass: 4, fail: 0, total: 4 },
     });
 
@@ -230,7 +230,7 @@ describe("Version row eval run UI", () => {
           }),
         });
       }
-      if (u.match(/\/api\/workflow\/prompts\/\d+$/) && !u.includes("/versions")) {
+      if (u.match(/\/api\/workflow\/prompts\/[^/]+$/) && !u.includes("/versions")) {
         return Promise.resolve({
           ok: true,
           json: async () => ({ success: true, data: mockPrompt }),
@@ -242,11 +242,11 @@ describe("Version row eval run UI", () => {
           json: async () => ({ success: true, data: { versions: mockVersions } }),
         });
       }
-      // Eval run GET — returns both data and history for version 1
-      const evalRunMatch = u.match(/\/versions\/(\d+)\/run-evals/);
+      // Eval run GET — returns both data and history for version ckversion0000000001
+      const evalRunMatch = u.match(/\/versions\/([^/]+)\/run-evals/);
       if (evalRunMatch) {
-        const vId = parseInt(evalRunMatch[1], 10);
-        if (vId === 1) {
+        const vId = evalRunMatch[1];
+        if (vId === "ckversion0000000001") {
           return Promise.resolve({
             ok: true,
             json: async () => ({ success: true, data: run1, history: [run1, run2] }),
@@ -257,7 +257,7 @@ describe("Version row eval run UI", () => {
           json: async () => ({ success: true, data: null, history: [] }),
         });
       }
-      if (u.match(/\/versions\/\d+$/)) {
+      if (u.match(/\/versions\/[^/]+$/)) {
         return Promise.resolve({
           ok: true,
           json: async () => ({ success: true, data: { value: "version content", description: "" } }),

--- a/src/app/api/mock/prompts/[promptId]/versions/[versionId]/run-evals/route.ts
+++ b/src/app/api/mock/prompts/[promptId]/versions/[versionId]/run-evals/route.ts
@@ -4,9 +4,20 @@ type RouteParams = {
   params: Promise<{ promptId: string; versionId: string }>;
 };
 
+// Keyed by cuid-style version ids matching what mockSeedData.ts seeds for prompt versions.
+// These are intentionally generic patterns — in mock mode, any versionId not in this map
+// returns data: null (no run yet), which is the correct default.
 const SEEDED_RUNS: Record<string, { status: string; result: string | null; evalSetId: string }> = {
-  "1": { status: "COMPLETED", result: '{"pass":8,"fail":2,"total":10}', evalSetId: "eval-set-1" },
-  "2": { status: "IN_PROGRESS", result: null, evalSetId: "eval-set-2" },
+  "mock-version-id-1": {
+    status: "COMPLETED",
+    result: '{"pass":8,"fail":2,"total":10}',
+    evalSetId: "eval-set-1",
+  },
+  "mock-version-id-2": {
+    status: "IN_PROGRESS",
+    result: null,
+    evalSetId: "eval-set-2",
+  },
 };
 
 /**

--- a/src/app/api/workspaces/[slug]/prompts/[promptId]/versions/[versionId]/run-evals/route.ts
+++ b/src/app/api/workspaces/[slug]/prompts/[promptId]/versions/[versionId]/run-evals/route.ts
@@ -55,6 +55,14 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       return NextResponse.json(await mockResponse.json(), { status: mockResponse.status });
     }
 
+    // Relational validation — verify versionId exists and belongs to promptId
+    const promptVersion = await db.promptVersion.findFirst({
+      where: { id: versionId, promptId },
+    });
+    if (!promptVersion) {
+      return NextResponse.json({ error: "Prompt version not found" }, { status: 404 });
+    }
+
     // Parse + validate body
     let body: { evalSetId?: string; promptName?: string };
     try {
@@ -80,20 +88,15 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       );
     }
 
-    const promptVersionIdInt = parseInt(versionId, 10);
-    if (isNaN(promptVersionIdInt)) {
-      return NextResponse.json({ error: "Invalid versionId" }, { status: 400 });
-    }
-
     const baseUrl =
       process.env.NEXTAUTH_URL || `${request.nextUrl.protocol}//${request.nextUrl.host}`;
 
-    // Create StakworkRun record
+    // Create StakworkRun record using the cuid string versionId directly
     const run = await db.stakworkRun.create({
       data: {
         type: "PROMPT_EVAL",
         workspaceId,
-        promptVersionId: promptVersionIdInt,
+        promptVersionId: versionId,
         evalSetId,
         status: "PENDING",
         webhookUrl: `${baseUrl}/api/stakwork/webhook?run_id=placeholder`,
@@ -119,7 +122,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
               evalSetId,
               swarmUrl,
               swarmSecretAlias: swarmSecretAlias ?? "",
-              prompt_overrides: [{ name: promptName, prompt_version_id: promptVersionIdInt }],
+              prompt_overrides: [{ name: promptName, prompt_version_id: versionId }],
               webhookUrl: `${baseUrl}/api/webhook/stakwork/response?type=PROMPT_EVAL&workspace_id=${workspaceId}`,
             },
           },
@@ -177,7 +180,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const userOrResponse = requireAuth(context);
     if (userOrResponse instanceof NextResponse) return userOrResponse;
 
-    const { slug, promptId: _promptId, versionId } = await params;
+    const { slug, promptId, versionId } = await params;
 
     // IDOR guard — verify authenticated user has access to the workspace
     const swarmAccessResult = await getWorkspaceSwarmAccess(slug, userOrResponse.id);
@@ -189,21 +192,24 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
     if (process.env.USE_MOCKS === "true") {
       const mockResponse = await fetch(
-        `${request.nextUrl.origin}/api/mock/prompts/${_promptId}/versions/${versionId}/run-evals`,
+        `${request.nextUrl.origin}/api/mock/prompts/${promptId}/versions/${versionId}/run-evals`,
         { headers: { "Content-Type": "application/json" } },
       );
       return NextResponse.json(await mockResponse.json(), { status: mockResponse.status });
     }
 
-    const promptVersionIdInt = parseInt(versionId, 10);
-    if (isNaN(promptVersionIdInt)) {
-      return NextResponse.json({ error: "Invalid versionId" }, { status: 400 });
+    // Relational validation — verify versionId exists and belongs to promptId
+    const promptVersion = await db.promptVersion.findFirst({
+      where: { id: versionId, promptId },
+    });
+    if (!promptVersion) {
+      return NextResponse.json({ error: "Prompt version not found" }, { status: 404 });
     }
 
     const runs = await db.stakworkRun.findMany({
       where: {
         type: "PROMPT_EVAL",
-        promptVersionId: promptVersionIdInt,
+        promptVersionId: versionId,
         workspaceId,
       },
       orderBy: { createdAt: "desc" },


### PR DESCRIPTION
Generated with Hive: Fix run-evals route to support cuid version IDs and validate prompt ownership