### PR TITLE
Fix hill-climb-series to resolve multiple PRODUCED_BY edges, include all attempts, and compute best-so-far after sorting

### DIFF
--- a/src/__tests__/unit/lib/harvey-lab/hill-climb-series.test.ts
+++ b/src/__tests__/unit/lib/harvey-lab/hill-climb-series.test.ts
@@ -276,9 +276,9 @@ describe("buildHillClimbSeries", () => {
     expect(series[1].n_passed).toBe(55);
   });
 
-  // ── Rejected / pending exclusion ─────────────────────────────────────────
+  // ── Rejected / pending now emit x-slots (accepted=false) ─────────────────
 
-  it("eval_status=rejected → excluded from series", () => {
+  it("eval_status=rejected → emits a point with accepted=false (x-slot, not excluded)", () => {
     const evalSetId = "evalset-1";
     const triggerId = uid("trig");
     const baseOutputId = uid("out");
@@ -302,12 +302,14 @@ describe("buildHillClimbSeries", () => {
     };
 
     const series = buildHillClimbSeries(sg);
-    // Only baseline — rejected fix excluded
-    expect(series).toHaveLength(1);
+    // Rejected fix now emits an x-slot (accepted=false) instead of being silently dropped
+    expect(series).toHaveLength(2);
     expect(series[0].n_passed).toBe(50);
+    expect(series[1].accepted).toBe(false);
+    expect(series[1].label).toBe("r1");
   });
 
-  it("eval_status=pending → excluded from series", () => {
+  it("eval_status=pending → emits a point with accepted=false (x-slot, not excluded)", () => {
     const evalSetId = "evalset-1";
     const triggerId = uid("trig");
     const baseOutputId = uid("out");
@@ -331,7 +333,9 @@ describe("buildHillClimbSeries", () => {
     };
 
     const series = buildHillClimbSeries(sg);
-    expect(series).toHaveLength(1);
+    // Pending fix now emits an x-slot too (accepted=false)
+    expect(series).toHaveLength(2);
+    expect(series[1].accepted).toBe(false);
   });
 
   // ── PRODUCED_BY edge — primary score hop ─────────────────────────────────
@@ -621,10 +625,312 @@ describe("buildHillClimbSeries", () => {
 
     const series = buildHillClimbSeries(sg);
     for (const pt of series) {
-      expect(pt.n_passed).toBeDefined();
-      expect(pt.n_total).toBeDefined();
       if (pt.n_passed != null) expect(isNaN(pt.n_passed)).toBe(false);
       if (pt.n_total != null) expect(isNaN(pt.n_total)).toBe(false);
     }
+  });
+
+  // ── NEW: Multi-PRODUCED_BY edge resolution ────────────────────────────────
+
+  it("two PRODUCED_BY edges: accepted fix picks the valid output (n_passed=32/n_total=33)", () => {
+    const evalSetId = "evalset-1";
+    const triggerId = uid("trig");
+    const baseOutputId = uid("out");
+    const fixId = uid("fix");
+    const emptyOutputId = uid("out"); // no n_passed/n_total — must be skipped
+    const validOutputId = uid("out"); // n_passed=32, n_total=33 — must be picked
+
+    const sg: Subgraph = {
+      nodes: [
+        evalSetNode(evalSetId),
+        triggerNode(triggerId, "1720001000"),
+        outputNode(baseOutputId, 24, 33, "1720001500"),
+        fixNode(fixId, { eval_status: "accepted", ts: "1720002000" }),
+        // Empty output — no n_passed/n_total
+        {
+          ref_id: emptyOutputId,
+          node_type: "EvalTriggerOutput",
+          date_added_to_graph: "1720002200",
+          properties: { attempt_number: 2, result: "", score: 0 },
+        },
+        // Valid output
+        outputNode(validOutputId, 32, 33, "1720002500"),
+      ],
+      edges: [
+        edge(evalSetId, triggerId, "HAS_BASELINE_TRIGGER"),
+        edge(triggerId, baseOutputId, "HAS_OUTPUT"),
+        edge(triggerId, fixId, "HAS_PROPOSED_FIX"),
+        // Two PRODUCED_BY edges — empty listed first so find() would pick it (old bug)
+        edge(fixId, emptyOutputId, "PRODUCED_BY"),
+        edge(fixId, validOutputId, "PRODUCED_BY"),
+      ],
+    };
+
+    const series = buildHillClimbSeries(sg);
+    expect(series).toHaveLength(2);
+    expect(series[1].n_passed).toBe(32);
+    expect(series[1].n_total).toBe(33);
+  });
+
+  // ── NEW: Rejected attempt — point emitted with accepted=false ────────────
+
+  it("rejected fix emits a point with accepted=false and bestPassed unchanged (flat line)", () => {
+    const evalSetId = "evalset-1";
+    const triggerId = uid("trig");
+    const baseOutputId = uid("out");
+    const fixId = uid("fix");
+
+    const sg: Subgraph = {
+      nodes: [
+        evalSetNode(evalSetId),
+        triggerNode(triggerId, "1720001000"),
+        outputNode(baseOutputId, 24, 33, "1720001500"),
+        // Rejected with derivable score via before/after
+        fixNode(fixId, {
+          eval_status: "rejected",
+          before_score: "24",
+          after_score: "20",
+          ts: "1720002000",
+        }),
+      ],
+      edges: [
+        edge(evalSetId, triggerId, "HAS_BASELINE_TRIGGER"),
+        edge(triggerId, baseOutputId, "HAS_OUTPUT"),
+        edge(triggerId, fixId, "HAS_PROPOSED_FIX"),
+        // No PRODUCED_BY — score resolved via before/after
+      ],
+    };
+
+    const series = buildHillClimbSeries(sg);
+    // Should have baseline + rejected attempt point
+    expect(series).toHaveLength(2);
+    const rejectedPt = series.find((pt) => pt.accepted === false);
+    expect(rejectedPt).toBeDefined();
+    expect(rejectedPt!.accepted).toBe(false);
+    // actualPassed is the derived value from after_score=20
+    expect(rejectedPt!.actualPassed).toBe(20);
+    // bestPassed is flat — remains the baseline's best (24), not the rejected dip
+    expect(rejectedPt!.bestPassed).toBe(24);
+  });
+
+  // ── NEW: bestPassed is monotonic non-decreasing after chronological sort ──
+
+  it("bestPassed is monotonic non-decreasing in final sorted order", () => {
+    const evalSetId = "evalset-1";
+    const triggerId = uid("trig");
+    const baseOutputId = uid("out");
+    const fix1Id = uid("fix");
+    const fix1OutId = uid("out");
+    const fix2Id = uid("fix"); // rejected — flat
+    const fix3Id = uid("fix");
+    const fix3OutId = uid("out");
+
+    const sg: Subgraph = {
+      nodes: [
+        evalSetNode(evalSetId),
+        triggerNode(triggerId, "1720001000"),
+        outputNode(baseOutputId, 24, 33, "1720001500"),
+        // fix1: accepted 30/33
+        fixNode(fix1Id, { eval_status: "accepted", ts: "1720002000" }),
+        outputNode(fix1OutId, 30, 33, "1720002500"),
+        // fix2: rejected with lower score
+        fixNode(fix2Id, {
+          eval_status: "rejected",
+          before_score: "30",
+          after_score: "25",
+          ts: "1720003000",
+        }),
+        // fix3: accepted 32/33
+        fixNode(fix3Id, { eval_status: "accepted", ts: "1720004000" }),
+        outputNode(fix3OutId, 32, 33, "1720004500"),
+      ],
+      edges: [
+        edge(evalSetId, triggerId, "HAS_BASELINE_TRIGGER"),
+        edge(triggerId, baseOutputId, "HAS_OUTPUT"),
+        edge(triggerId, fix1Id, "HAS_PROPOSED_FIX"),
+        edge(fix1Id, fix1OutId, "PRODUCED_BY"),
+        edge(fix2Id, fix1Id, "DERIVED_FROM"),
+        edge(fix3Id, fix2Id, "DERIVED_FROM"),
+        edge(fix3Id, fix3OutId, "PRODUCED_BY"),
+      ],
+    };
+
+    const series = buildHillClimbSeries(sg);
+    // Should have: baseline(24), fix1(30), fix2(rejected,25), fix3(32)
+    expect(series.length).toBe(4);
+
+    // bestPassed must be monotonically non-decreasing
+    for (let i = 1; i < series.length; i++) {
+      expect(series[i].bestPassed!).toBeGreaterThanOrEqual(series[i - 1].bestPassed!);
+    }
+
+    // Verify the rejected point (fix2) does NOT advance bestPassed
+    const rejectedPt = series.find((pt) => pt.accepted === false);
+    expect(rejectedPt).toBeDefined();
+    expect(rejectedPt!.bestPassed).toBe(30); // flat at prior accepted best, not 25
+  });
+
+  // ── NEW: Unresolvable rejected attempt — x-slot kept, no dot ─────────────
+
+  it("rejected fix with no resolvable score: actualPassed=null, x-slot and label still present", () => {
+    const evalSetId = "evalset-1";
+    const triggerId = uid("trig");
+    const baseOutputId = uid("out");
+    const fix1Id = uid("fix");
+    const fix1OutId = uid("out");
+    const fix2Id = uid("fix"); // rejected, no score
+    const fix3Id = uid("fix");
+    const fix3OutId = uid("out");
+
+    const sg: Subgraph = {
+      nodes: [
+        evalSetNode(evalSetId),
+        triggerNode(triggerId, "1720001000"),
+        outputNode(baseOutputId, 24, 33, "1720001500"),
+        fixNode(fix1Id, { eval_status: "accepted", ts: "1720002000" }),
+        outputNode(fix1OutId, 30, 33, "1720002500"),
+        // fix2: rejected, no PRODUCED_BY, no rerun_run_id, no after_score → null
+        fixNode(fix2Id, { eval_status: "rejected", ts: "1720003000" }),
+        // fix3: accepted after the rejected slot
+        fixNode(fix3Id, { eval_status: "accepted", ts: "1720004000" }),
+        outputNode(fix3OutId, 32, 33, "1720004500"),
+      ],
+      edges: [
+        edge(evalSetId, triggerId, "HAS_BASELINE_TRIGGER"),
+        edge(triggerId, baseOutputId, "HAS_OUTPUT"),
+        edge(triggerId, fix1Id, "HAS_PROPOSED_FIX"),
+        edge(fix1Id, fix1OutId, "PRODUCED_BY"),
+        edge(fix2Id, fix1Id, "DERIVED_FROM"),
+        edge(fix3Id, fix2Id, "DERIVED_FROM"),
+        edge(fix3Id, fix3OutId, "PRODUCED_BY"),
+      ],
+    };
+
+    const series = buildHillClimbSeries(sg);
+    // 4 points: baseline, fix1, fix2 (slot-only), fix3
+    expect(series).toHaveLength(4);
+
+    // Verify labels are stable and in order
+    const labels = series.map((pt) => pt.label);
+    expect(labels).toEqual(["base", "r1", "r2", "r3"]);
+
+    // The unresolvable rejected point has actualPassed=null
+    const unresolvable = series.find((pt) => pt.accepted === false && pt.actualPassed === null);
+    expect(unresolvable).toBeDefined();
+    expect(unresolvable!.label).toBe("r2");
+
+    // Subsequent point (fix3) still has correct label r3
+    const fix3Pt = series.find((pt) => pt.label === "r3");
+    expect(fix3Pt).toBeDefined();
+    expect(fix3Pt!.n_passed).toBe(32);
+  });
+
+  // ── NEW: Behavioral check — baseline 24/33 + accepted 32/33 ──────────────
+
+  it("baseline 24/33 + accepted fix 32/33 → two-point series with correct bestPassed", () => {
+    const evalSetId = "evalset-1";
+    const triggerId = uid("trig");
+    const baseOutputId = uid("out");
+    const fixId = uid("fix");
+    const fixOutId = uid("out");
+
+    const sg: Subgraph = {
+      nodes: [
+        evalSetNode(evalSetId),
+        triggerNode(triggerId, "1720001000"),
+        outputNode(baseOutputId, 24, 33, "1720001500"),
+        fixNode(fixId, { eval_status: "accepted", ts: "1720002000" }),
+        outputNode(fixOutId, 32, 33, "1720002500"),
+      ],
+      edges: [
+        edge(evalSetId, triggerId, "HAS_BASELINE_TRIGGER"),
+        edge(triggerId, baseOutputId, "HAS_OUTPUT"),
+        edge(triggerId, fixId, "HAS_PROPOSED_FIX"),
+        edge(fixId, fixOutId, "PRODUCED_BY"),
+      ],
+    };
+
+    const series = buildHillClimbSeries(sg);
+
+    expect(series).toHaveLength(2);
+
+    // Baseline
+    expect(series[0].isBaseline).toBe(true);
+    expect(series[0].accepted).toBe(true);
+    expect(series[0].actualPassed).toBe(24);
+    expect(series[0].bestPassed).toBe(24);
+    expect(series[0].label).toBe("base");
+
+    // Accepted fix
+    expect(series[1].isBaseline).toBe(false);
+    expect(series[1].accepted).toBe(true);
+    expect(series[1].actualPassed).toBe(32);
+    expect(series[1].bestPassed).toBe(32);
+    expect(series[1].label).toBe("r1");
+  });
+
+  // ── NEW: Regression — eval_status=rejected now yields a point (not excluded) ─
+
+  it("rejected fix is now included in series (not excluded like before)", () => {
+    const evalSetId = "evalset-1";
+    const triggerId = uid("trig");
+    const baseOutputId = uid("out");
+    const fixId = uid("fix");
+
+    const sg: Subgraph = {
+      nodes: [
+        evalSetNode(evalSetId),
+        triggerNode(triggerId, "1720001000"),
+        outputNode(baseOutputId, 50, 74, "1720001500"),
+        // Rejected with resolvable score
+        fixNode(fixId, {
+          eval_status: "rejected",
+          before_score: "50",
+          after_score: "48",
+          ts: "1720002000",
+        }),
+      ],
+      edges: [
+        edge(evalSetId, triggerId, "HAS_BASELINE_TRIGGER"),
+        edge(triggerId, baseOutputId, "HAS_OUTPUT"),
+        edge(triggerId, fixId, "HAS_PROPOSED_FIX"),
+      ],
+    };
+
+    const series = buildHillClimbSeries(sg);
+    // New behaviour: rejected attempts get an x-slot
+    expect(series).toHaveLength(2);
+    expect(series[1].accepted).toBe(false);
+    expect(series[1].label).toBe("r1");
+  });
+
+  // ── NEW: isBaseline flag ──────────────────────────────────────────────────
+
+  it("baseline point has isBaseline=true; fix points have isBaseline=false", () => {
+    const evalSetId = "evalset-1";
+    const triggerId = uid("trig");
+    const baseOutputId = uid("out");
+    const fixId = uid("fix");
+    const fixOutId = uid("out");
+
+    const sg: Subgraph = {
+      nodes: [
+        evalSetNode(evalSetId),
+        triggerNode(triggerId, "1720001000"),
+        outputNode(baseOutputId, 50, 74, "1720001500"),
+        fixNode(fixId, { eval_status: "accepted", ts: "1720002000" }),
+        outputNode(fixOutId, 58, 74, "1720002500"),
+      ],
+      edges: [
+        edge(evalSetId, triggerId, "HAS_BASELINE_TRIGGER"),
+        edge(triggerId, baseOutputId, "HAS_OUTPUT"),
+        edge(triggerId, fixId, "HAS_PROPOSED_FIX"),
+        edge(fixId, fixOutId, "PRODUCED_BY"),
+      ],
+    };
+
+    const series = buildHillClimbSeries(sg);
+    expect(series[0].isBaseline).toBe(true);
+    expect(series[1].isBaseline).toBe(false);
   });
 });

--- a/src/app/api/mock/jarvis/graph/recursion-fixture.ts
+++ b/src/app/api/mock/jarvis/graph/recursion-fixture.ts
@@ -1,5 +1,6 @@
 /**
- * Recursion subgraph mock fixture — exercises the full eval_status contract.
+ * Recursion subgraph mock fixture — exercises the full eval_status contract,
+ * multi-edge PRODUCED_BY resolution, rejected-attempt dots, and unresolvable slots.
  *
  * Ontology modelled:
  *   EvalSet
@@ -9,13 +10,21 @@
  *         --PRODUCED_BY--> EvalTriggerOutput (rerun-1, higher n_passed)
  *         --DERIVED_FROM-- ProposedFix (derived, accepted via status fallback)
  *                           --PRODUCED_BY--> EvalTriggerOutput (rerun-2)
+ *         --DERIVED_FROM-- ProposedFix (multi-edge, accepted)
+ *                           --PRODUCED_BY--> EvalTriggerOutput (empty — no n_passed/n_total)
+ *                           --PRODUCED_BY--> EvalTriggerOutput (valid — n_passed=32, n_total=33) ← must be picked
+ *         --DERIVED_FROM-- ProposedFix (rejected, resolvable via before/after score)
+ *         --DERIVED_FROM-- ProposedFix (rejected, no resolvable score — x-slot only)
  *     --HAS_TRIGGER--> EvalTrigger (rerun trigger, casing variant "evaltrigger")
  *       --HAS_PROPOSED_FIX--> ProposedFix (rejected — must NOT appear in accepted series)
  *
  * eval_status coverage:
  *   - fix-root:    eval_status:"accepted"  status:"rejected"  → eval_status wins
  *   - fix-derived: NO eval_status           status:"accepted"  → status fallback
- *   - fix-rejected: eval_status:"rejected"                    → excluded from series
+ *   - fix-multi-edge: eval_status:"accepted"                  → picks valid PRODUCED_BY edge
+ *   - fix-rejected-scored: eval_status:"rejected"             → x-slot with derived actualPassed
+ *   - fix-rejected-unscored: eval_status:"rejected"           → x-slot only, no dot
+ *   - fix-rejected (rerun trigger): eval_status:"rejected"    → excluded from accepted series
  */
 
 import type { JarvisNode } from "@/types/jarvis";
@@ -33,6 +42,18 @@ const FIX_ROOT_RERUN_OUTPUT_ID = "mock-evaltriggeroutput-rerun-001";
 
 const FIX_DERIVED_ID = "mock-proposedfix-derived-001";
 const FIX_DERIVED_RERUN_OUTPUT_ID = "mock-evaltriggeroutput-rerun-002";
+
+// ── NEW: Multi-edge PRODUCED_BY fix (accepted) ──────────────────────────────
+// Two PRODUCED_BY edges: one empty output, one valid (n_passed=32, n_total=33)
+export const FIX_MULTI_EDGE_ID = "mock-proposedfix-multiedge-001";
+const FIX_MULTI_EDGE_EMPTY_OUTPUT_ID = "mock-evaltriggeroutput-multiedge-empty-001";
+export const FIX_MULTI_EDGE_VALID_OUTPUT_ID = "mock-evaltriggeroutput-multiedge-valid-001";
+
+// ── NEW: Rejected fix with resolvable score (before/after) ──────────────────
+export const FIX_REJECTED_SCORED_ID = "mock-proposedfix-rejected-scored-001";
+
+// ── NEW: Rejected fix with NO resolvable score (x-slot only) ────────────────
+export const FIX_REJECTED_UNSCORED_ID = "mock-proposedfix-rejected-unscored-001";
 
 const FIX_REJECTED_ID = "mock-proposedfix-rejected-001";
 
@@ -189,7 +210,90 @@ export function buildRecursionNodes(): JarvisNode[] {
       },
     },
 
-    // ── Rejected ProposedFix (must NOT appear in accepted series) ─────────────
+    // ── NEW: Multi-edge accepted ProposedFix ──────────────────────────────────
+    // Has TWO PRODUCED_BY edges: one empty EvalTriggerOutput (no n_passed/n_total),
+    // one valid (n_passed=32, n_total=33). The builder must pick the valid one.
+    {
+      ref_id: FIX_MULTI_EDGE_ID,
+      node_type: "ProposedFix",
+      date_added_to_graph: ts,
+      properties: {
+        criterion_id: "criterion-multi",
+        criterion_title: "Mock criterion multi-edge",
+        eval_status: "accepted",
+        before_score: "58",
+        after_score: "32",
+        rerun_run_id: null,
+      },
+    },
+
+    // ── Empty EvalTriggerOutput (no n_passed/n_total) — must NOT be picked ────
+    {
+      ref_id: FIX_MULTI_EDGE_EMPTY_OUTPUT_ID,
+      node_type: "EvalTriggerOutput",
+      date_added_to_graph: ts,
+      properties: {
+        attempt_number: 4,
+        result: "",
+        score: 0,
+        // Intentionally no n_passed / n_total — exercises the "skip empty" path
+      },
+    },
+
+    // ── Valid EvalTriggerOutput (n_passed=32, n_total=33) — must be picked ────
+    {
+      ref_id: FIX_MULTI_EDGE_VALID_OUTPUT_ID,
+      node_type: "EvalTriggerOutput",
+      date_added_to_graph: ts,
+      properties: {
+        attempt_number: 5,
+        result: "partial",
+        score: 32 / 33,
+        n_passed: 32,
+        n_total: 33,
+        judge_notes: "32/33 criteria passed (multi-edge valid output)",
+      },
+    },
+
+    // ── NEW: Rejected ProposedFix with resolvable score ───────────────────────
+    // Score derivable via before_score/after_score → actualPassed approximation
+    // Current FIX_REJECTED_ID has no PRODUCED_BY edge and rerun_run_id: null.
+    // This new node builds on that pattern but has a valid after_score to derive from.
+    {
+      ref_id: FIX_REJECTED_SCORED_ID,
+      node_type: "ProposedFix",
+      date_added_to_graph: ts,
+      properties: {
+        criterion_id: "criterion-rejected-scored",
+        criterion_title: "Mock criterion rejected-scored",
+        eval_status: "rejected",
+        status: "rejected",
+        before_score: "58",
+        after_score: "55",
+        score_delta: "-3",
+        rerun_run_id: null,
+        rerun_status: null,
+      },
+    },
+
+    // ── NEW: Rejected ProposedFix with NO resolvable score ────────────────────
+    // No PRODUCED_BY edge, no rerun_run_id, no after_score → x-slot only, dot skipped
+    {
+      ref_id: FIX_REJECTED_UNSCORED_ID,
+      node_type: "ProposedFix",
+      date_added_to_graph: ts,
+      properties: {
+        criterion_id: "criterion-rejected-unscored",
+        criterion_title: "Mock criterion rejected-unscored",
+        eval_status: "rejected",
+        status: "rejected",
+        rerun_run_id: null,
+        rerun_status: null,
+        // No before_score / after_score → unresolvable
+      },
+    },
+
+    // ── Rejected ProposedFix (original — must NOT appear in accepted series) ──
     {
       ref_id: FIX_REJECTED_ID,
       node_type: "ProposedFix",
@@ -232,7 +336,22 @@ export function buildRecursionEdges() {
     // Derived fix → its rerun output
     { source: FIX_DERIVED_ID, target: FIX_DERIVED_RERUN_OUTPUT_ID, edge_type: "PRODUCED_BY" },
 
-    // Rerun trigger → rejected fix
+    // Multi-edge fix derived from derived fix
+    { source: FIX_MULTI_EDGE_ID, target: FIX_DERIVED_ID, edge_type: "DERIVED_FROM" },
+    // Multi-edge fix → empty output (no n_passed/n_total — must be skipped)
+    { source: FIX_MULTI_EDGE_ID, target: FIX_MULTI_EDGE_EMPTY_OUTPUT_ID, edge_type: "PRODUCED_BY" },
+    // Multi-edge fix → valid output (n_passed=32, n_total=33 — must be picked)
+    { source: FIX_MULTI_EDGE_ID, target: FIX_MULTI_EDGE_VALID_OUTPUT_ID, edge_type: "PRODUCED_BY" },
+
+    // Rejected fix with resolvable score (derived from multi-edge fix)
+    { source: FIX_REJECTED_SCORED_ID, target: FIX_MULTI_EDGE_ID, edge_type: "DERIVED_FROM" },
+    // (No PRODUCED_BY edge — score resolved via before/after derivation)
+
+    // Rejected fix with no resolvable score (derived from rejected-scored)
+    { source: FIX_REJECTED_UNSCORED_ID, target: FIX_REJECTED_SCORED_ID, edge_type: "DERIVED_FROM" },
+    // (No PRODUCED_BY edge, no after_score — x-slot only)
+
+    // Rerun trigger → rejected fix (original — attached to rerun trigger, not baseline)
     { source: RERUN_TRIGGER_ID, target: FIX_REJECTED_ID, edge_type: "HAS_PROPOSED_FIX" },
   ];
 }
@@ -246,5 +365,10 @@ export const RECURSION_NODE_IDS = {
   FIX_ROOT_RERUN_OUTPUT_ID,
   FIX_DERIVED_ID,
   FIX_DERIVED_RERUN_OUTPUT_ID,
+  FIX_MULTI_EDGE_ID,
+  FIX_MULTI_EDGE_EMPTY_OUTPUT_ID,
+  FIX_MULTI_EDGE_VALID_OUTPUT_ID,
+  FIX_REJECTED_SCORED_ID,
+  FIX_REJECTED_UNSCORED_ID,
   FIX_REJECTED_ID,
 } as const;

--- a/src/lib/harvey-lab/eval-normalizers.ts
+++ b/src/lib/harvey-lab/eval-normalizers.ts
@@ -17,6 +17,17 @@ export interface EvalTriggerOutput {
   date_added_to_graph?: string;
   /** Node id (e.g. "task_slug-source_run_id" or "task_slug-source_run_id--<rerun_id>") */
   id?: string;
+  // ── Hill-climb series fields (set by buildHillClimbSeries) ───────────────
+  /** Whether this attempt was accepted; false for rejected/pending */
+  accepted?: boolean;
+  /** True only for the baseline point */
+  isBaseline?: boolean;
+  /** Actual n_passed for dot rendering; null = no dot, x-slot is preserved */
+  actualPassed?: number | null;
+  /** Running best n_passed for the connected line (monotonic non-decreasing) */
+  bestPassed?: number;
+  /** Display label: "base" for baseline, "r1"/"r2"/… for subsequent attempts */
+  label?: string;
 }
 
 export interface EvalTrigger {

--- a/src/lib/harvey-lab/hill-climb-series.ts
+++ b/src/lib/harvey-lab/hill-climb-series.ts
@@ -122,7 +122,7 @@ function walkDerivedFromChain(
 /**
  * Attempt to resolve an EvalTriggerOutput for a given fix node.
  * Order:
- *  1. PRODUCED_BY edge → EvalTriggerOutput node (primary)
+ *  1. ALL PRODUCED_BY edges → pick first EvalTriggerOutput with valid n_passed/n_total
  *  2. fix.rerun_run_id matched to an in-subgraph EvalTriggerOutput.id (fallback, no second fetch)
  *  3. Parse fix.before_score / after_score as numbers, derive n_passed against baseline n_total
  *  4. Drop (return null) — never emit NaN/undefined
@@ -134,11 +134,11 @@ function resolveFixOutput(
   outputsByInternalId: Map<string, EvalTriggerOutput>,
   baselineNTotal: number | undefined,
 ): EvalTriggerOutput | null {
-  // 1. PRODUCED_BY edge
-  const producedByEdge = edges.find(
+  // 1. Iterate ALL PRODUCED_BY edges — pick first with valid n_passed/n_total
+  const producedByEdges = edges.filter(
     (e) => e.source === fixNode.ref_id && e.edge_type === "PRODUCED_BY",
   );
-  if (producedByEdge) {
+  for (const producedByEdge of producedByEdges) {
     const targetNode = nodeMap.get(producedByEdge.target);
     if (targetNode && isNodeType(targetNode, "EvalTriggerOutput")) {
       const normalized = normalizeOutput(targetNode as RawJarvisNode);
@@ -291,9 +291,17 @@ export function buildHillClimbSeries(subgraph: Subgraph): EvalTriggerOutput[] {
     (e) => e.source === baselineTriggerNode.ref_id && e.edge_type === "HAS_PROPOSED_FIX",
   );
 
-  const series: EvalTriggerOutput[] = [baselineOutput];
+  // Baseline carries its n_passed as actualPassed; it is always "accepted" (it's the ground truth)
+  const baselineWithMeta: EvalTriggerOutput = {
+    ...baselineOutput,
+    isBaseline: true,
+    accepted: true,
+    actualPassed: baselineOutput.n_passed ?? null,
+    label: "base",
+  };
+
+  const series: EvalTriggerOutput[] = [baselineWithMeta];
   let derivedFixCount = 0;
-  let acceptedFixCount = 0;
 
   if (rootFixEdge) {
     const fixChain = walkDerivedFromChain(rootFixEdge.target, nodeMap, edges);
@@ -303,8 +311,7 @@ export function buildHillClimbSeries(subgraph: Subgraph): EvalTriggerOutput[] {
       if (!isNodeType(fixNode, "ProposedFix")) continue;
 
       // Accept/reject — eval_status is canonical, status is fallback
-      if (!isAccepted(fixNode.properties)) continue;
-      acceptedFixCount++;
+      const accepted = isAccepted(fixNode.properties);
 
       const output = resolveFixOutput(
         fixNode,
@@ -313,14 +320,46 @@ export function buildHillClimbSeries(subgraph: Subgraph): EvalTriggerOutput[] {
         outputsByInternalId,
         baselineNTotal,
       );
+
       if (output !== null) {
-        series.push(output);
+        series.push({
+          ...output,
+          accepted,
+          isBaseline: false,
+          actualPassed: output.n_passed ?? null,
+          // label and bestPassed computed after sort below
+        });
       } else {
-        logger.warn(
-          "[legal/benchmarks/hill-climb] Accepted fix has no usable score — dropping point",
-          "legal",
-          { fixId: fixNode.ref_id },
-        );
+        // Keep an x-slot even when no score is resolvable — dot will be skipped
+        if (!accepted) {
+          logger.warn(
+            "[legal/benchmarks/hill-climb] Rejected fix has no resolvable score — x-slot kept, dot skipped, best-line stays flat",
+            "legal",
+            { fixId: fixNode.ref_id },
+          );
+        } else {
+          logger.warn(
+            "[legal/benchmarks/hill-climb] Accepted fix has no usable score — dropping point",
+            "legal",
+            { fixId: fixNode.ref_id },
+          );
+          // For accepted fixes with no score, we still drop the point (legacy behaviour)
+          continue;
+        }
+        // Emit a slot-only point for rejected with no score
+        const slotPoint: EvalTriggerOutput = {
+          ref_id: `slot-${fixNode.ref_id}`,
+          attempt_number: 0,
+          result: "",
+          score: 0,
+          accepted: false,
+          isBaseline: false,
+          actualPassed: null,
+          date_added_to_graph: fixNode.date_added_to_graph
+            ? String(fixNode.date_added_to_graph)
+            : undefined,
+        };
+        series.push(slotPoint);
       }
     }
   } else {
@@ -331,6 +370,34 @@ export function buildHillClimbSeries(subgraph: Subgraph): EvalTriggerOutput[] {
     );
   }
 
+  // ── 6. Sort chronologically (baseline first) using the shared utility ──────
+  const sorted = sortAttemptsChronologically(series);
+
+  // ── 7. Forward pass: assign labels + bestPassed after sort ────────────────
+  let runningBest = baselineOutput.n_passed ?? 0;
+  let rerunCounter = 0;
+  for (const pt of sorted) {
+    if (pt.isBaseline) {
+      pt.label = "base";
+      pt.bestPassed = pt.actualPassed ?? runningBest;
+      runningBest = pt.bestPassed;
+    } else {
+      rerunCounter++;
+      pt.label = `r${rerunCounter}`;
+      if (pt.accepted) {
+        // Accepted: best advances if this attempt scored higher
+        const candidate = pt.actualPassed ?? runningBest;
+        runningBest = Math.max(runningBest, candidate);
+      }
+      // Rejected (or accepted with null actualPassed): best-line stays flat
+      pt.bestPassed = runningBest;
+    }
+  }
+
+  // ── 8. Compute final counts for logging ───────────────────────────────────
+  const acceptedFixCount = sorted.filter((pt) => !pt.isBaseline && pt.accepted === true).length;
+  const rejectedCount = sorted.filter((pt) => pt.accepted === false).length;
+
   logger.info(
     "[legal/benchmarks/hill-climb] Series built",
     "legal",
@@ -340,10 +407,10 @@ export function buildHillClimbSeries(subgraph: Subgraph): EvalTriggerOutput[] {
       edgeCount: edges.length,
       derivedFixCount,
       acceptedFixCount,
-      seriesLength: series.length,
+      rejectedCount,
+      seriesLength: sorted.length,
     },
   );
 
-  // ── 6. Sort chronologically (baseline first) using the shared utility ──────
-  return sortAttemptsChronologically(series);
+  return sorted;
 }


### PR DESCRIPTION
Generated with Hive: Fix hill-climb-series to resolve multiple PRODUCED_BY edges, include all attempts, and compute best-so-far after sorting