### PR TITLE
Bring graph-walker kg tools to parity with stakgraph mode=graph agent

### DIFF
--- a/src/__tests__/unit/lib/ai/graphWalkerTools.test.ts
+++ b/src/__tests__/unit/lib/ai/graphWalkerTools.test.ts
@@ -715,7 +715,11 @@ describe("buildGraphWalkerTools", () => {
         "https://jarvis.example.com",
         "key-123",
         "c1",
-        { edgeTypes: ["MODIFIES", "CITES"], nodeTypes: ["File"] },
+        {
+          edgeTypes: ["MODIFIES", "CITES"],
+          nodeTypes: ["File"],
+          includeEdgeCounts: true,
+        },
       );
     });
   });
@@ -866,6 +870,60 @@ describe("buildGraphWalkerTools", () => {
       expect(results[0].urn).toContain("n1");
     });
 
+    it("kg arm: forwards input_q/output_q/domains and passes through description + edges", async () => {
+      mockResolveKgSeam.mockResolvedValue({
+        workspace: "my-ws",
+        swarmUrl: "https://jarvis.example.com",
+        jarvisUrl: "https://jarvis.example.com",
+        swarmApiKey: "key-kg",
+      });
+      mockKgSearch.mockResolvedValue([
+        {
+          ref_id: "wf1",
+          node_type: "Workflow",
+          name: "Transcribe",
+          description: "Transcribes a video.",
+          edges: { HAS_STEP: 4 },
+        },
+      ]);
+      mockFormatUrn.mockImplementation(
+        (p: { realm: string; org: string; workspace?: string; type: string; id: string }) =>
+          `urn:${p.org}:${p.realm}:${p.workspace ? p.workspace + ":" : ""}${p.type}:${p.id}`,
+      );
+
+      const tools = getTools();
+      const result = await tools.graph_search.execute(
+        {
+          query: "transcribe",
+          realm: "kg",
+          workspace: "my-ws",
+          input_q: "a video file url",
+          output_q: "a transcript",
+          domains: "content",
+        },
+        {} as never,
+      );
+
+      expect(mockKgSearch).toHaveBeenCalledWith(
+        "https://jarvis.example.com",
+        "key-kg",
+        "transcribe",
+        expect.objectContaining({
+          inputQ: "a video file url",
+          outputQ: "a transcript",
+          domains: "content",
+        }),
+      );
+
+      const results = (
+        result as {
+          results: Array<{ description?: string; edges?: Record<string, number> }>;
+        }
+      ).results;
+      expect(results[0].description).toBe("Transcribes a video.");
+      expect(results[0].edges).toEqual({ HAS_STEP: 4 });
+    });
+
     it("kg arm without workspace: fans out to all member workspaces, skips unreachable", async () => {
       dbWorkspace.findMany.mockResolvedValue([
         { id: "ws-1", slug: "workspace-one" },
@@ -961,13 +1019,16 @@ describe("graph_ontology", () => {
     dbSourceControlOrg.findUnique.mockResolvedValue({ githubLogin: "my-org" });
     mockFormatUrn.mockReturnValue("urn:my-org:kg:test-ws:node:x");
     mockResolveKgSeam.mockResolvedValue(SEAM);
-    mockKgGetOntology.mockResolvedValue([
-      { type: "File", description: "A source file." },
-      { type: "Function", description: "A code function." },
-    ]);
+    mockKgGetOntology.mockResolvedValue({
+      domains: ["code"],
+      node_types: [
+        { type: "File", domain: "code", description: "A source file." },
+        { type: "Function", domain: "code", description: "A code function." },
+      ],
+    });
   });
 
-  it("returns node_types on a resolvable, authorized seam", async () => {
+  it("returns domains + node_types on a resolvable, authorized seam", async () => {
     const tools = getTools();
     const result = await tools.graph_ontology.execute(
       { workspace: "test-ws" },
@@ -975,9 +1036,10 @@ describe("graph_ontology", () => {
     );
 
     expect(result).toEqual({
+      domains: ["code"],
       node_types: [
-        { type: "File", description: "A source file." },
-        { type: "Function", description: "A code function." },
+        { type: "File", domain: "code", description: "A source file." },
+        { type: "Function", domain: "code", description: "A code function." },
       ],
     });
     expect(mockKgGetOntology).toHaveBeenCalledWith(SEAM.jarvisUrl, SEAM.swarmApiKey);
@@ -1029,8 +1091,8 @@ describe("graph_ontology", () => {
     expect(mockKgGetOntology).not.toHaveBeenCalled();
   });
 
-  it("forwards empty node_types array when kgGetOntology returns []", async () => {
-    mockKgGetOntology.mockResolvedValue([]);
+  it("forwards an empty ontology when kgGetOntology returns no types", async () => {
+    mockKgGetOntology.mockResolvedValue({ domains: [], node_types: [] });
     const tools = getTools();
 
     const result = await tools.graph_ontology.execute(
@@ -1038,7 +1100,7 @@ describe("graph_ontology", () => {
       {} as never,
     );
 
-    expect(result).toEqual({ node_types: [] });
+    expect(result).toEqual({ domains: [], node_types: [] });
   });
 });
 

--- a/src/__tests__/unit/lib/ai/kg-adapter.test.ts
+++ b/src/__tests__/unit/lib/ai/kg-adapter.test.ts
@@ -91,6 +91,61 @@ describe("kgGetNode", () => {
     expect(result?.name).toBe("Auth");
   });
 
+  it("includeEdgeCounts: fetches /connection-counts and attaches a collapsed edges map", async () => {
+    const node = { ref_id: "node-abc", node_type: "Function", name: "myFn", properties: {} };
+    const counts = {
+      counts: [
+        { edge_type: "MODIFIES", target_type: "File", count: 3 },
+        { edge_type: "MODIFIES", target_type: "Function", count: 2 },
+        { edge_type: "CITES", target_type: "Paper", count: 1 },
+      ],
+    };
+    globalThis.fetch = vi.fn().mockImplementation((url: string) =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve(url.includes("/connection-counts") ? counts : node),
+      }),
+    );
+
+    const result = await kgGetNode(JARVIS_URL, API_KEY, "node-abc", {
+      includeEdgeCounts: true,
+    });
+
+    // Counts collapse across target types: MODIFIES 3+2, CITES 1.
+    expect(result?.edges).toEqual({ MODIFIES: 5, CITES: 1 });
+    const urls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[0] as string,
+    );
+    expect(urls.some((u) => u.includes("/v2/nodes/node-abc/connection-counts"))).toBe(true);
+  });
+
+  it("includeEdgeCounts: a failed counts lookup leaves edges as {} without failing the call", async () => {
+    const node = { ref_id: "node-abc", node_type: "Function", name: "myFn", properties: {} };
+    globalThis.fetch = vi.fn().mockImplementation((url: string) =>
+      url.includes("/connection-counts")
+        ? Promise.reject(new Error("boom"))
+        : Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(node) }),
+    );
+
+    const result = await kgGetNode(JARVIS_URL, API_KEY, "node-abc", {
+      includeEdgeCounts: true,
+    });
+
+    expect(result?.ref_id).toBe("node-abc");
+    expect(result?.edges).toEqual({});
+  });
+
+  it("does not fetch connection-counts by default", async () => {
+    globalThis.fetch = mockFetch({ ref_id: "n", node_type: "File", properties: {} });
+
+    const result = await kgGetNode(JARVIS_URL, API_KEY, "n");
+
+    expect(result?.edges).toBeUndefined();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
   it("returns null on HTTP error (non-2xx)", async () => {
     globalThis.fetch = mockFetch(null, false, 404);
     const result = await kgGetNode(JARVIS_URL, API_KEY, "missing-node");
@@ -380,6 +435,53 @@ describe("kgGetNeighbors", () => {
     expect(calledUrl).toContain('node_type=%5B%22File%22%5D');
   });
 
+  it("includeEdgeCounts: sends include_edge_counts=true and attaches each neighbor's edges map", async () => {
+    const raw = {
+      nodes: [
+        { ref_id: QUERIED_REF, node_type: "Concept" },
+        {
+          ref_id: "ref-file",
+          node_type: "File",
+          name: "a.ts",
+          edges: { MODIFIES: 4, TOUCHES: 2 },
+        },
+      ],
+      edges: [
+        { source: QUERIED_REF, target: "ref-file", edge_type: "MODIFIES", properties: {} },
+      ],
+    };
+    globalThis.fetch = mockFetch(raw);
+
+    const { neighbors } = await kgGetNeighbors(JARVIS_URL, API_KEY, QUERIED_REF, {
+      includeEdgeCounts: true,
+    });
+
+    const calledUrl = (globalThis.fetch as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(calledUrl).toContain("include_edge_counts=true");
+    expect(neighbors[0].edges).toEqual({ MODIFIES: 4, TOUCHES: 2 });
+  });
+
+  it("does not send include_edge_counts (and omits edges) by default", async () => {
+    const raw = {
+      nodes: [
+        { ref_id: QUERIED_REF, node_type: "Concept" },
+        { ref_id: "ref-file", node_type: "File", name: "a.ts", edges: { MODIFIES: 4 } },
+      ],
+      edges: [
+        { source: QUERIED_REF, target: "ref-file", edge_type: "MODIFIES", properties: {} },
+      ],
+    };
+    globalThis.fetch = mockFetch(raw);
+
+    const { neighbors } = await kgGetNeighbors(JARVIS_URL, API_KEY, QUERIED_REF);
+
+    const calledUrl = (globalThis.fetch as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(calledUrl).not.toContain("include_edge_counts");
+    expect(neighbors[0].edges).toBeUndefined();
+  });
+
   it("sends canonicalize=false so multi-hump node_type filters match real labels", async () => {
     globalThis.fetch = mockFetch({ nodes: [], edges: [] });
 
@@ -479,11 +581,16 @@ describe("kgGetNodesByRefs", () => {
 // ---------------------------------------------------------------------------
 
 describe("kgSearch", () => {
-  it("hits the lite /v2/nodes/search endpoint and maps { nodes:[{title}] }", async () => {
+  it("hits the ranked /v2/nodes pipeline and maps hits with name/description/edges", async () => {
     const raw = {
       nodes: [
-        { ref_id: "n1", node_type: "Function", title: "doThing" },
-        { ref_id: "n2", node_type: "File", title: "utils.ts" },
+        {
+          ref_id: "n1",
+          node_type: "Function",
+          properties: { name: "doThing", description: "Does the thing." },
+          edges: { MODIFIES: 3, CALLS: 1 },
+        },
+        { ref_id: "n2", node_type: "File", properties: { file_name: "utils.ts" } },
       ],
     };
     globalThis.fetch = mockFetch(raw);
@@ -491,22 +598,36 @@ describe("kgSearch", () => {
     const results = await kgSearch(JARVIS_URL, API_KEY, "doThing");
 
     expect(results).toHaveLength(2);
-    expect(results[0]).toMatchObject({
+    expect(results[0]).toEqual({
       ref_id: "n1",
       node_type: "Function",
       name: "doThing",
+      description: "Does the thing.",
+      edges: { MODIFIES: 3, CALLS: 1 },
     });
-    expect(results[1]).toMatchObject({ ref_id: "n2", node_type: "File", name: "utils.ts" });
+    expect(results[1]).toMatchObject({
+      ref_id: "n2",
+      node_type: "File",
+      name: "utils.ts",
+      description: "",
+      edges: {},
+    });
 
     const calledUrl = (globalThis.fetch as ReturnType<typeof vi.fn>).mock
       .calls[0][0] as string;
-    expect(calledUrl).toContain("/v2/nodes/search");
+    expect(calledUrl).toContain("/v2/nodes?");
+    expect(calledUrl).not.toContain("/v2/nodes/search");
+    expect(calledUrl).toContain("q=doThing");
+    expect(calledUrl).toContain("include_edge_counts=true");
   });
 
-  it("returns [] when response is not the { nodes } object shape", async () => {
-    globalThis.fetch = mockFetch([{ ref_id: "x" }]); // bare array → ignored
-    const results = await kgSearch(JARVIS_URL, API_KEY, "anything");
-    expect(results).toEqual([]);
+  it("handles a bare-array response shape", async () => {
+    globalThis.fetch = mockFetch([
+      { ref_id: "x", node_type: "Topic", properties: { name: "Auth" } },
+    ]);
+    const results = await kgSearch(JARVIS_URL, API_KEY, "auth");
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ ref_id: "x", name: "Auth" });
   });
 
   it("returns empty array on fetch error", async () => {
@@ -521,14 +642,21 @@ describe("kgSearch", () => {
     expect(results).toEqual([]);
   });
 
-  it("node_type filter forwarded comma-separated (not a Python list literal)", async () => {
+  it("returns [] without fetching when no query and no input_q/output_q", async () => {
+    globalThis.fetch = mockFetch({ nodes: [] });
+    const results = await kgSearch(JARVIS_URL, API_KEY, "");
+    expect(results).toEqual([]);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("type filter forwarded comma-separated (not a Python list literal)", async () => {
     globalThis.fetch = mockFetch({ nodes: [] });
 
-    await kgSearch(JARVIS_URL, API_KEY, "func", { type: "Function" });
+    await kgSearch(JARVIS_URL, API_KEY, "func", { type: "Function,File" });
 
     const calledUrl = (globalThis.fetch as ReturnType<typeof vi.fn>).mock
       .calls[0][0] as string;
-    expect(calledUrl).toContain("node_type=Function");
+    expect(calledUrl).toContain("type=Function%2CFile");
     expect(calledUrl).not.toContain("%5B"); // no "["
   });
 
@@ -542,14 +670,62 @@ describe("kgSearch", () => {
     expect(calledUrl).toContain("limit=42");
   });
 
-  it("sends canonicalize=false so multi-hump labels match real Neo4j labels", async () => {
+  it("forwards input_q / output_q / domains as field-scoped retriever params", async () => {
     globalThis.fetch = mockFetch({ nodes: [] });
 
-    await kgSearch(JARVIS_URL, API_KEY, "pr", { type: "PullRequest" });
+    await kgSearch(JARVIS_URL, API_KEY, "transcribe", {
+      inputQ: "a video file url",
+      outputQ: "transcript",
+      domains: "content,entity",
+    });
 
     const calledUrl = (globalThis.fetch as ReturnType<typeof vi.fn>).mock
       .calls[0][0] as string;
-    expect(calledUrl).toContain("canonicalize=false");
+    expect(calledUrl).toContain("input_q=a+video+file+url");
+    expect(calledUrl).toContain("output_q=transcript");
+    expect(calledUrl).toContain("domains=content%2Centity");
+  });
+
+  it("searches with only input_q (no keyword query)", async () => {
+    globalThis.fetch = mockFetch({ nodes: [] });
+
+    await kgSearch(JARVIS_URL, API_KEY, "", { inputQ: "pdf document" });
+
+    const calledUrl = (globalThis.fetch as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(calledUrl).toContain("input_q=pdf+document");
+    expect(new URL(calledUrl).searchParams.get("q")).toBeNull();
+  });
+
+  it("filters excluded internal types (Hint/Memory/Clip/Turn) client-side", async () => {
+    const raw = {
+      nodes: [
+        { ref_id: "good", node_type: "Topic", properties: { name: "Auth" } },
+        { ref_id: "bad-1", node_type: "Hint", properties: { name: "hint" } },
+        { ref_id: "bad-2", node_type: "clip", properties: { name: "clip" } },
+      ],
+    };
+    globalThis.fetch = mockFetch(raw);
+
+    const results = await kgSearch(JARVIS_URL, API_KEY, "auth");
+
+    expect(results.map((r) => r.ref_id)).toEqual(["good"]);
+  });
+
+  it("truncates long descriptions to 300 chars", async () => {
+    const raw = {
+      nodes: [
+        {
+          ref_id: "n1",
+          node_type: "Topic",
+          properties: { name: "Auth", description: "x".repeat(500) },
+        },
+      ],
+    };
+    globalThis.fetch = mockFetch(raw);
+
+    const results = await kgSearch(JARVIS_URL, API_KEY, "auth");
+    expect(results[0].description).toHaveLength(300);
   });
 });
 
@@ -558,96 +734,160 @@ describe("kgSearch", () => {
 // ---------------------------------------------------------------------------
 
 describe("kgGetOntology", () => {
-  it("parses data.labels (real Neo4j labels) into { type, description }[]", async () => {
-    const raw = {
-      labels: [
-        { type: "PullRequest", description: "A GitHub pull request." },
-        { type: "File", description: "A source file." },
-      ],
-    };
-    globalThis.fetch = mockFetch(raw);
+  /** Route fetch to per-endpoint responses for the two ontology sources. */
+  function mockOntologyFetch(
+    labelsResponse: unknown,
+    schemaResponse: unknown,
+    { labelsOk = true, schemaOk = true } = {},
+  ) {
+    return vi.fn().mockImplementation((url: string) => {
+      const isLabels = url.includes("/graph/labels");
+      return Promise.resolve({
+        ok: isLabels ? labelsOk : schemaOk,
+        status: 200,
+        json: () => Promise.resolve(isLabels ? labelsResponse : schemaResponse),
+      });
+    });
+  }
+
+  it("merges /graph/labels (real casing) with /v2/schema (domains + descriptions)", async () => {
+    globalThis.fetch = mockOntologyFetch(
+      {
+        labels: [
+          { type: "PullRequest", description: "A GitHub pull request." },
+          { type: "File" },
+        ],
+      },
+      {
+        schemas: [
+          { type: "Pullrequest", domain: "Code", description: "schema PR desc" },
+          { type: "File", domain: "code", description: "A source file." },
+        ],
+      },
+    );
 
     const result = await kgGetOntology(JARVIS_URL, API_KEY);
 
-    expect(result).toEqual([
-      { type: "PullRequest", description: "A GitHub pull request." },
-      { type: "File", description: "A source file." },
+    expect(result).toEqual({
+      domains: ["code"],
+      node_types: [
+        // Real label casing wins; label description preferred over schema's.
+        { type: "PullRequest", domain: "code", description: "A GitHub pull request." },
+        // Missing label description falls back to schema description.
+        { type: "File", domain: "code", description: "A source file." },
+      ],
+    });
+  });
+
+  it("requests both /graph/labels and /v2/schema with x-api-token", async () => {
+    globalThis.fetch = mockOntologyFetch({ labels: [] }, { schemas: [] });
+
+    await kgGetOntology(JARVIS_URL, API_KEY);
+
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    const urls = calls.map((c) => c[0] as string).sort();
+    expect(urls).toEqual([`${JARVIS_URL}/graph/labels`, `${JARVIS_URL}/v2/schema`]);
+    for (const call of calls) {
+      expect(call[1]).toMatchObject({ headers: { "x-api-token": API_KEY } });
+    }
+  });
+
+  it("includes schema-only types (registered but no live nodes yet)", async () => {
+    globalThis.fetch = mockOntologyFetch(
+      { labels: [{ type: "File" }] },
+      {
+        schemas: [
+          { type: "Statute", domain: "legal", description: "A legal statute." },
+        ],
+      },
+    );
+
+    const result = await kgGetOntology(JARVIS_URL, API_KEY);
+
+    expect(result.node_types).toEqual([
+      { type: "File", domain: null, description: "" },
+      { type: "Statute", domain: "legal", description: "A legal statute." },
+    ]);
+    expect(result.domains).toEqual(["legal"]);
+  });
+
+  it("filters wildcard and deleted schema entries", async () => {
+    globalThis.fetch = mockOntologyFetch(
+      { labels: [] },
+      {
+        schemas: [
+          { type: "*", domain: "meta" },
+          { type: "Ghost", domain: "old", is_deleted: true },
+          { type: "Keep", domain: "entity" },
+        ],
+      },
+    );
+
+    const result = await kgGetOntology(JARVIS_URL, API_KEY);
+
+    expect(result.node_types).toEqual([
+      { type: "Keep", domain: "entity", description: "" },
+    ]);
+    expect(result.domains).toEqual(["entity"]);
+  });
+
+  it("still returns labels when /v2/schema fails (best-effort merge)", async () => {
+    globalThis.fetch = mockOntologyFetch(
+      { labels: [{ type: "PullRequest", description: "PR" }] },
+      null,
+      { schemaOk: false },
+    );
+
+    const result = await kgGetOntology(JARVIS_URL, API_KEY);
+
+    expect(result).toEqual({
+      domains: [],
+      node_types: [{ type: "PullRequest", domain: null, description: "PR" }],
+    });
+  });
+
+  it("still returns schema types when /graph/labels fails", async () => {
+    globalThis.fetch = mockOntologyFetch(
+      null,
+      { schemas: [{ type: "File", domain: "code", description: "A file." }] },
+      { labelsOk: false },
+    );
+
+    const result = await kgGetOntology(JARVIS_URL, API_KEY);
+
+    expect(result.node_types).toEqual([
+      { type: "File", domain: "code", description: "A file." },
     ]);
   });
 
-  it("requests GET /graph/labels (not /schema/all)", async () => {
-    globalThis.fetch = mockFetch({ labels: [] });
-
-    await kgGetOntology(JARVIS_URL, API_KEY);
-
-    const calledUrl = (globalThis.fetch as ReturnType<typeof vi.fn>).mock
-      .calls[0][0] as string;
-    expect(calledUrl).toBe(`${JARVIS_URL}/graph/labels`);
-    expect(calledUrl).not.toContain("/schema/all");
-  });
-
-  it("sends x-api-token header", async () => {
-    globalThis.fetch = mockFetch({ labels: [] });
-
-    await kgGetOntology(JARVIS_URL, API_KEY);
-
-    expect(globalThis.fetch).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({ headers: { "x-api-token": API_KEY } }),
+  it("filters out label entries missing a type", async () => {
+    globalThis.fetch = mockOntologyFetch(
+      { labels: [{ description: "no type here" }, { type: "File" }] },
+      { schemas: [] },
     );
-  });
-
-  it("fills missing description with empty string (newly-ingested type, no schema)", async () => {
-    globalThis.fetch = mockFetch({ labels: [{ type: "PullRequest" }] });
 
     const result = await kgGetOntology(JARVIS_URL, API_KEY);
 
-    expect(result).toEqual([{ type: "PullRequest", description: "" }]);
+    expect(result.node_types).toEqual([{ type: "File", domain: null, description: "" }]);
   });
 
-  it("filters out entries missing a type", async () => {
-    globalThis.fetch = mockFetch({
-      labels: [
-        { description: "no type here" },
-        { type: "File", description: "valid" },
-      ],
-    });
-
-    const result = await kgGetOntology(JARVIS_URL, API_KEY);
-
-    expect(result).toEqual([{ type: "File", description: "valid" }]);
-  });
-
-  it("returns [] on non-ok response", async () => {
-    globalThis.fetch = mockFetch(null, false, 503);
-
-    const result = await kgGetOntology(JARVIS_URL, API_KEY);
-
-    expect(result).toEqual([]);
-  });
-
-  it("returns [] on thrown fetch", async () => {
+  it("returns empty payload when both fetches throw", async () => {
     globalThis.fetch = mockFetchThrow();
 
     const result = await kgGetOntology(JARVIS_URL, API_KEY);
 
-    expect(result).toEqual([]);
+    expect(result).toEqual({ domains: [], node_types: [] });
   });
 
-  it("returns [] when labels is missing from response", async () => {
-    globalThis.fetch = mockFetch({ edges: [{ type: "RELATED_TO" }] });
+  it("returns empty payload on malformed responses", async () => {
+    globalThis.fetch = mockOntologyFetch(
+      { labels: "not-an-array" },
+      { schemas: "nope" },
+    );
 
     const result = await kgGetOntology(JARVIS_URL, API_KEY);
 
-    expect(result).toEqual([]);
-  });
-
-  it("returns [] when labels is not an array", async () => {
-    globalThis.fetch = mockFetch({ labels: "not-an-array" });
-
-    const result = await kgGetOntology(JARVIS_URL, API_KEY);
-
-    expect(result).toEqual([]);
+    expect(result).toEqual({ domains: [], node_types: [] });
   });
 });
 

--- a/src/lib/ai/graphWalkerTools.ts
+++ b/src/lib/ai/graphWalkerTools.ts
@@ -89,6 +89,13 @@ interface SearchResult {
   type: string;
   title: string;
   realm: "pg" | "canvas" | "kg";
+  /** kg realm only: short description of the node, when one exists. */
+  description?: string;
+  /**
+   * kg realm only: {EDGE_TYPE: count} map of the node's relationships —
+   * shows how connected it is and which edge types graph_neighbors can follow.
+   */
+  edges?: Record<string, number>;
 }
 
 // ---------------------------------------------------------------------------
@@ -723,7 +730,7 @@ async function searchConversations(
 // ---------------------------------------------------------------------------
 
 /**
- * Keyword search over Jarvis v2 knowledge-graph nodes.
+ * Hybrid (keyword + semantic) search over Jarvis v2 knowledge-graph nodes.
  *
  * - With `workspace`: resolves a single synthetic kg URN → IDOR guard → search.
  * - Without `workspace`: fans out to all org workspaces the user is a member of,
@@ -738,6 +745,9 @@ async function searchKg(
     workspace,
     type,
     limit,
+    inputQ,
+    outputQ,
+    domains,
   }: {
     orgId: string;
     urnOrg: string;
@@ -745,9 +755,12 @@ async function searchKg(
     workspace?: string;
     type?: string;
     limit: number;
+    inputQ?: string;
+    outputQ?: string;
+    domains?: string;
   },
 ): Promise<SearchResult[]> {
-  const opts = { type, limit };
+  const opts = { type, limit, inputQ, outputQ, domains };
 
   if (workspace) {
     // Single-workspace path — synthetic URN for IDOR guard
@@ -772,6 +785,8 @@ async function searchKg(
       type: hit.node_type,
       title: hit.name,
       realm: "kg" as const,
+      ...(hit.description ? { description: hit.description } : {}),
+      edges: hit.edges,
     }));
   }
 
@@ -808,6 +823,8 @@ async function searchKg(
         type: hit.node_type,
         title: hit.name,
         realm: "kg" as const,
+        ...(hit.description ? { description: hit.description } : {}),
+        edges: hit.edges,
       }));
     }),
   );
@@ -835,7 +852,9 @@ export function buildGraphWalkerTools(
       description:
         "Resolve a single URN to its full node content. " +
         "Routes by realm: `canvas` URNs are resolved locally; " +
-        "`kg` URNs are resolved live from the swarm knowledge graph (Jarvis). " +
+        "`kg` URNs are resolved live from the swarm knowledge graph (Jarvis), " +
+        "including an `edges` map ({EDGE_TYPE: count}) showing how connected the " +
+        "node is and which relationship types graph_neighbors can traverse next. " +
         "The `pg` realm is DISABLED (its entities now live in the kg). " +
         "Use this when you have a specific URN and need the entity's data.",
       inputSchema: z.object({
@@ -866,7 +885,9 @@ export function buildGraphWalkerTools(
           case "kg": {
             const seam = await resolveKgSeam(urn, { userId });
             if (!seam) return { error: "swarm not configured or access denied" };
-            const node = await kgGetNode(seam.jarvisUrl, seam.swarmApiKey, parsed.id);
+            const node = await kgGetNode(seam.jarvisUrl, seam.swarmApiKey, parsed.id, {
+              includeEdgeCounts: true,
+            });
             if (!node) return { error: "node not found" };
             return node;
           }
@@ -879,7 +900,9 @@ export function buildGraphWalkerTools(
         "Return all adjacent URNs reachable in one hop from the given node, " +
         "with edgeType and direction. " +
         "For `canvas` URNs, unions structural canvas edges with UrnEdge cross-realm edges. " +
-        "For `kg` URNs, calls Jarvis v2 with optional edge_type / node_type filters (kg-specific, ignored by other realms). " +
+        "For `kg` URNs, calls Jarvis v2 with optional edge_type / node_type filters (kg-specific, ignored by other realms); " +
+        "each kg neighbor also carries an `edges` map ({EDGE_TYPE: count}) of its OWN relationships, " +
+        "showing how connected it is and which edge types you can hop along next. " +
         "The `pg` realm is DISABLED (its entities now live in the kg).",
       inputSchema: z.object({
         urn: z.string().describe("Canonical URN of the node to expand."),
@@ -952,7 +975,7 @@ export function buildGraphWalkerTools(
               seam.jarvisUrl,
               seam.swarmApiKey,
               parsed.id,
-              { edgeTypes: edge_type, nodeTypes: node_type },
+              { edgeTypes: edge_type, nodeTypes: node_type, includeEdgeCounts: true },
             );
             if (!reachable) return { error: "swarm unreachable" };
             // Surface the derived node label as `title` (consistent with the pg
@@ -977,9 +1000,11 @@ export function buildGraphWalkerTools(
 
     graph_ontology: tool({
       description:
-        "Fetch the list of valid KG node types (with descriptions) for a workspace's knowledge graph. " +
+        "Fetch the list of valid KG node types (with domain grouping and descriptions) " +
+        "and the canonical list of valid `domains` for a workspace's knowledge graph. " +
         "Read-only. Call this FIRST before using `graph_search` with `realm: \"kg\"` — " +
-        "the returned `type` values are the exact strings to pass as the `type` filter in `graph_search`. " +
+        "the returned `type` values are the exact strings to pass as the `type` filter, " +
+        "and the `domains` values are the exact strings for the `domains` filter. " +
         "This avoids guessing node type names blind.",
       inputSchema: z.object({
         workspace: z.string().describe("Workspace slug whose KG ontology to fetch."),
@@ -1002,24 +1027,33 @@ export function buildGraphWalkerTools(
         const seam = await resolveKgSeam(syntheticUrn, { userId });
         if (!seam) return { error: "swarm not configured or access denied" };
 
-        const node_types = await kgGetOntology(seam.jarvisUrl, seam.swarmApiKey);
-        return { node_types };
+        const { domains, node_types } = await kgGetOntology(
+          seam.jarvisUrl,
+          seam.swarmApiKey,
+        );
+        return { domains, node_types };
       },
     }),
 
     graph_search: tool({
       description:
-        "Search for nodes by keyword across the canvas and kg realms, " +
+        "Search for nodes across the canvas and kg realms, " +
         "returning ranked results with URN, type, title, and realm. " +
-        "The kg realm searches Jarvis knowledge-graph nodes — including Hive " +
-        "Features, Tasks, and ChatMessages, which are mirrored into the kg as " +
-        "HiveFeature / HiveTask / HiveChatMessage nodes; the canvas realm covers " +
-        "canvas nodes. " +
+        "The kg realm runs hybrid (keyword + semantic) search over Jarvis " +
+        "knowledge-graph nodes — including Hive Features, Tasks, and " +
+        "ChatMessages, which are mirrored into the kg as HiveFeature / " +
+        "HiveTask / HiveChatMessage nodes; each kg result also carries a " +
+        "`description` and an `edges` map ({EDGE_TYPE: count}) showing how " +
+        "connected the node is and which relationship types graph_neighbors " +
+        "can traverse next. The canvas realm covers canvas nodes. " +
         "The `pg` realm is DISABLED (roadmap/chat data now lives in the kg). " +
-        "Scope with `realm`, `type`, or `workspace` to narrow results. " +
+        "Scope with `realm`, `type`, `domains`, or `workspace` to narrow results. " +
         "Default (no realm) searches canvas + kg (kg fanned out across all " +
         "member workspaces). " +
-        "For kg: provide `workspace` to search one workspace, or omit to fan-out across all member workspaces.",
+        "For kg: provide `workspace` to search one workspace, or omit to fan-out across all member workspaces. " +
+        "`input_q` / `output_q` add semantic retrievers scoped to node input/output " +
+        "schemas (e.g. find Workflows by what they consume or produce), fused with " +
+        "`query` into one ranked result set.",
       inputSchema: z.object({
         query: z.string().min(1).describe("Keyword(s) to search for."),
         realm: z
@@ -1041,6 +1075,28 @@ export function buildGraphWalkerTools(
               "(e.g. 'hivefeature', 'hivetask', 'hivechatmessage', 'File', 'Function'); " +
               "for canvas use 'node' / 'text'.",
           ),
+        input_q: z
+          .string()
+          .optional()
+          .describe(
+            "kg realm only: semantic search scoped to node INPUT schemas — find " +
+              "nodes by what they take as input, e.g. 'a video file url'. " +
+              "Applies to node types with input embeddings (Workflow, Skill).",
+          ),
+        output_q: z
+          .string()
+          .optional()
+          .describe(
+            "kg realm only: semantic search scoped to node OUTPUT schemas — find " +
+              "nodes by what they produce, e.g. 'transcript with word-level timestamps'.",
+          ),
+        domains: z
+          .string()
+          .optional()
+          .describe(
+            "kg realm only: comma-separated domain filter, e.g. 'entity' or " +
+              "'content,entity'. Call graph_ontology to see valid domains.",
+          ),
         limit: z
           .number()
           .int()
@@ -1054,12 +1110,18 @@ export function buildGraphWalkerTools(
         realm,
         workspace,
         type,
+        input_q,
+        output_q,
+        domains,
         limit = 20,
       }: {
         query: string;
         realm?: "pg" | "canvas" | "kg";
         workspace?: string;
         type?: string;
+        input_q?: string;
+        output_q?: string;
+        domains?: string;
         limit?: number;
       }) => {
         const arms: Promise<SearchResult[]>[] = [];
@@ -1090,7 +1152,17 @@ export function buildGraphWalkerTools(
         // user's member workspaces when no `workspace` is given).
         if (realm === "kg" || !realm) {
           arms.push(
-            searchKg(query, { orgId, urnOrg, userId, workspace, type, limit }),
+            searchKg(query, {
+              orgId,
+              urnOrg,
+              userId,
+              workspace,
+              type,
+              limit,
+              inputQ: input_q,
+              outputQ: output_q,
+              domains,
+            }),
           );
         }
 

--- a/src/lib/ai/kg-adapter.ts
+++ b/src/lib/ai/kg-adapter.ts
@@ -19,6 +19,12 @@ export interface KgNode {
   node_type: string;
   name: string;
   properties?: unknown;
+  /**
+   * {EDGE_TYPE: count} map of the node's relationships — how connected it is
+   * and which edge types can be traversed next. Present only when the call
+   * opted in via `includeEdgeCounts`.
+   */
+  edges?: Record<string, number>;
 }
 
 interface JarvisEdge {
@@ -46,6 +52,12 @@ export interface KgNeighborResult extends NeighborResult {
   ref_id: string;
   /** Best-effort human-readable label for the neighbor (see deriveNodeName). */
   name: string;
+  /**
+   * {EDGE_TYPE: count} map of this neighbor's OWN relationships — shows how
+   * connected it is and which edge types can be hopped along next. Present
+   * only when the call opted in via `includeEdgeCounts`.
+   */
+  edges?: Record<string, number>;
 }
 
 export interface KgNeighborsResponse {
@@ -192,6 +204,55 @@ function deriveNodeName(
 // ---------------------------------------------------------------------------
 
 /**
+ * Collapse Jarvis `/connection-counts` rows ([{edge_type, target_type, count}])
+ * into a compact `{EDGE_TYPE: totalCount}` map, summing across target types.
+ * This mirrors the inline `edges` map returned by kgSearch so both present
+ * connectivity the same way.
+ */
+export function collapseConnectionCounts(
+  counts: Array<{ edge_type: string; target_type?: string; count: number }>,
+): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const c of counts ?? []) {
+    if (!c?.edge_type) continue;
+    out[c.edge_type] = (out[c.edge_type] ?? 0) + Number(c.count ?? 0);
+  }
+  return out;
+}
+
+/**
+ * Fetch edge-type connectivity for a node from the dedicated aggregation
+ * endpoint (cheap: counts only, no neighbor materialization). Best-effort —
+ * returns `{}` on any error, never throws.
+ */
+async function fetchConnectionCounts(
+  jarvisUrl: string,
+  swarmApiKey: string,
+  refId: string,
+): Promise<Record<string, number>> {
+  try {
+    const url = `${jarvisUrl.replace(/\/$/, "")}/v2/nodes/${encodeURIComponent(refId)}/connection-counts`;
+    const res = await kgFetch(url, swarmApiKey);
+    if (!res.ok) return {};
+    const data = (await res.json()) as {
+      counts?: Array<{ edge_type: string; target_type?: string; count: number }>;
+    };
+    return collapseConnectionCounts(data?.counts ?? []);
+  } catch {
+    return {};
+  }
+}
+
+export interface KgGetNodeOpts {
+  /**
+   * When true, also fetch `/connection-counts` and attach an `edges`
+   * ({EDGE_TYPE: count}) map to the returned node. One extra (cheap,
+   * aggregation-only) request; failures leave `edges` as `{}`.
+   */
+  includeEdgeCounts?: boolean;
+}
+
+/**
  * Fetch a single node by refId.
  * Returns `{ name, node_type, ref_id, properties }` or `null` on any error.
  *
@@ -203,6 +264,7 @@ export async function kgGetNode(
   jarvisUrl: string,
   swarmApiKey: string,
   refId: string,
+  opts?: KgGetNodeOpts,
 ): Promise<KgNode | null> {
   try {
     // limit=1 keeps Jarvis from materializing the node's whole neighborhood
@@ -222,12 +284,16 @@ export async function kgGetNode(
 
     if (!raw || !raw.ref_id) return null;
     const properties = (raw.properties ?? {}) as Record<string, unknown>;
-    return {
+    const node: KgNode = {
       ref_id: raw.ref_id,
       node_type: raw.node_type,
       name: deriveNodeName(raw, properties),
       properties: raw.properties,
     };
+    if (opts?.includeEdgeCounts) {
+      node.edges = await fetchConnectionCounts(jarvisUrl, swarmApiKey, refId);
+    }
+    return node;
   } catch {
     return null;
   }
@@ -295,6 +361,12 @@ export async function kgGetNodesByRefs(
 export interface KgGetNeighborsOpts {
   edgeTypes?: string[];
   nodeTypes?: string[];
+  /**
+   * When true, ask Jarvis to attach each neighbor's own {EDGE_TYPE: count}
+   * map (`include_edge_counts=true`) so the agent can see where it can hop
+   * next without a per-neighbor round trip.
+   */
+  includeEdgeCounts?: boolean;
 }
 
 /**
@@ -341,6 +413,9 @@ export async function kgGetNeighbors(
     if (opts?.nodeTypes && opts.nodeTypes.length > 0) {
       params.set("node_type", toPythonListLiteral(opts.nodeTypes));
     }
+    if (opts?.includeEdgeCounts) {
+      params.set("include_edge_counts", "true");
+    }
     const url = `${jarvisUrl}/v2/nodes/${encodeURIComponent(refId)}?${params.toString()}`;
     const res = await kgFetch(url, swarmApiKey);
     if (!res.ok) return { neighbors: [], reachable: false };
@@ -350,12 +425,18 @@ export async function kgGetNeighbors(
     // Build a lookup map for node details keyed by ref_id, excluding the queried
     // node itself. Derive a human-readable label here while we still have the
     // node's properties — otherwise the caller only sees a bare ref_id.
-    const nodeMap = new Map<string, { node_type: string; name: string }>();
+    const nodeMap = new Map<
+      string,
+      { node_type: string; name: string; edges?: Record<string, number> }
+    >();
     for (const node of data.nodes ?? []) {
       if (node.ref_id !== refId) {
         nodeMap.set(node.ref_id, {
           node_type: node.node_type,
           name: deriveNodeName(node, (node.properties ?? {}) as Record<string, unknown>),
+          ...(opts?.includeEdgeCounts
+            ? { edges: (node as { edges?: Record<string, number> }).edges ?? {} }
+            : {}),
         });
       }
     }
@@ -389,6 +470,7 @@ export async function kgGetNeighbors(
         ref_id: neighborRefId,
         name: nodeDetail?.name ?? "",
         ...(importance !== undefined ? { importance } : {}),
+        ...(nodeDetail?.edges !== undefined ? { edges: nodeDetail.edges } : {}),
       });
 
       // Cap to keep tool output within the agent's context/token budget.
@@ -407,43 +489,132 @@ export async function kgGetNeighbors(
 
 export interface KgSchemaType {
   type: string;
+  /** Domain grouping (lowercased), or null when the type has no domain. */
+  domain: string | null;
   description: string;
+}
+
+export interface KgOntology {
+  /** Distinct, non-null, lowercased, sorted domain list. */
+  domains: string[];
+  node_types: KgSchemaType[];
 }
 
 interface JarvisGraphLabelsResponse {
   labels?: Array<{ type?: string; description?: string }>;
 }
 
+interface JarvisSchemaResponse {
+  schemas?: Array<{
+    type?: string;
+    domain?: string;
+    description?: string;
+    is_deleted?: boolean;
+  }>;
+}
+
 /**
- * Fetch the workspace's KG node-type ontology from `GET /graph/labels`.
+ * Fetch the workspace's KG node-type ontology, merging TWO sources:
  *
- * Unlike `/schema/all` (which reports capitalize-normalized schema types —
- * e.g. `Pullrequest`), `/graph/labels` returns the REAL Neo4j labels via
- * `db.labels()` (e.g. `PullRequest`), merged with schema descriptions where
- * available and including newly-ingested types that have no schema yet. This is
- * the correct discovery source for the graph-walker type filters, which now
- * match against real labels. See docs/plans/graph-walker-label-canonicalization.md.
+ * - `GET /graph/labels` — the REAL Neo4j labels via `db.labels()` (e.g.
+ *   `PullRequest`, not the capitalize-normalized `Pullrequest`), including
+ *   newly-ingested types that have no schema yet. These are the exact strings
+ *   the graph-walker type filters match against. See
+ *   docs/plans/graph-walker-label-canonicalization.md.
+ * - `GET /v2/schema` — the schema registry, which carries each type's
+ *   `domain` grouping and richer descriptions, plus registered types that have
+ *   no live nodes yet.
  *
- * Returns a `{ type, description }[]` list parsed from `data.labels`.
- * Returns `[]` on non-ok response, thrown fetch, or malformed/missing labels.
+ * The union prefers the real label casing when a type exists in both; domain
+ * and description are enriched from the schema (matched case-insensitively).
+ * Each source is best-effort: if one fetch fails the other still populates the
+ * result. Returns `{ domains: [], node_types: [] }` when both fail.
  * Never throws — matches the behavior of `kgGetNode` / `kgSearch`.
  */
 export async function kgGetOntology(
   jarvisUrl: string,
   swarmApiKey: string,
-): Promise<KgSchemaType[]> {
-  try {
-    const url = `${jarvisUrl.replace(/\/$/, "")}/graph/labels`;
-    const res = await kgFetch(url, swarmApiKey);
-    if (!res.ok) return [];
-    const data = (await res.json()) as JarvisGraphLabelsResponse;
-    if (!Array.isArray(data?.labels)) return [];
-    return data.labels
-      .filter((s) => typeof s?.type === "string" && s.type.length > 0)
-      .map((s) => ({ type: s.type as string, description: s.description ?? "" }));
-  } catch {
-    return [];
+): Promise<KgOntology> {
+  const base = jarvisUrl.replace(/\/$/, "");
+
+  const [labels, schemas] = await Promise.all([
+    (async () => {
+      try {
+        const res = await kgFetch(`${base}/graph/labels`, swarmApiKey);
+        if (!res.ok) return [];
+        const data = (await res.json()) as JarvisGraphLabelsResponse;
+        if (!Array.isArray(data?.labels)) return [];
+        return data.labels.filter(
+          (s): s is { type: string; description?: string } =>
+            typeof s?.type === "string" && s.type.length > 0,
+        );
+      } catch {
+        return [];
+      }
+    })(),
+    (async () => {
+      try {
+        const res = await kgFetch(`${base}/v2/schema`, swarmApiKey);
+        if (!res.ok) return [];
+        const data = (await res.json()) as JarvisSchemaResponse;
+        if (!Array.isArray(data?.schemas)) return [];
+        return data.schemas.filter(
+          (s): s is { type: string; domain?: string; description?: string } =>
+            typeof s?.type === "string" &&
+            s.type.length > 0 &&
+            s.type !== "*" &&
+            !s.is_deleted,
+        );
+      } catch {
+        return [];
+      }
+    })(),
+  ]);
+
+  // lower(type) → schema entry, for case-insensitive enrichment of labels.
+  const schemaByLower = new Map<
+    string,
+    { type: string; domain: string | null; description: string }
+  >();
+  for (const s of schemas) {
+    schemaByLower.set(s.type.toLowerCase(), {
+      type: s.type,
+      domain: s.domain ? s.domain.toLowerCase() : null,
+      description: s.description ?? "",
+    });
   }
+
+  const node_types: KgSchemaType[] = [];
+  const seenLower = new Set<string>();
+
+  // Real labels first — their casing wins, enriched from the schema.
+  for (const l of labels) {
+    const lower = l.type.toLowerCase();
+    if (seenLower.has(lower)) continue;
+    seenLower.add(lower);
+    const schema = schemaByLower.get(lower);
+    node_types.push({
+      type: l.type,
+      domain: schema?.domain ?? null,
+      description: l.description || schema?.description || "",
+    });
+  }
+
+  // Schema-only types (registered but no live nodes yet).
+  for (const s of schemaByLower.values()) {
+    const lower = s.type.toLowerCase();
+    if (seenLower.has(lower)) continue;
+    seenLower.add(lower);
+    node_types.push({ type: s.type, domain: s.domain, description: s.description });
+  }
+
+  const domains = [
+    ...new Set(
+      node_types.flatMap((nt) => (nt.domain !== null ? [nt.domain] : [])),
+    ),
+  ].sort();
+
+  return { domains, node_types };
 }
 
 // ---------------------------------------------------------------------------
@@ -493,53 +664,97 @@ export async function kgGetNodesByType(
 export interface KgSearchOpts {
   type?: string;
   limit?: number;
+  /**
+   * Semantic search scoped to node INPUT schemas — find nodes by what they
+   * take as input (e.g. "a video file url"). Fused with `query` via RRF.
+   * Applies to node types with input embeddings (Workflow, Skill).
+   */
+  inputQ?: string;
+  /**
+   * Semantic search scoped to node OUTPUT schemas — find nodes by what they
+   * produce (e.g. "transcript with word-level timestamps").
+   */
+  outputQ?: string;
+  /** Comma-separated domain filter (e.g. "entity" or "content,entity"). */
+  domains?: string;
 }
 
-interface JarvisSearchLiteResponse {
-  nodes?: Array<{ node_type: string; ref_id: string; title?: string }>;
+/** A search hit: node summary plus description and connectivity map. */
+export interface KgSearchHit extends KgNode {
+  description: string;
+  /** {EDGE_TYPE: count} map of the node's relationships. */
+  edges: Record<string, number>;
 }
 
 /**
- * Keyword search over Jarvis v2 nodes via the lightweight `/v2/nodes/search`
- * endpoint, which returns matches-only `{ nodes: [{ node_type, ref_id, title }] }`
- * (no neighbor expansion, no paid properties to strip). The `type` filter is
- * comma-separated; `limit` is capped at 50 server-side.
- * Returns an array of matching node summaries, or `[]` on any error.
+ * Max length of a search hit's description — long descriptive blobs (content
+ * bodies, summaries) must not flood the agent's context in a ranked list.
+ */
+const DESCRIPTION_MAX = 300;
+
+/** Lowercased set for client-side filtering of internal/low-signal types. */
+const EXCLUDED_NODE_TYPES_LOWER = new Set(
+  EXCLUDED_NODE_TYPES.map((t) => t.toLowerCase()),
+);
+
+/**
+ * Hybrid (keyword + semantic) search over Jarvis v2 nodes via the ranked
+ * `/v2/nodes` pipeline (the same endpoint the stakgraph mode=graph agent uses).
+ * `query`, `inputQ`, and `outputQ` each act as their own retriever, fused into
+ * one ranked result set. `include_edge_counts=true` attaches a per-node
+ * {EDGE_TYPE: count} map so the agent can gauge connectivity and see which
+ * relationship types it can traverse next — without a per-node round trip.
+ *
+ * The `type` filter is comma-separated; Jarvis resolves it case-insensitively
+ * against real Neo4j labels first (so `PullRequest` matches — see
+ * docs/plans/graph-walker-label-canonicalization.md). Internal/low-signal
+ * types (Hint/Memory/Clip/Turn) are filtered client-side since this endpoint
+ * has no node-type denylist param.
+ * Returns an array of matching hits, or `[]` on any error.
  */
 export async function kgSearch(
   jarvisUrl: string,
   swarmApiKey: string,
   query: string,
   opts?: KgSearchOpts,
-): Promise<KgNode[]> {
+): Promise<KgSearchHit[]> {
+  if (!query && !opts?.inputQ && !opts?.outputQ) return [];
   try {
     const params = new URLSearchParams({
-      q: query,
       limit: String(opts?.limit ?? 20),
-      // Match against the REAL Neo4j label so multi-hump types (e.g.
-      // `PullRequest`) resolve. Unresolved types simply match nothing (no 400).
-      // See docs/plans/graph-walker-label-canonicalization.md.
-      canonicalize: "false",
-      // Denylist internal/low-signal types (Hint/Memory/Clip/Turn). Jarvis
-      // drops them in the Cypher before LIMIT so they don't fill result slots.
-      // Comma-separated, matching this endpoint's node_type convention.
-      exclude_type: EXCLUDED_NODE_TYPES.join(","),
+      // Attach each hit's {EDGE_TYPE: count} connectivity map inline.
+      include_edge_counts: "true",
     });
-    if (opts?.type) {
-      params.set("node_type", opts.type);
-    }
-    const url = `${jarvisUrl}/v2/nodes/search?${params.toString()}`;
+    if (query) params.set("q", query);
+    if (opts?.inputQ) params.set("input_q", opts.inputQ);
+    if (opts?.outputQ) params.set("output_q", opts.outputQ);
+    if (opts?.type) params.set("type", opts.type);
+    if (opts?.domains) params.set("domains", opts.domains);
+    const url = `${jarvisUrl.replace(/\/$/, "")}/v2/nodes?${params.toString()}`;
     const res = await kgFetch(url, swarmApiKey);
     if (!res.ok) return [];
-    const data = (await res.json()) as JarvisSearchLiteResponse;
-    const nodes = Array.isArray(data?.nodes) ? data.nodes : [];
+    const data = (await res.json()) as JarvisNode[] | { nodes?: JarvisNode[] };
+    const nodes = Array.isArray(data) ? data : (data?.nodes ?? []);
     return nodes
-      .filter((n) => n.ref_id)
-      .map((n) => ({
-        ref_id: n.ref_id,
-        node_type: n.node_type,
-        name: n.title ?? "",
-      }));
+      .filter(
+        (n) =>
+          n.ref_id &&
+          !EXCLUDED_NODE_TYPES_LOWER.has((n.node_type ?? "").toLowerCase()),
+      )
+      .map((n) => {
+        const properties = (n.properties ?? {}) as Record<string, unknown>;
+        const rawDesc =
+          properties.description ?? properties.summary ?? properties.text ?? "";
+        const desc = typeof rawDesc === "string" ? rawDesc.trim() : "";
+        return {
+          ref_id: n.ref_id,
+          node_type: n.node_type,
+          name: deriveNodeName(n, properties),
+          description:
+            desc.length > DESCRIPTION_MAX ? desc.slice(0, DESCRIPTION_MAX) : desc,
+          edges: (n as { edges?: Record<string, number> }).edges ?? {},
+        };
+      });
   } catch {
     return [];
   }


### PR DESCRIPTION
## Summary

Jamie's direct graph-walker tools and the stakgraph `mode=graph` agent both traverse the same Jarvis knowledge graph, but the stakgraph tools (`mcp/src/repo/toolsJarvis.ts`) had a richer, more mature query surface. This PR ports those improvements into hive's `kg-adapter`, leaving the URN/auth/multi-tenant layer untouched.

### kg-adapter (`src/lib/ai/kg-adapter.ts`)

- **Hybrid search**: `kgSearch` moves from the keyword-only `/v2/nodes/search` endpoint to the ranked hybrid (keyword + semantic) `/v2/nodes` pipeline — the same one the stakgraph agent uses. Adds `input_q` / `output_q` field-scoped semantic retrievers (find Workflows/Skills by what they consume or produce, fused via RRF) and a `domains` filter. Each hit now carries a `description` (truncated to 300 chars) and an `edges` `{EDGE_TYPE: count}` connectivity map. Internal types (Hint/Memory/Clip/Turn) are filtered client-side since this endpoint has no denylist param.
- **Edge counts on `kgGetNode`**: opt-in `includeEdgeCounts` fetches the cheap `/connection-counts` aggregation and attaches a collapsed `{EDGE_TYPE: count}` map. Opt-in so existing consumers (legal benchmark routes, lingo collect) are unaffected.
- **Edge counts on `kgGetNeighbors`**: opt-in `include_edge_counts=true` attaches each neighbor's *own* connectivity map, so the agent can decide where to hop next without a per-neighbor round trip.
- **Merged ontology**: `kgGetOntology` now unions `/v2/schema` (domain grouping + descriptions + registered-but-empty types) with `/graph/labels` (real Neo4j label casing, e.g. `PullRequest`, plus newly-ingested types with no schema). Real label casing wins; each source is best-effort so one failing fetch doesn't blank the other. Returns `{ domains, node_types }`.

### graph-walker tools (`src/lib/ai/graphWalkerTools.ts`)

- `graph_search` gains `input_q`, `output_q`, and `domains` params (kg realm), and kg results surface `description` + `edges`.
- `graph_get` / `graph_neighbors` opt in to edge counts for kg URNs.
- `graph_ontology` returns the `domains` list alongside node types; tool descriptions updated to teach the agent the new connectivity signals.

All params verified against the Jarvis backend (`node_service_v2.py`): `/v2/nodes` supports `q`/`input_q`/`output_q`/`domains`/`include_edge_counts`, and the type filter resolves case-insensitively against real Neo4j labels first — so ontology-supplied labels like `PullRequest` match.

Not ported (intentionally): the recursive `graph_sub_agent` and ontology write tools — hive covers delegation via `dispatch_graph_walk`, and the write posture stays read-only.

## Test plan

- `vitest run` on `kg-adapter.test.ts` + `graphWalkerTools.test.ts`: 96 tests pass, including new coverage for hybrid search params, client-side type exclusion, description truncation, connection-count collapsing, per-neighbor edge maps, and the merged/best-effort ontology.
- `tsc` / `eslint`: no new errors or warnings on touched files (remaining ones pre-exist on master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)