### PR TITLE
Make graph_walker a core capability (on by default)

### DIFF
--- a/src/lib/ai/capabilities.ts
+++ b/src/lib/ai/capabilities.ts
@@ -24,10 +24,13 @@
  * Each capability is tagged `core: true | false`.
  *   - **Core** capabilities' prompt snippets are emitted up-front in
  *     the agent's system prompt every turn. These are the hot path:
- *     `roadmap` (propose a feature / organize the roadmap) and
- *     `planner` (drive it with `send_to_feature_planner`).
+ *     `roadmap` (propose a feature / organize the roadmap), `planner`
+ *     (drive it with `send_to_feature_planner`), and `graph_walker`
+ *     (walk the knowledge graph / dereference URNs — common enough that
+ *     its snippet rides up-front rather than behind `learn_capability`;
+ *     ephemeral prompt caching makes the marginal cost a cached read).
  *   - **Loadable** capabilities (`whiteboard`, `research`,
- *     `connections`) are NOT in the up-front prompt. Instead the core
+ *     `connections`, `infra`) are NOT in the up-front prompt. Instead the core
  *     suffix carries a one-line menu, and the agent calls the
  *     `learn_capability` tool to pull a loadable snippet on demand. The
  *     tools themselves are always registered (the AI SDK fixes the
@@ -298,17 +301,12 @@ export const CAPABILITY_REGISTRY: Record<OrgCapability, CapabilityDefinition> =
         ...buildGraphWalkDispatchTools(ctx),
       }),
       promptSnippet: getGraphWalkerCapabilitySnippet,
-      core: false,
-      menuBlurb:
-        "**graph_walker** — fetch KG node-type ontology (`graph_ontology`), " +
-        "dereference any URN (`graph_get`), expand 1-hop neighbors (`graph_neighbors`), " +
-        "search the swarm knowledge graph (`graph_search`, realm `kg`) — Hive " +
-        "Features/Tasks/ChatMessages now live there as HiveFeature/HiveTask/" +
-        "HiveChatMessage, alongside the code graph. Load when you need to walk the " +
-        "knowledge graph or dereference a URN from another tool. (The `pg` realm is disabled.) " +
-        "For multi-hop or slow graph queries, use `dispatch_graph_walk` to run them in the " +
-        "background and receive the answer as an assistant bubble; for quick single-node " +
-        "lookups or a single `graph_search`, use the inline tools directly.",
+      // CORE: graph traversal is a hot path (walking roadmap→code, URN
+      // dereference from other tools), so its snippet rides in the
+      // up-front prompt every turn rather than behind `learn_capability`.
+      // With ephemeral prompt caching the marginal cost is a cached read.
+      // No menuBlurb: core capabilities are inlined, not menu-listed.
+      core: true,
       // dispatch_graph_walk and finalize_graph_walk are stripped in readonly mode
       // to prevent sub-agents from re-dispatching themselves.
       writeToolNames: ["dispatch_graph_walk", "finalize_graph_walk"],
@@ -375,10 +373,8 @@ function buildLearnCapabilityTool(resolved: readonly OrgCapability[]): ToolSet {
         loadable.join(", ") +
         ". Call this FIRST whenever the user wants to: draw / diagram / " +
         "annotate / re-lay-out the canvas (`whiteboard`), create a saved " +
-        "research writeup (`research`), document a system integration " +
-        "(`connections`), or search / walk / traverse the knowledge graph or " +
-        "dereference a URN (`graph_walker` — this covers ANY use of " +
-        "`graph_search`, `graph_ontology`, `graph_get`, or `graph_neighbors`). " +
+        "research writeup (`research`), or document a system integration " +
+        "(`connections`). " +
         "You MUST load a capability before calling any of its tools; if you " +
         "find yourself about to call one of those tools without having loaded " +
         "its capability this turn, call `learn_capability` first. Returns the " +
@@ -459,7 +455,7 @@ These advanced capabilities are available but their detailed rules are NOT loade
 
 ${menu}
 
-Only load a capability when the user's request actually calls for it; for the common "propose a feature, then send it to its planner" flow you don't need any of these. But whenever the user asks you to search, walk, or traverse the graph / knowledge graph, or to look up an entity by URN, that REQUIRES the \`graph_walker\` capability — call \`learn_capability("graph_walker")\` before using \`graph_search\` / \`graph_ontology\` / \`graph_get\` / \`graph_neighbors\`.`
+Only load a capability when the user's request actually calls for it; for the common "propose a feature, then send it to its planner" flow you don't need any of these.`
   );
 }
 

--- a/src/lib/constants/prompt.ts
+++ b/src/lib/constants/prompt.ts
@@ -835,6 +835,10 @@ Walk it hop-by-hop with \`graph_neighbors\`, filtering by \`node_type\` at each 
 
 Also available: \`HiveFeature\` / \`HiveTask\` \`HAS_MESSAGE\` \`HiveChatMessage\` for the conversation history behind a task.
 
+### Stakwork workflows
+
+In the \`stakwork\` workspace specifically, the kg also holds \`Workflow\` nodes describing Stakwork automation workflows. To look up workflow info (id, name, description) there, \`graph_search({ query, realm: "kg", workspace: "stakwork", type: "Workflow" })\` — confirm the exact type string via \`graph_ontology({ workspace: "stakwork" })\` first. (Only that workspace has \`Workflow\` nodes; don't expect them elsewhere.)
+
 kg traversal talks to the live swarm, so it can fail if the swarm is unconfigured/unreachable — those calls return an \`{ error }\` you should treat as "unavailable", not "empty".
 
 ### Read-only


### PR DESCRIPTION
## What

Promotes `graph_walker` from a **loadable** to a **core** org-agent capability, so its instructions ride in the up-front system prompt every turn instead of being gated behind `learn_capability`.

## Why

- `graph_walker`'s tools (`graph_search` / `graph_ontology` / `graph_get` / `graph_neighbors` / `dispatch_graph_walk`) were **already always registered** via `roadmap.includes` — the only gate was the prompt. So this doesn't add any new tools, it just stops making the agent spend a `learn_capability` round-trip (and risk forgetting to) before it can walk the graph.
- Graph traversal is a hot path: walking the roadmap->code chain (`HiveFeature -> HiveTask -> PullRequest -> File`) and dereferencing URNs handed over by other tools.
- LLM APIs are stateless, so the system prompt is re-sent on every model call regardless — but with **ephemeral prompt caching** on, the marginal cost of inlining the snippet is a cached read, which removes the token objection to making it core.

## Changes

- `capabilities.ts`: `graph_walker` -> `core: true`; removed its now-dead `menuBlurb` (core caps are inlined, not menu-listed).
- Removed `graph_walker` from the `learn_capability` tool description and the load-on-demand nudge in the prompt suffix (both stale once it's core).
- Updated the core/loadable module doc.
- `prompt.ts`: added a **Stakwork workflows** hint to the `graph_walker` snippet — in the `stakwork` workspace the agent can `graph_search({ realm: "kg", workspace: "stakwork", type: "Workflow" })` for workflow info (mirroring the ask-flow `stakwork__search_workflows` tool).

## Testing

- `graphWalkerTools.test.ts`, `infraTools.test.ts`, `canvas-graph-walk-worker.test.ts` — 63 passed.

## Notes

- The dedicated `stakwork__search_workflows` tool (`askTools.ts`) still lives only in the ask flow; untouched. The new snippet gives the org agent an equivalent path via `graph_search`, but it depends on `Workflow` being an ingested kg node type in that workspace — worth a sanity check against a real stakwork swarm.