### PR TITLE
Pass swarmSecretAlias instead of decrypted API key to Stakwork in Harvey benchmark run route

### DIFF
--- a/src/__tests__/unit/api/legal-benchmark.test.ts
+++ b/src/__tests__/unit/api/legal-benchmark.test.ts
@@ -133,6 +133,19 @@ const MOCK_SWARM_ACCESS = {
     swarmApiKey: "key",
     swarmStatus: "ACTIVE",
     poolName: "pool",
+    swarmSecretAlias: "test-swarm-alias",
+  },
+};
+
+const MOCK_SWARM_ACCESS_NO_ALIAS = {
+  success: true,
+  data: {
+    workspaceId: "ws-1",
+    swarmName: "test-swarm",
+    swarmUrl: "https://swarm.example.com",
+    swarmApiKey: "key",
+    swarmStatus: "ACTIVE",
+    poolName: "pool",
     swarmSecretAlias: null,
   },
 };
@@ -200,6 +213,45 @@ describe("POST /api/workspaces/[slug]/legal/benchmarks/run", () => {
       params: Promise.resolve({ slug: "openlaw" }),
     });
     expect(res.status).toBe(400);
+  });
+
+  test("returns 500 when swarmSecretAlias is null", async () => {
+    (getWorkspaceSwarmAccess as Mock).mockResolvedValue(MOCK_SWARM_ACCESS_NO_ALIAS);
+    const res = await postRun(makeRunRequest({ taskSlug: "task-a", taskTitle: "Task A" }), {
+      params: Promise.resolve({ slug: "openlaw" }),
+    });
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/swarm secret alias not configured/i);
+  });
+
+  test("returns 500 when swarmSecretAlias is empty string", async () => {
+    (getWorkspaceSwarmAccess as Mock).mockResolvedValue({
+      ...MOCK_SWARM_ACCESS,
+      data: { ...MOCK_SWARM_ACCESS.data, swarmSecretAlias: "" },
+    });
+    const res = await postRun(makeRunRequest({ taskSlug: "task-a", taskTitle: "Task A" }), {
+      params: Promise.resolve({ slug: "openlaw" }),
+    });
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/swarm secret alias not configured/i);
+  });
+
+  test("does NOT call Stakwork /projects when swarmSecretAlias is null", async () => {
+    (getWorkspaceSwarmAccess as Mock).mockResolvedValue(MOCK_SWARM_ACCESS_NO_ALIAS);
+    const mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+
+    await postRun(makeRunRequest({ taskSlug: "task-a", taskTitle: "Task A" }), {
+      params: Promise.resolve({ slug: "openlaw" }),
+    });
+
+    // fetch should never be called with the Stakwork projects endpoint
+    const stakworkCalls = mockFetch.mock.calls.filter(([url]: [string]) =>
+      String(url).includes("/projects"),
+    );
+    expect(stakworkCalls).toHaveLength(0);
   });
 
   test("returns 409 when active run already exists", async () => {
@@ -270,6 +322,62 @@ describe("POST /api/workspaces/[slug]/legal/benchmarks/run", () => {
 // ═══════════════════════════════════════════════════════════════════════════
 // POST /run — task context pre-fetch (task_goal, task_output_desc, documents)
 // ═══════════════════════════════════════════════════════════════════════════
+
+describe("POST /run — credential pattern: swarmSecretAlias in payload", () => {
+  beforeEach(() => {
+    (getWorkspaceSwarmAccess as Mock).mockResolvedValue(MOCK_SWARM_ACCESS);
+    mockDbLegalBenchmarkRunFindFirst.mockResolvedValue(null);
+    mockDbLegalBenchmarkRunCreate.mockResolvedValue({ ...MOCK_RUN, id: "run-new", status: "PENDING" });
+    mockDbLegalBenchmarkRunUpdate.mockResolvedValue({ ...MOCK_RUN, id: "run-new", status: "RUNNING" });
+  });
+
+  test("vars.secret equals swarmSecretAlias (not the decrypted apiKey)", async () => {
+    const capturedPayloads: unknown[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((url: string, opts?: RequestInit) => {
+        if (String(url).includes("task.json") || String(url).includes("contents")) {
+          return Promise.resolve({ ok: false, status: 404 });
+        }
+        capturedPayloads.push(opts?.body ? JSON.parse(opts.body as string) : null);
+        return Promise.resolve({ ok: true, json: async () => ({ data: { project_id: 99 } }) });
+      }),
+    );
+
+    const res = await postRun(makeRunRequest({ taskSlug: "task-a", taskTitle: "Task A" }), {
+      params: Promise.resolve({ slug: "openlaw" }),
+    });
+    expect(res.status).toBe(201);
+
+    const vars = (capturedPayloads[0] as { workflow_params: { set_var: { attributes: { vars: Record<string, string> } } } }).workflow_params.set_var.attributes.vars;
+    expect(vars.secret).toBe("test-swarm-alias");
+    expect(vars.swarm_secret_alias).toBe("test-swarm-alias");
+    // Decrypted key ("supersecret") must NOT appear in the payload
+    expect(vars.secret).not.toBe("supersecret");
+    expect(JSON.stringify(capturedPayloads[0])).not.toContain("supersecret");
+  });
+
+  test("vars.graph_base_url is still present in the payload", async () => {
+    const capturedPayloads: unknown[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((url: string, opts?: RequestInit) => {
+        if (String(url).includes("task.json") || String(url).includes("contents")) {
+          return Promise.resolve({ ok: false, status: 404 });
+        }
+        capturedPayloads.push(opts?.body ? JSON.parse(opts.body as string) : null);
+        return Promise.resolve({ ok: true, json: async () => ({ data: { project_id: 99 } }) });
+      }),
+    );
+
+    await postRun(makeRunRequest({ taskSlug: "task-a", taskTitle: "Task A" }), {
+      params: Promise.resolve({ slug: "openlaw" }),
+    });
+
+    const vars = (capturedPayloads[0] as { workflow_params: { set_var: { attributes: { vars: Record<string, string> } } } }).workflow_params.set_var.attributes.vars;
+    expect(vars.graph_base_url).toBe("https://graph.example.com");
+  });
+});
 
 describe("POST /run — task context pre-fetch for Stakwork vars", () => {
   beforeEach(() => {

--- a/src/app/api/workspaces/[slug]/legal/benchmarks/run/route.ts
+++ b/src/app/api/workspaces/[slug]/legal/benchmarks/run/route.ts
@@ -67,7 +67,14 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       return handleSwarmAccessError(swarmResult.error);
     }
 
-    const { workspaceId } = swarmResult.data;
+    const { workspaceId, swarmSecretAlias } = swarmResult.data;
+
+    if (!swarmSecretAlias) {
+      return NextResponse.json(
+        { error: "Swarm secret alias not configured" },
+        { status: 500 },
+      );
+    }
 
     const BENCHMARK_MODEL = "claude-opus-4-5";
     let bifrost: Awaited<ReturnType<typeof getBifrostForLLM>> | undefined;
@@ -129,7 +136,6 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       return NextResponse.json({ error: "Swarm not configured for workspace" }, { status: 500 });
     }
     const graphBaseUrl = jarvisConfig.jarvisUrl;
-    const graphSecret = jarvisConfig.apiKey;
 
     // Pre-fetch task context for Stakwork workflow vars
     let taskGoal = "";
@@ -187,7 +193,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
               documents: JSON.stringify(documents),
               webhook_url: webhookUrl,
               graph_base_url: graphBaseUrl,
-              secret: graphSecret,
+              swarm_secret_alias: swarmSecretAlias,
+              secret: swarmSecretAlias,
               model: BENCHMARK_MODEL,
               apiKey: bifrost?.apiKey ?? getApiKeyForModel(BENCHMARK_MODEL) ?? "",
               baseUrl: bifrost?.baseUrl ?? "",


### PR DESCRIPTION
Generated with Hive: Pass swarmSecretAlias instead of decrypted API key to Stakwork in Harvey benchmark run route