### PR TITLE
Fix repo-scoping filter to use file path prefix instead of repository_id in ErrorIssue KG edges

### DIFF
--- a/src/__tests__/integration/api/errors-webhook.test.ts
+++ b/src/__tests__/integration/api/errors-webhook.test.ts
@@ -765,15 +765,15 @@ describe("POST /api/webhook/errors — KG projection (best-effort)", () => {
           node_type: "File",
           properties: {
             file: "stakwork/hive/src/foo/bar.ts",
-            repository_id: ctx.repo.id,
+            namespace: "default",
           },
         },
         {
           ref_id: "file-in-other-repo",
           node_type: "File",
           properties: {
-            file: "stakwork/hive/src/foo/bar.ts",
-            repository_id: "other-repo-id",
+            file: "other-org/secret-repo/src/foo/bar.ts",
+            namespace: "default",
           },
         },
       ],
@@ -816,7 +816,7 @@ describe("POST /api/webhook/errors — KG projection (best-effort)", () => {
           node_type: "File",
           properties: {
             file: "stakwork/hive/src/completely/different.ts",
-            repository_id: ctx.repo.id,
+            namespace: "default",
           },
         },
       ],
@@ -1215,7 +1215,7 @@ describe("POST /api/webhook/errors — KG edges from structured frames (Ruby + J
           node_type: "File",
           properties: {
             file: "stakwork/hive/app/workers/script_graph_recorder_worker.rb",
-            repository_id: ctx.repo.id,
+            namespace: "default",
           },
         },
         {
@@ -1224,7 +1224,7 @@ describe("POST /api/webhook/errors — KG edges from structured frames (Ruby + J
           properties: {
             name: "perform",
             file: "stakwork/hive/app/workers/script_graph_recorder_worker.rb",
-            repository_id: ctx.repo.id,
+            namespace: "default",
           },
         },
         {
@@ -1233,7 +1233,7 @@ describe("POST /api/webhook/errors — KG edges from structured frames (Ruby + J
           properties: {
             name: "perform",
             file: "stakwork/hive/app/workers/other_worker.rb",
-            repository_id: ctx.repo.id,
+            namespace: "default",
           },
         },
       ],
@@ -1278,7 +1278,7 @@ describe("POST /api/webhook/errors — KG edges from structured frames (Ruby + J
           node_type: "File",
           properties: {
             file: "stakwork/hive/src/foo/bar.ts",
-            repository_id: ctx.repo.id,
+            namespace: "default",
           },
         },
       ],
@@ -1314,7 +1314,7 @@ describe("POST /api/webhook/errors — KG edges from structured frames (Ruby + J
           properties: {
             // Deliberately no file_path — only the real `file` key
             file: "stakwork/hive/app/services/my_service.rb",
-            repository_id: ctx.repo.id,
+            namespace: "default",
           },
         },
       ],

--- a/src/__tests__/unit/lib/utils/error-stack-frames.test.ts
+++ b/src/__tests__/unit/lib/utils/error-stack-frames.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { scopeNodesToRepo } from "@/lib/utils/error-stack-frames";
+
+const makeNode = (file: string, extra?: Record<string, unknown>) => ({
+  ref_id: `ref-${file}`,
+  node_type: "File" as const,
+  properties: { file, namespace: "default", ...extra },
+});
+
+const makeFuncNode = (name: string, file: string) => ({
+  ref_id: `ref-func-${name}`,
+  node_type: "Function" as const,
+  properties: { name, file, namespace: "default" },
+});
+
+describe("scopeNodesToRepo", () => {
+  const targetRepo = "stakwork/senza-lnd";
+  const nodes = [
+    makeNode("stakwork/senza-lnd/app/controllers/admin/blacklists_controller.rb"),
+    makeNode("stakwork/senza-lnd/app/workers/process_job.rb"),
+    makeFuncNode("perform", "stakwork/senza-lnd/app/workers/process_job.rb"),
+    makeNode("stakwork/stakwork-lambda/src/index.ts"),
+    makeFuncNode("handler", "stakwork/stakwork-lambda/src/index.ts"),
+  ];
+
+  it("keeps nodes whose file path starts with the ownerRepo prefix", () => {
+    const result = scopeNodesToRepo(nodes, targetRepo);
+    expect(result).toHaveLength(3);
+    expect(result.map((n) => n.ref_id)).toEqual([
+      "ref-stakwork/senza-lnd/app/controllers/admin/blacklists_controller.rb",
+      "ref-stakwork/senza-lnd/app/workers/process_job.rb",
+      "ref-func-perform",
+    ]);
+  });
+
+  it("drops nodes from a different repo (stakwork/stakwork-lambda)", () => {
+    const result = scopeNodesToRepo(nodes, targetRepo);
+    const refIds = result.map((n) => n.ref_id);
+    expect(refIds).not.toContain("ref-stakwork/stakwork-lambda/src/index.ts");
+    expect(refIds).not.toContain("ref-func-handler");
+  });
+
+  it("returns [] when ownerRepo is an empty string", () => {
+    expect(scopeNodesToRepo(nodes, "")).toEqual([]);
+  });
+
+  it('returns [] when ownerRepo is "unknown"', () => {
+    expect(scopeNodesToRepo(nodes, "unknown")).toEqual([]);
+  });
+
+  it("returns [] when ownerRepo is shorter than 3 characters", () => {
+    expect(scopeNodesToRepo(nodes, "ab")).toEqual([]);
+  });
+
+  it("returns [] for an empty node list", () => {
+    expect(scopeNodesToRepo([], targetRepo)).toEqual([]);
+  });
+
+  it("falls back to file_path when file property is absent", () => {
+    const filePath = "stakwork/senza-lnd/lib/helper.rb";
+    const nodeWithFilePath = {
+      ref_id: "ref-fp",
+      node_type: "File" as const,
+      properties: { file_path: filePath, namespace: "default" },
+    };
+    const result = scopeNodesToRepo([nodeWithFilePath], targetRepo);
+    expect(result).toHaveLength(1);
+    expect(result[0].ref_id).toBe("ref-fp");
+  });
+
+  it("excludes nodes with no file or file_path property", () => {
+    const noPath = {
+      ref_id: "ref-nopath",
+      node_type: "File" as const,
+      properties: { namespace: "default" },
+    };
+    expect(scopeNodesToRepo([noPath], targetRepo)).toEqual([]);
+  });
+
+  it("does not match a node whose file path merely contains ownerRepo as a substring (not prefix)", () => {
+    const node = makeNode("other-org/stakwork/senza-lnd/some/file.rb");
+    expect(scopeNodesToRepo([node], targetRepo)).toEqual([]);
+  });
+});

--- a/src/app/api/webhook/errors/route.ts
+++ b/src/app/api/webhook/errors/route.ts
@@ -6,7 +6,7 @@ import { validateApiKey } from "@/lib/api-keys";
 import { pusherServer, getWorkspaceChannelName, PUSHER_EVENTS } from "@/lib/pusher";
 import { resolveRepoKey, computeFingerprint } from "@/lib/utils/error-fingerprint";
 import { sanitizeFrames } from "@/lib/utils/error-frames";
-import { selectFrameCandidates, matchFileNode, matchesFilePath } from "@/lib/utils/error-stack-frames";
+import { selectFrameCandidates, matchFileNode, matchesFilePath, scopeNodesToRepo } from "@/lib/utils/error-stack-frames";
 import { getJarvisConfigForWorkspace } from "@/lib/helpers/jarvis-config";
 import { addNode, addEdge, searchLatestByTypes, getReferencedNodeCentrality } from "@/services/swarm/api/nodes";
 import { detectOnset } from "@/services/error-issues/spike-detection";
@@ -329,15 +329,19 @@ export async function POST(request: NextRequest) {
               });
             } else {
               // Filter nodes to only those belonging to this issue's own repo
-              // by matching the repository_id property on the node.  Never draw
-              // edges to nodes from a different repo in the same workspace.
-              const repoNodes = searchResult.nodes.filter((n) => {
-                const props = n.properties ?? {};
-                return (
-                  props.repository_id === issue.repositoryId ||
-                  props.repo_id === issue.repositoryId
-                );
-              });
+              // by checking the `file` path prefix (e.g. "stakwork/senza-lnd/").
+              // Real stakgraph nodes carry no `repository_id` — repo identity
+              // lives in the `file` prefix.  Never draw edges to nodes from a
+              // different repo in the same workspace.
+              const ownerRepo = issue.repoKey ?? "";
+              const repoNodes = scopeNodesToRepo(searchResult.nodes, ownerRepo);
+
+              if (repoNodes.length === 0) {
+                console.warn("[error-ingest] KG edges: 0 repo-scoped nodes", {
+                  ownerRepo,
+                  totalNodes: searchResult.nodes.length,
+                });
+              }
 
               let edgesDrawn = 0;
               const seenRefIds = new Set<string>();

--- a/src/lib/utils/error-stack-frames.ts
+++ b/src/lib/utils/error-stack-frames.ts
@@ -140,6 +140,29 @@ export function matchFileNode(
 }
 
 /**
+ * Scope a set of KG nodes to a single repository by checking that their
+ * `file` path starts with the canonical `owner/repo/` prefix.
+ *
+ * Real stakgraph File/Function nodes carry no `repository_id` — repo identity
+ * lives entirely in the `file` path prefix (e.g. `"stakwork/senza-lnd/..."`).
+ * Using `repositoryId` (a Hive cuid) to filter always yields an empty set.
+ *
+ * Guard: returns `[]` when `ownerRepo` is falsy, `"unknown"`, or shorter than
+ * 3 characters (guards against degenerate/unparsed keys).
+ */
+export function scopeNodesToRepo(
+  nodes: Array<{ ref_id?: string; node_type: string; properties?: Record<string, unknown> }>,
+  ownerRepo: string,
+): Array<{ ref_id?: string; node_type: string; properties?: Record<string, unknown> }> {
+  if (!ownerRepo || ownerRepo === "unknown" || ownerRepo.length < 3) return [];
+  const prefix = `${ownerRepo}/`;
+  return nodes.filter((n) => {
+    const path = (n.properties?.file ?? n.properties?.file_path) as string | undefined;
+    return typeof path === "string" && path.startsWith(prefix);
+  });
+}
+
+/**
  * Return true when the node's path ends with or equals `framePath`.
  * Reads `file` (real node property) falling back to `file_path`.
  */


### PR DESCRIPTION
Generated with Hive: Fix repo-scoping filter to use file path prefix instead of repository_id in ErrorIssue KG edges