### PR TITLE
Fix ErrorIssue KG edge fetch to use per-file exact match instead of repo-wide contains

### DIFF
--- a/src/__tests__/integration/api/errors-webhook.test.ts
+++ b/src/__tests__/integration/api/errors-webhook.test.ts
@@ -751,12 +751,13 @@ describe("POST /api/webhook/errors — KG projection (best-effort)", () => {
     expect(issue?.kgRefId).toBe("issue-ref-no-repo");
   });
 
-  test("File/Function edges drawn only to nodes in issue's own repo", async () => {
+  test("File/Function edges drawn only to nodes matching the queried file path (exact =)", async () => {
     mockGetJarvisConfig.mockResolvedValue(MOCK_JARVIS_CONFIG);
     mockAddNode.mockResolvedValue({ success: true, ref_id: "issue-ref-with-edges" });
     mockAddEdge.mockResolvedValue({ success: true });
 
-    // Simulate: one File node in the correct repo, one in a different repo
+    // Per-file exact query: returns only the node for that file path.
+    // The other-repo node would never appear since we query by exact file path.
     mockSearchNodesByAttributes.mockResolvedValue({
       ok: true,
       nodes: [
@@ -765,14 +766,6 @@ describe("POST /api/webhook/errors — KG projection (best-effort)", () => {
           node_type: "File",
           properties: {
             file: "stakwork/hive/src/foo/bar.ts",
-            namespace: "default",
-          },
-        },
-        {
-          ref_id: "file-in-other-repo",
-          node_type: "File",
-          properties: {
-            file: "other-org/secret-repo/src/foo/bar.ts",
             namespace: "default",
           },
         },
@@ -794,13 +787,15 @@ describe("POST /api/webhook/errors — KG projection (best-effort)", () => {
 
     expect(res.status).toBe(201);
 
-    // Verify the new repo-scoped call was used (not the old global searchLatestByTypes)
+    // Verify per-file exact-match call with comparator "=" (not "contains")
     expect(mockSearchNodesByAttributes).toHaveBeenCalledOnce();
     const [, searchParams] = mockSearchNodesByAttributes.mock.calls[0];
     expect(searchParams.nodeTypes).toEqual(["File", "Function"]);
-    expect(searchParams.filters).toEqual([
-      { attribute: "file", value: "stakwork/hive/", comparator: "contains" },
-    ]);
+    // The filter must use exact "=" comparator on the full repo-qualified path
+    expect(searchParams.filters).toHaveLength(1);
+    expect(searchParams.filters[0].attribute).toBe("file");
+    expect(searchParams.filters[0].comparator).toBe("=");
+    expect(searchParams.filters[0].value).toBe("stakwork/hive/bar.ts"); // basename from stackTrace fallback
     expect(searchParams.includeProperties).toBe(true);
 
     // Only one edge drawn — to the node in the correct repo
@@ -809,8 +804,6 @@ describe("POST /api/webhook/errors — KG projection (best-effort)", () => {
     expect(edgePayload.edge.edge_type).toBe("REFERENCES");
     expect(edgePayload.source.ref_id).toBe("issue-ref-with-edges");
     expect(edgePayload.target.ref_id).toBe("file-in-correct-repo");
-    // Must NOT reference the node from the other repo
-    expect(edgePayload.target.ref_id).not.toBe("file-in-other-repo");
   });
 
   test("regression guard: >1000 total workspace nodes — repo-scoped fetch returns issue's repo nodes regardless", async () => {
@@ -868,12 +861,16 @@ describe("POST /api/webhook/errors — KG projection (best-effort)", () => {
 
       expect(res.status).toBe(201);
 
-      // searchNodesByAttributes was called with senza-lnd repo filter
+      // searchNodesByAttributes was called with per-file exact-match for the frame's path
       expect(mockSearchNodesByAttributes).toHaveBeenCalledOnce();
       const [, searchParams] = mockSearchNodesByAttributes.mock.calls[0];
-      expect(searchParams.filters).toEqual([
-        { attribute: "file", value: "stakwork/senza-lnd/", comparator: "contains" },
-      ]);
+      expect(searchParams.filters).toHaveLength(1);
+      expect(searchParams.filters[0].attribute).toBe("file");
+      expect(searchParams.filters[0].comparator).toBe("=");
+      // Exact path: repoKey + "/" + normalized frame path
+      expect(searchParams.filters[0].value).toBe(
+        "stakwork/senza-lnd/app/controllers/admin/blacklists_controller.rb",
+      );
 
       // Edge drawn to the correct node — old-repo bug would have drawn 0 edges
       expect(mockAddEdge).toHaveBeenCalledOnce();
@@ -1420,5 +1417,304 @@ describe("POST /api/webhook/errors — KG edges from structured frames (Ruby + J
     expect(mockAddEdge).toHaveBeenCalledOnce();
     const [, edgePayload] = mockAddEdge.mock.calls[0];
     expect(edgePayload.target.ref_id).toBe("file-only-file-key");
+  });
+});
+
+// ── Per-file exact-match KG fetch tests ──────────────────────────────────────
+
+describe("POST /api/webhook/errors — per-file exact-match KG fetch (comparator '=')", () => {
+  const MOCK_JARVIS_CONFIG = { jarvisUrl: "https://jarvis.example.com", apiKey: "jarvis-key" };
+  let ctx: Awaited<ReturnType<typeof createTestSetup>>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    ctx = await createTestSetup();
+    mockPusherTrigger.mockResolvedValue(undefined);
+    mockGetReferencedNodeCentrality.mockResolvedValue({ ok: true, nodes: [] });
+    mockComputeImpactScore.mockReturnValue(null);
+    mockGetJarvisConfig.mockResolvedValue(MOCK_JARVIS_CONFIG);
+    mockAddNode.mockResolvedValue({ success: true, ref_id: "issue-ref-exact" });
+    mockAddEdge.mockResolvedValue({ success: true });
+  });
+
+  afterEach(async () => {
+    await db.errorEvent.deleteMany({ where: { workspaceId: ctx.workspace.id } });
+    await db.errorIssue.deleteMany({ where: { workspaceId: ctx.workspace.id } });
+    await db.workspaceApiKey.deleteMany({ where: { id: ctx.apiKey.id } });
+    await db.repository.deleteMany({ where: { id: ctx.repo.id } });
+    await db.workspace.deleteMany({ where: { id: ctx.workspace.id } });
+    await db.user.deleteMany({ where: { id: ctx.owner.id } });
+    await db.errorEvent.deleteMany({ where: { workspaceId: ctx.workspace2.id } });
+    await db.errorIssue.deleteMany({ where: { workspaceId: ctx.workspace2.id } });
+    await db.repository.deleteMany({ where: { id: ctx.repo2.id } });
+    await db.workspace.deleteMany({ where: { id: ctx.workspace2.id } });
+    await db.user.deleteMany({ where: { id: ctx.owner2.id } });
+  });
+
+  test("jarvis request uses comparator '=' on attribute 'file', never 'contains'", async () => {
+    mockSearchNodesByAttributes.mockResolvedValue({
+      ok: true,
+      nodes: [
+        {
+          ref_id: "file-controller",
+          node_type: "File",
+          properties: { file: "stakwork/hive/app/controllers/admin/translations_controller.rb" },
+        },
+        {
+          ref_id: "func-edit",
+          node_type: "Function",
+          properties: {
+            name: "edit",
+            file: "stakwork/hive/app/controllers/admin/translations_controller.rb",
+          },
+        },
+      ],
+    });
+
+    const res = await POST(
+      buildRequest(
+        {
+          exceptionType: "ActiveRecord::NotFound",
+          message: "Couldn't find Translation",
+          frames: [
+            {
+              filename: "app/controllers/admin/translations_controller.rb",
+              function: "edit",
+              lineno: 14,
+              inApp: true,
+            },
+          ],
+          repository: "https://github.com/stakwork/hive",
+        },
+        RAW_KEY,
+      ),
+    );
+
+    expect(res.status).toBe(201);
+
+    // All calls must use "=" comparator — never "contains" or "~="
+    for (const call of mockSearchNodesByAttributes.mock.calls) {
+      const [, params] = call;
+      for (const filter of params.filters) {
+        expect(filter.comparator).toBe("=");
+        expect(filter.comparator).not.toBe("contains");
+        expect(filter.comparator).not.toBe("~=");
+      }
+    }
+
+    // Both File and Function edges drawn
+    expect(mockAddEdge).toHaveBeenCalledTimes(2);
+    const targetRefIds = mockAddEdge.mock.calls.map(
+      (c: unknown[]) => (c[1] as { target: { ref_id: string } }).target.ref_id,
+    );
+    expect(targetRefIds).toContain("file-controller");
+    expect(targetRefIds).toContain("func-edit");
+  });
+
+  test("exact file= match → REFERENCES edges drawn + non-null impact score persisted", async () => {
+    mockSearchNodesByAttributes.mockResolvedValue({
+      ok: true,
+      nodes: [
+        {
+          ref_id: "func-edit-central",
+          node_type: "Function",
+          properties: {
+            name: "edit",
+            file: "stakwork/hive/app/controllers/admin/translations_controller.rb",
+            pagerank: 0.405,
+          },
+        },
+      ],
+    });
+    mockGetReferencedNodeCentrality.mockResolvedValue({
+      ok: true,
+      nodes: [{ ref_id: "func-edit-central", node_type: "Function", name: "edit", pagerank: 0.405 }],
+    });
+    mockComputeImpactScore.mockReturnValue({
+      score: 0.405,
+      meta: { topNodeName: "edit", topNodeType: "Function", topPagerank: 0.405, nodeCount: 1 },
+    });
+
+    const res = await POST(
+      buildRequest(
+        {
+          exceptionType: "ActiveRecord::NotFound",
+          message: "Couldn't find Translation",
+          frames: [
+            {
+              filename: "app/controllers/admin/translations_controller.rb",
+              function: "edit",
+              lineno: 14,
+              inApp: true,
+            },
+          ],
+          repository: "https://github.com/stakwork/hive",
+        },
+        RAW_KEY,
+      ),
+    );
+
+    expect(res.status).toBe(201);
+
+    // Edge drawn
+    expect(mockAddEdge).toHaveBeenCalledOnce();
+    const [, edgePayload] = mockAddEdge.mock.calls[0];
+    expect(edgePayload.target.ref_id).toBe("func-edit-central");
+
+    // Allow async DB write to complete
+    await new Promise((r) => setTimeout(r, 50));
+
+    const body = await res.json();
+    const issue = await db.errorIssue.findUnique({ where: { id: body.data.issueId } });
+    expect(issue?.impactScore).toBe(0.405);
+    expect(issue?.impactScoredAt).not.toBeNull();
+  });
+
+  test("one failed per-file query does not block others — remaining edges drawn, 201 returned", async () => {
+    // First call fails, second succeeds
+    mockSearchNodesByAttributes
+      .mockResolvedValueOnce({ ok: false, error: "lookup timeout", nodes: [] })
+      .mockResolvedValueOnce({
+        ok: true,
+        nodes: [
+          {
+            ref_id: "file-service",
+            node_type: "File",
+            properties: { file: "stakwork/hive/app/services/my_service.rb" },
+          },
+        ],
+      });
+
+    const res = await POST(
+      buildRequest(
+        {
+          exceptionType: "RuntimeError",
+          message: "service crashed",
+          frames: [
+            // Two different files — first will fail, second will succeed
+            { filename: "app/controllers/admin/broken_controller.rb", function: "index", lineno: 5, inApp: true },
+            { filename: "app/services/my_service.rb", function: "call", lineno: 20, inApp: true },
+          ],
+          repository: "https://github.com/stakwork/hive",
+        },
+        RAW_KEY,
+      ),
+    );
+
+    // Must still return 201 — one failed file is non-fatal
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+
+    // Two per-file queries were made
+    expect(mockSearchNodesByAttributes).toHaveBeenCalledTimes(2);
+
+    // Edge drawn for the successful file only
+    expect(mockAddEdge).toHaveBeenCalledOnce();
+    const [, edgePayload] = mockAddEdge.mock.calls[0];
+    expect(edgePayload.target.ref_id).toBe("file-service");
+  });
+
+  test("rejected/thrown per-file query is skipped — others draw, 201 returned", async () => {
+    mockSearchNodesByAttributes
+      .mockRejectedValueOnce(new Error("network timeout for broken_controller"))
+      .mockResolvedValueOnce({
+        ok: true,
+        nodes: [
+          {
+            ref_id: "file-worker",
+            node_type: "File",
+            properties: { file: "stakwork/hive/app/workers/my_worker.rb" },
+          },
+        ],
+      });
+
+    const res = await POST(
+      buildRequest(
+        {
+          exceptionType: "Sidekiq::Error",
+          message: "job failed",
+          frames: [
+            { filename: "app/controllers/admin/broken_controller.rb", function: "index", lineno: 5, inApp: true },
+            { filename: "app/workers/my_worker.rb", function: "perform", lineno: 12, inApp: true },
+          ],
+          repository: "https://github.com/stakwork/hive",
+        },
+        RAW_KEY,
+      ),
+    );
+
+    expect(res.status).toBe(201);
+    expect(mockAddEdge).toHaveBeenCalledOnce();
+    const [, edgePayload] = mockAddEdge.mock.calls[0];
+    expect(edgePayload.target.ref_id).toBe("file-worker");
+  });
+
+  test("basename-only stackTrace fallback frame produces no edge (documented limitation)", async () => {
+    // parseStackFrames (stackTrace fallback) reduces paths to a bare basename
+    // (e.g. "bar.ts"), so the per-file exact query becomes
+    // "stakwork/hive/bar.ts" — jarvis returns no nodes for that path because
+    // the real node lives at "stakwork/hive/src/foo/bar.ts".
+    // We simulate this by returning empty nodes for the exact query on the basename.
+    mockSearchNodesByAttributes.mockResolvedValue({ ok: true, nodes: [] });
+
+    const res = await POST(
+      buildRequest(
+        {
+          exceptionType: "TypeError",
+          message: "x is not defined",
+          // No frames — triggers stackTrace fallback; parseStackFrames returns basename "bar.ts"
+          stackTrace: "  at doThing (src/foo/bar.ts:10:5)",
+          repository: "https://github.com/stakwork/hive",
+        },
+        RAW_KEY,
+      ),
+    );
+
+    expect(res.status).toBe(201);
+    // The query was made with the basename path (not the full path), and
+    // jarvis returned no nodes → no edge drawn. Non-fatal, no throw.
+    expect(mockSearchNodesByAttributes).toHaveBeenCalledOnce();
+    const [, params] = mockSearchNodesByAttributes.mock.calls[0];
+    // Query uses basename "bar.ts" (not the full "src/foo/bar.ts")
+    expect(params.filters[0].value).toBe("stakwork/hive/bar.ts");
+    expect(mockAddEdge).not.toHaveBeenCalled();
+  });
+
+  test("multiple frames pointing to same file → only one per-file query (deduped)", async () => {
+    mockSearchNodesByAttributes.mockResolvedValue({
+      ok: true,
+      nodes: [
+        {
+          ref_id: "file-controller",
+          node_type: "File",
+          properties: { file: "stakwork/hive/app/controllers/orders_controller.rb" },
+        },
+      ],
+    });
+
+    const res = await POST(
+      buildRequest(
+        {
+          exceptionType: "ActiveRecord::NotFound",
+          message: "Order not found",
+          frames: [
+            // Three frames from the same file — should dedupe to one query
+            { filename: "app/controllers/orders_controller.rb", function: "show", lineno: 10, inApp: true },
+            { filename: "app/controllers/orders_controller.rb", function: "authorize", lineno: 25, inApp: true },
+            { filename: "app/controllers/orders_controller.rb", function: "find_order", lineno: 40, inApp: true },
+          ],
+          repository: "https://github.com/stakwork/hive",
+        },
+        RAW_KEY,
+      ),
+    );
+
+    expect(res.status).toBe(201);
+
+    // Only ONE query issued despite 3 frames from the same file
+    expect(mockSearchNodesByAttributes).toHaveBeenCalledOnce();
+    const [, params] = mockSearchNodesByAttributes.mock.calls[0];
+    expect(params.filters[0].value).toBe("stakwork/hive/app/controllers/orders_controller.rb");
   });
 });

--- a/src/__tests__/unit/api/errors-kg-edge-resolution.test.ts
+++ b/src/__tests__/unit/api/errors-kg-edge-resolution.test.ts
@@ -281,3 +281,166 @@ describe("parseStackFrames (V8 / Firefox fallback)", () => {
     expect(parseStackFrames("")).toHaveLength(0);
   });
 });
+
+// ── Per-file path normalization (new exact-match fetch logic) ─────────────────
+
+/**
+ * Helper: mirrors the normalization logic in the webhook route's KG edge block.
+ * Used to verify path-building correctness without importing the route itself.
+ */
+function normalizePath(filePath: string | null | undefined): string | null {
+  if (!filePath) return null;
+  const norm = filePath.replace(/^(?:\.\/|\/+|(?:[A-Za-z]:)?[/\\]+)/, "");
+  return norm || null;
+}
+
+function buildFullPath(repoKey: string, filePath: string | null | undefined): string | null {
+  const norm = normalizePath(filePath);
+  if (!norm) return null;
+  return `${repoKey}/${norm}`;
+}
+
+describe("per-file path normalization — buildFullPath", () => {
+  const REPO_KEY = "stakwork/senza-lnd";
+
+  test("bare relative path unchanged", () => {
+    expect(buildFullPath(REPO_KEY, "app/controllers/admin/translations_controller.rb"))
+      .toBe("stakwork/senza-lnd/app/controllers/admin/translations_controller.rb");
+  });
+
+  test("leading '/' stripped", () => {
+    expect(buildFullPath(REPO_KEY, "/app/controllers/admin/translations_controller.rb"))
+      .toBe("stakwork/senza-lnd/app/controllers/admin/translations_controller.rb");
+  });
+
+  test("leading './' stripped", () => {
+    expect(buildFullPath(REPO_KEY, "./app/workers/my_worker.rb"))
+      .toBe("stakwork/senza-lnd/app/workers/my_worker.rb");
+  });
+
+  test("multiple leading slashes stripped", () => {
+    expect(buildFullPath(REPO_KEY, "///app/services/foo.rb"))
+      .toBe("stakwork/senza-lnd/app/services/foo.rb");
+  });
+
+  test("null filePath → returns null (null guard)", () => {
+    expect(buildFullPath(REPO_KEY, null)).toBeNull();
+  });
+
+  test("undefined filePath → returns null (null guard)", () => {
+    expect(buildFullPath(REPO_KEY, undefined)).toBeNull();
+  });
+
+  test("empty string filePath → returns null (null guard)", () => {
+    expect(buildFullPath(REPO_KEY, "")).toBeNull();
+  });
+
+  test("basename-only (no directory) still builds a path", () => {
+    // parseStackFrames fallback produces basenames — documented limitation
+    expect(buildFullPath(REPO_KEY, "bar.ts")).toBe("stakwork/senza-lnd/bar.ts");
+  });
+});
+
+describe("per-file deduplication via Set", () => {
+  const REPO_KEY = "stakwork/hive";
+
+  test("multiple frames pointing to the same file dedupe to one entry", () => {
+    const candidates: Array<{ filePath: string | null }> = [
+      { filePath: "app/controllers/orders_controller.rb" },
+      { filePath: "app/controllers/orders_controller.rb" },
+      { filePath: "app/controllers/orders_controller.rb" },
+    ];
+
+    const uniquePaths = new Set<string>();
+    for (const frame of candidates) {
+      if (!frame.filePath) continue;
+      const norm = normalizePath(frame.filePath);
+      if (!norm) continue;
+      uniquePaths.add(`${REPO_KEY}/${norm}`);
+    }
+
+    expect(uniquePaths.size).toBe(1);
+    expect(Array.from(uniquePaths)[0]).toBe("stakwork/hive/app/controllers/orders_controller.rb");
+  });
+
+  test("frames pointing to different files produce separate entries", () => {
+    const candidates: Array<{ filePath: string | null }> = [
+      { filePath: "app/controllers/orders_controller.rb" },
+      { filePath: "app/services/order_service.rb" },
+      { filePath: "app/workers/order_worker.rb" },
+    ];
+
+    const uniquePaths = new Set<string>();
+    for (const frame of candidates) {
+      if (!frame.filePath) continue;
+      const norm = normalizePath(frame.filePath);
+      if (!norm) continue;
+      uniquePaths.add(`${REPO_KEY}/${norm}`);
+    }
+
+    expect(uniquePaths.size).toBe(3);
+  });
+
+  test("null filePath candidates are skipped and not added to Set", () => {
+    const candidates: Array<{ filePath: string | null }> = [
+      { filePath: null },
+      { filePath: "app/workers/my_worker.rb" },
+      { filePath: null },
+    ];
+
+    const uniquePaths = new Set<string>();
+    for (const frame of candidates) {
+      if (!frame.filePath) continue;
+      const norm = normalizePath(frame.filePath);
+      if (!norm) continue;
+      uniquePaths.add(`${REPO_KEY}/${norm}`);
+    }
+
+    expect(uniquePaths.size).toBe(1);
+  });
+});
+
+describe("File(null pagerank) + Function(non-null pagerank) — matcher selects Function's score", () => {
+  // When pooled nodes include a File node with no pagerank and a Function node
+  // with a pagerank score, matchFileNode + the function search both succeed,
+  // both edges are drawn, and computeImpactScore (which picks max pagerank)
+  // correctly returns the Function's score (not null from the File node).
+
+  test("matchFileNode resolves File node even when pagerank is null", () => {
+    const nodes: MockNode[] = [
+      {
+        ref_id: "file-ref",
+        node_type: "File",
+        properties: { file: "stakwork/senza-lnd/app/controllers/admin/translations_controller.rb" },
+        // No pagerank — null/missing
+      },
+      {
+        ref_id: "func-ref",
+        node_type: "Function",
+        properties: {
+          name: "edit",
+          file: "stakwork/senza-lnd/app/controllers/admin/translations_controller.rb",
+          pagerank: 0.405,
+        },
+      },
+    ];
+
+    const fileMatch = matchFileNode(nodes, "app/controllers/admin/translations_controller.rb");
+    expect(fileMatch?.ref_id).toBe("file-ref");
+
+    const funcMatch = nodes.find(
+      (n) =>
+        n.node_type === "Function" &&
+        n.properties.name === "edit" &&
+        matchesFilePath(
+          n.properties.file as string,
+          "app/controllers/admin/translations_controller.rb",
+        ),
+    );
+    expect(funcMatch?.ref_id).toBe("func-ref");
+    // The Function node has the non-null pagerank — computeImpactScore would pick this
+    expect(funcMatch?.properties.pagerank).toBe(0.405);
+    // The File node has no pagerank — confirms scorer must look at all matched nodes
+    expect(fileMatch?.properties?.pagerank).toBeUndefined();
+  });
+});

--- a/src/app/api/webhook/errors/route.ts
+++ b/src/app/api/webhook/errors/route.ts
@@ -6,7 +6,7 @@ import { validateApiKey } from "@/lib/api-keys";
 import { pusherServer, getWorkspaceChannelName, PUSHER_EVENTS } from "@/lib/pusher";
 import { resolveRepoKey, computeFingerprint } from "@/lib/utils/error-fingerprint";
 import { sanitizeFrames } from "@/lib/utils/error-frames";
-import { selectFrameCandidates, matchFileNode, matchesFilePath, scopeNodesToRepo } from "@/lib/utils/error-stack-frames";
+import { selectFrameCandidates, matchFileNode, matchesFilePath } from "@/lib/utils/error-stack-frames";
 import { getJarvisConfigForWorkspace } from "@/lib/helpers/jarvis-config";
 import { addNode, addEdge, searchNodesByAttributes, getReferencedNodeCentrality } from "@/services/swarm/api/nodes";
 import { detectOnset } from "@/services/error-issues/spike-detection";
@@ -322,133 +322,173 @@ export async function POST(request: NextRequest) {
           });
 
           if (candidates.length > 0) {
-            // Fetch File and Function nodes scoped to this repo via the
-            // attributes search endpoint, filtering on the `file` property
-            // prefix (e.g. "stakwork/senza-lnd/"). This ensures nodes for
-            // older/smaller repos are returned regardless of global node count,
-            // and keeps the payload small enough to stay well under the
-            // serverless timeout.
             console.info("[error-ingest] KG debug", { issueId: issue.id, aboutToSearch: true, repoKey: issue.repoKey });
 
-            // Guard: skip the search if repoKey is missing or too short to be
-            // a valid owner/repo — a malformed filter would over-match or error.
+            // Guard: skip the search if repoKey is missing or malformed.
             const ownerRepo = issue.repoKey ?? "";
             if (!ownerRepo || ownerRepo.length < 3 || !ownerRepo.includes("/")) {
               console.warn("[error-ingest] KG edges: invalid repoKey, skipping search", { repoKey: ownerRepo });
             } else {
-              const searchResult = await searchNodesByAttributes(
-                jarvisConfig,
-                {
-                  nodeTypes: ["File", "Function"],
-                  filters: [{ attribute: "file", value: `${ownerRepo}/`, comparator: "contains" }],
-                  includeProperties: true,
-                  limit: 1000,
-                },
-              );
+              // Build the set of unique full file paths to query.
+              // Each path is: `${repoKey}/${normalizedFramePath}` where the
+              // frame path has any leading `/`, `./`, or absolute-prefix stripped.
+              //
+              // NOTE (known limitation): frames resolved via the stackTrace
+              // fallback path in selectFrameCandidates reduce to a bare basename
+              // and will not exact-match a repo-qualified `owner/repo/path` node.
+              // This is accepted — jarvis hard-rejects `contains` (the only
+              // alternative), and structured in-app frames carry full repo-relative
+              // paths and will match correctly.
+              const PER_FILE_TIMEOUT_MS = 8_000;
+              const uniqueFilePaths = new Set<string>();
+              for (const frame of candidates) {
+                if (!frame.filePath) continue;
+                // Normalize: strip leading `/`, `./`, or absolute-path prefix
+                const normPath = frame.filePath.replace(/^(?:\.\/|\/+|(?:[A-Za-z]:)?[/\\]+)/, "");
+                if (!normPath) continue;
+                uniqueFilePaths.add(`${ownerRepo}/${normPath}`);
+              }
 
               console.info("[error-ingest] KG debug", {
                 issueId: issue.id,
-                searchOk: searchResult.ok,
-                totalNodesReturned: searchResult.ok ? searchResult.nodes.length : null,
-                repoKey: ownerRepo,
-                error: searchResult.ok ? null : searchResult.error,
+                uniqueFilePaths: Array.from(uniqueFilePaths),
+                candidatesCount: candidates.length,
               });
 
-              if (!searchResult.ok) {
-                console.warn("[error-ingest] KG code-node search failed (skipping edges)", {
-                  error: searchResult.error,
-                  repoKey: ownerRepo,
-                });
-              } else {
-                // Safety-filter nodes to only those belonging to this issue's
-                // own repo. The `contains` comparator is not a strict prefix
-                // match (it is a Lucene wildcard), so a repo whose name is a
-                // substring of another (e.g. senza-lnd vs senza-lnd-fork)
-                // could over-match. scopeNodesToRepo guards that edge case.
-                const repoNodes = scopeNodesToRepo(searchResult.nodes, ownerRepo);
+              // Run one exact-match attributes search per unique file path in
+              // parallel. `=` comparator is exempt from jarvis's searchable-
+              // attribute allowlist (unlike `contains`/`~=`), so these never
+              // get rejected with HTTP 400.
+              const fileQueryResults = await Promise.allSettled(
+                Array.from(uniqueFilePaths).map((fullPath) =>
+                  searchNodesByAttributes(jarvisConfig, {
+                    nodeTypes: ["File", "Function"],
+                    filters: [{ attribute: "file", value: fullPath, comparator: "=" }],
+                    includeProperties: true,
+                    limit: 100,
+                    timeoutMs: PER_FILE_TIMEOUT_MS,
+                  }).then((result) => ({ fullPath, result })),
+                ),
+              );
 
-                console.info("[error-ingest] KG debug", {
-                  issueId: issue.id,
-                  ownerRepo,
-                  totalNodes: searchResult.nodes.length,
-                  repoScopedCount: repoNodes.length,
-                  sampleNodeFiles: searchResult.nodes.slice(0, 5).map((n) => n.properties?.file ?? n.properties?.file_path ?? null),
-                });
+              // Pool all successful per-file results; log + skip failures.
+              const pooledNodes: Array<{ ref_id?: string; node_type: string; properties?: Record<string, unknown> }> = [];
+              let totalNodesFetched = 0;
 
-                if (repoNodes.length === 0) {
-                  console.warn("[error-ingest] KG edges: 0 repo-scoped nodes", {
-                    ownerRepo,
-                    totalNodes: searchResult.nodes.length,
+              for (const settled of fileQueryResults) {
+                if (settled.status === "rejected") {
+                  // We can't get fullPath from a rejection at this level —
+                  // the per-file promise wraps the result so rejections carry
+                  // the error. Log what we can.
+                  console.warn("[error-ingest] KG code-node search failed (skipping edges)", {
+                    error: settled.reason instanceof Error ? settled.reason.message : String(settled.reason),
                   });
+                  continue;
                 }
+                const { fullPath, result } = settled.value;
+                if (!result.ok) {
+                  console.warn("[error-ingest] KG code-node search failed (skipping edges)", {
+                    error: result.error,
+                    filePath: fullPath,
+                  });
+                  continue;
+                }
+                totalNodesFetched += result.nodes.length;
+                for (const node of result.nodes) {
+                  pooledNodes.push(node);
+                }
+              }
 
-                let edgesDrawn = 0;
-                const seenRefIds = new Set<string>();
-                let frameIndex = 0;
+              console.info("[error-ingest] KG debug", {
+                issueId: issue.id,
+                ownerRepo,
+                totalNodesFetched,
+                pooledNodesCount: pooledNodes.length,
+                sampleNodeFiles: pooledNodes.slice(0, 5).map((n) => n.properties?.file ?? n.properties?.file_path ?? null),
+              });
 
-                for (const frame of candidates) {
-                  // Try to match a File node by path, then a Function node by
-                  // name AND same-file path (same-file guard prevents shared
-                  // method names like `perform` from linking the wrong worker).
-                  const fileNode = frame.filePath
-                    ? matchFileNode(repoNodes, frame.filePath)
-                    : undefined;
-                  const funcNode =
-                    frame.functionName && frame.filePath
-                      ? repoNodes.find(
-                          (n) =>
-                            n.node_type === "Function" &&
-                            (n.properties?.name as string | undefined) === frame.functionName &&
-                            matchesFilePath(
-                              (n.properties?.file ?? n.properties?.file_path) as string | undefined,
-                              frame.filePath,
-                            ),
-                        )
-                      : undefined;
+              let edgesDrawn = 0;
+              const seenRefIds = new Set<string>();
+              let frameIndex = 0;
 
-                  if (frameIndex < 5) {
-                    console.info("[error-ingest] KG debug", {
+              for (const frame of candidates) {
+                // Try to match a File node by path, then a Function node by
+                // name AND same-file path (same-file guard prevents shared
+                // method names like `perform` from linking the wrong worker).
+                const fileNode = frame.filePath
+                  ? matchFileNode(pooledNodes, frame.filePath)
+                  : undefined;
+
+                // Debug: ambiguous file node case — matchFileNode returns
+                // undefined when >1 exact File match exists for this path.
+                if (frame.filePath && !fileNode) {
+                  const exactMatches = pooledNodes.filter(
+                    (n) => n.node_type === "File" &&
+                      ((n.properties?.file ?? n.properties?.file_path) as string | undefined)?.endsWith(frame.filePath!),
+                  );
+                  if (exactMatches.length > 1) {
+                    console.info("[error-ingest] KG debug ambiguous file node", {
                       issueId: issue.id,
                       framePath: frame.filePath,
-                      frameFunc: frame.functionName,
-                      matchedFile: fileNode?.ref_id ?? null,
-                      matchedFunc: funcNode?.ref_id ?? null,
+                      matchCount: exactMatches.length,
                     });
-                  }
-                  frameIndex++;
-
-                  for (const targetNode of [fileNode, funcNode]) {
-                    if (!targetNode?.ref_id) continue;
-                    if (seenRefIds.has(targetNode.ref_id)) continue;
-                    seenRefIds.add(targetNode.ref_id);
-
-                    const edgeResult = await addEdge(jarvisConfig, {
-                      edge: { edge_type: "REFERENCES" },
-                      source: { ref_id: issueNodeResult.ref_id },
-                      target: { ref_id: targetNode.ref_id },
-                    });
-                    if (edgeResult.success) {
-                      edgesDrawn++;
-                    } else {
-                      console.warn("[error-ingest] REFERENCES edge failed (skipped)", {
-                        targetRefId: targetNode.ref_id,
-                        nodeType: targetNode.node_type,
-                        error: edgeResult.error,
-                      });
-                    }
                   }
                 }
 
-                console.info("[error-ingest] KG edges drawn", {
-                  issueId: issue.id,
-                  source: candidateSource,
-                  candidatesScanned: candidates.length,
-                  edgesDrawn,
-                  repoKey: ownerRepo,
-                  nodesFetched: searchResult.nodes.length,
-                  repoNodesAvailable: repoNodes.length,
-                });
+                const funcNode =
+                  frame.functionName && frame.filePath
+                    ? pooledNodes.find(
+                        (n) =>
+                          n.node_type === "Function" &&
+                          (n.properties?.name as string | undefined) === frame.functionName &&
+                          matchesFilePath(
+                            (n.properties?.file ?? n.properties?.file_path) as string | undefined,
+                            frame.filePath,
+                          ),
+                      )
+                    : undefined;
+
+                if (frameIndex < 5) {
+                  console.info("[error-ingest] KG debug", {
+                    issueId: issue.id,
+                    framePath: frame.filePath,
+                    frameFunc: frame.functionName,
+                    matchedFile: fileNode?.ref_id ?? null,
+                    matchedFunc: funcNode?.ref_id ?? null,
+                  });
+                }
+                frameIndex++;
+
+                for (const targetNode of [fileNode, funcNode]) {
+                  if (!targetNode?.ref_id) continue;
+                  if (seenRefIds.has(targetNode.ref_id)) continue;
+                  seenRefIds.add(targetNode.ref_id);
+
+                  const edgeResult = await addEdge(jarvisConfig, {
+                    edge: { edge_type: "REFERENCES" },
+                    source: { ref_id: issueNodeResult.ref_id },
+                    target: { ref_id: targetNode.ref_id },
+                  });
+                  if (edgeResult.success) {
+                    edgesDrawn++;
+                  } else {
+                    console.warn("[error-ingest] REFERENCES edge failed (skipped)", {
+                      targetRefId: targetNode.ref_id,
+                      nodeType: targetNode.node_type,
+                      error: edgeResult.error,
+                    });
+                  }
+                }
               }
+
+              console.info("[error-ingest] KG edges drawn", {
+                issueId: issue.id,
+                source: candidateSource,
+                candidatesScanned: candidates.length,
+                edgesDrawn,
+                repoKey: ownerRepo,
+                repoNodesAvailable: pooledNodes.length,
+              });
             } // end ownerRepo guard
           }
         }


### PR DESCRIPTION
Generated with Hive: Fix ErrorIssue KG edge fetch to use per-file exact match instead of repo-wide contains