### PR TITLE
Wire onNodeClick and onNodeDoubleClick event handlers in OrgCanvasBackground

### DIFF
--- a/src/__tests__/unit/canvas/OrgCanvasBackground.nodeClick.test.tsx
+++ b/src/__tests__/unit/canvas/OrgCanvasBackground.nodeClick.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+/**
+ * Unit tests for `onNodeClick` and `onNodeDoubleClick` wiring in
+ * `OrgCanvasBackground`.
+ *
+ * Strategy: source-level prop assertion (same pattern as the
+ * multiSelectKey test) — we verify the compiled TSX contains the
+ * correct prop bindings rather than fully mounting the component,
+ * which would require mocking ~40 deep dependencies.
+ *
+ * Additionally we verify that `onSelectionChange` is still present
+ * alongside the new callbacks so the three props co-exist on the
+ * same `<SystemCanvas>` mount.
+ */
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+const SOURCE_PATH = path.resolve(
+  process.cwd(),
+  "src/app/org/[githubLogin]/connections/OrgCanvasBackground.tsx",
+);
+
+const source = fs.readFileSync(SOURCE_PATH, "utf-8");
+
+// Pull out the SystemCanvas JSX block for scoped assertions
+const systemCanvasBlock =
+  source.match(/<SystemCanvas\s+ref=[\s\S]*?\/>/)?.[0] ?? "";
+
+describe("OrgCanvasBackground – onNodeClick / onNodeDoubleClick wiring", () => {
+  it("passes onNodeClick={handleNodeClick} to <SystemCanvas>", () => {
+    expect(systemCanvasBlock).toContain("onNodeClick={handleNodeClick}");
+  });
+
+  it("passes onNodeDoubleClick={handleNodeDoubleClick} to <SystemCanvas>", () => {
+    expect(systemCanvasBlock).toContain(
+      "onNodeDoubleClick={handleNodeDoubleClick}",
+    );
+  });
+
+  it("onSelectionChange still present alongside the new callbacks", () => {
+    expect(systemCanvasBlock).toContain(
+      "onSelectionChange={handleSelectionChange}",
+    );
+  });
+
+  it("defines handleNodeClick as a useCallback in the component body", () => {
+    expect(source).toContain("const handleNodeClick = useCallback(");
+  });
+
+  it("defines handleNodeDoubleClick as a useCallback in the component body", () => {
+    expect(source).toContain("const handleNodeDoubleClick = useCallback(");
+  });
+
+  it("handleNodeClick accepts a CanvasNode parameter", () => {
+    // Check the callback signature includes (node: CanvasNode)
+    const match = source.match(
+      /const handleNodeClick = useCallback\(\s*\(([^)]+)\)/,
+    );
+    expect(match).not.toBeNull();
+    expect(match![1]).toContain("node");
+  });
+
+  it("handleNodeDoubleClick accepts a CanvasNode parameter", () => {
+    const match = source.match(
+      /const handleNodeDoubleClick = useCallback\(\s*\(([^)]+)\)/,
+    );
+    expect(match).not.toBeNull();
+    expect(match![1]).toContain("node");
+  });
+});

--- a/src/app/org/[githubLogin]/connections/OrgCanvasBackground.tsx
+++ b/src/app/org/[githubLogin]/connections/OrgCanvasBackground.tsx
@@ -429,6 +429,41 @@ export function OrgCanvasBackground({
     [onSelectionChange],
   );
 
+  /**
+   * Forwarded to `<SystemCanvas onNodeClick>`. Fires on a single click
+   * of a node — distinct from the selection-change path (`onSelectionChange`
+   * still fires for every selection mutation). Use cases: open detail
+   * panel, highlight related nodes, trigger focused view.
+   *
+   * Note: `zoomNavigation` handles sub-canvas drill-in internally; this
+   * callback fires in addition to (not instead of) that behaviour, so no
+   * conflict arises.
+   */
+  const handleNodeClick = useCallback(
+    (node: CanvasNode) => {
+      // Currently a no-op beyond what `handleSelectionChange` already does.
+      // Wired so consumers can extend without touching the lib boundary.
+      void node;
+    },
+    [],
+  );
+
+  /**
+   * Forwarded to `<SystemCanvas onNodeDoubleClick>`. Fires on a
+   * double-click of a node. `zoomNavigation` auto-navigates into
+   * ref-bearing nodes independently; this callback co-exists safely
+   * because the lib fires it before triggering the zoom transition.
+   */
+  const handleNodeDoubleClick = useCallback(
+    (node: CanvasNode) => {
+      // Currently a no-op — sub-canvas navigation is handled internally
+      // by `zoomNavigation`. Wired so consumers can attach behaviour
+      // (e.g. open inline edit mode) without touching the lib boundary.
+      void node;
+    },
+    [],
+  );
+
   const currentRefRef = useRef(currentRef);
   useEffect(() => {
     currentRefRef.current = currentRef;
@@ -1190,6 +1225,8 @@ export function OrgCanvasBackground({
           onResolveCanvas={onResolveCanvas}
           onBreadcrumbsChange={handleBreadcrumbsChange}
           onSelectionChange={handleSelectionChange}
+          onNodeClick={handleNodeClick}
+          onNodeDoubleClick={handleNodeDoubleClick}
           onNodeAdd={handleNodeAdd}
           onNodeUpdate={handleNodeUpdate}
           onNodesUpdate={handleNodesUpdate}


### PR DESCRIPTION
Generated with Hive: Wire onNodeClick and onNodeDoubleClick event handlers in OrgCanvasBackground