### PR TITLE
Fix EvalSet lookup and namespaced writes in Legal Benchmark Recursion

### DIFF
--- a/src/__tests__/unit/api/workspaces/legal-benchmark-recursion-route.test.ts
+++ b/src/__tests__/unit/api/workspaces/legal-benchmark-recursion-route.test.ts
@@ -346,7 +346,8 @@ describe("PATCH /api/workspaces/[slug]/legal/benchmarks/recursion/[refId]", () =
     expect(body.enabled).toBe(false);
   });
 
-  test("calls setEvalSetRecursion with correct refId and enabled=true", async () => {
+  test("calls setEvalSetRecursion with correct refId, enabled=true, and derived namespace", async () => {
+    // MOCK_EVAL_SET_NODE.properties.id = "practice-area/draft-contract"
     await PATCH(
       makePatchRequest("ref-evalset-1", { enabled: true }),
       makePatchParams(),
@@ -355,10 +356,11 @@ describe("PATCH /api/workspaces/[slug]/legal/benchmarks/recursion/[refId]", () =
       MOCK_JARVIS_CONFIG,
       "ref-evalset-1",
       true,
+      "practice-area/draft-contract",
     );
   });
 
-  test("calls setEvalSetRecursion with correct refId and enabled=false", async () => {
+  test("calls setEvalSetRecursion with correct refId, enabled=false, and derived namespace", async () => {
     await PATCH(
       makePatchRequest("ref-evalset-1", { enabled: false }),
       makePatchParams(),
@@ -367,6 +369,7 @@ describe("PATCH /api/workspaces/[slug]/legal/benchmarks/recursion/[refId]", () =
       MOCK_JARVIS_CONFIG,
       "ref-evalset-1",
       false,
+      "practice-area/draft-contract",
     );
   });
 
@@ -417,5 +420,75 @@ describe("PATCH /api/workspaces/[slug]/legal/benchmarks/recursion/[refId]", () =
 
     // workspaceId must come from swarmResult.data, not a raw request param
     expect(mockGetJarvisConfigForWorkspace).toHaveBeenCalledWith("ws-openlaw");
+  });
+
+  test("derives namespace from properties.id and forwards it to setEvalSetRecursion", async () => {
+    // MOCK_EVAL_SET_NODE has properties.id = "practice-area/draft-contract"
+    await PATCH(
+      makePatchRequest("ref-evalset-1", { enabled: true }),
+      makePatchParams(),
+    );
+
+    expect(mockSetEvalSetRecursion).toHaveBeenCalledWith(
+      MOCK_JARVIS_CONFIG,
+      "ref-evalset-1",
+      true,
+      "practice-area/draft-contract",
+    );
+  });
+
+  test("returns 502 when node's properties.id is absent (cannot derive namespace)", async () => {
+    // Node without properties.id
+    mockKgGetNode.mockResolvedValue({
+      ref_id: "ref-evalset-no-id",
+      node_type: "EvalSet",
+      name: "No ID EvalSet",
+      properties: { name: "No ID EvalSet" }, // no `id` property
+    });
+
+    const res = await PATCH(
+      makePatchRequest("ref-evalset-no-id", { enabled: true }),
+      makePatchParams("openlaw", "ref-evalset-no-id"),
+    );
+
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).toMatch(/namespace/i);
+    // Must not call setEvalSetRecursion without a namespace
+    expect(mockSetEvalSetRecursion).not.toHaveBeenCalled();
+  });
+
+  test("returns 502 when node has no properties at all (cannot derive namespace)", async () => {
+    mockKgGetNode.mockResolvedValue({
+      ref_id: "ref-evalset-no-props",
+      node_type: "EvalSet",
+      name: "No Props EvalSet",
+      // no properties field
+    });
+
+    const res = await PATCH(
+      makePatchRequest("ref-evalset-no-props", { enabled: true }),
+      makePatchParams("openlaw", "ref-evalset-no-props"),
+    );
+
+    expect(res.status).toBe(502);
+    expect(mockSetEvalSetRecursion).not.toHaveBeenCalled();
+  });
+
+  test("IDOR guard still runs before namespace derivation (wrong node type rejected first)", async () => {
+    mockKgGetNode.mockResolvedValue({
+      ref_id: "ref-other",
+      node_type: "ProposedFix",
+      properties: { id: "some/slug" },
+    });
+
+    const res = await PATCH(
+      makePatchRequest("ref-other", { enabled: true }),
+      makePatchParams("openlaw", "ref-other"),
+    );
+
+    // IDOR guard fires before namespace check — 404, not 502
+    expect(res.status).toBe(404);
+    expect(mockSetEvalSetRecursion).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/unit/services/legal-benchmark-recursion.test.ts
+++ b/src/__tests__/unit/services/legal-benchmark-recursion.test.ts
@@ -8,10 +8,12 @@ import { describe, test, expect, vi, beforeEach } from "vitest";
 
 const mockSearchNodesByAttributes = vi.hoisted(() => vi.fn());
 const mockUpdateNode = vi.hoisted(() => vi.fn());
+const mockCheckNodeByKey = vi.hoisted(() => vi.fn());
 
 vi.mock("@/services/swarm/api/nodes", () => ({
   searchNodesByAttributes: mockSearchNodesByAttributes,
   updateNode: mockUpdateNode,
+  checkNodeByKey: mockCheckNodeByKey,
 }));
 
 vi.mock("@/lib/logger", () => ({
@@ -24,6 +26,7 @@ import {
   listRecursionEvalSets,
   setEvalSetRecursion,
   enableRecursionForTaskSlug,
+  writeBackEvalProjectId,
 } from "@/services/legal-benchmark-recursion";
 import { logger } from "@/lib/logger";
 
@@ -220,68 +223,110 @@ describe("enableRecursionForTaskSlug", () => {
     vi.clearAllMocks();
   });
 
-  test("resolves EvalSet ref_id from task-slug and calls setEvalSetRecursion with true", async () => {
-    mockSearchNodesByAttributes.mockResolvedValue({ ok: true, nodes: [EVAL_SET_NODE] });
+  test("uses checkNodeByKey (not searchNodesByAttributes with attribute:id) to resolve EvalSet", async () => {
+    mockCheckNodeByKey.mockResolvedValue({ ok: true, exists: true, refId: "ref-abc-123" });
+    mockUpdateNode.mockResolvedValue({ success: true });
+
+    await enableRecursionForTaskSlug(CONFIG, TASK_SLUG);
+
+    // Must use checkNodeByKey, NOT searchNodesByAttributes with attribute "id"
+    expect(mockCheckNodeByKey).toHaveBeenCalledOnce();
+    expect(mockSearchNodesByAttributes).not.toHaveBeenCalled();
+  });
+
+  test("calls checkNodeByKey with correct nodeType, key, and namespace (all = task slug)", async () => {
+    mockCheckNodeByKey.mockResolvedValue({ ok: true, exists: true, refId: "ref-abc-123" });
+    mockUpdateNode.mockResolvedValue({ success: true });
+
+    await enableRecursionForTaskSlug(CONFIG, TASK_SLUG);
+
+    const [, params] = mockCheckNodeByKey.mock.calls[0] as [unknown, {
+      nodeType: string;
+      key: string;
+      namespace: string;
+    }];
+    expect(params.nodeType).toBe("EvalSet");
+    expect(params.key).toBe(TASK_SLUG);
+    expect(params.namespace).toBe(TASK_SLUG);
+  });
+
+  test("calls setEvalSetRecursion (updateNode) with resolved ref_id, recursion=true, and slug as namespace", async () => {
+    mockCheckNodeByKey.mockResolvedValue({ ok: true, exists: true, refId: "ref-abc-123" });
     mockUpdateNode.mockResolvedValue({ success: true });
 
     const result = await enableRecursionForTaskSlug(CONFIG, TASK_SLUG);
 
-    // Search was called with id filter matching the task-slug
-    expect(mockSearchNodesByAttributes).toHaveBeenCalledOnce();
-    const [, searchParams] = mockSearchNodesByAttributes.mock.calls[0] as [unknown, {
-      nodeTypes: string[];
-      filters: Array<{ attribute: string; value: unknown; comparator: string }>;
-      includeProperties: boolean;
-    }];
-    expect(searchParams.nodeTypes).toEqual(["EvalSet"]);
-    expect(searchParams.filters).toEqual([{ attribute: "id", value: TASK_SLUG, comparator: "=" }]);
-    expect(searchParams.includeProperties).toBe(true);
-
-    // updateNode was called with the resolved ref_id and recursion=true
     expect(mockUpdateNode).toHaveBeenCalledOnce();
-    const [, updateReq] = mockUpdateNode.mock.calls[0] as [unknown, {
-      ref_id: string;
-      node_type: string;
-      node_data: Record<string, unknown>;
-    }];
+    const [, updateReq, updateOpts] = mockUpdateNode.mock.calls[0] as [
+      unknown,
+      { ref_id: string; node_type: string; node_data: Record<string, unknown> },
+      { namespace?: string } | undefined,
+    ];
     expect(updateReq.ref_id).toBe("ref-abc-123");
     expect(updateReq.node_type).toBe("EvalSet");
     expect(updateReq.node_data).toEqual({ recursion: true });
+    expect(updateOpts?.namespace).toBe(TASK_SLUG);
 
     expect(result.ok).toBe(true);
     expect(result).not.toHaveProperty("notFound");
   });
 
-  test("returns not-found result without calling updateNode when no EvalSet matches", async () => {
-    mockSearchNodesByAttributes.mockResolvedValue({ ok: true, nodes: [] });
+  test("returns notFound:true ONLY when checkNodeByKey returns ok:true + exists:false (genuine miss)", async () => {
+    mockCheckNodeByKey.mockResolvedValue({ ok: true, exists: false });
 
     const result = await enableRecursionForTaskSlug(CONFIG, "nonexistent/task");
 
-    expect(mockSearchNodesByAttributes).toHaveBeenCalledOnce();
     expect(mockUpdateNode).not.toHaveBeenCalled();
-
     expect(result.ok).toBe(false);
     expect(result).toHaveProperty("notFound", true);
+    expect(result.error).toBe("EvalSet not found for task slug");
+  });
+
+  test("returns error (NOT notFound) when checkNodeByKey reports a transport failure", async () => {
+    mockCheckNodeByKey.mockResolvedValue({ ok: false, exists: false, error: "Network timeout" });
+
+    const result = await enableRecursionForTaskSlug(CONFIG, TASK_SLUG);
+
+    expect(mockUpdateNode).not.toHaveBeenCalled();
+    expect(result.ok).toBe(false);
+    expect(result).not.toHaveProperty("notFound");
     expect(result.error).toBeDefined();
   });
 
-  test("returns error without calling updateNode when graph search fails", async () => {
-    mockSearchNodesByAttributes.mockResolvedValue({
+  test("returns error (NOT notFound) when checkNodeByKey returns endpointMissing:true (400/version mismatch)", async () => {
+    mockCheckNodeByKey.mockResolvedValue({
       ok: false,
-      nodes: [],
-      error: "Upstream timeout",
+      exists: false,
+      endpointMissing: true,
+      status: 404,
     });
 
     const result = await enableRecursionForTaskSlug(CONFIG, TASK_SLUG);
 
     expect(mockUpdateNode).not.toHaveBeenCalled();
     expect(result.ok).toBe(false);
-    expect(result.error).toBe("Upstream timeout");
     expect(result).not.toHaveProperty("notFound");
+    // endpointMissing is an error, not a miss
+    expect(result.error).toBeDefined();
+  });
+
+  test("returns error (NOT notFound) on a 400 INVALID_NAMESPACE response", async () => {
+    mockCheckNodeByKey.mockResolvedValue({
+      ok: false,
+      exists: false,
+      status: 400,
+      error: "checkNodeByKey failed (status: 400)",
+    });
+
+    const result = await enableRecursionForTaskSlug(CONFIG, TASK_SLUG);
+
+    expect(result.ok).toBe(false);
+    expect(result).not.toHaveProperty("notFound");
+    expect(result.error).toBeDefined();
   });
 
   test("returns error when graph write fails after resolving ref_id", async () => {
-    mockSearchNodesByAttributes.mockResolvedValue({ ok: true, nodes: [EVAL_SET_NODE] });
+    mockCheckNodeByKey.mockResolvedValue({ ok: true, exists: true, refId: "ref-abc-123" });
     mockUpdateNode.mockResolvedValue({ success: false, error: "Write conflict" });
 
     const result = await enableRecursionForTaskSlug(CONFIG, TASK_SLUG);
@@ -293,14 +338,91 @@ describe("enableRecursionForTaskSlug", () => {
   });
 
   test("is idempotent — enabling an already-true flag succeeds", async () => {
-    // EvalSet already has recursion=true; enabling again should still succeed
-    mockSearchNodesByAttributes.mockResolvedValue({ ok: true, nodes: [EVAL_SET_NODE] });
+    mockCheckNodeByKey.mockResolvedValue({ ok: true, exists: true, refId: "ref-abc-123" });
     mockUpdateNode.mockResolvedValue({ success: true });
 
     const result = await enableRecursionForTaskSlug(CONFIG, TASK_SLUG);
 
     expect(result.ok).toBe(true);
-    // updateNode is still called (setEvalSetRecursion always writes, which is idempotent on the graph)
+    // updateNode is still called (setEvalSetRecursion always writes, idempotent on the graph)
     expect(mockUpdateNode).toHaveBeenCalledOnce();
+  });
+});
+
+// ── setEvalSetRecursion — namespace forwarding ────────────────────────────────
+
+describe("setEvalSetRecursion — namespace forwarding", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("forwards namespace to updateNode when provided", async () => {
+    mockUpdateNode.mockResolvedValue({ success: true });
+
+    await setEvalSetRecursion(CONFIG, "ref-abc-123", true, "practice-area/task-slug");
+
+    const [, , opts] = mockUpdateNode.mock.calls[0] as [
+      unknown,
+      unknown,
+      { namespace?: string } | undefined,
+    ];
+    expect(opts?.namespace).toBe("practice-area/task-slug");
+  });
+
+  test("omits namespace in opts when not provided (backward compat)", async () => {
+    mockUpdateNode.mockResolvedValue({ success: true });
+
+    await setEvalSetRecursion(CONFIG, "ref-abc-123", false);
+
+    const [, , opts] = mockUpdateNode.mock.calls[0] as [
+      unknown,
+      unknown,
+      { namespace?: string } | undefined,
+    ];
+    expect(opts).toBeUndefined();
+  });
+});
+
+// ── writeBackEvalProjectId — namespace forwarding ─────────────────────────────
+
+describe("writeBackEvalProjectId — namespace forwarding", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("forwards namespace to updateNode when provided", async () => {
+    mockUpdateNode.mockResolvedValue({ success: true });
+
+    await writeBackEvalProjectId(CONFIG, "ref-abc-123", 42, "practice-area/task-slug");
+
+    const [, req, opts] = mockUpdateNode.mock.calls[0] as [
+      unknown,
+      { ref_id: string; node_type: string; node_data: Record<string, unknown> },
+      { namespace?: string } | undefined,
+    ];
+    expect(req.node_data).toEqual({ project_id: 42 });
+    expect(opts?.namespace).toBe("practice-area/task-slug");
+  });
+
+  test("omits namespace when not provided (backward compat)", async () => {
+    mockUpdateNode.mockResolvedValue({ success: true });
+
+    await writeBackEvalProjectId(CONFIG, "ref-abc-123", 99);
+
+    const [, , opts] = mockUpdateNode.mock.calls[0] as [
+      unknown,
+      unknown,
+      { namespace?: string } | undefined,
+    ];
+    expect(opts).toBeUndefined();
+  });
+
+  test("returns ok:true on success", async () => {
+    mockUpdateNode.mockResolvedValue({ success: true });
+    const result = await writeBackEvalProjectId(CONFIG, "ref-abc-123", 42, "task/slug");
+    expect(result.ok).toBe(true);
+  });
+
+  test("returns ok:false on write failure", async () => {
+    mockUpdateNode.mockResolvedValue({ success: false, error: "ERROR_INVALID_REF_ID" });
+    const result = await writeBackEvalProjectId(CONFIG, "ref-abc-123", 42, "task/slug");
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("ERROR_INVALID_REF_ID");
   });
 });

--- a/src/__tests__/unit/services/legal-recursion-cron.test.ts
+++ b/src/__tests__/unit/services/legal-recursion-cron.test.ts
@@ -364,10 +364,10 @@ describe("executeScheduledLegalBenchmarkRecursion", () => {
 
   // ── Successful dispatch with write-back ─────────────────────────────────────
 
-  it("calls writeBackEvalProjectId with returned projectId after successful dispatch", async () => {
+  it("calls writeBackEvalProjectId with returned projectId and namespace (slug) after successful dispatch", async () => {
     mockListRecursionEvalSets.mockResolvedValue({
       ok: true,
-      nodes: [MOCK_EVAL_SET],
+      nodes: [MOCK_EVAL_SET], // id="task/some-task", ref_id="evalset-ref-1" — different
     });
     mockDbStakworkRunFindMany.mockResolvedValue([MOCK_RUNNER_RUN]);
     mockDispatchLegalBenchmarkEvalRun.mockResolvedValue({
@@ -378,10 +378,49 @@ describe("executeScheduledLegalBenchmarkRecursion", () => {
     await executeScheduledLegalBenchmarkRecursion();
 
     expect(mockWriteBackEvalProjectId).toHaveBeenCalledOnce();
+    // Namespace must be the slug (id), not ref_id
     expect(mockWriteBackEvalProjectId).toHaveBeenCalledWith(
       MOCK_JARVIS_CONFIG,
       MOCK_EVAL_SET.ref_id,
       54321,
+      MOCK_EVAL_SET.id, // "task/some-task" — the slug namespace
+    );
+  });
+
+  it("skips write-back with CRITICAL log when id === ref_id (no real slug available)", async () => {
+    const { logger } = await import("@/lib/logger");
+    // Simulate a node where properties.id was absent — listRecursionEvalSets
+    // falls back to ref_id for the id field (id === ref_id)
+    const evalSetNoSlug = {
+      ref_id: "evalset-ref-no-slug",
+      id: "evalset-ref-no-slug", // fallback: id === ref_id → no real slug
+      name: "Some Task",
+      projectId: null,
+    };
+
+    mockListRecursionEvalSets.mockResolvedValue({
+      ok: true,
+      nodes: [evalSetNoSlug],
+    });
+    // Provide a matching runner run (taskSlug must match evalSetNoSlug.id)
+    mockDbStakworkRunFindMany.mockResolvedValue([
+      { id: "run-no-slug", result: JSON.stringify({ taskSlug: "evalset-ref-no-slug" }) },
+    ]);
+    mockDbStakworkRunFindFirst.mockResolvedValue(null); // no recent duplicate
+    mockDispatchLegalBenchmarkEvalRun.mockResolvedValue({
+      evalRunId: "eval-run-skip",
+      projectId: 99999,
+    });
+
+    await executeScheduledLegalBenchmarkRecursion();
+
+    // Dispatch succeeded but write-back must be skipped (id === ref_id → no real namespace)
+    expect(mockWriteBackEvalProjectId).not.toHaveBeenCalled();
+    // A CRITICAL log (logger.error) must be emitted
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("CRITICAL"),
+      "legal",
+      expect.objectContaining({ refId: "evalset-ref-no-slug" }),
     );
   });
 

--- a/src/__tests__/unit/services/swarm/api/nodes.test.ts
+++ b/src/__tests__/unit/services/swarm/api/nodes.test.ts
@@ -9,7 +9,7 @@ beforeEach(() => {
   global.fetch = mockFetch;
 });
 
-const { addNode, addEdge, addEdgeBulk, addEdgeByRefBulk, addNodeBulk, updateNode, deleteNode, deleteEdge, getReferencedNodeCentrality, searchNodesByAttributes } = await import("@/services/swarm/api/nodes");
+const { addNode, addEdge, addEdgeBulk, addEdgeByRefBulk, addNodeBulk, updateNode, deleteNode, deleteEdge, getReferencedNodeCentrality, searchNodesByAttributes, checkNodeByKey } = await import("@/services/swarm/api/nodes");
 
 const config = {
   jarvisUrl: "https://test-swarm.sphinx.chat:8444",
@@ -823,6 +823,183 @@ describe("updateNode", () => {
       expect(result.success).toBe(false);
       expect(result.error).toBe("Network error");
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateNode — namespace parameter
+// ---------------------------------------------------------------------------
+
+describe("updateNode — namespace parameter", () => {
+  test("appends &namespace= to the PUT URL when namespace is supplied", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: "success" }),
+    });
+
+    await updateNode(
+      config,
+      { ref_id: "eval-set-1", node_type: "EvalSet", node_data: { recursion: true } },
+      { namespace: "practice-area/task-slug" },
+    );
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string;
+    expect(calledUrl).toContain("?ref_id=eval-set-1");
+    expect(calledUrl).toContain("&namespace=practice-area%2Ftask-slug");
+  });
+
+  test("does NOT append namespace param when namespace is omitted (backward compat)", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: "success" }),
+    });
+
+    await updateNode(config, {
+      ref_id: "eval-set-2",
+      node_type: "EvalSet",
+      node_data: { recursion: false },
+    });
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string;
+    expect(calledUrl).toBe("https://test-swarm.sphinx.chat:8444/node?ref_id=eval-set-2");
+    expect(calledUrl).not.toContain("namespace");
+  });
+
+  test("does NOT append namespace param when opts is empty object", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: "success" }),
+    });
+
+    await updateNode(
+      config,
+      { ref_id: "eval-set-3", node_type: "EvalSet", node_data: { recursion: true } },
+      {},
+    );
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string;
+    expect(calledUrl).not.toContain("namespace");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkNodeByKey
+// ---------------------------------------------------------------------------
+
+describe("checkNodeByKey", () => {
+  const CHECK_PARAMS = {
+    nodeType: "EvalSet",
+    key: "practice-area/task-slug",
+    namespace: "practice-area/task-slug",
+  };
+
+  test("builds correct /v2/nodes/check URL with node_type, key, and namespace query params", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ exists: true, ref_id: "ref-abc-123" }),
+    });
+
+    await checkNodeByKey(config, CHECK_PARAMS);
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string;
+    expect(calledUrl).toContain("/v2/nodes/check");
+    expect(calledUrl).toContain("node_type=EvalSet");
+    expect(calledUrl).toContain("key=practice-area%2Ftask-slug");
+    expect(calledUrl).toContain("namespace=practice-area%2Ftask-slug");
+    // Must use /v2/nodes/check — the bare /nodes/check path 404s on deployed jarvis
+    expect(calledUrl).toContain("/v2/nodes/check");
+  });
+
+  test("returns ok:true, exists:true, refId when node found", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ exists: true, ref_id: "ref-abc-123" }),
+    });
+
+    const result = await checkNodeByKey(config, CHECK_PARAMS);
+
+    expect(result.ok).toBe(true);
+    expect(result.exists).toBe(true);
+    expect(result.refId).toBe("ref-abc-123");
+    expect(result.endpointMissing).toBeUndefined();
+    expect(result.error).toBeUndefined();
+  });
+
+  test("returns ok:true, exists:false (genuine miss) when endpoint reports no match", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ exists: false }),
+    });
+
+    const result = await checkNodeByKey(config, CHECK_PARAMS);
+
+    expect(result.ok).toBe(true);
+    expect(result.exists).toBe(false);
+    expect(result.refId).toBeUndefined();
+    expect(result.endpointMissing).toBeUndefined();
+    expect(result.error).toBeUndefined();
+  });
+
+  test("returns ok:false, endpointMissing:true on 404 (endpoint absent on this jarvis version)", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      text: async () => "Not Found",
+    });
+
+    const result = await checkNodeByKey(config, CHECK_PARAMS);
+
+    expect(result.ok).toBe(false);
+    expect(result.endpointMissing).toBe(true);
+    expect(result.exists).toBe(false);
+    // Must NOT be treated as a genuine node miss
+    expect(result.error).toBeUndefined();
+  });
+
+  test("returns ok:false, error on 400 (not endpointMissing, not a genuine miss)", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      text: async () => "INVALID_NAMESPACE",
+    });
+
+    const result = await checkNodeByKey(config, CHECK_PARAMS);
+
+    expect(result.ok).toBe(false);
+    expect(result.exists).toBe(false);
+    expect(result.endpointMissing).toBeUndefined();
+    expect(result.error).toBeDefined();
+    expect(result.error).not.toContain("not found");
+  });
+
+  test("returns ok:false, error on transport failure (not a genuine miss)", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("Network timeout"));
+
+    const result = await checkNodeByKey(config, CHECK_PARAMS);
+
+    expect(result.ok).toBe(false);
+    expect(result.exists).toBe(false);
+    expect(result.endpointMissing).toBeUndefined();
+    expect(result.error).toBe("Network timeout");
+  });
+
+  test("uses GET method", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ exists: false }),
+    });
+
+    await checkNodeByKey(config, CHECK_PARAMS);
+
+    const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(opts.method).toBe("GET");
   });
 });
 

--- a/src/app/api/workspaces/[slug]/legal/benchmarks/recursion/[refId]/route.ts
+++ b/src/app/api/workspaces/[slug]/legal/benchmarks/recursion/[refId]/route.ts
@@ -85,14 +85,27 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       return NextResponse.json({ error: "EvalSet not found" }, { status: 404 });
     }
 
-    // Step 7: Resolve Jarvis config for updateNode (workspaceId from authorized swarm access)
+    // Step 7: Derive namespace from the fetched node's `properties.id` (the task slug).
+    // EvalSets are created under namespace = task_slug by Stakwork workflow 57389.
+    // Jarvis strips `namespace` from node-get responses, so we rely on `properties.id`
+    // being the slug. If absent, we cannot safely derive the namespace and must error
+    // rather than fall back to `refId` (which would silently fail with INVALID_NAMESPACE).
+    const namespace = (node as { properties?: Record<string, unknown> }).properties?.id;
+    if (!namespace || typeof namespace !== "string") {
+      return NextResponse.json(
+        { error: "Cannot resolve namespace for EvalSet" },
+        { status: 502 },
+      );
+    }
+
+    // Step 8: Resolve Jarvis config for updateNode (workspaceId from authorized swarm access)
     const jarvisConfig = await getJarvisConfigForWorkspace(workspaceId);
     if (!jarvisConfig) {
       return NextResponse.json({ error: "Swarm not configured" }, { status: 400 });
     }
 
-    // Step 8: Toggle the recursion attribute
-    const result = await setEvalSetRecursion(jarvisConfig, refId, enabled);
+    // Step 9: Toggle the recursion attribute, targeting the node's actual namespace
+    const result = await setEvalSetRecursion(jarvisConfig, refId, enabled, namespace);
 
     if (!result.ok) {
       return NextResponse.json(

--- a/src/services/legal-benchmark-recursion.ts
+++ b/src/services/legal-benchmark-recursion.ts
@@ -13,6 +13,7 @@ import type { JarvisConnectionConfig } from "@/types/jarvis";
 import {
   searchNodesByAttributes,
   updateNode,
+  checkNodeByKey,
 } from "@/services/swarm/api/nodes";
 import { logger } from "@/lib/logger";
 
@@ -114,24 +115,29 @@ export async function writeBackEvalProjectId(
   config: JarvisConnectionConfig,
   refId: string,
   projectId: number | string,
+  namespace?: string,
 ): Promise<RecursionServiceResult> {
   logger.info(
-    `[legal/benchmarks/recursion] writeBackEvalProjectId refId=${refId} projectId=${projectId}`,
+    `[legal/benchmarks/recursion] writeBackEvalProjectId refId=${refId} projectId=${projectId} namespace=${namespace ?? "default"}`,
     "legal",
-    { refId, projectId },
+    { refId, projectId, namespace },
   );
 
-  const result = await updateNode(config, {
-    ref_id: refId,
-    node_type: "EvalSet",
-    node_data: { project_id: projectId },
-  });
+  const result = await updateNode(
+    config,
+    {
+      ref_id: refId,
+      node_type: "EvalSet",
+      node_data: { project_id: projectId },
+    },
+    namespace ? { namespace } : undefined,
+  );
 
   if (!result.success) {
     logger.warn(
       `[legal/benchmarks/recursion] writeBackEvalProjectId failed refId=${refId}`,
       "legal",
-      { refId, projectId, error: result.error },
+      { refId, projectId, namespace, error: result.error },
     );
     return { ok: false, error: result.error ?? "Graph update failed" };
   }
@@ -163,23 +169,39 @@ export async function enableRecursionForTaskSlug(
     { taskSlug },
   );
 
-  // Resolve EvalSet ref_id from the task-slug (stored as the node's `id` property)
-  const searchResult = await searchNodesByAttributes(config, {
-    nodeTypes: ["EvalSet"],
-    filters: [{ attribute: "id", value: taskSlug, comparator: "=" }],
-    includeProperties: true,
+  // Resolve EvalSet ref_id via jarvis's natural-key endpoint.
+  // The slug is used as both the `key` and `namespace` (matching how
+  // Stakwork workflow 57389 creates these nodes: namespace = task_slug).
+  // Pass the raw slug — jarvis re-sanitizes it with the same node_key
+  // template used at creation, so pre-sanitizing here would double-apply.
+  const checkResult = await checkNodeByKey(config, {
+    nodeType: "EvalSet",
+    key: taskSlug,
+    namespace: taskSlug,
   });
 
-  if (!searchResult.ok) {
+  if (!checkResult.ok) {
+    // Transport failure, 400, or endpoint absent on this jarvis version —
+    // surface as an error, never as a "not found". Collapsing these would
+    // mask a broken lookup as a genuine miss (requirement #1).
     logger.warn(
-      `[legal/benchmarks/recursion] enableRecursionForTaskSlug graph search failed taskSlug=${taskSlug}`,
+      `[legal/benchmarks/recursion] enableRecursionForTaskSlug checkNodeByKey failed taskSlug=${taskSlug}`,
       "legal",
-      { taskSlug, error: searchResult.error },
+      {
+        taskSlug,
+        error: checkResult.error,
+        status: checkResult.status,
+        endpointMissing: checkResult.endpointMissing,
+      },
     );
-    return { ok: false, error: searchResult.error ?? "Graph search failed" };
+    return {
+      ok: false,
+      error: checkResult.error ?? `checkNodeByKey failed (status: ${checkResult.status ?? "unknown"})`,
+    };
   }
 
-  if (searchResult.nodes.length === 0) {
+  if (!checkResult.exists) {
+    // Genuine miss: endpoint responded but no node matched this key+namespace.
     logger.info(
       `[legal/benchmarks/recursion] enableRecursionForTaskSlug no EvalSet found taskSlug=${taskSlug}`,
       "legal",
@@ -188,8 +210,14 @@ export async function enableRecursionForTaskSlug(
     return { ok: false, notFound: true, error: "EvalSet not found for task slug" };
   }
 
-  const refId = searchResult.nodes[0].ref_id;
-  return setEvalSetRecursion(config, refId, true);
+  const refId = checkResult.refId!;
+  logger.info(
+    `[legal/benchmarks/recursion] enableRecursionForTaskSlug resolved refId=${refId} namespace=${taskSlug}`,
+    "legal",
+    { taskSlug, refId, namespace: taskSlug },
+  );
+
+  return setEvalSetRecursion(config, refId, true, taskSlug);
 }
 
 // ── setEvalSetRecursion ────────────────────────────────────────────────────
@@ -205,24 +233,29 @@ export async function setEvalSetRecursion(
   config: JarvisConnectionConfig,
   refId: string,
   enabled: boolean,
+  namespace?: string,
 ): Promise<RecursionServiceResult> {
   logger.info(
-    `[legal/benchmarks/recursion] setEvalSetRecursion refId=${refId} enabled=${enabled}`,
+    `[legal/benchmarks/recursion] setEvalSetRecursion refId=${refId} enabled=${enabled} namespace=${namespace ?? "default"}`,
     "legal",
-    { refId, enabled },
+    { refId, enabled, namespace },
   );
 
-  const result = await updateNode(config, {
-    ref_id: refId,
-    node_type: "EvalSet",
-    node_data: { recursion: enabled },
-  });
+  const result = await updateNode(
+    config,
+    {
+      ref_id: refId,
+      node_type: "EvalSet",
+      node_data: { recursion: enabled },
+    },
+    namespace ? { namespace } : undefined,
+  );
 
   if (!result.success) {
     logger.warn(
       `[legal/benchmarks/recursion] setEvalSetRecursion failed refId=${refId}`,
       "legal",
-      { refId, enabled, error: result.error },
+      { refId, enabled, namespace, error: result.error },
     );
     return { ok: false, error: result.error ?? "Graph update failed" };
   }

--- a/src/services/legal-recursion-cron.ts
+++ b/src/services/legal-recursion-cron.ts
@@ -140,10 +140,11 @@ async function writeBackWithRetry(
   config: Parameters<typeof writeBackEvalProjectId>[0],
   refId: string,
   projectId: number | string,
+  namespace?: string,
   maxRetries = 3,
 ): Promise<void> {
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
-    const result = await writeBackEvalProjectId(config, refId, projectId);
+    const result = await writeBackEvalProjectId(config, refId, projectId, namespace);
     if (result.ok) {
       logger.info(
         `${LOG_PREFIX} write-back succeeded refId=${refId} projectId=${projectId} attempt=${attempt}`,
@@ -359,9 +360,22 @@ export async function executeScheduledLegalBenchmarkRecursion(): Promise<Recursi
       result.dispatched++;
       available--; // Decrement in-pass to hold cap under status lag
 
-      // Write back the returned projectId so the next pass sees the running project
+      // Write back the returned projectId so the next pass sees the running project.
+      // The namespace for the write must be the task slug (= evalSet.id), NOT ref_id.
+      // listRecursionEvalSets falls back to ref_id when properties.id is missing on
+      // older/mismatched nodes — in that case we cannot safely derive a namespace and
+      // must skip rather than issue a doomed write the retry loop would silently swallow.
       if (dispatchResult.projectId != null) {
-        await writeBackWithRetry(jarvisConfig, evalSet.ref_id, dispatchResult.projectId);
+        if (evalSet.id === evalSet.ref_id) {
+          // No real slug available — id is just a ref_id fallback.
+          logger.error(
+            `${LOG_PREFIX} CRITICAL: cannot derive namespace for EvalSet refId=${evalSet.ref_id} — properties.id is absent (id===ref_id fallback). Write-back skipped to avoid doomed namespaced PUT. Manually verify EvalSet node schema on the swarm.`,
+            "legal",
+            { refId: evalSet.ref_id, projectId: dispatchResult.projectId },
+          );
+        } else {
+          await writeBackWithRetry(jarvisConfig, evalSet.ref_id, dispatchResult.projectId, evalSet.id);
+        }
       } else {
         logger.warn(
           `${LOG_PREFIX} dispatch returned no projectId for EvalSet ${evalSet.ref_id} — write-back skipped`,

--- a/src/services/swarm/api/nodes.ts
+++ b/src/services/swarm/api/nodes.ts
@@ -452,17 +452,95 @@ export async function searchNodesByAttributes(
   return { ok: true, nodes: Array.isArray(body?.nodes) ? body!.nodes : [], status: result.status };
 }
 
+/** Return shape for `checkNodeByKey` — mirrors `SearchLatestResult` for consistency. */
+export interface CheckNodeByKeyResult {
+  ok: boolean;
+  /** True only when the check succeeded and no matching node was found (a genuine miss). */
+  exists: boolean;
+  refId?: string;
+  status?: number;
+  /** True when the `/v2/nodes/check` endpoint is absent on this jarvis version. */
+  endpointMissing?: boolean;
+  error?: string;
+}
+
+/**
+ * Resolve a node's `ref_id` via jarvis's natural-key endpoint:
+ *   `GET /v2/nodes/check?node_type=<nodeType>&key=<key>&namespace=<namespace>`
+ *
+ * Pass the **raw** slug as `key` — jarvis re-sanitizes it with the same
+ * `node_key` template used at creation, so double-sanitizing would miss.
+ *
+ * Return contract (critical — callers must never conflate transport errors with genuine misses):
+ *  - `ok: true,  exists: true`  → node found; `refId` is set.
+ *  - `ok: true,  exists: false` → genuine miss (node does not exist in this namespace).
+ *  - `ok: false, endpointMissing: true` → endpoint not present on this jarvis version (404).
+ *  - `ok: false, error: string` → any other transport/HTTP failure.
+ *
+ * Never throws.
+ */
+export async function checkNodeByKey(
+  config: JarvisConnectionConfig,
+  params: { nodeType: string; key: string; namespace: string },
+): Promise<CheckNodeByKeyResult> {
+  const qs = new URLSearchParams({
+    node_type: params.nodeType,
+    key: params.key,
+    namespace: params.namespace,
+  });
+
+  const result = await jarvisRequest({
+    config,
+    endpoint: `/v2/nodes/check?${qs.toString()}`,
+    method: "GET",
+  });
+
+  if (!result.ok) {
+    // 404 → the endpoint itself is absent on this jarvis version
+    if (result.status === 404) {
+      return { ok: false, exists: false, status: result.status, endpointMissing: true };
+    }
+    // Any other non-2xx / transport failure — surface as error, never as "not found"
+    return {
+      ok: false,
+      exists: false,
+      status: result.status,
+      error: result.error || `checkNodeByKey failed with status ${result.status}`,
+    };
+  }
+
+  const body = result.body as { exists?: boolean; ref_id?: string } | undefined;
+
+  if (!body?.exists) {
+    // Genuine miss: endpoint responded successfully but node not found
+    return { ok: true, exists: false, status: result.status };
+  }
+
+  return {
+    ok: true,
+    exists: true,
+    refId: body.ref_id,
+    status: result.status,
+  };
+}
+
 export async function updateNode(
   config: JarvisConnectionConfig,
   request: UpdateNodeRequest,
+  opts?: { namespace?: string },
 ): Promise<{ success: boolean; error?: string }> {
   if (!request.ref_id) {
     return { success: false, error: "ref_id is required to update a node" };
   }
 
+  let endpoint = `/node?ref_id=${encodeURIComponent(request.ref_id)}`;
+  if (opts?.namespace) {
+    endpoint += `&namespace=${encodeURIComponent(opts.namespace)}`;
+  }
+
   const result = await jarvisRequest({
     config,
-    endpoint: `/node?ref_id=${encodeURIComponent(request.ref_id)}`,
+    endpoint,
     method: "PUT",
     data: {
       ref_id: request.ref_id,


### PR DESCRIPTION
Generated with Hive: Fix EvalSet lookup and namespaced writes in Legal Benchmark Recursion