### PR TITLE
Make EvalSet node_type matching case-insensitive in legal benchmark recursion

### DIFF
--- a/src/__tests__/unit/api/workspaces/legal-benchmark-recursion-route.test.ts
+++ b/src/__tests__/unit/api/workspaces/legal-benchmark-recursion-route.test.ts
@@ -41,6 +41,10 @@ vi.mock("@/lib/ai/kg-adapter", () => ({
 vi.mock("@/services/legal-benchmark-recursion", () => ({
   listRecursionEvalSets: mockListRecursionEvalSets,
   setEvalSetRecursion: mockSetEvalSetRecursion,
+  // Real helper — not mocked; tests exercise the actual case-insensitive logic
+  EVALSET_NODE_LABELS: ["EvalSet", "Evalset"],
+  isEvalSetLabel: (label: string | null | undefined) =>
+    (label ?? "").toLowerCase() === "evalset",
 }));
 
 vi.mock("@/lib/rate-limit", () => ({
@@ -308,7 +312,7 @@ describe("PATCH /api/workspaces/[slug]/legal/benchmarks/recursion/[refId]", () =
     expect(body.error).toMatch(/not found/i);
   });
 
-  test("returns 404 when node exists but is not an EvalSet (IDOR guard)", async () => {
+  test("returns 404 when node exists but is not an EvalSet (IDOR guard) — ProposedFix rejected", async () => {
     mockKgGetNode.mockResolvedValue({
       ref_id: "ref-other",
       node_type: "ProposedFix",
@@ -322,6 +326,48 @@ describe("PATCH /api/workspaces/[slug]/legal/benchmarks/recursion/[refId]", () =
     expect(res.status).toBe(404);
     const body = await res.json();
     expect(body.error).toMatch(/not found/i);
+    // Write must not have been called
+    expect(mockSetEvalSetRecursion).not.toHaveBeenCalled();
+  });
+
+  test("returns 404 when node has node_type 'Task' (IDOR guard rejects non-EvalSet)", async () => {
+    mockKgGetNode.mockResolvedValue({
+      ref_id: "ref-task",
+      node_type: "Task",
+      name: "some task",
+    });
+
+    const res = await PATCH(
+      makePatchRequest("ref-task", { enabled: true }),
+      makePatchParams("openlaw", "ref-task"),
+    );
+    expect(res.status).toBe(404);
+    expect(mockSetEvalSetRecursion).not.toHaveBeenCalled();
+  });
+
+  test("IDOR guard accepts node with stored jarvis label 'Evalset' (case-insensitive fix)", async () => {
+    // Simulates the real jarvis label casing: "Evalset" not "EvalSet"
+    mockKgGetNode.mockResolvedValue({
+      ref_id: "ref-evalset-jarvis",
+      node_type: "Evalset",  // ← the actual stored casing in jarvis
+      name: "Draft a contract",
+      properties: {},
+    });
+
+    const res = await PATCH(
+      makePatchRequest("ref-evalset-jarvis", { enabled: false }),
+      makePatchParams("openlaw", "ref-evalset-jarvis"),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.enabled).toBe(false);
+    // Write was called — guard passed
+    expect(mockSetEvalSetRecursion).toHaveBeenCalledWith(
+      MOCK_JARVIS_CONFIG,
+      "ref-evalset-jarvis",
+      false,
+    );
   });
 
   test("returns 200 with success: true on enable", async () => {

--- a/src/__tests__/unit/services/legal-benchmark-recursion.test.ts
+++ b/src/__tests__/unit/services/legal-benchmark-recursion.test.ts
@@ -24,6 +24,8 @@ import {
   listRecursionEvalSets,
   setEvalSetRecursion,
   enableRecursionForTaskSlug,
+  EVALSET_NODE_LABELS,
+  isEvalSetLabel,
 } from "@/services/legal-benchmark-recursion";
 import { logger } from "@/lib/logger";
 
@@ -61,7 +63,10 @@ describe("listRecursionEvalSets", () => {
       includeProperties: boolean;
     }];
 
-    expect(params.nodeTypes).toEqual(["EvalSet"]);
+    // Both casings must be present — regression guard against reverting to a single casing
+    expect(params.nodeTypes).toContain("EvalSet");
+    expect(params.nodeTypes).toContain("Evalset");
+    expect(params.nodeTypes).toEqual(EVALSET_NODE_LABELS);
     expect(params.includeProperties).toBe(true);
     expect(params.filters).toHaveLength(1);
     const filter = params.filters[0];
@@ -233,7 +238,10 @@ describe("enableRecursionForTaskSlug", () => {
       filters: Array<{ attribute: string; value: unknown; comparator: string }>;
       includeProperties: boolean;
     }];
-    expect(searchParams.nodeTypes).toEqual(["EvalSet"]);
+    // Both casings must be present — regression guard against reverting to single casing
+    expect(searchParams.nodeTypes).toContain("EvalSet");
+    expect(searchParams.nodeTypes).toContain("Evalset");
+    expect(searchParams.nodeTypes).toEqual(EVALSET_NODE_LABELS);
     expect(searchParams.filters).toEqual([{ attribute: "id", value: TASK_SLUG, comparator: "=" }]);
     expect(searchParams.includeProperties).toBe(true);
 
@@ -302,5 +310,149 @@ describe("enableRecursionForTaskSlug", () => {
     expect(result.ok).toBe(true);
     // updateNode is still called (setEvalSetRecursion always writes, which is idempotent on the graph)
     expect(mockUpdateNode).toHaveBeenCalledOnce();
+  });
+
+  test("notFound: true only when search returns empty nodes — never on transport failure", async () => {
+    // Transport failure: ok=false → must return error, NOT notFound
+    mockSearchNodesByAttributes.mockResolvedValue({
+      ok: false,
+      nodes: [],
+      error: "Connection refused",
+    });
+    const transportResult = await enableRecursionForTaskSlug(CONFIG, TASK_SLUG);
+    expect(transportResult.ok).toBe(false);
+    expect(transportResult).not.toHaveProperty("notFound");
+    expect(transportResult.error).toBe("Connection refused");
+
+    vi.clearAllMocks();
+
+    // Genuine empty result: ok=true, nodes=[] → must return notFound
+    mockSearchNodesByAttributes.mockResolvedValue({ ok: true, nodes: [] });
+    const emptyResult = await enableRecursionForTaskSlug(CONFIG, "nonexistent/slug");
+    expect(emptyResult.ok).toBe(false);
+    expect(emptyResult.notFound).toBe(true);
+    expect(emptyResult.error).toBeDefined();
+    expect(mockUpdateNode).not.toHaveBeenCalled();
+  });
+
+  test("deterministic tie-break: selects canonical 'EvalSet'-labelled node and logs warning when multiple nodes match", async () => {
+    const evalsetNode = { ...EVAL_SET_NODE, node_type: "Evalset", ref_id: "ref-old-evalset" };
+    const canonicalNode = { ...EVAL_SET_NODE, node_type: "EvalSet", ref_id: "ref-canonical-evalset" };
+
+    mockSearchNodesByAttributes.mockResolvedValue({
+      ok: true,
+      nodes: [evalsetNode, canonicalNode],
+    });
+    mockUpdateNode.mockResolvedValue({ success: true });
+
+    const result = await enableRecursionForTaskSlug(CONFIG, TASK_SLUG);
+
+    // Warning must be logged
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("multiple EvalSet nodes matched"),
+      "legal",
+      expect.objectContaining({ taskSlug: TASK_SLUG, count: 2 }),
+    );
+
+    // Must pick the canonical "EvalSet" node, not the first (Evalset) one
+    expect(mockUpdateNode).toHaveBeenCalledOnce();
+    const [, updateReq] = mockUpdateNode.mock.calls[0] as [unknown, { ref_id: string }];
+    expect(updateReq.ref_id).toBe("ref-canonical-evalset");
+
+    expect(result.ok).toBe(true);
+  });
+
+  test("deterministic tie-break falls back to stable ref_id sort when no canonical node present", async () => {
+    const nodeA = { ...EVAL_SET_NODE, node_type: "Evalset", ref_id: "ref-zzz" };
+    const nodeB = { ...EVAL_SET_NODE, node_type: "Evalset", ref_id: "ref-aaa" };
+
+    mockSearchNodesByAttributes.mockResolvedValue({
+      ok: true,
+      nodes: [nodeA, nodeB], // nodeA first, but nodeB has lower ref_id
+    });
+    mockUpdateNode.mockResolvedValue({ success: true });
+
+    await enableRecursionForTaskSlug(CONFIG, TASK_SLUG);
+
+    // Falls back to lowest ref_id sort
+    const [, updateReq] = mockUpdateNode.mock.calls[0] as [unknown, { ref_id: string }];
+    expect(updateReq.ref_id).toBe("ref-aaa");
+  });
+
+  test("logs resolved ref_id on successful enable", async () => {
+    mockSearchNodesByAttributes.mockResolvedValue({ ok: true, nodes: [EVAL_SET_NODE] });
+    mockUpdateNode.mockResolvedValue({ success: true });
+
+    await enableRecursionForTaskSlug(CONFIG, TASK_SLUG);
+
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("resolved ref_id=ref-abc-123"),
+      "legal",
+      expect.objectContaining({ refId: "ref-abc-123", taskSlug: TASK_SLUG }),
+    );
+  });
+
+  test("enable → list round-trip: list returns the newly-enabled node (mocked jarvis)", async () => {
+    // Enable: search finds the node, write succeeds
+    mockSearchNodesByAttributes.mockResolvedValueOnce({ ok: true, nodes: [EVAL_SET_NODE] });
+    mockUpdateNode.mockResolvedValue({ success: true });
+
+    const enableResult = await enableRecursionForTaskSlug(CONFIG, TASK_SLUG);
+    expect(enableResult.ok).toBe(true);
+
+    // List: returns the same node (now with recursion=true)
+    mockSearchNodesByAttributes.mockResolvedValueOnce({
+      ok: true,
+      nodes: [EVAL_SET_NODE],
+    });
+
+    const listResult = await listRecursionEvalSets(CONFIG);
+
+    // Both calls use the both-casing nodeTypes list
+    for (const [, params] of mockSearchNodesByAttributes.mock.calls as [unknown, { nodeTypes: string[] }][]) {
+      expect(params.nodeTypes).toContain("EvalSet");
+      expect(params.nodeTypes).toContain("Evalset");
+    }
+
+    expect(listResult.ok).toBe(true);
+    expect(listResult.nodes).toHaveLength(1);
+    expect(listResult.nodes![0].ref_id).toBe("ref-abc-123");
+  });
+});
+
+// ── EVALSET_NODE_LABELS / isEvalSetLabel helpers ─────────────────────────────
+
+describe("EVALSET_NODE_LABELS and isEvalSetLabel", () => {
+  test("EVALSET_NODE_LABELS contains both 'EvalSet' and 'Evalset'", () => {
+    expect(EVALSET_NODE_LABELS).toContain("EvalSet");
+    expect(EVALSET_NODE_LABELS).toContain("Evalset");
+    // Must have at least two entries (regression: not collapsed to a single casing)
+    expect(EVALSET_NODE_LABELS.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("isEvalSetLabel returns true for 'EvalSet'", () => {
+    expect(isEvalSetLabel("EvalSet")).toBe(true);
+  });
+
+  test("isEvalSetLabel returns true for 'Evalset' (stored jarvis label)", () => {
+    expect(isEvalSetLabel("Evalset")).toBe(true);
+  });
+
+  test("isEvalSetLabel returns true for any casing variant", () => {
+    expect(isEvalSetLabel("evalset")).toBe(true);
+    expect(isEvalSetLabel("EVALSET")).toBe(true);
+    expect(isEvalSetLabel("eVaLsEt")).toBe(true);
+  });
+
+  test("isEvalSetLabel returns false for genuinely different node types", () => {
+    expect(isEvalSetLabel("Task")).toBe(false);
+    expect(isEvalSetLabel("ProposedFix")).toBe(false);
+    expect(isEvalSetLabel("EvalTrigger")).toBe(false);
+    expect(isEvalSetLabel("")).toBe(false);
+  });
+
+  test("isEvalSetLabel returns false for null and undefined", () => {
+    expect(isEvalSetLabel(null)).toBe(false);
+    expect(isEvalSetLabel(undefined)).toBe(false);
   });
 });

--- a/src/app/api/workspaces/[slug]/legal/benchmarks/recursion/[refId]/route.ts
+++ b/src/app/api/workspaces/[slug]/legal/benchmarks/recursion/[refId]/route.ts
@@ -4,7 +4,7 @@ import { getWorkspaceSwarmAccess } from "@/lib/helpers/swarm-access";
 import { getJarvisConfigForWorkspace } from "@/lib/helpers/jarvis-config";
 import { getJarvisUrl } from "@/lib/utils/swarm";
 import { kgGetNode } from "@/lib/ai/kg-adapter";
-import { setEvalSetRecursion } from "@/services/legal-benchmark-recursion";
+import { setEvalSetRecursion, isEvalSetLabel } from "@/services/legal-benchmark-recursion";
 import { checkRateLimit, getClientIp } from "@/lib/rate-limit";
 
 export const runtime = "nodejs";
@@ -79,9 +79,12 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     const { workspaceId, swarmName, swarmApiKey } = swarmResult.data;
     const jarvisUrl = getJarvisUrl(swarmName);
 
-    // Step 6: IDOR guard — resolve node before writing
+    // Step 6: IDOR guard — resolve node before writing.
+    // Uses isEvalSetLabel (case-insensitive) to match both "EvalSet" and "Evalset"
+    // — a bridge for the jarvis label-casing defect (see EVALSET_NODE_LABELS comment
+    // in legal-benchmark-recursion.ts). Guard remains fail-closed and runs before any write.
     const node = await kgGetNode(jarvisUrl, swarmApiKey, refId);
-    if (!node || node.node_type !== "EvalSet") {
+    if (!node || !isEvalSetLabel(node.node_type)) {
       return NextResponse.json({ error: "EvalSet not found" }, { status: 404 });
     }
 

--- a/src/services/legal-benchmark-recursion.ts
+++ b/src/services/legal-benchmark-recursion.ts
@@ -16,6 +16,41 @@ import {
 } from "@/services/swarm/api/nodes";
 import { logger } from "@/lib/logger";
 
+// ── EvalSet label casing helpers ───────────────────────────────────────────
+//
+// Bridge for a known jarvis label-casing defect: eval-ontology nodes carry the
+// Neo4j label "Evalset" (capital E, lowercase s) — a leftover from a since-removed
+// historical `str.capitalize()` normalization. jarvis's WRITE path canonicalizes
+// `node_type` case-insensitively (resolves against `db.labels()`), so writes land
+// on the existing "Evalset" label. Its SEARCH path passes `node_type` verbatim
+// (case-sensitive Cypher IN), so sending only "EvalSet" misses every stored node.
+//
+// Fix: send BOTH casings server-side; compare case-insensitively client-side.
+// This works before AND after a planned jarvis heal migration that relabels
+// "Evalset" → "EvalSet" and adds symmetric search canonicalization
+// (tracked in the separate jarvis/graphmindset ticket).
+//
+// CLEANUP TRIGGER: once the jarvis heal migration has run and search
+// canonicalization has shipped, collapse EVALSET_NODE_LABELS to ["EvalSet"]
+// and revert isEvalSetLabel to a direct === comparison.
+//
+// Mirrors the pattern in src/app/api/workspaces/[slug]/evals/[evalSetId]/requirements/route.ts
+// which already compares String(n.node_type ?? "").toLowerCase() === "evalrequirement"
+// with an ("Evalset" / "Evalrequirement") comment for the same reason.
+
+/**
+ * Both casings sent to searchNodesByAttributes so the node is found regardless
+ * of whether the stored Neo4j label is "Evalset" (current) or "EvalSet" (post-heal).
+ */
+export const EVALSET_NODE_LABELS: string[] = ["EvalSet", "Evalset"];
+
+/**
+ * Case-insensitive check for an EvalSet node_type label.
+ * Accepts "EvalSet", "Evalset", and any other casing variant.
+ */
+export const isEvalSetLabel = (label: string | null | undefined): boolean =>
+  (label ?? "").toLowerCase() === "evalset";
+
 // ── Normalized result shape ────────────────────────────────────────────────
 // Both underlying helpers return different shapes; we map everything onto this
 // single contract so callers never branch on two incompatible results.
@@ -55,7 +90,7 @@ export async function listRecursionEvalSets(
   config: JarvisConnectionConfig,
 ): Promise<RecursionServiceResult> {
   const result = await searchNodesByAttributes(config, {
-    nodeTypes: ["EvalSet"],
+    nodeTypes: EVALSET_NODE_LABELS,
     filters: [{ attribute: "recursion", value: true, comparator: "=" }],
     includeProperties: true,
   });
@@ -163,9 +198,11 @@ export async function enableRecursionForTaskSlug(
     { taskSlug },
   );
 
-  // Resolve EvalSet ref_id from the task-slug (stored as the node's `id` property)
+  // Resolve EvalSet ref_id from the task-slug (stored as the node's `id` property).
+  // Both casings sent so the node is found whether the stored label is "Evalset" (current)
+  // or "EvalSet" (post-heal). See EVALSET_NODE_LABELS comment above.
   const searchResult = await searchNodesByAttributes(config, {
-    nodeTypes: ["EvalSet"],
+    nodeTypes: EVALSET_NODE_LABELS,
     filters: [{ attribute: "id", value: taskSlug, comparator: "=" }],
     includeProperties: true,
   });
@@ -188,7 +225,29 @@ export async function enableRecursionForTaskSlug(
     return { ok: false, notFound: true, error: "EvalSet not found for task slug" };
   }
 
-  const refId = searchResult.nodes[0].ref_id;
+  // Deterministic tie-break: during the jarvis heal-migration window, both a legacy
+  // "Evalset"-labelled node and a healed "EvalSet"-labelled node could transiently
+  // share the same `id`. Prefer the canonical "EvalSet" label; fall back to stable
+  // order (sort by ref_id) rather than an arbitrary first result.
+  let selectedNode = searchResult.nodes[0];
+  if (searchResult.nodes.length > 1) {
+    const labels = searchResult.nodes.map((n) => n.node_type).join(", ");
+    logger.warn(
+      `[legal/benchmarks/recursion] enableRecursionForTaskSlug multiple EvalSet nodes matched taskSlug=${taskSlug} count=${searchResult.nodes.length} labels=[${labels}] — selecting deterministically`,
+      "legal",
+      { taskSlug, count: searchResult.nodes.length, labels },
+    );
+    // Prefer canonical "EvalSet" label; otherwise take the lowest ref_id for stability
+    const canonical = searchResult.nodes.find((n) => n.node_type === "EvalSet");
+    selectedNode = canonical ?? [...searchResult.nodes].sort((a, b) => a.ref_id.localeCompare(b.ref_id))[0];
+  }
+
+  const refId = selectedNode.ref_id;
+  logger.info(
+    `[legal/benchmarks/recursion] enableRecursionForTaskSlug resolved ref_id=${refId} taskSlug=${taskSlug}`,
+    "legal",
+    { taskSlug, refId },
+  );
   return setEvalSetRecursion(config, refId, true);
 }
 


### PR DESCRIPTION
Generated with Hive: Make EvalSet node_type matching case-insensitive in legal benchmark recursion