### PR TITLE
Canvas agent: add read_concept_documentation tool

### DIFF
--- a/src/lib/ai/capabilities.ts
+++ b/src/lib/ai/capabilities.ts
@@ -383,21 +383,23 @@ export const CAPABILITY_REGISTRY: Record<OrgCapability, CapabilityDefinition> =
       orgGate: isPromptsCapabilityEnabledForOrg,
     },
     concepts: {
-      // Workspace-scoped propose tools (like `propose_feature`): the agent
-      // passes a `workspaceSlug`, the tool resolves it under `orgId` and
-      // reaches that workspace's swarm. Reading concepts is already covered
-      // by the per-workspace `list_concepts` / `learn_concept` tools that
-      // runCanvasAgent composes, so this capability only adds the writes.
+      // Workspace-scoped tools (like `propose_feature`): the agent passes a
+      // `workspaceSlug`, the tool resolves it under `orgId` and reaches that
+      // workspace's swarm. Adds `read_concept_documentation` (raw markdown,
+      // no approval) plus the two propose/write tools; concept discovery is
+      // still covered by the per-workspace `list_concepts` tool that
+      // runCanvasAgent composes.
       buildTools: (ctx) => buildConceptTools(ctx.orgId, ctx.userId),
       promptSnippet: getConceptsCapabilitySnippet,
       core: false,
       menuBlurb:
-        "**concepts** — capture and update workspace knowledge-base concepts " +
-        "via human approval: `propose_new_concept` (create from documentation " +
-        "you provide, no codebase analysis) and `propose_concept_update` " +
-        "(edit a concept's documentation, shown as a diff). Load when the user " +
-        'says things like "remember this", "note this down", or asks to ' +
-        "create/update a concept.",
+        "**concepts** — read, capture, and update workspace knowledge-base " +
+        "concepts: `read_concept_documentation` (read raw markdown, no " +
+        "approval) plus `propose_new_concept` (create from documentation you " +
+        "provide, no codebase analysis) and `propose_concept_update` (edit a " +
+        "concept's documentation, shown as a diff) via human approval. Load " +
+        'when the user says things like "remember this", "note this down", or ' +
+        "asks to create/update a concept.",
       // Not gated: unlike the global prompt library, concepts are per-workspace
       // and every workspace already exposes concept read tools to the agent.
       writeToolNames: [PROPOSE_NEW_CONCEPT_TOOL, PROPOSE_CONCEPT_UPDATE_TOOL],

--- a/src/lib/ai/conceptTools.ts
+++ b/src/lib/ai/conceptTools.ts
@@ -17,9 +17,12 @@
  * approval handler (which only has `orgId` + `userId`) can re-resolve the
  * workspace and reach its swarm.
  *
- * Reading concepts (to discover ids/slugs before proposing) is already
- * covered by the existing `list_concepts` / `learn_concept` tools that
- * `runCanvasAgent` composes per workspace.
+ * Discovering concept ids/slugs is covered by the existing `list_concepts`
+ * tool. To read a single concept's CURRENT documentation before proposing
+ * an update, this capability also exposes `read_concept_documentation`,
+ * which returns the raw markdown body only (no PRs/commits/metadata
+ * wrapper) so the agent can reproduce it faithfully in the FULL new body
+ * that `propose_concept_update` requires.
  */
 
 import { tool, type ToolSet } from "ai";
@@ -32,6 +35,10 @@ import {
   PROPOSE_NEW_CONCEPT_TOOL,
   PROPOSE_CONCEPT_UPDATE_TOOL,
 } from "@/lib/proposals/types";
+
+/** Read-only tool: fetch a single concept's current documentation body. */
+export const READ_CONCEPT_DOCUMENTATION_TOOL =
+  "read_concept_documentation" as const;
 
 /** Resolve a workspace slug to its cuid + name, scoped to the org. */
 async function resolveWorkspace(orgId: string, slug: string) {
@@ -64,6 +71,92 @@ export function buildConceptTools(orgId: string, userId: string): ToolSet {
   void userId; // carried through the proposal payload for attribution at approval time
 
   return {
+    [READ_CONCEPT_DOCUMENTATION_TOOL]: tool({
+      description:
+        "Read the CURRENT documentation of a single concept and return it " +
+        "as raw markdown — nothing else (no PRs, commits, or metadata). Use " +
+        "this before `propose_concept_update` so you can reproduce the " +
+        "existing body faithfully and add only what's needed (the update " +
+        "replaces the whole documentation field). Obtain the concept id " +
+        "from `list_concepts` first.",
+      inputSchema: z.object({
+        workspaceSlug: z
+          .string()
+          .min(1)
+          .describe(
+            "Slug of the workspace the concept belongs to (from the " +
+              "Available Workspaces list). Required.",
+          ),
+        conceptId: z
+          .string()
+          .min(1)
+          .describe(
+            "The concept id to read (obtain via `list_concepts`). Never " +
+              "fabricate this.",
+          ),
+      }),
+      execute: async ({
+        workspaceSlug,
+        conceptId,
+      }: {
+        workspaceSlug: string;
+        conceptId: string;
+      }) => {
+        try {
+          const workspace = await resolveWorkspace(orgId, workspaceSlug);
+          if (!workspace) {
+            return {
+              error:
+                "Workspace slug not found in this organization. Pick a slug from the Available Workspaces list.",
+            };
+          }
+
+          const swarm = await getSwarmAccessByWorkspaceId(workspace.id);
+          if (!swarm.success) {
+            return {
+              error: `The ${workspace.slug} swarm is not available (${swarm.error.type}).`,
+            };
+          }
+
+          const res = await fetch(
+            `${swarm.data.swarmUrl}/gitree/concepts/${encodeURIComponent(conceptId)}`,
+            {
+              method: "GET",
+              headers: {
+                "Content-Type": "application/json",
+                "x-api-token": swarm.data.swarmApiKey,
+              },
+            },
+          );
+          if (res.status === 404) {
+            return {
+              error: `Concept '${conceptId}' not found in ${workspace.slug}. Use list_concepts to find the correct id.`,
+            };
+          }
+          if (!res.ok) {
+            return {
+              error: `Failed to read concept '${conceptId}' from ${workspace.slug} (status ${res.status}).`,
+            };
+          }
+          const data = await res.json();
+          const concept = data?.concept ?? data?.feature ?? {};
+          const documentation =
+            typeof concept.documentation === "string"
+              ? concept.documentation
+              : "";
+          return { documentation };
+        } catch (e) {
+          console.error(
+            "[conceptTools.read_concept_documentation] error:",
+            e,
+          );
+          const message =
+            e instanceof Error ? e.message : "Failed to read concept";
+          return { error: message };
+        }
+      },
+    }),
+
     [PROPOSE_NEW_CONCEPT_TOOL]: tool({
       description:
         "Propose creating a NEW concept (a workspace knowledge-base entry) " +

--- a/src/lib/constants/prompt.ts
+++ b/src/lib/constants/prompt.ts
@@ -1130,14 +1130,18 @@ export function getConceptsCapabilitySnippet(): string {
 
 ## Concept Tools
 
-**Concepts** are a workspace's knowledge-base entries — durable, human-readable documentation about a system, decision, runbook, or anything worth remembering. They live on each workspace's swarm (per-workspace, NOT global). You already have read tools (\`list_concepts\` / \`learn_concept\`, or the workspace-prefixed \`{slug}__list_concepts\` / \`{slug}__learn_concept\`); this capability adds two WRITE tools that go through human approval.
+**Concepts** are a workspace's knowledge-base entries — durable, human-readable documentation about a system, decision, runbook, or anything worth remembering. They live on each workspace's swarm (per-workspace, NOT global). You already have read tools (\`list_concepts\` / \`learn_concept\`, or the workspace-prefixed \`{slug}__list_concepts\` / \`{slug}__learn_concept\`); this capability adds \`read_concept_documentation\` plus two WRITE tools that go through human approval.
 
 ### "Remember this" is the trigger
 
 When the user says things like **"Jamie, remember this"**, "note this down", "save this for later", "capture this as a concept", "document this", or "add this to the knowledge base" — that is a request to CREATE or UPDATE a concept. Do it proactively:
 1. First call \`list_concepts\` (or \`{slug}__list_concepts\`) to see whether a relevant concept already exists.
-2. If a good match exists → \`propose_concept_update\` to extend it (read its current documentation with \`learn_concept\` first, then supply the FULL merged body).
+2. If a good match exists → read its current documentation with \`read_concept_documentation\` first, then \`propose_concept_update\` with the FULL merged body.
 3. If nothing fits → \`propose_new_concept\` to create a new one.
+
+### Read tool (no approval)
+
+- **\`read_concept_documentation({ workspaceSlug, conceptId })\`** — Returns the concept's CURRENT documentation as raw markdown only (no PRs/commits/metadata). Use this right before \`propose_concept_update\` so you can reproduce the existing body faithfully and add only what's needed.
 
 ### Write tools (require user approval)
 
@@ -1148,8 +1152,8 @@ When the user says things like **"Jamie, remember this"**, "note this down", "sa
 
 - Always pass the \`workspaceSlug\` from the Available Workspaces list — never an opaque id.
 - Concept writes go through approval; nothing is saved until the user clicks Approve.
-- Before updating, read the concept's current documentation (\`learn_concept\`) so your new body preserves what should stay.
-- Never fabricate a \`conceptId\` — use ids returned by \`list_concepts\` / \`learn_concept\`.
+- Before updating, read the concept's current documentation (\`read_concept_documentation\`) so your new body preserves what should stay.
+- Never fabricate a \`conceptId\` — use ids returned by \`list_concepts\`.
 - Keep documentation self-contained and generic enough to be useful later; lead with what the concept is and why it matters.
 `;
 }


### PR DESCRIPTION
## What

Adds a read-only `read_concept_documentation` tool to the **concepts** capability (the one added in #4787). It returns a concept's current documentation as **raw markdown only** — no PRs, commits, or metadata wrapper.

## Why

`propose_concept_update` is a **full-field replacement**: the agent must re-emit the entire documentation body, and approval overwrites the whole field. Today the agent reads the current doc via `learn_concept`, which returns a fat JSON object (`{ concept: { documentation, PRs, commits, ... } }`). Fishing the body out of that noise makes faithful reproduction harder — risky for docs containing code snippets, embedded JSON, or escaped newlines.

`read_concept_documentation` gives the agent a lean, focused read right before proposing an update, so it can reproduce the existing body faithfully and add only what's needed.

## Scope

- Tool lives only in the concepts capability (`buildConceptTools`), **not** the global ask tools.
- Read-only, no approval (not in `writeToolNames`).
- Updates the capability prompt snippet + menu blurb to point the "remember this" / "before updating" flows at the new tool.

## Note

This cleans up the read side but does not change that `propose_concept_update` is still a full replacement — the human diff on the approval card remains the correctness backstop. An append/anchored-patch write path would be the follow-up to fully close the fidelity gap.