### PR TITLE
Fix updateNode to send ref_id in query and body with falsy-id guard

### DIFF
--- a/src/__tests__/unit/services/swarm/api/nodes.test.ts
+++ b/src/__tests__/unit/services/swarm/api/nodes.test.ts
@@ -675,7 +675,7 @@ describe("updateNode", () => {
       expect(result).toEqual({ success: true });
 
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://test-swarm.sphinx.chat:8444/node",
+        "https://test-swarm.sphinx.chat:8444/node?ref_id=eval-set-1",
         expect.objectContaining({
           method: "PUT",
           headers: expect.objectContaining({
@@ -693,6 +693,60 @@ describe("updateNode", () => {
       // Verify that legacy 'properties' key is NOT sent
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body as string);
       expect(sentBody).not.toHaveProperty("properties");
+      // Verify ref_id is in the URL (never "undefined")
+      const calledUrl = mockFetch.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("?ref_id=eval-set-1");
+      expect(calledUrl).not.toContain("undefined");
+    });
+
+    test("accept status: ref_id appears in query string and body (never 'undefined')", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ status: "success" }),
+      });
+
+      const now = new Date().toISOString();
+      const result = await updateNode(config, {
+        ref_id: "fix-ref-abc123",
+        node_type: "ProposedFix",
+        node_data: { status: "accepted", resolved_by: "user-1", resolved_at: now },
+      });
+
+      expect(result).toEqual({ success: true });
+
+      const calledUrl = mockFetch.mock.calls[0][0] as string;
+      expect(calledUrl).toBe("https://test-swarm.sphinx.chat:8444/node?ref_id=fix-ref-abc123");
+      expect(calledUrl).not.toContain("undefined");
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+      expect(sentBody.ref_id).toBe("fix-ref-abc123");
+      expect(sentBody.node_data.status).toBe("accepted");
+    });
+
+    test("reject status: ref_id appears in query string and body (never 'undefined')", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ status: "success" }),
+      });
+
+      const now = new Date().toISOString();
+      const result = await updateNode(config, {
+        ref_id: "fix-ref-xyz789",
+        node_type: "ProposedFix",
+        node_data: { status: "rejected", resolved_by: "user-2", resolved_at: now },
+      });
+
+      expect(result).toEqual({ success: true });
+
+      const calledUrl = mockFetch.mock.calls[0][0] as string;
+      expect(calledUrl).toBe("https://test-swarm.sphinx.chat:8444/node?ref_id=fix-ref-xyz789");
+      expect(calledUrl).not.toContain("undefined");
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+      expect(sentBody.ref_id).toBe("fix-ref-xyz789");
+      expect(sentBody.node_data.status).toBe("rejected");
     });
 
     test("returns success for EvalRequirement update", async () => {
@@ -718,6 +772,28 @@ describe("updateNode", () => {
   });
 
   describe("Failure cases", () => {
+    test("returns failure without calling fetch when ref_id is missing", async () => {
+      const result = await updateNode(config, {
+        ref_id: "",
+        node_type: "ProposedFix",
+        node_data: { status: "accepted" },
+      });
+
+      expect(result).toEqual({ success: false, error: "ref_id is required to update a node" });
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    test("returns failure without calling fetch when ref_id is undefined", async () => {
+      const result = await updateNode(config, {
+        ref_id: undefined as unknown as string,
+        node_type: "ProposedFix",
+        node_data: { status: "rejected" },
+      });
+
+      expect(result).toEqual({ success: false, error: "ref_id is required to update a node" });
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
     test("returns failure when HTTP response is not ok", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,

--- a/src/services/swarm/api/nodes.ts
+++ b/src/services/swarm/api/nodes.ts
@@ -456,9 +456,13 @@ export async function updateNode(
   config: JarvisConnectionConfig,
   request: UpdateNodeRequest,
 ): Promise<{ success: boolean; error?: string }> {
+  if (!request.ref_id) {
+    return { success: false, error: "ref_id is required to update a node" };
+  }
+
   const result = await jarvisRequest({
     config,
-    endpoint: "/node",
+    endpoint: `/node?ref_id=${encodeURIComponent(request.ref_id)}`,
     method: "PUT",
     data: {
       ref_id: request.ref_id,


### PR DESCRIPTION
Generated with Hive: Fix updateNode to send ref_id in query and body with falsy-id guard