### PR TITLE
Generated with Hive: Add atomic CAS claim to prevent duplicate agent-fix dispatch in PR Monitor

### DIFF
--- a/src/__tests__/integration/lib/github/pr-monitor-cas-claim.test.ts
+++ b/src/__tests__/integration/lib/github/pr-monitor-cas-claim.test.ts
@@ -1,0 +1,375 @@
+/**
+ * Integration tests for the atomic CAS claim in PR Monitor.
+ *
+ * These tests use the REAL Postgres database to verify that
+ * `claimPRFixInProgress` provides true atomicity via Postgres
+ * READ COMMITTED row-lock re-evaluation (EPQ).
+ *
+ * Key guarantees verified:
+ * 1. N concurrent claims → exactly one winner (affected === 1)
+ * 2. Stale `in_progress` rows are reclaimable after timeout
+ * 3. `gave_up` rows are never re-claimed
+ * 4. Attempt counter increments correctly in the DB
+ * 5. `findSinglePRArtifact` and `claimPRFixInProgress` use the same stale window
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { db } from "@/lib/db";
+import {
+  createTestUser,
+  createTestWorkspace,
+  createTestTask,
+  createTestChatMessage,
+} from "@/__tests__/support/factories";
+import { resetDatabase } from "@/__tests__/support/utilities/database";
+import { claimPRFixInProgress, monitorSinglePR } from "@/lib/github/pr-monitor";
+import type { PullRequestContent } from "@/lib/chat";
+
+// ── Mock all external I/O except the DB ────────────────────────────────────────
+
+vi.mock("@/lib/pusher", () => ({
+  pusherServer: { trigger: vi.fn().mockResolvedValue(undefined) },
+  getTaskChannelName: (id: string) => `task-${id}`,
+  getWorkspaceChannelName: (slug: string) => `workspace-${slug}`,
+  getFeatureChannelName: (id: string) => `feature-${id}`,
+  PUSHER_EVENTS: {
+    PR_STATUS_CHANGE: "pr-status-change",
+    AGENT_LOG_UPDATED: "agent-log-updated",
+  },
+}));
+
+vi.mock("@vercel/blob", () => ({
+  put: vi.fn().mockResolvedValue({ url: "https://blob.vercel.com/fake" }),
+}));
+
+vi.mock("@/lib/encryption", () => ({
+  EncryptionService: {
+    getInstance: vi.fn(() => ({
+      decryptField: vi.fn().mockReturnValue("decrypted"),
+      encryptField: vi.fn().mockReturnValue({ data: "enc", iv: "iv", tag: "tag", keyId: "k", version: 1, encryptedAt: "" }),
+    })),
+  },
+}));
+
+vi.mock("@/lib/githubApp", () => ({
+  getUserAppTokens: vi.fn().mockResolvedValue({ accessToken: "github-token" }),
+}));
+
+vi.mock("@/lib/github/pr-ci", () => ({
+  fetchCIStatus: vi.fn().mockResolvedValue({
+    status: "failure",
+    summary: "Tests failed",
+    failedChecks: ["unit-tests"],
+    failedCheckLogs: {},
+  }),
+}));
+
+vi.mock("@octokit/rest", () => ({
+  Octokit: vi.fn().mockImplementation(() => ({
+    pulls: {
+      get: vi.fn().mockResolvedValue({
+        data: {
+          state: "open",
+          merged: false,
+          mergeable: true,
+          mergeable_state: "unstable",
+          head: { ref: "feature/test", sha: "head-sha" },
+          base: { ref: "main", sha: "base-sha" },
+        },
+      }),
+      updateBranch: vi.fn(),
+    },
+    repos: {
+      compareCommits: vi.fn().mockResolvedValue({ data: { ahead_by: 0 } }),
+      merge: vi.fn(),
+    },
+  })),
+}));
+
+vi.mock("@/lib/auth/nextauth", () => ({
+  getGithubUsernameAndPAT: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/auth/agent-jwt", () => ({
+  createWebhookToken: vi.fn().mockResolvedValue("mock-token"),
+  generateWebhookSecret: vi.fn().mockReturnValue("mock-secret"),
+}));
+
+vi.mock("@/lib/pods/utils", () => ({
+  releaseTaskPod: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+// Spy on triggerFix so we can count dispatches
+vi.mock("@/services/task-workflow", () => ({
+  createChatMessageAndTriggerStakwork: vi.fn().mockResolvedValue({
+    stakworkData: { projectId: "proj-cas-integration" },
+  }),
+}));
+
+vi.mock("@/services/bifrost/orchestrator", () => ({
+  getBifrostForLLM: vi.fn().mockResolvedValue({ token: "bifrost-token" }),
+}));
+
+vi.mock("@/lib/helpers/chat-history", () => ({
+  fetchChatHistory: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/services/task-coordinator", () => ({
+  buildFeatureContext: vi.fn().mockResolvedValue(null),
+}));
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const PR_FIX_STALE_TIMEOUT_MS = parseInt(process.env.PR_FIX_STALE_TIMEOUT_MS || "1800000", 10);
+
+async function createPRArtifactScenario(opts: {
+  workspaceId: string;
+  ownerId: string;
+  prUrl: string;
+  progressOverride?: Record<string, unknown>;
+  enableMonitor?: boolean;
+  enableCifix?: boolean;
+}) {
+  const {
+    workspaceId,
+    ownerId,
+    prUrl,
+    progressOverride,
+    enableMonitor = true,
+    enableCifix = true,
+  } = opts;
+
+  // Task with mode=live and workflowStatus=COMPLETED so triggerLiveModeFix can dispatch
+  // (the live-mode fix gate skips if workflowStatus !== "COMPLETED")
+  const task = await createTestTask({ workspaceId, createdById: ownerId, workflowStatus: "COMPLETED" });
+  await db.task.update({ where: { id: task.id }, data: { mode: "live" } });
+
+  const msg = await createTestChatMessage({ taskId: task.id, message: "pr check" });
+
+  const content: PullRequestContent = {
+    url: prUrl,
+    status: "open",
+    progress: progressOverride as any,
+  };
+
+  const artifact = await db.artifact.create({
+    data: {
+      messageId: msg.id,
+      type: "PULL_REQUEST",
+      content: content as any,
+    },
+  });
+
+  // Janitor config: enable PR monitoring
+  await db.janitorConfig.upsert({
+    where: { workspaceId },
+    create: {
+      workspaceId,
+      prMonitorEnabled: enableMonitor,
+      prCiFailureFixEnabled: enableCifix,
+      prConflictFixEnabled: false,
+    },
+    update: {
+      prMonitorEnabled: enableMonitor,
+      prCiFailureFixEnabled: enableCifix,
+    },
+  });
+
+  return { task, msg, artifact };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("claimPRFixInProgress — real Postgres atomicity", () => {
+  let workspaceId: string;
+  let ownerId: string;
+
+  beforeEach(async () => {
+    await resetDatabase();
+    vi.clearAllMocks();
+
+    const user = await createTestUser();
+    const workspace = await createTestWorkspace({ ownerId: user.id });
+    workspaceId = workspace.id;
+    ownerId = user.id;
+  });
+
+  it("exactly one concurrent claim wins when N invocations race on the same artifact", async () => {
+    const prUrl = "https://github.com/org/repo/pull/100";
+    const { artifact } = await createPRArtifactScenario({ workspaceId, ownerId, prUrl });
+
+    // Fire N concurrent claims — each runs as its own autocommit statement (no wrapping tx)
+    const N = 8;
+    const results = await Promise.all(
+      Array.from({ length: N }, () =>
+        claimPRFixInProgress(artifact.id, PR_FIX_STALE_TIMEOUT_MS),
+      ),
+    );
+
+    const winners = results.filter(Boolean);
+    const losers = results.filter((r) => !r);
+
+    expect(winners).toHaveLength(1);
+    expect(losers).toHaveLength(N - 1);
+  });
+
+  it("claim increments the attempt counter in the DB (not from in-memory snapshot)", async () => {
+    const prUrl = "https://github.com/org/repo/pull/101";
+    const { artifact } = await createPRArtifactScenario({
+      workspaceId,
+      ownerId,
+      prUrl,
+      progressOverride: {
+        state: "ci_failure",
+        lastCheckedAt: new Date().toISOString(),
+        resolution: { status: "notified", attempts: 3, lastAttemptAt: new Date(Date.now() - 700000).toISOString() },
+      },
+    });
+
+    const won = await claimPRFixInProgress(artifact.id, PR_FIX_STALE_TIMEOUT_MS);
+    expect(won).toBe(true);
+
+    // Read back the DB row and confirm attempts = 4
+    const updated = await db.artifact.findUnique({ where: { id: artifact.id } });
+    const resolution = (updated?.content as PullRequestContent | null)?.progress?.resolution;
+    expect(resolution?.status).toBe("in_progress");
+    expect(resolution?.attempts).toBe(4);
+  });
+
+  it("stale in_progress (older than stale timeout) is reclaimable", async () => {
+    const prUrl = "https://github.com/org/repo/pull/102";
+    const staleDate = new Date(Date.now() - PR_FIX_STALE_TIMEOUT_MS - 5000).toISOString();
+
+    const { artifact } = await createPRArtifactScenario({
+      workspaceId,
+      ownerId,
+      prUrl,
+      progressOverride: {
+        state: "ci_failure",
+        lastCheckedAt: staleDate,
+        resolution: { status: "in_progress", attempts: 1, lastAttemptAt: staleDate },
+      },
+    });
+
+    const won = await claimPRFixInProgress(artifact.id, PR_FIX_STALE_TIMEOUT_MS);
+    expect(won).toBe(true);
+
+    const updated = await db.artifact.findUnique({ where: { id: artifact.id } });
+    const resolution = (updated?.content as PullRequestContent | null)?.progress?.resolution;
+    expect(resolution?.status).toBe("in_progress");
+    expect(resolution?.attempts).toBe(2);
+  });
+
+  it("fresh in_progress (within timeout) cannot be claimed again", async () => {
+    const prUrl = "https://github.com/org/repo/pull/103";
+    const recentDate = new Date(Date.now() - 60000).toISOString(); // 1 minute ago
+
+    const { artifact } = await createPRArtifactScenario({
+      workspaceId,
+      ownerId,
+      prUrl,
+      progressOverride: {
+        state: "ci_failure",
+        lastCheckedAt: recentDate,
+        resolution: { status: "in_progress", attempts: 1, lastAttemptAt: recentDate },
+      },
+    });
+
+    const won = await claimPRFixInProgress(artifact.id, PR_FIX_STALE_TIMEOUT_MS);
+    expect(won).toBe(false);
+  });
+
+  it("gave_up artifact is never re-claimed by CAS", async () => {
+    const prUrl = "https://github.com/org/repo/pull/104";
+
+    const { artifact } = await createPRArtifactScenario({
+      workspaceId,
+      ownerId,
+      prUrl,
+      progressOverride: {
+        state: "ci_failure",
+        lastCheckedAt: new Date().toISOString(),
+        resolution: {
+          status: "gave_up",
+          attempts: 6,
+          lastAttemptAt: new Date().toISOString(),
+          lastError: "Max attempts exceeded",
+        },
+      },
+    });
+
+    const won = await claimPRFixInProgress(artifact.id, PR_FIX_STALE_TIMEOUT_MS);
+    expect(won).toBe(false);
+
+    // Confirm the DB was not mutated
+    const unchanged = await db.artifact.findUnique({ where: { id: artifact.id } });
+    const resolution = (unchanged?.content as PullRequestContent | null)?.progress?.resolution;
+    expect(resolution?.status).toBe("gave_up");
+  });
+
+  it("row with no progress object claims cleanly (defensive jsonb_set wrapper)", async () => {
+    const prUrl = "https://github.com/org/repo/pull/105";
+
+    const { artifact } = await createPRArtifactScenario({
+      workspaceId,
+      ownerId,
+      prUrl,
+      // No progressOverride → content.progress is undefined
+    });
+
+    const won = await claimPRFixInProgress(artifact.id, PR_FIX_STALE_TIMEOUT_MS);
+    expect(won).toBe(true);
+
+    const updated = await db.artifact.findUnique({ where: { id: artifact.id } });
+    const resolution = (updated?.content as PullRequestContent | null)?.progress?.resolution;
+    expect(resolution?.status).toBe("in_progress");
+    expect(resolution?.attempts).toBe(1);
+  });
+});
+
+describe("monitorSinglePR — concurrent dispatch integration (real DB)", () => {
+  let workspaceId: string;
+  let ownerId: string;
+
+  beforeEach(async () => {
+    await resetDatabase();
+    vi.clearAllMocks();
+
+    const user = await createTestUser();
+    const workspace = await createTestWorkspace({ ownerId: user.id });
+    workspaceId = workspace.id;
+    ownerId = user.id;
+  });
+
+  it("N concurrent monitorSinglePR invocations dispatch triggerFix exactly once and notify exactly once", async () => {
+    const prUrl = "https://github.com/org/repo/pull/200";
+
+    const user = await createTestUser();
+    const workspace = await createTestWorkspace({ ownerId: user.id });
+
+    await createPRArtifactScenario({
+      workspaceId: workspace.id,
+      ownerId: user.id,
+      prUrl,
+    });
+
+    const { pusherServer } = await import("@/lib/pusher");
+    const { createChatMessageAndTriggerStakwork } = await import("@/services/task-workflow");
+
+    // Fire 4 concurrent webhook-style invocations
+    const N = 4;
+    await Promise.all(Array.from({ length: N }, () => monitorSinglePR(prUrl)));
+
+    // triggerFix dispatched exactly once
+    const triggerCalls = vi.mocked(createChatMessageAndTriggerStakwork).mock.calls.length;
+    expect(triggerCalls).toBe(1);
+
+    // PR_STATUS_CHANGE notification fired exactly once
+    const prStatusCalls = vi.mocked(pusherServer.trigger).mock.calls.filter(
+      (c) => c[1] === "pr-status-change",
+    );
+    // At minimum 1 (task channel); could be 2 if workspace channel also fires
+    // but must NOT be N (no duplicates from losers)
+    expect(prStatusCalls.length).toBeGreaterThanOrEqual(1);
+    expect(prStatusCalls.length).toBeLessThanOrEqual(2); // task + optional workspace channel
+  });
+});

--- a/src/__tests__/unit/lib/github/pr-monitor.test.ts
+++ b/src/__tests__/unit/lib/github/pr-monitor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { mergeBaseBranch, rebaseOntoBaseBranch, triggerAgentModeFix, triggerLiveModeFix, createPrLogger, monitorSinglePR } from "@/lib/github/pr-monitor";
+import { mergeBaseBranch, rebaseOntoBaseBranch, triggerAgentModeFix, triggerLiveModeFix, createPrLogger, monitorSinglePR, claimPRFixInProgress } from "@/lib/github/pr-monitor";
 import type { Octokit } from "@octokit/rest";
 import { ChatRole, ChatStatus } from "@prisma/client";
 
@@ -1295,6 +1295,9 @@ describe("PR Monitor - Zombie PR fixes", () => {
           base: { ref: "main", sha: "base-sha" },
         },
       });
+
+      // CAS claim: default to winning so fix-path tests can proceed
+      vi.mocked(db.$executeRaw).mockResolvedValue(1);
     });
 
     it("calls triggerLiveModeFix and sets resolution to in_progress when podId is null", async () => {
@@ -1934,5 +1937,300 @@ describe("monitorSinglePR", () => {
       agentTriggered: 0,
       notified: 0,
     });
+  });
+});
+
+// ─── CAS claim: claimPRFixInProgress unit tests ────────────────────────────────
+
+describe("claimPRFixInProgress", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns true when $executeRaw returns 1 (claim won)", async () => {
+    vi.mocked(db.$executeRaw).mockResolvedValue(1);
+    const result = await claimPRFixInProgress("artifact-1", 1800000);
+    expect(result).toBe(true);
+    expect(db.$executeRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns false when $executeRaw returns 0 (claim lost)", async () => {
+    vi.mocked(db.$executeRaw).mockResolvedValue(0);
+    const result = await claimPRFixInProgress("artifact-1", 1800000);
+    expect(result).toBe(false);
+    expect(db.$executeRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it("first call wins, subsequent calls lose — simulates concurrent duplicate deliveries", async () => {
+    vi.mocked(db.$executeRaw)
+      .mockResolvedValueOnce(1) // first invocation wins
+      .mockResolvedValue(0);   // all others lose
+
+    const [r1, r2, r3] = await Promise.all([
+      claimPRFixInProgress("artifact-1", 1800000),
+      claimPRFixInProgress("artifact-1", 1800000),
+      claimPRFixInProgress("artifact-1", 1800000),
+    ]);
+
+    expect(r1).toBe(true);
+    expect(r2).toBe(false);
+    expect(r3).toBe(false);
+    expect(db.$executeRaw).toHaveBeenCalledTimes(3);
+  });
+});
+
+// ─── CAS-gated processOnePR / monitorSinglePR integration-style unit tests ────
+
+describe("monitorSinglePR — CAS claim gates notify + dispatch", () => {
+  const prUrl = "https://github.com/org/repo/pull/99";
+
+  function makeCIFailureRow(overrides: Record<string, unknown> = {}) {
+    return {
+      id: "artifact-cas-1",
+      content: {
+        url: prUrl,
+        status: "IN_PROGRESS",
+        progress: overrides.progress ?? undefined,
+      },
+      task_id: "task-cas-1",
+      pod_id: null,
+      workspace_id: "ws-cas-1",
+      owner_id: "owner-cas-1",
+      last_checked_at: null,
+      pr_monitor_enabled: true,
+      pr_conflict_fix_enabled: false,
+      pr_ci_failure_fix_enabled: true,
+      pr_out_of_date_fix_enabled: false,
+      pr_use_rebase_for_updates: false,
+    };
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    vi.mocked(db.task.findUnique).mockResolvedValue({
+      id: "task-cas-1",
+      featureId: "feature-cas-1",
+      mode: "live",
+      workflowStatus: "COMPLETED",
+      createdById: "creator-1",
+      workspace: { ownerId: "owner-cas-1", slug: "cas-ws" },
+    } as any);
+
+    vi.mocked(db.artifact.findUnique).mockResolvedValue({
+      content: { url: prUrl, status: "IN_PROGRESS" },
+    } as any);
+    vi.mocked(db.artifact.update).mockResolvedValue({} as any);
+
+    // Default CI: failing
+    const { fetchCIStatus } = await import("@/lib/github/pr-ci");
+    vi.mocked(fetchCIStatus).mockResolvedValue({
+      status: "failure",
+      summary: "Tests failed",
+      failedChecks: ["unit-tests"],
+      failedCheckLogs: {},
+    });
+
+    // Default Octokit: open PR, not behind base
+    const { Octokit } = await import("@octokit/rest");
+    vi.mocked(Octokit).mockImplementation(() => ({
+      pulls: {
+        get: vi.fn().mockResolvedValue({
+          data: {
+            state: "open",
+            merged: false,
+            mergeable: true,
+            mergeable_state: "unstable",
+            head: { ref: "feature/cas-test", sha: "head-sha-cas" },
+            base: { ref: "main", sha: "base-sha-cas" },
+          },
+        }),
+        updateBranch: vi.fn(),
+      },
+      repos: {
+        compareCommits: vi.fn().mockResolvedValue({ data: { ahead_by: 0 } }),
+        merge: vi.fn(),
+      },
+    }));
+
+    // createChatMessageAndTriggerStakwork — used by triggerLiveModeFix
+    vi.mocked(createChatMessageAndTriggerStakwork).mockResolvedValue({
+      stakworkData: { projectId: "proj-cas" },
+    } as any);
+  });
+
+  it("winner (claim returns 1): dispatches fix exactly once and notifies once", async () => {
+    vi.mocked(db.$queryRaw).mockResolvedValue([makeCIFailureRow()]);
+    vi.mocked(db.$executeRaw).mockResolvedValue(1); // claim won
+
+    const stats = await monitorSinglePR(prUrl);
+
+    expect(stats.agentTriggered).toBe(1);
+    expect(stats.notified).toBe(1);
+    expect(db.artifact.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("loser (claim returns 0): no-ops — no notify, no dispatch, no DB write", async () => {
+    vi.mocked(db.$queryRaw).mockResolvedValue([makeCIFailureRow()]);
+    vi.mocked(db.$executeRaw).mockResolvedValue(0); // claim lost
+
+    const stats = await monitorSinglePR(prUrl);
+
+    // Loser returns immediately — no trigger, no notify, no trailing write
+    expect(stats.agentTriggered).toBe(0);
+    expect(stats.notified).toBe(0);
+    // artifact.update must not be called by the losing path
+    expect(db.artifact.update).not.toHaveBeenCalled();
+  });
+
+  it("non-fix path (fix-type disabled): notifies without going through CAS", async () => {
+    // pr_ci_failure_fix_enabled = false → shouldTriggerFix=false, no CAS attempted
+    vi.mocked(db.$queryRaw).mockResolvedValue([
+      makeCIFailureRow({ pr_ci_failure_fix_enabled: false } as any),
+    ]);
+    // Override: make row have fix disabled
+    const row = makeCIFailureRow();
+    row.pr_ci_failure_fix_enabled = false;
+    vi.mocked(db.$queryRaw).mockResolvedValue([row]);
+
+    const stats = await monitorSinglePR(prUrl);
+
+    // No CAS attempted on the non-fix path
+    expect(db.$executeRaw).not.toHaveBeenCalled();
+    // But still notifies (non-fix status change)
+    expect(stats.notified).toBe(1);
+    expect(stats.agentTriggered).toBe(0);
+  });
+
+  it("on triggerFix failure: claim is released (resolution cleared) so next run retries", async () => {
+    vi.mocked(db.$queryRaw).mockResolvedValue([makeCIFailureRow()]);
+    vi.mocked(db.$executeRaw).mockResolvedValue(1); // claim won
+
+    // Make triggerFix fail
+    vi.mocked(createChatMessageAndTriggerStakwork).mockResolvedValue({
+      stakworkData: { error: "network timeout" },
+    } as any);
+
+    const stats = await monitorSinglePR(prUrl);
+
+    // Dispatch failed → agentTriggered not incremented
+    expect(stats.agentTriggered).toBe(0);
+    // But notify still fired (claim was won before dispatch)
+    expect(stats.notified).toBe(1);
+
+    // The trailing updatePRArtifactProgress must be called and resolution must be cleared
+    // (undefined) so next run can retry. Verify artifact.update was called.
+    expect(db.artifact.update).toHaveBeenCalledTimes(1);
+    const updateCall = vi.mocked(db.artifact.update).mock.calls[0][0];
+    const updatedContent = updateCall.data.content as { progress?: { resolution?: unknown } };
+    expect(updatedContent?.progress?.resolution).toBeUndefined();
+  });
+
+  it("no-clobber: terminal resolution written after claim is preserved by trailing write", async () => {
+    vi.mocked(db.$queryRaw).mockResolvedValue([makeCIFailureRow()]);
+    vi.mocked(db.$executeRaw).mockResolvedValue(1); // claim won
+
+    // Simulate agent-completion webhook writing terminal 'resolved' AFTER the claim
+    vi.mocked(db.artifact.findUnique).mockResolvedValue({
+      content: {
+        url: prUrl,
+        status: "IN_PROGRESS",
+        progress: {
+          state: "healthy",
+          lastCheckedAt: new Date().toISOString(),
+          resolution: {
+            status: "resolved",
+            attempts: 1,
+            lastAttemptAt: new Date().toISOString(),
+          },
+        },
+      },
+    } as any);
+
+    const stats = await monitorSinglePR(prUrl);
+
+    expect(stats.agentTriggered).toBe(1); // dispatch succeeded
+
+    // The trailing write should preserve the terminal 'resolved' state
+    const updateCall = vi.mocked(db.artifact.update).mock.calls[0][0];
+    const updatedContent = updateCall.data.content as {
+      progress?: { resolution?: { status: string } };
+    };
+    expect(updatedContent?.progress?.resolution?.status).toBe("resolved");
+  });
+
+  it("stale in_progress (older than PR_FIX_STALE_TIMEOUT_MS): claim is attempted again", async () => {
+    const staleMs = 1800000;
+    const staleDate = new Date(Date.now() - staleMs - 1000).toISOString();
+
+    vi.mocked(db.$queryRaw).mockResolvedValue([
+      makeCIFailureRow({
+        progress: {
+          state: "ci_failure",
+          lastCheckedAt: staleDate,
+          resolution: {
+            status: "in_progress",
+            attempts: 1,
+            lastAttemptAt: staleDate,
+          },
+        },
+      }),
+    ]);
+    vi.mocked(db.$executeRaw).mockResolvedValue(1); // stale row is reclaimable → claim wins
+
+    const stats = await monitorSinglePR(prUrl);
+
+    // CAS was called (stale row is reclaimable)
+    expect(db.$executeRaw).toHaveBeenCalledTimes(1);
+    expect(stats.agentTriggered).toBe(1);
+    expect(stats.notified).toBe(1);
+  });
+
+  it("gave_up artifact: CAS claim is never attempted (shouldTriggerFix=false due to gave_up gate)", async () => {
+    vi.mocked(db.$queryRaw).mockResolvedValue([
+      makeCIFailureRow({
+        progress: {
+          state: "ci_failure",
+          lastCheckedAt: new Date().toISOString(),
+          resolution: {
+            status: "gave_up",
+            attempts: 6,
+            lastAttemptAt: new Date().toISOString(),
+            lastError: "Max fix attempts (6) exceeded",
+          },
+        },
+      }),
+    ]);
+
+    const stats = await monitorSinglePR(prUrl);
+
+    // gave_up → shouldTriggerFix=false → CAS never called
+    expect(db.$executeRaw).not.toHaveBeenCalled();
+    expect(stats.agentTriggered).toBe(0);
+  });
+
+  it("attempt count is incremented by the SQL, not by in-memory snapshot (unit-level)", async () => {
+    // This test verifies that our helper delegates counting to SQL by confirming
+    // the in-memory progress.resolution.attempts reflects currentAttempts+1 for
+    // the winner path (a local estimate that matches the SQL increment).
+    // Use NO prior resolution so canAttemptFix=true (no existing resolution).
+    vi.mocked(db.$queryRaw).mockResolvedValue([
+      makeCIFailureRow({
+        // No progress → no existing resolution, so canAttemptFix=true via
+        // the !pr.progress?.resolution branch. The in-memory currentAttempts
+        // reads as 0, so the winner sets attempts=1 in progress.resolution.
+      }),
+    ]);
+    vi.mocked(db.$executeRaw).mockResolvedValue(1); // claim won
+
+    await monitorSinglePR(prUrl);
+
+    // The artifact update should contain attempts = 1 (in-memory estimate: 0+1)
+    const updateCall = vi.mocked(db.artifact.update).mock.calls[0][0];
+    const updatedContent = updateCall.data.content as {
+      progress?: { resolution?: { attempts: number; status: string } };
+    };
+    expect(updatedContent?.progress?.resolution?.attempts).toBe(1);
+    expect(updatedContent?.progress?.resolution?.status).toBe("in_progress");
   });
 });

--- a/src/lib/github/pr-monitor.ts
+++ b/src/lib/github/pr-monitor.ts
@@ -474,6 +474,67 @@ export async function checkPR(
 }
 
 /**
+ * Atomically claim an artifact's fix slot by performing a compare-and-set (CAS)
+ * UPDATE on its `content.progress.resolution` JSON.
+ *
+ * Returns true if this invocation won the claim (affected === 1), false if
+ * another concurrent invocation already holds it (or it is permanently gave_up).
+ *
+ * ISOLATION NOTE: Correctness depends on Postgres READ COMMITTED row-lock
+ * re-evaluation (EPQ). When the winner commits, the loser's UPDATE re-checks
+ * the WHERE clause against the freshly committed row and gets 0 rows instead of
+ * a serialisation error.  This helper MUST be called as its own autocommit
+ * statement — do NOT wrap it in a REPEATABLE READ or SERIALIZABLE interactive
+ * transaction, which would raise a serialisation error instead of silently losing.
+ *
+ * The WHERE clause mirrors `findSinglePRArtifact`/`findOpenPRArtifacts` exactly
+ * so the claim is self-sufficient and never relies on upstream filtering to
+ * prevent re-claiming a `gave_up` artifact.
+ *
+ * The attempt counter is incremented inside the SQL off the row's own current
+ * value — not the pre-claim in-memory snapshot — so concurrent winners cannot
+ * under-count and break the `PR_FIX_MAX_ATTEMPTS` gate.
+ *
+ * The outer `jsonb_set(…,'{progress}',COALESCE(…))` wrapper ensures a row with
+ * a missing/malformed `progress` object still claims cleanly.
+ */
+export async function claimPRFixInProgress(
+  artifactId: string,
+  staleTimeoutMs: number,
+): Promise<boolean> {
+  const nowIso = new Date().toISOString();
+  // Pass staleTimeoutMs as a string parameter and construct the Postgres interval
+  // via `((n::text) || ' milliseconds')::interval` — a raw ms integer cannot be
+  // subtracted from NOW() directly.
+  const affected = await db.$executeRaw`
+    UPDATE artifacts
+    SET content = jsonb_set(
+      jsonb_set(
+        content,
+        '{progress}',
+        COALESCE(content->'progress', '{}'::jsonb)
+      ),
+      '{progress,resolution}',
+      jsonb_build_object(
+        'status',       'in_progress',
+        'attempts',     COALESCE((content->'progress'->'resolution'->>'attempts')::int, 0) + 1,
+        'lastAttemptAt', ${nowIso}
+      )
+    )
+    WHERE id = ${artifactId}
+      AND type = 'PULL_REQUEST'
+      AND COALESCE(content->'progress'->'resolution'->>'status', '') != 'gave_up'
+      AND (
+        COALESCE(content->'progress'->'resolution'->>'status', '') != 'in_progress'
+        OR (content->'progress'->'resolution'->>'lastAttemptAt') IS NULL
+        OR (content->'progress'->'resolution'->>'lastAttemptAt')::timestamptz
+             < NOW() - ((${staleTimeoutMs}::text) || ' milliseconds')::interval
+      )
+  `;
+  return affected === 1;
+}
+
+/**
  * Update a PR artifact with new progress state
  */
 export async function updatePRArtifactProgress(
@@ -683,7 +744,7 @@ export async function findOpenPRArtifacts(limit: number = 50): Promise<
         AND (
           COALESCE(a.content->'progress'->'resolution'->>'status', '') != 'in_progress'
           OR a.content->'progress'->'resolution'->>'lastAttemptAt' IS NULL
-          OR (a.content->'progress'->'resolution'->>'lastAttemptAt')::timestamptz < NOW() - INTERVAL '30 minutes'
+          OR (a.content->'progress'->'resolution'->>'lastAttemptAt')::timestamptz < NOW() - ((${PR_FIX_STALE_TIMEOUT_MS}::text) || ' milliseconds')::interval
         )
         -- Cooldown logic: only "healthy" PRs (CI passed, no issues) have 1-hour cooldown
         -- All other states (checking, conflict, ci_failure) are re-checked every cron run
@@ -1046,17 +1107,6 @@ async function processOnePR(
       });
     }
 
-    // Notify via Pusher and create chat message
-    prLog.info("Notifying PR status change", {
-      taskId: pr.taskId,
-      prNumber: result.prNumber,
-      state: result.state,
-      problemDetails: result.problemDetails,
-      hasPod: !!pr.podId,
-    });
-    await notifyPRStatusChange(pr.taskId, result.prNumber, result.state, result.problemDetails);
-    stats.notified++;
-
     // Check if the specific fix type is enabled for this workspace
     const isFixEnabledForState =
       (result.state === "conflict" && pr.prMonitorConfig.prConflictFixEnabled) ||
@@ -1073,6 +1123,57 @@ async function processOnePR(
       progress.resolution?.status !== "gave_up";
 
     if (shouldTriggerFix) {
+      // ── Atomic CAS claim ────────────────────────────────────────────────────
+      // Perform a compare-and-set UPDATE to atomically claim the fix slot.
+      // Only the first concurrent invocation that wins the Postgres row-lock
+      // re-evaluation (EPQ) proceeds; losers see 0 affected rows and no-op.
+      // This MUST run as its own autocommit statement — see claimPRFixInProgress.
+      const claimWon = await claimPRFixInProgress(pr.artifactId, PR_FIX_STALE_TIMEOUT_MS);
+
+      if (!claimWon) {
+        // Another concurrent invocation already holds the claim. Stand down
+        // completely — no notify, no stats increment, no trailing DB write.
+        // This is intentional: the winner will write the authoritative snapshot.
+        prLog.info("CAS claim lost — duplicate delivery, standing down", {
+          taskId: pr.taskId,
+          prNumber: result.prNumber,
+          state: result.state,
+        });
+        return;
+      }
+
+      // Claim won. Reflect the claimed resolution in-memory so the trailing
+      // updatePRArtifactProgress does not clobber it (see below).
+      // Use a sentinel attempt count; the SQL incremented the real counter.
+      // We'll read it back from the claimed row if needed, but for the in-memory
+      // progress object we use currentAttempts + 1 as an accurate local estimate.
+      const claimedLastAttemptAt = new Date().toISOString();
+      progress.resolution = {
+        status: "in_progress",
+        attempts: currentAttempts + 1,
+        lastAttemptAt: claimedLastAttemptAt,
+      };
+
+      prLog.info("CAS claim won — proceeding to dispatch", {
+        taskId: pr.taskId,
+        prNumber: result.prNumber,
+        state: result.state,
+        attempt: currentAttempts + 1,
+        isStaleReclaim: isStaleInProgress,
+      });
+
+      // ── Notify (winner-only) ─────────────────────────────────────────────────
+      prLog.info("Notifying PR status change", {
+        taskId: pr.taskId,
+        prNumber: result.prNumber,
+        state: result.state,
+        problemDetails: result.problemDetails,
+        hasPod: !!pr.podId,
+      });
+      await notifyPRStatusChange(pr.taskId, result.prNumber, result.state, result.problemDetails);
+      stats.notified++;
+
+      // ── Dispatch fix (winner-only) ───────────────────────────────────────────
       const fixPrompt = buildFixPrompt(result);
       prLog.info("Triggering PR fix", {
         taskId: pr.taskId,
@@ -1087,21 +1188,19 @@ async function processOnePR(
       const triggerResult = await triggerFix(pr.taskId, fixPrompt);
       if (triggerResult.success) {
         stats.agentTriggered++;
-        // Only mark resolution as in_progress if the fix was actually dispatched
-        progress.resolution = {
-          status: "in_progress",
-          attempts: currentAttempts + 1,
-          lastAttemptAt: new Date().toISOString(),
-        };
+        // resolution is already in-memory `in_progress` from the claim above.
       } else {
-        prLog.info("Fix trigger did not dispatch, will retry next run", {
+        prLog.info("Fix trigger did not dispatch, releasing claim for retry next run", {
           taskId: pr.taskId,
           prNumber: result.prNumber,
           error: triggerResult.error,
         });
-        // Don't set resolution — leave it unset so next cron run retries
+        // Release the claim by clearing in-memory resolution so the trailing
+        // updatePRArtifactProgress writes it as undefined — the "leave unset so
+        // next cron run retries" convention from before the CAS.
+        progress.resolution = undefined;
       }
-    } else if (pr.podId && canAttemptFix && !isFixEnabledForState) {
+    } else if (canAttemptFix && !isFixEnabledForState) {
       prLog.info("Skipping PR fix - fix type disabled for workspace", {
         taskId: pr.taskId,
         prNumber: result.prNumber,
@@ -1109,7 +1208,7 @@ async function processOnePR(
         conflictFixEnabled: pr.prMonitorConfig.prConflictFixEnabled,
         ciFailureFixEnabled: pr.prMonitorConfig.prCiFailureFixEnabled,
       });
-    } else if (pr.podId && canAttemptFix && !cooldownElapsed) {
+    } else if (canAttemptFix && !cooldownElapsed) {
       prLog.info("Skipping PR fix due to cooldown", {
         taskId: pr.taskId,
         prNumber: result.prNumber,
@@ -1118,7 +1217,39 @@ async function processOnePR(
       });
     }
 
-    // Update artifact
+    if (!shouldTriggerFix) {
+      // Non-fix path: notify unconditionally for conflict/ci_failure state changes.
+      prLog.info("Notifying PR status change", {
+        taskId: pr.taskId,
+        prNumber: result.prNumber,
+        state: result.state,
+        problemDetails: result.problemDetails,
+        hasPod: !!pr.podId,
+      });
+      await notifyPRStatusChange(pr.taskId, result.prNumber, result.state, result.problemDetails);
+      stats.notified++;
+    }
+
+    // Update artifact — but preserve the just-claimed `resolution` if the
+    // dispatch succeeded so a fast agent-completion webhook that already flipped
+    // `resolution` to a terminal state isn't clobbered back to `in_progress`.
+    // We do this by re-fetching the current artifact's resolution before writing,
+    // and only overwriting if our in-memory resolution is still `in_progress`.
+    if (shouldTriggerFix && progress.resolution?.status === "in_progress") {
+      // Winner path: resolution was claimed atomically. Fetch the live artifact
+      // to check whether an agent-completion webhook already flipped it to a
+      // terminal state, and if so preserve that terminal state.
+      const live = await db.artifact.findUnique({
+        where: { id: pr.artifactId },
+        select: { content: true },
+      });
+      const liveContent = live?.content as PullRequestContent | undefined;
+      const liveResolution = liveContent?.progress?.resolution;
+      if (liveResolution && liveResolution.status !== "in_progress") {
+        // A terminal state was written after our CAS claim committed — preserve it.
+        progress.resolution = liveResolution;
+      }
+    }
     await updatePRArtifactProgress(pr.artifactId, progress);
   } else {
     // Track checking (CI pending) vs truly healthy
@@ -1243,7 +1374,7 @@ async function findSinglePRArtifact(prUrl: string): Promise<PRRecord | null> {
       AND (
         COALESCE(a.content->'progress'->'resolution'->>'status', '') != 'in_progress'
         OR a.content->'progress'->'resolution'->>'lastAttemptAt' IS NULL
-        OR (a.content->'progress'->'resolution'->>'lastAttemptAt')::timestamptz < NOW() - INTERVAL '30 minutes'
+        OR (a.content->'progress'->'resolution'->>'lastAttemptAt')::timestamptz < NOW() - ((${PR_FIX_STALE_TIMEOUT_MS}::text) || ' milliseconds')::interval
       )
       AND a.content->>'url' = ${prUrl}
     ORDER BY a.content->>'url', a.created_at DESC


### PR DESCRIPTION
Add atomic CAS claim to prevent duplicate agent-fix dispatch in PR Monitor