### PR TITLE
Fix 401 for authenticated sessions on claim-pod and improve error toasts

### DIFF
--- a/src/__tests__/unit/middleware/config.test.ts
+++ b/src/__tests__/unit/middleware/config.test.ts
@@ -421,4 +421,14 @@ describe("resolveRouteAccess", () => {
       ).toBe("protected");
     });
   });
+
+  describe("Claim Pod Route Access", () => {
+    it("resolves claim-pod route as protected (not webhook)", () => {
+      expect(resolveRouteAccess("/api/pool-manager/claim-pod/ws-123", "POST")).toBe("protected");
+    });
+
+    it("resolves claim-pod route as protected for any workspace id", () => {
+      expect(resolveRouteAccess("/api/pool-manager/claim-pod/some-other-workspace", "POST")).toBe("protected");
+    });
+  });
 });

--- a/src/app/api/pool-manager/claim-pod/[workspaceId]/route.ts
+++ b/src/app/api/pool-manager/claim-pod/[workspaceId]/route.ts
@@ -54,6 +54,17 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       return NextResponse.json({ success: false, error: "Workspace not found" }, { status: 404 });
     }
 
+    // Enforce ownership check only for session-based auth (API token callers are trusted system actors)
+    // Must run before any DB write, secret access, or third-party call.
+    if (!isApiTokenAuth) {
+      const isOwner = workspace.ownerId === userId;
+      const isMember = workspace.members.length > 0;
+
+      if (!isOwner && !isMember) {
+        return NextResponse.json({ success: false, error: "Access denied" }, { status: 403 });
+      }
+    }
+
     // If using custom local Goose URL, return mock URLs instead of claiming a real pod
     if (process.env.CUSTOM_GOOSE_URL) {
       const mockFrontend = process.env.MOCK_BROWSER_URL || "http://localhost:3000";
@@ -103,16 +114,6 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       "shouldUpdateToLatest:",
       shouldUpdateToLatest,
     );
-
-    // Enforce ownership check only for session-based auth (API token callers are trusted system actors)
-    if (!isApiTokenAuth) {
-      const isOwner = workspace.ownerId === userId;
-      const isMember = workspace.members.length > 0;
-
-      if (!isOwner && !isMember) {
-        return NextResponse.json({ success: false, error: "Access denied" }, { status: 403 });
-      }
-    }
 
     // Check if workspace has a swarm
     if (!workspace.swarm) {

--- a/src/components/UserJourneys.tsx
+++ b/src/components/UserJourneys.tsx
@@ -295,9 +295,19 @@ export default function UserJourneys({ onBrowserModeChange }: UserJourneysProps)
         const errorData = await response.json();
         console.error("Failed to claim pod:", errorData);
 
-        toast.error("Unable to Create User Journey", {
-          description: "No virtual machines are available right now. Please try again later.",
-        });
+        if (response.status === 401) {
+          toast.error("Session Expired", {
+            description: "Your session has expired. Please sign in again.",
+          });
+        } else if (response.status === 503 || errorData.error === "No available pods") {
+          toast.error("Unable to Create User Journey", {
+            description: "No virtual machines are available right now. Please try again later.",
+          });
+        } else {
+          toast.error("Unable to Create User Journey", {
+            description: "Something went wrong. Please try again later.",
+          });
+        }
         return;
       }
 

--- a/src/config/middleware.ts
+++ b/src/config/middleware.ts
@@ -196,7 +196,7 @@ export const ROUTE_POLICIES: ReadonlyArray<RoutePolicy> = [
   { path: "/api/workers", strategy: "prefix", access: "webhook" }, // machine-to-machine; each worker validates INTERNAL_WORKER_SECRET
   { path: "/api/workspaces", strategy: "exact", access: "webhook" },
   { path: "/api/features/*/title", strategy: "pattern", access: "webhook" },
-  { path: "/api/pool-manager/claim-pod/*", strategy: "pattern", access: "webhook" },
+
   { path: "/mcp", strategy: "prefix", access: "webhook" },
 ] as const;
 


### PR DESCRIPTION
Generated with Hive: Fix 401 for authenticated sessions on claim-pod and improve error toasts