### PR TITLE
evals: resolve Bifrost identity from the trigger's stored agent

### DIFF
--- a/src/__tests__/integration/api/gateway-evals.test.ts
+++ b/src/__tests__/integration/api/gateway-evals.test.ts
@@ -531,12 +531,14 @@ describe("DELETE /api/gateway/evals/:setId/requirements/:reqId", () => {
 // ── POST .../run ──────────────────────────────────────────────────────────────
 
 describe("POST /api/gateway/evals/:setId/requirements/:reqId/run", () => {
-  function mockTriggersResponse(triggers: Array<{ ref_id: string; source?: string }>) {
+  function mockTriggersResponse(
+    triggers: Array<{ ref_id: string; source?: string; agent?: string }>,
+  ) {
     const nodes = [
       ...triggers.map((t) => ({
         ref_id: t.ref_id,
         node_type: "EvalTrigger",
-        properties: { source: t.source ?? "repo_agent" },
+        properties: { source: t.source ?? "repo_agent", ...(t.agent ? { agent: t.agent } : {}) },
       })),
     ];
     mockFetch.mockResolvedValueOnce({
@@ -672,6 +674,156 @@ describe("POST /api/gateway/evals/:setId/requirements/:reqId/run", () => {
     // Bifrost vars must appear in the Stakwork payload
     const vars = await capturedStakworkVars();
     expect(vars?.bifrostApiKey).toBe("vk-key-abc");
+  });
+
+  test("resolves Bifrost identity from the trigger's stored agent", async () => {
+    const ctx = await createTestContext(RAW_KEY_1, SWARM_NAME_1 + "-run-trig-agent");
+
+    vi.mocked(getBifrostForLLM).mockResolvedValue({
+      apiKey: "vk-key-build",
+      baseUrl: "https://bifrost.example.com/anthropic/v1",
+      headers: { "x-macaroon": "test-mac" },
+      runId: "run-build",
+      agentName: "build-agent",
+    });
+
+    mockTriggersResponse([
+      { ref_id: TRIGGER_ID, source: "repo_agent", agent: "build-agent" },
+    ]);
+    mockStakworkSuccess("proj-build-1");
+
+    const req = makeRequest(
+      "POST",
+      `http://localhost/api/gateway/evals/${SET_ID}/requirements/${REQ_ID}/run`,
+      RAW_KEY_1,
+    );
+    const res = await runEvals(req as any, {
+      params: Promise.resolve({ setId: SET_ID, reqId: REQ_ID }),
+    });
+    expect(res.status).toBe(200);
+
+    // Identity must be the trigger's agent, not the source-mapped default.
+    expect(getBifrostForLLM).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ agentName: "build-agent" }),
+    );
+    void ctx;
+  });
+
+  test("falls back to the source-mapped agent when the trigger's agent yields no creds", async () => {
+    const ctx = await createTestContext(RAW_KEY_1, SWARM_NAME_1 + "-run-fallback");
+
+    // First call (build-agent) → undefined (e.g. partial
+    // BIFROST_ENABLED_AGENTS rollout); second call (repo-agent) → creds.
+    vi.mocked(getBifrostForLLM)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({
+        apiKey: "vk-key-repo",
+        baseUrl: "https://bifrost.example.com/anthropic/v1",
+        headers: { "x-macaroon": "test-mac" },
+        runId: "run-repo",
+        agentName: "repo-agent",
+      });
+
+    mockTriggersResponse([
+      { ref_id: TRIGGER_ID, source: "repo_agent", agent: "build-agent" },
+    ]);
+    mockStakworkSuccess("proj-fallback-1");
+
+    const req = makeRequest(
+      "POST",
+      `http://localhost/api/gateway/evals/${SET_ID}/requirements/${REQ_ID}/run`,
+      RAW_KEY_1,
+    );
+    const res = await runEvals(req as any, {
+      params: Promise.resolve({ setId: SET_ID, reqId: REQ_ID }),
+    });
+    expect(res.status).toBe(200);
+
+    expect(getBifrostForLLM).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      expect.objectContaining({ agentName: "build-agent" }),
+    );
+    expect(getBifrostForLLM).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      expect.objectContaining({ agentName: "repo-agent" }),
+    );
+
+    const vars = await capturedStakworkVars();
+    expect(vars?.bifrostApiKey).toBe("vk-key-repo");
+    void ctx;
+  });
+
+  test("body agent override beats the trigger's stored agent", async () => {
+    const ctx = await createTestContext(RAW_KEY_1, SWARM_NAME_1 + "-run-override");
+
+    vi.mocked(getBifrostForLLM).mockResolvedValue({
+      apiKey: "vk-key-test",
+      baseUrl: "https://bifrost.example.com/anthropic/v1",
+      headers: { "x-macaroon": "test-mac" },
+      runId: "run-test",
+      agentName: "test-agent",
+    });
+
+    mockTriggersResponse([
+      { ref_id: TRIGGER_ID, source: "repo_agent", agent: "build-agent" },
+    ]);
+    mockStakworkSuccess("proj-override-1");
+
+    const req = makeRequest(
+      "POST",
+      `http://localhost/api/gateway/evals/${SET_ID}/requirements/${REQ_ID}/run`,
+      RAW_KEY_1,
+      { agent: "test-agent" },
+    );
+    const res = await runEvals(req as any, {
+      params: Promise.resolve({ setId: SET_ID, reqId: REQ_ID }),
+    });
+    expect(res.status).toBe(200);
+
+    expect(getBifrostForLLM).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ agentName: "test-agent" }),
+    );
+    void ctx;
+  });
+
+  test("an invalid stored agent (e.g. wfe-agent) falls back to the source map", async () => {
+    const ctx = await createTestContext(RAW_KEY_1, SWARM_NAME_1 + "-run-wfe");
+
+    vi.mocked(getBifrostForLLM).mockResolvedValue({
+      apiKey: "vk-key-repo2",
+      baseUrl: "https://bifrost.example.com/anthropic/v1",
+      headers: { "x-macaroon": "test-mac" },
+      runId: "run-repo2",
+      agentName: "repo-agent",
+    });
+
+    mockTriggersResponse([
+      { ref_id: TRIGGER_ID, source: "repo_agent", agent: "wfe-agent" },
+    ]);
+    mockStakworkSuccess("proj-wfe-1");
+
+    const req = makeRequest(
+      "POST",
+      `http://localhost/api/gateway/evals/${SET_ID}/requirements/${REQ_ID}/run`,
+      RAW_KEY_1,
+    );
+    const res = await runEvals(req as any, {
+      params: Promise.resolve({ setId: SET_ID, reqId: REQ_ID }),
+    });
+    expect(res.status).toBe(200);
+
+    // wfe-agent is a capture name but not a BifrostAgentName — identity
+    // must resolve straight to the source-mapped default, one call only.
+    expect(getBifrostForLLM).toHaveBeenCalledTimes(1);
+    expect(getBifrostForLLM).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ agentName: "repo-agent" }),
+    );
+    void ctx;
   });
 
   test("returns 502 when Jarvis trigger fetch fails", async () => {

--- a/src/app/api/gateway/evals/[setId]/requirements/[reqId]/run/route.ts
+++ b/src/app/api/gateway/evals/[setId]/requirements/[reqId]/run/route.ts
@@ -12,7 +12,7 @@
  */
 import { NextRequest, NextResponse } from "next/server";
 import { resolveGatewayAuth } from "@/lib/evals/gateway-auth";
-import { dispatchEvalTriggerRun, fetchTriggerSource } from "@/lib/evals/dispatch-eval-trigger-run";
+import { dispatchEvalTriggerRun, fetchTriggerMeta } from "@/lib/evals/dispatch-eval-trigger-run";
 import type { EvalTriggerSource } from "@/lib/utils/eval-source";
 
 type RouteParams = { params: Promise<{ setId: string; reqId: string }> };
@@ -20,8 +20,9 @@ type RouteParams = { params: Promise<{ setId: string; reqId: string }> };
 interface TriggerNode {
   ref_id: string;
   node_type?: string;
-  properties?: { source?: string };
+  properties?: { source?: string; agent?: string };
   source?: string;
+  agent?: string;
 }
 
 export async function POST(request: NextRequest, { params }: RouteParams) {
@@ -43,8 +44,19 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
     const { setId, reqId } = await params;
 
+    // Optional per-run agent override — the gateway UI sends
+    // `{ "agent": "" }` by default, so treat empty/absent as no override.
+    let agentOverride: string | undefined;
+    try {
+      const body = await request.json();
+      const raw = body?.agent;
+      if (typeof raw === "string" && raw.trim()) agentOverride = raw.trim();
+    } catch {
+      // No/invalid JSON body is fine — the override is optional.
+    }
+
     console.log(
-      `[Gateway Evals Run POST] workspaceId=${workspaceId}, keyId=${keyId}, setId=${setId}, reqId=${reqId}, userId=${userId}`,
+      `[Gateway Evals Run POST] workspaceId=${workspaceId}, keyId=${keyId}, setId=${setId}, reqId=${reqId}, userId=${userId}, agentOverride=${agentOverride ?? "none"}`,
     );
 
     // ── Fetch requirement's HAS_TRIGGER triggers ──────────────────────────
@@ -83,13 +95,17 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
     for (const trigger of triggers) {
       try {
-        // Resolve source from the trigger node itself if available, else fetch
+        // Resolve source + agent from the trigger node itself if available,
+        // else fetch. The per-run body override beats the stored agent.
         let triggerSource: EvalTriggerSource =
           (trigger.properties?.source ?? trigger.source ?? "") as EvalTriggerSource;
+        let triggerAgent: string | undefined =
+          trigger.properties?.agent ?? trigger.agent ?? undefined;
 
         if (!triggerSource || !["repo_agent", "provider_direct", "jamie_agent"].includes(triggerSource)) {
-          const fetched = await fetchTriggerSource(jarvisUrl, swarmApiKey, trigger.ref_id);
+          const fetched = await fetchTriggerMeta(jarvisUrl, swarmApiKey, trigger.ref_id);
           triggerSource = fetched.source;
+          triggerAgent = triggerAgent ?? fetched.agent;
         }
 
         const result = await dispatchEvalTriggerRun({
@@ -104,6 +120,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           swarmUrl,
           swarmSecretAlias,
           triggerSource,
+          agentName: agentOverride ?? triggerAgent,
         });
 
         project_ids.push(result.project_id);

--- a/src/app/api/workspaces/[slug]/evals/[evalSetId]/requirements/[reqId]/triggers/[triggerId]/run/route.ts
+++ b/src/app/api/workspaces/[slug]/evals/[evalSetId]/requirements/[reqId]/triggers/[triggerId]/run/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getMiddlewareContext, requireAuth } from "@/lib/middleware/utils";
 import { getWorkspaceSwarmAccess } from "@/lib/helpers/swarm-access";
 import { getJarvisUrl } from "@/lib/utils/swarm";
-import { dispatchEvalTriggerRun, fetchTriggerSource } from "@/lib/evals/dispatch-eval-trigger-run";
+import { dispatchEvalTriggerRun, fetchTriggerMeta } from "@/lib/evals/dispatch-eval-trigger-run";
 
 type RouteParams = {
   params: Promise<{ slug: string; evalSetId: string; reqId: string; triggerId: string }>;
@@ -66,18 +66,19 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
     const jarvisUrl = getJarvisUrl(swarmName);
 
-    // Fetch the EvalTrigger node to read the stored `source` discriminator.
-    const { source: triggerSource, ok: triggerFetchOk } = await fetchTriggerSource(
-      jarvisUrl,
-      swarmApiKey,
-      triggerId,
-    );
+    // Fetch the EvalTrigger node to read the stored `source` discriminator
+    // and `agent` identity.
+    const {
+      source: triggerSource,
+      agent: triggerAgent,
+      ok: triggerFetchOk,
+    } = await fetchTriggerMeta(jarvisUrl, swarmApiKey, triggerId);
     if (!triggerFetchOk) {
       console.error(`[Evals Trigger Run POST] Failed to fetch trigger node`);
       return NextResponse.json({ error: "Failed to fetch trigger node" }, { status: 502 });
     }
 
-    console.log(`[Evals Trigger Run POST] swarmUrl set=${!!swarmUrl}, swarmSecretAlias set=${!!swarmSecretAlias}, source=${triggerSource}`);
+    console.log(`[Evals Trigger Run POST] swarmUrl set=${!!swarmUrl}, swarmSecretAlias set=${!!swarmSecretAlias}, source=${triggerSource}, agent=${triggerAgent ?? "none"}`);
 
     const result = await dispatchEvalTriggerRun({
       triggerId,
@@ -91,6 +92,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       swarmUrl: swarmUrl ?? "",
       swarmSecretAlias: swarmSecretAlias ?? null,
       triggerSource,
+      agentName: triggerAgent,
     });
 
     return NextResponse.json({ success: true, project_id: result.project_id });

--- a/src/lib/evals/dispatch-eval-trigger-run.ts
+++ b/src/lib/evals/dispatch-eval-trigger-run.ts
@@ -9,6 +9,7 @@ import { getJarvisUrl, transformSwarmUrlToRepo2Graph } from "@/lib/utils/swarm";
 import { getStakworkTokenReference } from "@/lib/vercel/stakwork-token";
 import { getBifrostForLLM } from "@/services/bifrost/orchestrator";
 import type { BifrostAgentName } from "@/services/bifrost/orchestrator";
+import { isBifrostAgentName } from "@/lib/utils/hive-agent";
 import type { EvalTriggerSource } from "@/lib/utils/eval-source";
 
 export interface DispatchEvalTriggerRunParams {
@@ -39,6 +40,15 @@ export interface DispatchEvalTriggerRunParams {
   swarmSecretAlias: string | null;
   /** EvalTrigger source discriminator (resolved by the caller) */
   triggerSource: EvalTriggerSource;
+  /**
+   * The agent identity this eval is about — the trigger's stored `agent`
+   * property, or an explicit per-run override. When it is a valid
+   * `BifrostAgentName`, Bifrost credentials are resolved under THAT
+   * identity (cost attribution, budget, per-agent gateway config)
+   * instead of the coarse source-derived default. Invalid / missing
+   * values (legacy triggers, `wfe-agent`) fall back to the source map.
+   */
+  agentName?: string | null;
 }
 
 export interface DispatchEvalTriggerRunResult {
@@ -85,6 +95,7 @@ export async function dispatchEvalTriggerRun(
     swarmUrl,
     swarmSecretAlias,
     triggerSource,
+    agentName,
   } = params;
 
   const evalWorkflowId = process.env.STAKWORK_EVAL_WORKFLOW_ID;
@@ -105,13 +116,30 @@ export async function dispatchEvalTriggerRun(
   const jarvisUrl = getJarvisUrl(swarmName);
 
   // Conditionally resolve Bifrost credentials for the triggering user.
-  const bifrostAgentName = EVAL_BIFROST_AGENT[triggerSource];
-  const bifrost = bifrostAgentName
-    ? await getBifrostForLLM(
+  //
+  // `source` decides only whether the replay transport is Bifrost-backed
+  // at all (`provider_direct` is not). The IDENTITY the creds are minted
+  // under prefers the trigger's own `agent` — that's who this eval is
+  // about, and it's what the gateway's per-agent cost/budget/observability
+  // keys on. The source-mapped default remains as fallback for legacy
+  // triggers without an agent, and for partial `BIFROST_ENABLED_AGENTS`
+  // rollouts where the trigger's agent isn't enabled yet but the coarse
+  // default is — losing correct attribution beats losing creds entirely.
+  const sourceAgent = EVAL_BIFROST_AGENT[triggerSource];
+  let bifrost: Awaited<ReturnType<typeof getBifrostForLLM>>;
+  if (sourceAgent) {
+    const preferredAgent = isBifrostAgentName(agentName) ? agentName : sourceAgent;
+    bifrost = await getBifrostForLLM(
+      { workspaceSlug, workspaceId, userId },
+      { agentName: preferredAgent },
+    );
+    if (!bifrost && preferredAgent !== sourceAgent) {
+      bifrost = await getBifrostForLLM(
         { workspaceSlug, workspaceId, userId },
-        { agentName: bifrostAgentName },
-      )
-    : undefined;
+        { agentName: sourceAgent },
+      );
+    }
+  }
 
   const vars = {
     triggerId,
@@ -171,24 +199,29 @@ export async function dispatchEvalTriggerRun(
 }
 
 /**
- * Fetch the EvalTrigger node from Jarvis and return its `source` discriminator.
- * Returns "repo_agent" as a safe default if the node can't be fetched or has no source.
+ * Fetch the EvalTrigger node from Jarvis and return its `source`
+ * discriminator plus its stored `agent` identity (undefined when the
+ * trigger predates the agent field).
+ * Returns "repo_agent" as a safe default source if the node can't be
+ * fetched or has no source.
  *
  * Exported so gateway routes can reuse the same fetch pattern.
  */
-export async function fetchTriggerSource(
+export async function fetchTriggerMeta(
   jarvisUrl: string,
   swarmApiKey: string,
   triggerId: string,
-): Promise<{ source: EvalTriggerSource; ok: boolean }> {
+): Promise<{ source: EvalTriggerSource; agent: string | undefined; ok: boolean }> {
   const triggerRes = await fetch(`${jarvisUrl}/node/${triggerId}`, {
     headers: { "x-api-token": swarmApiKey },
   });
   if (!triggerRes.ok) {
-    return { source: "repo_agent", ok: false };
+    return { source: "repo_agent", agent: undefined, ok: false };
   }
   const triggerNode = await triggerRes.json();
   const source: EvalTriggerSource =
     triggerNode?.properties?.source ?? triggerNode?.source ?? "repo_agent";
-  return { source, ok: true };
+  const agentRaw = triggerNode?.properties?.agent ?? triggerNode?.agent;
+  const agent = typeof agentRaw === "string" && agentRaw.trim() ? agentRaw : undefined;
+  return { source, agent, ok: true };
 }


### PR DESCRIPTION
## Problem

Eval run dispatch derived the Bifrost agent identity from the coarse `EvalTriggerSource` transport bucket (`repo_agent` → `repo-agent`, `jamie_agent` → `canvas-agent`), ignoring the fine-grained `agent` name the trigger already stores. A trigger captured for `build-agent` would run — and be cost-attributed, budgeted, and observed in the gateway — as `repo-agent`.

## Changes

- `dispatchEvalTriggerRun` gains `agentName`; when it is a valid `BifrostAgentName`, Bifrost creds are minted under that identity.
- Fallback to the source-mapped default is preserved for: legacy triggers with no stored agent, non-Bifrost capture names (`wfe-agent`), and partial `BIFROST_ENABLED_AGENTS` rollouts where the trigger's agent yields no creds but the coarse default does — losing correct attribution beats losing creds entirely.
- `source` keeps deciding transport only: replay URL selection is untouched, and `provider_direct` stays Bifrost-less regardless of stored agent.
- `fetchTriggerSource` → `fetchTriggerMeta`, now also returning the trigger's stored `agent`.
- The gateway proxy run route's body `{"agent": ...}` override — sent by the gateway plugin since #4752 but dropped on the floor — is now honored, with precedence: body override > stored trigger agent > source map.

## Tests

4 new integration tests in `gateway-evals.test.ts` (33/33 passing):
- identity resolves from the trigger's stored agent
- fallback to source map when the trigger's agent yields no creds
- body override beats stored agent
- invalid stored agent (`wfe-agent`) goes straight to the source map (single creds call)

Companion PR on the gateway side auto-links eval sets to agents via the same `t.agent` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)