### PR TITLE
Add workflow_explorer_agent capability to the canvas agent

### DIFF
--- a/src/__tests__/integration/api/ask/quick.test.ts
+++ b/src/__tests__/integration/api/ask/quick.test.ts
@@ -59,6 +59,7 @@ vi.mock('@/lib/constants/prompt', () => ({
   getConnectionsCapabilitySnippet: vi.fn(() => ''),
   getGraphWalkerCapabilitySnippet: vi.fn(() => ''),
   getInfraCapabilitySnippet: vi.fn(() => ''),
+  getWorkflowsCapabilitySnippet: vi.fn(() => ''),
   getPromptsCapabilitySnippet: vi.fn(() => ''),
   getConceptsCapabilitySnippet: vi.fn(() => ''),
   getCanvasPromptSuffix: vi.fn(() => ''),

--- a/src/__tests__/integration/api/ask/sync.test.ts
+++ b/src/__tests__/integration/api/ask/sync.test.ts
@@ -52,6 +52,7 @@ vi.mock('@/lib/constants/prompt', () => ({
   getConnectionsCapabilitySnippet: vi.fn(() => ''),
   getGraphWalkerCapabilitySnippet: vi.fn(() => ''),
   getInfraCapabilitySnippet: vi.fn(() => ''),
+  getWorkflowsCapabilitySnippet: vi.fn(() => ''),
   getPromptsCapabilitySnippet: vi.fn(() => ''),
   getConceptsCapabilitySnippet: vi.fn(() => ''),
   getCanvasPromptSuffix: vi.fn(() => ''),

--- a/src/__tests__/unit/lib/ai/filterReadonly.test.ts
+++ b/src/__tests__/unit/lib/ai/filterReadonly.test.ts
@@ -44,6 +44,7 @@ vi.mock("@/lib/constants/prompt", () => ({
   getConnectionsCapabilitySnippet: vi.fn(() => ""),
   getGraphWalkerCapabilitySnippet: vi.fn(() => ""),
   getInfraCapabilitySnippet: vi.fn(() => ""),
+  getWorkflowsCapabilitySnippet: vi.fn(() => ""),
   getPromptsCapabilitySnippet: vi.fn(() => ""),
   getConceptsCapabilitySnippet: vi.fn(() => ""),
   getCanvasPromptSuffix: vi.fn(() => ""),

--- a/src/__tests__/unit/lib/ai/graphWalkerTools.test.ts
+++ b/src/__tests__/unit/lib/ai/graphWalkerTools.test.ts
@@ -82,6 +82,7 @@ vi.mock("@/lib/constants/prompt", () => ({
   getConnectionsCapabilitySnippet: vi.fn(() => ""),
   getGraphWalkerCapabilitySnippet: vi.fn(() => ""),
   getInfraCapabilitySnippet: vi.fn(() => ""),
+  getWorkflowsCapabilitySnippet: vi.fn(() => ""),
   getPromptsCapabilitySnippet: vi.fn(() => ""),
   getConceptsCapabilitySnippet: vi.fn(() => ""),
 }));

--- a/src/__tests__/unit/lib/ai/infraTools.test.ts
+++ b/src/__tests__/unit/lib/ai/infraTools.test.ts
@@ -55,6 +55,7 @@ vi.mock("@/lib/constants/prompt", () => ({
   getConnectionsCapabilitySnippet: vi.fn(() => ""),
   getGraphWalkerCapabilitySnippet: vi.fn(() => ""),
   getInfraCapabilitySnippet: vi.fn(() => "infra-snippet"),
+  getWorkflowsCapabilitySnippet: vi.fn(() => "workflows-snippet"),
   getPromptsCapabilitySnippet: vi.fn(() => ""),
   getConceptsCapabilitySnippet: vi.fn(() => ""),
 }));

--- a/src/__tests__/unit/lib/ai/resolveOrgCapabilities.test.ts
+++ b/src/__tests__/unit/lib/ai/resolveOrgCapabilities.test.ts
@@ -21,6 +21,9 @@ vi.mock("@/lib/ai/graphWalkDispatchTools", () => ({
 }));
 vi.mock("@/lib/ai/promptTools", () => ({ buildPromptTools: vi.fn(() => ({})) }));
 vi.mock("@/lib/ai/conceptTools", () => ({ buildConceptTools: vi.fn(() => ({})) }));
+vi.mock("@/lib/ai/workflowExplorerTools", () => ({
+  buildWorkflowExplorerTools: vi.fn(() => ({})),
+}));
 vi.mock("@/lib/constants/prompt", () => ({
   getRoadmapCapabilitySnippet: vi.fn(() => ""),
   getPlannerCapabilitySnippet: vi.fn(() => ""),
@@ -29,6 +32,7 @@ vi.mock("@/lib/constants/prompt", () => ({
   getConnectionsCapabilitySnippet: vi.fn(() => ""),
   getGraphWalkerCapabilitySnippet: vi.fn(() => ""),
   getInfraCapabilitySnippet: vi.fn(() => ""),
+  getWorkflowsCapabilitySnippet: vi.fn(() => ""),
   getPromptsCapabilitySnippet: vi.fn(() => ""),
   getConceptsCapabilitySnippet: vi.fn(() => ""),
 }));
@@ -53,6 +57,7 @@ vi.mock("@/lib/ai/capabilityGates", () => ({
 }));
 
 import {
+  ALL_CAPABILITIES,
   resolveCapabilities,
   resolveOrgCapabilities,
 } from "@/lib/ai/capabilities";
@@ -101,5 +106,49 @@ describe("prompts capability org-gating", () => {
     const resolved = await resolveOrgCapabilities(["planner"], "org-x");
     expect(resolved).toEqual(["planner"]);
     expect(isPromptsCapabilityEnabledForOrg).not.toHaveBeenCalled();
+  });
+});
+
+describe("workflows capability org-gating", () => {
+  // `workflows` (the workflow_explorer_agent over the stakwork workspace's
+  // workflow library) reuses the same Stakwork-org allow-list gate as
+  // `prompts` — these tests lock the same contract for it.
+  beforeEach(() => {
+    isPromptsCapabilityEnabledForOrg.mockReset();
+  });
+
+  it("is in ALL_CAPABILITIES (default selection, subject to the gate)", () => {
+    expect(ALL_CAPABILITIES).toContain("workflows");
+  });
+
+  it("roadmap's sync includes expansion does NOT pull in workflows", () => {
+    const resolved = resolveCapabilities(["roadmap"]);
+    expect(resolved).not.toContain("workflows");
+  });
+
+  it("keeps workflows for an allow-listed (stakwork) org", async () => {
+    isPromptsCapabilityEnabledForOrg.mockResolvedValue(true);
+    const resolved = await resolveOrgCapabilities(
+      ["roadmap", "workflows"],
+      "org-stakwork",
+    );
+    expect(resolved).toContain("workflows");
+    expect(isPromptsCapabilityEnabledForOrg).toHaveBeenCalledWith("org-stakwork");
+  });
+
+  it("drops workflows for a non-allow-listed org even when explicitly selected", async () => {
+    isPromptsCapabilityEnabledForOrg.mockResolvedValue(false);
+    const resolved = await resolveOrgCapabilities(
+      ["roadmap", "workflows"],
+      "org-other",
+    );
+    expect(resolved).not.toContain("workflows");
+    expect(resolved).toContain("roadmap");
+  });
+
+  it("drops workflows when orgId is undefined (fails closed)", async () => {
+    isPromptsCapabilityEnabledForOrg.mockResolvedValue(false);
+    const resolved = await resolveOrgCapabilities(["workflows"], undefined);
+    expect(resolved).not.toContain("workflows");
   });
 });

--- a/src/lib/ai/askTools.ts
+++ b/src/lib/ai/askTools.ts
@@ -64,7 +64,11 @@ export async function repoAgent(
   swarmUrl: string,
   swarmApiKey: string,
   params: {
-    repo_url: string;
+    /**
+     * Optional for graph/workflow-mode calls: when omitted, the swarm-side
+     * agent falls back to the repos already ingested in its graph.
+     */
+    repo_url?: string;
     prompt: string;
     username?: string;
     pat?: string;
@@ -75,6 +79,12 @@ export async function repoAgent(
     model?: string;
     skills?: Record<string, boolean>;
     subAgents?: SubAgent[];
+    /**
+     * Swarm-side system-prompt persona. "graph" = generalized knowledge-graph
+     * walker; "workflow" = Workflow/Skill/Script research agent over the
+     * Jarvis workflow library. Omitted = the code-focused default.
+     */
+    mode?: "graph" | "workflow";
   },
   /**
    * Optional Bifrost routing. When provided, the swarm-side `repo/agent`

--- a/src/lib/ai/capabilities.ts
+++ b/src/lib/ai/capabilities.ts
@@ -81,6 +81,7 @@ import { buildInfraTools } from "@/lib/ai/infraTools";
 import { buildInitiativeTools } from "@/lib/ai/initiativeTools";
 import { buildPromptTools } from "@/lib/ai/promptTools";
 import { buildConceptTools } from "@/lib/ai/conceptTools";
+import { buildWorkflowExplorerTools } from "@/lib/ai/workflowExplorerTools";
 import { isPromptsCapabilityEnabledForOrg } from "@/lib/ai/capabilityGates";
 import {
   buildResearchTools,
@@ -106,6 +107,7 @@ import {
   getResearchCapabilitySnippet,
   getRoadmapCapabilitySnippet,
   getWhiteboardCapabilitySnippet,
+  getWorkflowsCapabilitySnippet,
 } from "@/lib/constants/prompt";
 
 export type OrgCapability =
@@ -117,7 +119,8 @@ export type OrgCapability =
   | "graph_walker"
   | "infra"
   | "prompts"
-  | "concepts";
+  | "concepts"
+  | "workflows";
 
 /**
  * Everything a capability's `buildTools` may need. Mirrors the
@@ -232,6 +235,7 @@ export const ALL_CAPABILITIES: readonly OrgCapability[] = [
   "infra",
   "prompts",
   "concepts",
+  "workflows",
 ];
 
 export const CAPABILITY_REGISTRY: Record<OrgCapability, CapabilityDefinition> =
@@ -403,6 +407,27 @@ export const CAPABILITY_REGISTRY: Record<OrgCapability, CapabilityDefinition> =
       // Not gated: unlike the global prompt library, concepts are per-workspace
       // and every workspace already exposes concept read tools to the agent.
       writeToolNames: [PROPOSE_NEW_CONCEPT_TOOL, PROPOSE_CONCEPT_UPDATE_TOOL],
+    },
+    workflows: {
+      // Not per-workspace: the tool always targets the hardcoded `stakwork`
+      // workspace's swarm, whose Jarvis graph holds the canonical Stakwork
+      // Workflow/Skill/Script library (see workflowExplorerTools.ts).
+      buildTools: () => buildWorkflowExplorerTools(),
+      promptSnippet: getWorkflowsCapabilitySnippet,
+      core: false,
+      menuBlurb:
+        "**workflows** — research the Stakwork workflow library via " +
+        "`workflow_explorer_agent`: find existing Workflows/Skills/Scripts " +
+        "by what they take as input and produce as output, read proven step " +
+        "orderings, and spot gaps. Load when designing or discussing a new " +
+        "Stakwork workflow.",
+      // Read-only research tool — nothing to strip in readonly mode.
+      writeToolNames: [],
+      // Org-gated to the Stakwork source-control org: the tool exposes the
+      // stakwork workspace's workflow graph, so it reuses the same allow-list
+      // gate as the global prompt library. Like `prompts`, it must never
+      // appear in an `includes` list (the sync resolver can't run the gate).
+      orgGate: isPromptsCapabilityEnabledForOrg,
     },
   };
 

--- a/src/lib/ai/workflowExplorerTools.ts
+++ b/src/lib/ai/workflowExplorerTools.ts
@@ -1,0 +1,107 @@
+/**
+ * `workflow_explorer_agent` — a read-only research sub-agent over the
+ * Stakwork workflow library.
+ *
+ * Unlike the per-workspace `repo_agent` tool (built in `askTools` from the
+ * acting workspace's swarm), this tool ALWAYS targets the hardcoded
+ * `stakwork` workspace's swarm — that swarm's Jarvis knowledge graph holds
+ * the canonical library of Stakwork Workflows, Skills, and Scripts. It
+ * invokes the swarm's `/repo/agent` endpoint with `mode: "workflow"`, a
+ * persona specialized for researching those node types (IO-schema semantic
+ * search, reading workflow recipes) so the canvas agent can ground new
+ * workflow designs in proven, reusable building blocks.
+ *
+ * Composed via the `workflows` capability, which is org-gated to the
+ * Stakwork source-control org (see `capabilities.ts`) — other orgs' agents
+ * never see this tool.
+ */
+
+import { tool, type ToolSet } from "ai";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { EncryptionService } from "@/lib/encryption";
+import { repoAgent } from "./askTools";
+
+/** The workspace whose swarm hosts the Jarvis workflow-library graph. */
+const WORKFLOW_LIBRARY_WORKSPACE_SLUG = "stakwork";
+
+/**
+ * Resolve the workflow-library workspace's swarm credentials by slug.
+ * Deliberately skips per-user membership validation — the tool is a
+ * fixed backend shared by every caller the `workflows` capability gate
+ * admits, not a per-user workspace surface. Mirrors the URL/decrypt
+ * conventions of `buildWorkspaceConfigs`.
+ */
+async function resolveWorkflowLibrarySwarm(): Promise<{
+  swarmUrl: string;
+  swarmApiKey: string;
+}> {
+  const workspace = await db.workspace.findFirst({
+    where: { slug: WORKFLOW_LIBRARY_WORKSPACE_SLUG, deleted: false },
+    select: { id: true },
+  });
+  if (!workspace) {
+    throw new Error(
+      `Workflow library workspace not found: ${WORKFLOW_LIBRARY_WORKSPACE_SLUG}`,
+    );
+  }
+
+  const swarm = await db.swarm.findFirst({
+    where: { workspaceId: workspace.id },
+  });
+  if (!swarm?.swarmUrl) {
+    throw new Error(
+      `Swarm not configured for workspace: ${WORKFLOW_LIBRARY_WORKSPACE_SLUG}`,
+    );
+  }
+
+  const swarmUrlObj = new URL(swarm.swarmUrl);
+  let baseSwarmUrl = `https://${swarmUrlObj.hostname}:3355`;
+  if (swarm.swarmUrl.includes("localhost")) {
+    baseSwarmUrl = "http://localhost:3355";
+  }
+
+  return {
+    swarmUrl: baseSwarmUrl,
+    swarmApiKey: EncryptionService.getInstance().decryptField(
+      "swarmApiKey",
+      swarm.swarmApiKey || "",
+    ),
+  };
+}
+
+export function buildWorkflowExplorerTools(): ToolSet {
+  return {
+    workflow_explorer_agent: tool({
+      description:
+        "Dispatch a research agent over the Stakwork workflow library (the stakwork workspace's knowledge graph) to find existing Workflows, Skills, and Scripts relevant to a workflow being designed. " +
+        "It searches components semantically by what they take as input and produce as output, reads full workflow recipes (step orderings + the skills each step uses), and reports proven, reusable building blocks with usage statistics — plus gaps where nothing exists yet. " +
+        "Use it when designing or discussing a NEW Stakwork workflow: e.g. 'what existing skills take a video url as input?', 'is there already a transcription workflow, and how does it compose its steps?'. " +
+        "STRICTLY READ-ONLY research — it cannot create or modify workflows. Heavy/slow (minutes): call it ONCE with a complete, self-contained prompt rather than several times.",
+      inputSchema: z.object({
+        prompt: z
+          .string()
+          .describe(
+            "Self-contained research task for the workflow explorer. State the goal of the workflow being designed, the input/output shapes if known (e.g. 'takes a video url, produces a transcript with timestamps'), and ask for reusable building blocks and gaps.",
+          ),
+      }),
+      execute: async ({ prompt }: { prompt: string }) => {
+        try {
+          const { swarmUrl, swarmApiKey } = await resolveWorkflowLibrarySwarm();
+          // No repo_url: workflow mode works entirely off the swarm's graph.
+          // No Bifrost routing either — the acting user generally isn't a
+          // member of the stakwork workspace, so we fall back to the swarm's
+          // default LLM key rather than minting a cross-workspace VK.
+          const rr = await repoAgent(swarmUrl, swarmApiKey, {
+            prompt,
+            mode: "workflow",
+          });
+          return rr.content;
+        } catch (e) {
+          console.error("Error executing workflow explorer agent:", e);
+          return "Could not execute workflow explorer agent";
+        }
+      },
+    }),
+  };
+}

--- a/src/lib/constants/prompt.ts
+++ b/src/lib/constants/prompt.ts
@@ -740,6 +740,35 @@ export function getGraphWalkDispatchSnippet(): string {
   - The traversal is shallow (1–2 hops)`;
 }
 
+export function getWorkflowsCapabilitySnippet(): string {
+  return `
+
+## Workflow Explorer
+
+You have one **read-only** sub-agent tool for researching the Stakwork workflow library — the canonical catalog of existing Workflows (complete automation recipes), Skills (reusable steps), and Scripts (code snippets).
+
+### Tool
+
+- **\`workflow_explorer_agent({ prompt })\`** — Dispatch a research agent over the workflow library's knowledge graph. It searches components semantically by their input/output schemas, reads full workflow recipes (the ordered steps and the skill each step invokes), weighs usage statistics, and reports back concrete reusable building blocks plus gaps where no existing component covers a needed capability.
+
+### When to use
+
+- The user is designing, scoping, or discussing a NEW Stakwork workflow and you need to know what proven components already exist.
+- Questions like: "is there already a workflow that processes video?", "which skills take a video url as input?", "how do the existing transcription workflows compose their steps?"
+
+### Prompting tips
+
+- The prompt must be self-contained — the explorer cannot see this conversation.
+- State the goal of the workflow being designed, and the input/output shapes if known (e.g. "takes a video url, produces a transcript with word-level timestamps").
+- Ask for reusable building blocks (with usage stats) AND gaps, not just a yes/no.
+
+### Caveats
+
+- **Heavy/slow** (an agentic loop on the swarm; can take minutes). Call it ONCE with a complete prompt rather than iterating.
+- **Strictly read-only research** — it cannot create, modify, or run workflows. Actual workflow creation happens elsewhere.
+`;
+}
+
 export function getInfraCapabilitySnippet(): string {
   return `
 


### PR DESCRIPTION
## What

Gives the canvas agent (Jamie) a **read-only research sub-agent over the Stakwork workflow library**: a new `workflow_explorer_agent` tool that dispatches the **stakwork workspace's** swarm `/repo/agent` with `mode: "workflow"` — a persona specialized for researching existing **Workflow / Skill / Script** nodes in the Jarvis knowledge graph (semantic search by input/output schemas, reading proven step orderings from workflow recipes, usage stats) so new workflow designs can be grounded in proven, reusable building blocks.

## How it's wired

- **`src/lib/ai/workflowExplorerTools.ts`** (new) — builds the tool. Unlike the per-workspace `repo_agent`, it ALWAYS targets the hardcoded `stakwork` workspace's swarm (resolved by slug at execute time, no per-user membership check — it's a fixed shared backend). Same initiate-then-poll flow as `repo_agent`; no Bifrost minting (the acting user generally isn't a stakwork-workspace member), falls back to the swarm's default LLM key.
- **New `workflows` capability** in the registry — loadable (non-core) with a `learn_capability` menu blurb; the full instructions (self-contained prompts, IO-shape phrasing, "heavy/slow — call once", strictly read-only) live in `getWorkflowsCapabilitySnippet`. `writeToolNames: []`, so it survives readonly sub-agent contexts.
- **Org-gated to the Stakwork source-control org** via the existing `isPromptsCapabilityEnabledForOrg` gate (same allow-list as the `prompts` capability). Fails closed, and like `prompts` it is excluded from `includes` expansion so the sync resolver can't bypass the gate.
- **`repoAgent` plumbing** (`askTools.ts`) — `repo_url` is now optional (workflow mode works entirely off the swarm's graph) and a `mode?: "graph" | "workflow"` param passes through to the swarm.

## Tests

- New gate-contract block in `resolveOrgCapabilities.test.ts` mirroring the `prompts` coverage: in `ALL_CAPABILITIES`, NOT pulled in by `roadmap`'s `includes`, kept for allow-listed orgs, dropped for others, fails closed without an orgId.
- Added the new snippet export to the four test files that mock `@/lib/constants/prompt`.
- `vitest run src/__tests__/unit/lib/ai/`: 27 files, 438 tests passing.
- `tsc --noEmit` adds zero new errors vs clean HEAD (verified by stash-compare).

## Dependency

End-to-end behavior requires the stakwork workspace's swarm to run a stakgraph build including stakwork/stakgraph#1469 (`mode="workflow"` + `input_q`/`output_q` search params). Older swarms ignore the `mode` param and fall back to the default code-exploration persona — degraded but not broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)