### PR TITLE
Prompt-update proposal: show only changed hunks in a diff modal

### DIFF
--- a/src/__tests__/unit/lib/diff/unifiedLineDiff.test.ts
+++ b/src/__tests__/unit/lib/diff/unifiedLineDiff.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { computeUnifiedDiff } from "@/lib/diff/unifiedLineDiff";
+
+describe("computeUnifiedDiff", () => {
+  it("reports no change when before === after", () => {
+    const d = computeUnifiedDiff("same\ntext", "same\ntext");
+    expect(d.unchanged).toBe(true);
+    expect(d.hunks).toHaveLength(0);
+    expect(d.added).toBe(0);
+    expect(d.removed).toBe(0);
+  });
+
+  it("shows only the changed region, collapsing far-away context", () => {
+    const before = Array.from({ length: 40 }, (_, i) => `line ${i}`).join("\n");
+    // Change only line 20.
+    const afterLines = before.split("\n");
+    afterLines[20] = "line 20 CHANGED";
+    const after = afterLines.join("\n");
+
+    const d = computeUnifiedDiff(before, after, 3);
+    expect(d.unchanged).toBe(false);
+    expect(d.added).toBe(1);
+    expect(d.removed).toBe(1);
+    // Single hunk, with the far-away lines collapsed into a gap.
+    expect(d.hunks).toHaveLength(1);
+    expect(d.hunks[0].gapBefore).toBeGreaterThan(0);
+
+    const rows = d.hunks[0].rows;
+    // 3 context above + del + add + 3 context below = 8 rows.
+    expect(rows).toHaveLength(8);
+    expect(rows.filter((r) => r.type === "del").map((r) => r.text)).toEqual([
+      "line 20",
+    ]);
+    expect(rows.filter((r) => r.type === "add").map((r) => r.text)).toEqual([
+      "line 20 CHANGED",
+    ]);
+    // The full document is NOT dumped — only ~8 rows shown.
+    expect(rows.length).toBeLessThan(before.split("\n").length);
+  });
+
+  it("handles a pure insertion (added lines only)", () => {
+    const before = "a\nb\nc";
+    const after = "a\nb\nNEW\nc";
+    const d = computeUnifiedDiff(before, after);
+    expect(d.added).toBe(1);
+    expect(d.removed).toBe(0);
+    const addRows = d.hunks.flatMap((h) => h.rows).filter((r) => r.type === "add");
+    expect(addRows.map((r) => r.text)).toEqual(["NEW"]);
+  });
+
+  it("keeps separate changes as separate hunks when far apart", () => {
+    const before = Array.from({ length: 60 }, (_, i) => `l${i}`).join("\n");
+    const lines = before.split("\n");
+    lines[5] = "l5-x";
+    lines[50] = "l50-x";
+    const after = lines.join("\n");
+    const d = computeUnifiedDiff(before, after, 2);
+    expect(d.hunks.length).toBe(2);
+    expect(d.added).toBe(2);
+    expect(d.removed).toBe(2);
+  });
+
+  it("carries line numbers for context/del/add rows", () => {
+    const d = computeUnifiedDiff("a\nb\nc", "a\nB\nc", 3);
+    const del = d.hunks[0].rows.find((r) => r.type === "del");
+    const add = d.hunks[0].rows.find((r) => r.type === "add");
+    expect(del?.oldLine).toBe(2);
+    expect(add?.newLine).toBe(2);
+  });
+});

--- a/src/app/org/[githubLogin]/_components/ProposalCard.tsx
+++ b/src/app/org/[githubLogin]/_components/ProposalCard.tsx
@@ -1,7 +1,16 @@
 "use client";
 
 import React, { useMemo, useState } from "react";
-import { Check, X, ExternalLink, Loader2, Lightbulb, Info } from "lucide-react";
+import {
+  Check,
+  X,
+  ExternalLink,
+  Loader2,
+  Lightbulb,
+  Info,
+  FileDiff,
+} from "lucide-react";
+import { computeUnifiedDiff, type UnifiedDiff } from "@/lib/diff/unifiedLineDiff";
 import { Switch } from "@/components/ui/switch";
 import ReactMarkdown from "react-markdown";
 import {
@@ -105,10 +114,15 @@ export function ProposalCard({
         : proposal.kind === "promptCreate"
           ? proposal.payload.name
           : proposal.kind === "promptUpdate"
-            ? proposal.payload.promptId
+            ? (proposal.meta.promptName ?? proposal.payload.promptId)
             : proposal.payload.title;
   const [editedTitle, setEditedTitle] = useState(initialTitle);
   const [isEditing, setIsEditing] = useState(false);
+  // Prompt proposals forward no inline-edit override (handleApprove sets
+  // payload = undefined for them), so an editable title would be a lie —
+  // the name/id shown is fixed. Only roadmap kinds get the click-to-edit.
+  const titleEditable =
+    proposal.kind !== "promptCreate" && proposal.kind !== "promptUpdate";
 
   // Feature-only: per-feature auto-respond toggle.
   // Initialized from the proposal payload (which is seeded from the
@@ -310,8 +324,8 @@ export function ProposalCard({
                   : `Proposed ${proposal.kind}`}
             </span>
           </div>
-          {/* Title — inline-editable on click while pending */}
-          {isPending && isEditing ? (
+          {/* Title — inline-editable on click while pending (roadmap kinds only) */}
+          {isPending && isEditing && titleEditable ? (
             <input
               type="text"
               value={editedTitle}
@@ -330,9 +344,9 @@ export function ProposalCard({
           ) : (
             <div
               className={`mt-0.5 break-words text-sm font-medium ${
-                isPending ? "cursor-text" : ""
+                isPending && titleEditable ? "cursor-text" : ""
               }`}
-              onClick={() => isPending && setIsEditing(true)}
+              onClick={() => isPending && titleEditable && setIsEditing(true)}
             >
               {editedTitle}
             </div>
@@ -498,7 +512,7 @@ function ProposalDetailsDialog({
         : proposal.kind === "promptCreate"
           ? proposal.payload.name
           : proposal.kind === "promptUpdate"
-            ? proposal.payload.promptId
+            ? (proposal.meta.promptName ?? proposal.payload.promptId)
             : proposal.payload.title;
 
   return (
@@ -909,40 +923,158 @@ function PromptCreateMeta({
 }
 
 /**
- * Shows a stacked before/after diff for prompt update proposals.
- * oldStr in red, newStr in green — monospace, no diff library.
- * Visual pattern matches InsightImprove (see ScorerDashboard.tsx ~line 1288).
+ * Compact summary line for a prompt-update proposal: version tag + a
+ * +adds/−dels stat, and a "View changes" button that opens the diff modal.
+ * The inline card intentionally shows NO diff body — a large prompt with a
+ * one-line edit should render as one line here, not two walls of text.
  */
 function PromptUpdateMeta({
   meta,
 }: {
-  meta: { oldStr: string; newStr: string };
+  meta: {
+    oldStr: string;
+    newStr: string;
+    promptName?: string;
+    versionNumber?: number;
+  };
 }) {
-  // Truncate long strings for the inline card view; full content in the details dialog.
-  const MAX_INLINE = 300;
-  const oldDisplay =
-    meta.oldStr.length > MAX_INLINE
-      ? meta.oldStr.slice(0, MAX_INLINE) + "…"
-      : meta.oldStr;
-  const newDisplay =
-    meta.newStr.length > MAX_INLINE
-      ? meta.newStr.slice(0, MAX_INLINE) + "…"
-      : meta.newStr;
+  const [open, setOpen] = useState(false);
+  const diff = useMemo(
+    () => computeUnifiedDiff(meta.oldStr, meta.newStr),
+    [meta.oldStr, meta.newStr],
+  );
+
+  // value unchanged → description-only update (mcpUpdatePrompt requires the
+  // full value even for a description tweak, so oldStr === newStr here).
+  const textUnchanged = diff.unchanged;
 
   return (
-    <div className="mt-1.5 space-y-1">
-      <div className="rounded bg-red-500/10 px-2 py-1.5">
-        <div className="text-[9px] uppercase tracking-wide text-red-400 mb-0.5">Before</div>
-        <pre className="text-[11px] font-mono text-red-400 whitespace-pre-wrap break-words">
-          {oldDisplay}
-        </pre>
+    <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-muted-foreground">
+      {meta.versionNumber != null && (
+        <span className="font-mono">v{meta.versionNumber}</span>
+      )}
+      {textUnchanged ? (
+        <span className="italic">No prompt-text change</span>
+      ) : (
+        <>
+          <span className="font-mono">
+            <span className="text-emerald-600 dark:text-emerald-400">
+              +{diff.added}
+            </span>{" "}
+            <span className="text-rose-600 dark:text-rose-400">
+              −{diff.removed}
+            </span>
+          </span>
+          <button
+            type="button"
+            onClick={() => setOpen(true)}
+            className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-foreground/80 transition-colors hover:bg-muted/60 hover:text-foreground"
+          >
+            <FileDiff className="h-3 w-3" />
+            View changes
+          </button>
+          <PromptDiffDialog
+            open={open}
+            onOpenChange={setOpen}
+            promptName={meta.promptName}
+            versionNumber={meta.versionNumber}
+            diff={diff}
+          />
+        </>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Modal showing ONLY the changed hunks of a prompt update (a few lines of
+ * context around each edit, long unchanged runs collapsed) — GitHub-style
+ * unified diff, monospace, no diff library.
+ */
+function PromptDiffDialog({
+  open,
+  onOpenChange,
+  promptName,
+  versionNumber,
+  diff,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  promptName?: string;
+  versionNumber?: number;
+  diff: UnifiedDiff;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-3xl">
+        <DialogHeader className="min-w-0">
+          <div className={SECTION_LABEL_CLASS}>Prompt changes</div>
+          <DialogTitle className="text-base min-w-0 break-words [overflow-wrap:anywhere]">
+            {promptName ?? "Prompt update"}
+            {versionNumber != null && (
+              <span className="ml-2 font-mono text-xs font-normal text-muted-foreground">
+                v{versionNumber}
+              </span>
+            )}
+          </DialogTitle>
+          <div className="mt-0.5 font-mono text-xs">
+            <span className="text-emerald-600 dark:text-emerald-400">
+              +{diff.added}
+            </span>{" "}
+            <span className="text-rose-600 dark:text-rose-400">
+              −{diff.removed}
+            </span>
+          </div>
+        </DialogHeader>
+
+        <ScrollArea className="max-h-[65vh] min-w-0">
+          <UnifiedDiffView diff={diff} />
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/** Renders a {@link UnifiedDiff} as red/green rows with collapsed gaps. */
+function UnifiedDiffView({ diff }: { diff: UnifiedDiff }) {
+  if (diff.unchanged || diff.hunks.length === 0) {
+    return (
+      <div className="px-1 py-2 text-xs text-muted-foreground italic">
+        No prompt-text changes.
       </div>
-      <div className="rounded bg-green-500/10 px-2 py-1.5">
-        <div className="text-[9px] uppercase tracking-wide text-green-400 mb-0.5">After</div>
-        <pre className="text-[11px] font-mono text-green-400 whitespace-pre-wrap break-words">
-          {newDisplay}
-        </pre>
-      </div>
+    );
+  }
+  return (
+    <div className="overflow-hidden rounded border font-mono text-[11px] leading-relaxed">
+      {diff.hunks.map((hunk, hi) => (
+        <React.Fragment key={hi}>
+          {hunk.gapBefore > 0 && (
+            <div className="bg-muted/40 px-3 py-0.5 text-[10px] text-muted-foreground">
+              ⋯ {hunk.gapBefore} unchanged line{hunk.gapBefore === 1 ? "" : "s"}
+            </div>
+          )}
+          {hunk.rows.map((row, ri) => {
+            const sign =
+              row.type === "add" ? "+" : row.type === "del" ? "−" : " ";
+            const rowClass =
+              row.type === "add"
+                ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+                : row.type === "del"
+                  ? "bg-rose-500/10 text-rose-700 dark:text-rose-300"
+                  : "text-muted-foreground";
+            return (
+              <div key={ri} className={`flex ${rowClass}`}>
+                <span className="w-4 flex-shrink-0 select-none px-1 text-center opacity-60">
+                  {sign}
+                </span>
+                <pre className="min-w-0 flex-1 whitespace-pre-wrap break-words py-0.5 pr-2">
+                  {row.text === "" ? " " : row.text}
+                </pre>
+              </div>
+            );
+          })}
+        </React.Fragment>
+      ))}
     </div>
   );
 }

--- a/src/lib/ai/promptTools.ts
+++ b/src/lib/ai/promptTools.ts
@@ -261,7 +261,12 @@ export function buildPromptTools(userId: string): ToolSet {
           kind: "promptUpdate" as const,
           proposalId,
           payload: { promptId: prompt_id, value, description },
-          meta: { oldStr: raw.value, newStr: value },
+          meta: {
+            oldStr: raw.value,
+            newStr: value,
+            promptName: raw.name,
+            versionNumber: raw.versionNumber,
+          },
           ...(rationale && { rationale }),
         };
       },

--- a/src/lib/diff/unifiedLineDiff.ts
+++ b/src/lib/diff/unifiedLineDiff.ts
@@ -1,0 +1,133 @@
+/**
+ * Minimal unified line diff — the "show ONLY the part that changed" util.
+ *
+ * Given a `before` and `after` string, produces the changed regions (hunks)
+ * with a few lines of surrounding context, collapsing long unchanged runs
+ * into a gap marker. This is what lets a proposal card / modal show just the
+ * edited slice of a large prompt instead of the whole before + whole after.
+ *
+ * Pure and dependency-free (LCS over lines), so it's safe to import into
+ * client components. Inputs are prompt-sized (hundreds of lines at most).
+ */
+
+export type DiffRowType = "context" | "add" | "del";
+
+export interface DiffRow {
+  type: DiffRowType;
+  text: string;
+  /** 1-based line number in the `before` doc (undefined for pure additions). */
+  oldLine?: number;
+  /** 1-based line number in the `after` doc (undefined for pure deletions). */
+  newLine?: number;
+}
+
+export interface DiffHunk {
+  /** Rows in this contiguous changed region (incl. leading/trailing context). */
+  rows: DiffRow[];
+  /** Number of collapsed unchanged lines immediately BEFORE this hunk. */
+  gapBefore: number;
+}
+
+export interface UnifiedDiff {
+  hunks: DiffHunk[];
+  added: number;
+  removed: number;
+  /** True when before === after (no changes to show). */
+  unchanged: boolean;
+}
+
+type Op = { type: DiffRowType; text: string; oldLine?: number; newLine?: number };
+
+/**
+ * LCS-based line diff. Returns an ordered op list (context / del / add).
+ * O(n·m) DP — fine for prompt-sized inputs.
+ */
+function diffLines(beforeLines: string[], afterLines: string[]): Op[] {
+  const n = beforeLines.length;
+  const m = afterLines.length;
+
+  // dp[i][j] = LCS length of beforeLines[i:] and afterLines[j:]
+  const dp: number[][] = Array.from({ length: n + 1 }, () =>
+    new Array<number>(m + 1).fill(0),
+  );
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      dp[i][j] =
+        beforeLines[i] === afterLines[j]
+          ? dp[i + 1][j + 1] + 1
+          : Math.max(dp[i + 1][j], dp[i][j + 1]);
+    }
+  }
+
+  const ops: Op[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (beforeLines[i] === afterLines[j]) {
+      ops.push({ type: "context", text: beforeLines[i], oldLine: i + 1, newLine: j + 1 });
+      i++;
+      j++;
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      ops.push({ type: "del", text: beforeLines[i], oldLine: i + 1 });
+      i++;
+    } else {
+      ops.push({ type: "add", text: afterLines[j], newLine: j + 1 });
+      j++;
+    }
+  }
+  while (i < n) ops.push({ type: "del", text: beforeLines[i], oldLine: ++i });
+  while (j < m) ops.push({ type: "add", text: afterLines[j], newLine: ++j });
+  return ops;
+}
+
+/**
+ * Build a unified diff with `context` lines around each change, collapsing
+ * unchanged runs longer than `2 * context` into a gap.
+ */
+export function computeUnifiedDiff(
+  before: string,
+  after: string,
+  context = 3,
+): UnifiedDiff {
+  if (before === after) {
+    return { hunks: [], added: 0, removed: 0, unchanged: true };
+  }
+
+  const ops = diffLines(before.split("\n"), after.split("\n"));
+
+  const added = ops.filter((o) => o.type === "add").length;
+  const removed = ops.filter((o) => o.type === "del").length;
+
+  // Mark which context ops to keep (within `context` of any change).
+  const keep = new Array<boolean>(ops.length).fill(false);
+  ops.forEach((op, idx) => {
+    if (op.type !== "context") {
+      for (let k = idx - context; k <= idx + context; k++) {
+        if (k >= 0 && k < ops.length) keep[k] = true;
+      }
+    }
+  });
+
+  // Group kept ops into hunks; count dropped (collapsed) context lines
+  // that precede each hunk.
+  const hunks: DiffHunk[] = [];
+  let current: DiffRow[] | null = null;
+  let gap = 0;
+  for (let idx = 0; idx < ops.length; idx++) {
+    if (keep[idx]) {
+      if (!current) {
+        current = [];
+        hunks.push({ rows: current, gapBefore: gap });
+        gap = 0;
+      }
+      const op = ops[idx];
+      current.push({ type: op.type, text: op.text, oldLine: op.oldLine, newLine: op.newLine });
+    } else {
+      // Dropped line — only unchanged (context) lines are ever dropped.
+      current = null;
+      gap++;
+    }
+  }
+
+  return { hunks, added, removed, unchanged: false };
+}

--- a/src/lib/proposals/types.ts
+++ b/src/lib/proposals/types.ts
@@ -291,8 +291,15 @@ export type ProposalOutput =
       rationale?: string;
       /** Render-only diff metadata: raw stored value before the update (oldStr)
        *  and the proposed new raw value (newStr). Anchored to the same version
-       *  that `get_prompt` resolves (published if set, else latest). */
-      meta: { oldStr: string; newStr: string };
+       *  that `get_prompt` resolves (published if set, else latest).
+       *  `promptName` / `versionNumber` are the friendly labels for the card
+       *  (optional for backward-compat with pre-meta proposals). */
+      meta: {
+        oldStr: string;
+        newStr: string;
+        promptName?: string;
+        versionNumber?: number;
+      };
     };
 
 // ─── Prompt proposal payloads ──────────────────────────────────────────


### PR DESCRIPTION
## Problem

The prompt-update proposal card rendered the **entire** before value (red) and the **entire** after value (green), each truncated to 300 chars. A one-line edit (e.g. adding an emoji rule) produced two walls of text — really bad UX.

<img width="800" alt="before" src="https://github.com/user-attachments/assets/placeholder" />

## Change

Show **only the part that changed**, in a modal — mirroring how the scorer stores/renders minimal `str_replace` hunks.

- **`src/lib/diff/unifiedLineDiff.ts`** (new, pure) — `computeUnifiedDiff(before, after, context=3)`: LCS line diff producing only the changed hunks with a few context lines, collapsing far-away unchanged runs into a `⋯ N unchanged lines` gap. Returns `{ hunks, added, removed, unchanged }`.
- **Inline card** collapses to one compact line: `v3 · +1 −0 · [View changes]` — no diff body.
- **New diff modal** (`PromptDiffDialog`) opens on *View changes*: GitHub-style unified diff (red removed / green added / muted context, collapsed gaps), scrollable.
- Card title now shows the prompt's **real name** instead of the raw cuid.
- Disabled the misleading click-to-edit title on prompt proposals (their edits were never forwarded).
- Description-only updates show `No prompt-text change` (no empty diff).

`proposals/types.ts` + `promptTools.ts` gain optional `promptName` / `versionNumber` on the render-only `promptUpdate.meta`.

## Notes

Server write path is unchanged — `meta` is display-only, the diff is computed client-side, and approval still sends the full value with the drift check intact.

## Tests

- New diff util unit tests (5) pass.
- Existing `ProposalCard` tests (53) pass; typecheck + eslint clean on touched files.