### PR TITLE
Fix Graph Explorer query proxy: wrong stakgraph endpoint path and missing language field

### DIFF
--- a/src/app/api/workspaces/[slug]/graph/query/route.ts
+++ b/src/app/api/workspaces/[slug]/graph/query/route.ts
@@ -133,13 +133,14 @@ export async function POST(
     const stakgraphUrl = getStakgraphUrl(getSwarmVanityAddress(swarm.name));
 
     // Forward to stakgraph Cypher endpoint
-    const apiResult = await fetch(`${stakgraphUrl}/api/stakgraph/query`, {
+    const apiResult = await fetch(`${stakgraphUrl}/api/hive/query`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         "x-api-token": apiKey,
       },
       body: JSON.stringify({
+        language: "cypher",
         query,
         limit: limit ?? 100,
       }),


### PR DESCRIPTION
## Problem

The Graph Explorer's Cypher query proxy (`/api/workspaces/[slug]/graph/query`) fails on prod for every request.

Two mismatches with the stakgraph read-only Cypher endpoint added in stakwork/stakgraph#1468:

1. **Wrong path** — the proxy forwarded to `${stakgraphUrl}/api/stakgraph/query`, but stakgraph registers the route as `POST /api/hive/query`, so every request returned 404.
2. **Missing `language` field** — the stakgraph handler requires `language: "cypher"` in the request body and returns 400 without it. The proxy only sent `{ query, limit }`.

Mock mode (`USE_MOCKS`) short-circuits before the fetch, which is why this wasn't caught by the existing tests.

## Fix

- Forward to `/api/hive/query`
- Include `language: "cypher"` in the request body

Auth (`x-api-token`) and the `{ columns, rows }` response shape already match, so no other changes are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)