### PR TITLE
Forward stakwork workspace API key to workflow explorer agent

### DIFF
--- a/src/lib/ai/askTools.ts
+++ b/src/lib/ai/askTools.ts
@@ -86,6 +86,13 @@ export async function repoAgent(
      * Jarvis workflow library. Omitted = the code-focused default.
      */
     mode?: "graph" | "workflow";
+    /**
+     * Stakwork API token forwarded server-to-server on the request body
+     * (never an LLM-visible parameter). When present, the swarm-side agent
+     * registers read-only run-research tools (skill usage stats, recent
+     * workflow runs, per-step params/outputs) against the Stakwork API.
+     */
+    stakworkApiKey?: string;
   },
   /**
    * Optional Bifrost routing. When provided, the swarm-side `repo/agent`

--- a/src/lib/ai/workflowExplorerTools.ts
+++ b/src/lib/ai/workflowExplorerTools.ts
@@ -35,10 +35,11 @@ const WORKFLOW_LIBRARY_WORKSPACE_SLUG = "stakwork";
 async function resolveWorkflowLibrarySwarm(): Promise<{
   swarmUrl: string;
   swarmApiKey: string;
+  stakworkApiKey?: string;
 }> {
   const workspace = await db.workspace.findFirst({
     where: { slug: WORKFLOW_LIBRARY_WORKSPACE_SLUG, deleted: false },
-    select: { id: true },
+    select: { id: true, stakworkApiKey: true },
   });
   if (!workspace) {
     throw new Error(
@@ -61,12 +62,32 @@ async function resolveWorkflowLibrarySwarm(): Promise<{
     baseSwarmUrl = "http://localhost:3355";
   }
 
+  // The stakwork workspace's Stakwork API token: forwarded to the swarm
+  // agent so it can research real run data (skill usage stats, recent runs,
+  // per-step params/outputs) via the Stakwork API. Optional — without it the
+  // explorer still works, minus the run-research tools.
+  let stakworkApiKey: string | undefined;
+  if (workspace.stakworkApiKey) {
+    try {
+      stakworkApiKey = EncryptionService.getInstance().decryptField(
+        "stakworkApiKey",
+        workspace.stakworkApiKey,
+      );
+    } catch (e) {
+      console.error(
+        "Failed to decrypt stakworkApiKey for workflow library workspace:",
+        e,
+      );
+    }
+  }
+
   return {
     swarmUrl: baseSwarmUrl,
     swarmApiKey: EncryptionService.getInstance().decryptField(
       "swarmApiKey",
       swarm.swarmApiKey || "",
     ),
+    stakworkApiKey,
   };
 }
 
@@ -76,7 +97,8 @@ export function buildWorkflowExplorerTools(): ToolSet {
       description:
         "Dispatch a research agent over the Stakwork workflow library (the stakwork workspace's knowledge graph) to find existing Workflows, Skills, and Scripts relevant to a workflow being designed. " +
         "It searches components semantically by what they take as input and produce as output, reads full workflow recipes (step orderings + the skills each step uses), and reports proven, reusable building blocks with usage statistics — plus gaps where nothing exists yet. " +
-        "Use it when designing or discussing a NEW Stakwork workflow: e.g. 'what existing skills take a video url as input?', 'is there already a transcription workflow, and how does it compose its steps?'. " +
+        "It can also pull ground-truth run data from the Stakwork API: which workflows invoke a skill (with real use counts), recent runs and their success/error states, and the actual params and outputs each step sent — useful for citing working configurations (exact URL formats, variable interpolations) or diagnosing why a similar workflow failed. " +
+        "Use it when designing or discussing a NEW Stakwork workflow: e.g. 'what existing skills take a video url as input?', 'is there already a transcription workflow, and how does it compose its steps?', 'show me real params from a successful run that uses AzureOCR'. " +
         "STRICTLY READ-ONLY research — it cannot create or modify workflows. Heavy/slow (minutes): call it ONCE with a complete, self-contained prompt rather than several times.",
       inputSchema: z.object({
         prompt: z
@@ -87,7 +109,8 @@ export function buildWorkflowExplorerTools(): ToolSet {
       }),
       execute: async ({ prompt }: { prompt: string }) => {
         try {
-          const { swarmUrl, swarmApiKey } = await resolveWorkflowLibrarySwarm();
+          const { swarmUrl, swarmApiKey, stakworkApiKey } =
+            await resolveWorkflowLibrarySwarm();
           // No repo_url: workflow mode works entirely off the swarm's graph.
           // No Bifrost routing either — the acting user generally isn't a
           // member of the stakwork workspace, so we fall back to the swarm's
@@ -95,6 +118,7 @@ export function buildWorkflowExplorerTools(): ToolSet {
           const rr = await repoAgent(swarmUrl, swarmApiKey, {
             prompt,
             mode: "workflow",
+            stakworkApiKey,
           });
           return rr.content;
         } catch (e) {


### PR DESCRIPTION
## What

Companion to stakwork/stakgraph#1474. The swarm-side `/repo/agent` workflow mode now registers read-only Stakwork run-research tools (`stakwork_skill_usage`, `stakwork_workflow_runs`, `stakwork_run_steps`) when the request body carries a `stakworkApiKey` — letting the workflow explorer cite real run data (which workflows invoke a skill, recent run success/error states, the actual params/outputs each step sent) instead of guessing from schemas.

This PR supplies that key from Hive:

- `resolveWorkflowLibrarySwarm()` additionally selects the stakwork workspace's encrypted `stakworkApiKey`, decrypts it via `EncryptionService`, and returns it. Missing or undecryptable key degrades gracefully — the explorer still works, minus the run tools.
- `repoAgent()` params accept `stakworkApiKey`, spread into the POST body like the other server-to-server secrets. It is never an LLM-visible tool parameter.
- `workflow_explorer_agent`'s description now advertises the run-research capability so the canvas agent knows it can ask for real params from successful runs.

Note: Stakwork scopes runs/stats to the customer that owns the API key, so the explorer sees the stakwork workspace's own executions.

## Testing

- `tsc --noEmit`: no errors in the changed files (the 143 errors in `src/__tests__/unit/lib/ai/askTools.test.ts` pre-exist this change — identical count with the diff stashed)
- End-to-end tool behavior verified live from the stakgraph side (see companion PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)