### PR TITLE
Fix repo_agent Stop control: end the turn on cancel, fix empty tool output, and streaming UI status

### DIFF
--- a/src/__tests__/integration/api/ask/sync.test.ts
+++ b/src/__tests__/integration/api/ask/sync.test.ts
@@ -581,7 +581,8 @@ describe('POST /api/ask/sync', () => {
         mockFinishedStream([{ text: 'one step', toolCalls: [], toolResults: [] }]) as any,
       );
 
-      // Without maxTurns: only the default end-marker stop condition.
+      // Without maxTurns: the default conditions only (end-marker +
+      // user-cancellation).
       await POST(
         createAuthenticatedPostRequest(
           '/api/ask/sync',
@@ -590,9 +591,9 @@ describe('POST /api/ask/sync', () => {
         ),
       );
       const noCap = vi.mocked(streamText).mock.calls.at(-1)![0];
-      expect(noCap.stopWhen).toHaveLength(1);
+      expect(noCap.stopWhen).toHaveLength(2);
 
-      // With maxTurns: the cap is appended (end-marker + step cap).
+      // With maxTurns: the step cap is appended on top of the defaults.
       await POST(
         createAuthenticatedPostRequest(
           '/api/ask/sync',
@@ -601,7 +602,7 @@ describe('POST /api/ask/sync', () => {
         ),
       );
       const capped = vi.mocked(streamText).mock.calls.at(-1)![0];
-      expect(capped.stopWhen).toHaveLength(2);
+      expect(capped.stopWhen).toHaveLength(3);
     });
 
     it('counts generated steps, not input messages (100 in, 1 step out)', async () => {

--- a/src/app/org/[githubLogin]/_components/SidebarChat.tsx
+++ b/src/app/org/[githubLogin]/_components/SidebarChat.tsx
@@ -434,7 +434,10 @@ export function SidebarChat({ githubLogin }: SidebarChatProps) {
         <div className="space-y-2">
           {messages.map((message, index) => {
             const isLastMessage = index === messages.length - 1;
-            const isMessageStreaming = isLastMessage && isLoading;
+            // `isStreaming` (true until the stream settles), NOT `isLoading`
+            // (cleared on the first chunk) — with isLoading every row
+            // rendered as "done" the moment anything streamed in.
+            const isMessageStreaming = isLastMessage && isStreaming;
 
             // User messages that ride structured Approve / Reject
             // intents are not chat content for the user — the proposal

--- a/src/components/streaming/StreamingMessage.tsx
+++ b/src/components/streaming/StreamingMessage.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { CheckIcon } from "lucide-react";
 import type {
   BaseStreamingMessage,
   StreamTextPart as StreamTextPartType,
@@ -95,14 +94,8 @@ export function StreamingMessage({
       {/* Render timeline items in order */}
       {regularTimeline?.map((item) => renderTimelineItem(item))}
 
-      {!message.isStreaming && (
-        <>
-          {message.usage && <TurnTokenUsage usage={message.usage} />}
-          <div className="text-xs text-muted-foreground flex items-center gap-1 mt-1">
-            <CheckIcon className="h-3 w-3" />
-            <span>Complete</span>
-          </div>
-        </>
+      {!message.isStreaming && message.usage && (
+        <TurnTokenUsage usage={message.usage} />
       )}
 
       {shouldShowThinking() && (

--- a/src/lib/ai/askTools.ts
+++ b/src/lib/ai/askTools.ts
@@ -236,7 +236,16 @@ export async function repoAgent(
       // Requirement 5: if the run truly completed with a real result even
       // after abort was requested, return the REAL result (not cancelled).
       const result = progressData.result;
-      if (result && (typeof result === "object" || typeof result === "string")) {
+      // A bare string result is normalized to `{ content }` so callers'
+      // `.content` unwrap never silently drops a real answer.
+      if (typeof result === "string" && result.trim()) {
+        return { content: result };
+      }
+      // An empty object (what an aborted-mid-run swarm reports as
+      // "completed") is NOT a usable result — without this check it
+      // unwrapped to `.content === undefined` and the model saw a tool
+      // call with no output at all.
+      if (result && typeof result === "object" && Object.keys(result).length > 0) {
         return result as Record<string, string>;
       }
       // Completed but no usable result (e.g. empty body after abort).
@@ -244,7 +253,7 @@ export async function repoAgent(
         console.log(`[repoAgent] Completed without usable result after abort. Returning cancelled marker. requestId: ${requestId}`);
         return REPO_AGENT_CANCELLED_MARKER;
       }
-      return progressData.result || {};
+      return {};
     } else if (progressData.status === "failed" || progressData.status === "aborted") {
       if (abortRequested) {
         // Cancelled ≠ error: return structured marker, never throw.
@@ -283,6 +292,14 @@ export interface AskToolsContext {
   conversationId?: string;
   /** Client-generated turn id for this user turn. */
   turnId?: string;
+  /**
+   * Shared mutable cancellation flag for the whole turn. A repo_agent
+   * execute sets `requested: true` when the user cancels its run;
+   * `runCanvasAgent` reads it in a `stopWhen` condition to end the agent
+   * loop after the current step — so a Stop stops the TURN, instead of
+   * the model treating the cancellation as a tool failure and retrying.
+   */
+  cancellation?: { requested: boolean };
 }
 
 export function askTools(swarmUrl: string, swarmApiKey: string, repoUrls: string[], pat: string, apiKey: string, workspaceAuth?: WorkspaceAuth, context?: AskToolsContext) {
@@ -456,9 +473,23 @@ export function askTools(swarmUrl: string, swarmApiKey: string, repoUrls: string
             hooks,
           );
           if (rr === REPO_AGENT_CANCELLED_MARKER) {
-            return "The repo agent investigation was cancelled by the user.";
+            // Flag the whole turn so runCanvasAgent's stopWhen ends the
+            // agent loop — the model must not treat this as a transient
+            // failure and start another run.
+            if (context?.cancellation) context.cancellation.requested = true;
+            return "The user cancelled this investigation. Stop working on it now — do not retry and do not start another repo agent run.";
           }
-          return (rr as Record<string, string>).content;
+          const out = rr as Record<string, unknown>;
+          if (typeof out.content === "string" && out.content.trim()) {
+            return out.content;
+          }
+          // Unexpected result shape (no `content` key) — surface whatever
+          // came back rather than returning `undefined` (which the model
+          // reads as "no output" and treats as a failure to retry).
+          const fallback = JSON.stringify(out);
+          return fallback && fallback !== "{}"
+            ? fallback
+            : "The repo agent finished without returning any content.";
         } catch (e) {
           console.error("Error executing repo agent:", e);
           return "Could not execute repo agent";

--- a/src/lib/ai/askToolsMulti.ts
+++ b/src/lib/ai/askToolsMulti.ts
@@ -329,9 +329,23 @@ export function askToolsMulti(
             hooks,
           );
           if (rr === REPO_AGENT_CANCELLED_MARKER) {
-            return `The repo agent investigation for ${ws.slug} was cancelled by the user.`;
+            // Flag the whole turn so runCanvasAgent's stopWhen ends the
+            // agent loop — the model must not treat this as a transient
+            // failure and start another run.
+            if (context?.cancellation) context.cancellation.requested = true;
+            return `The user cancelled the ${ws.slug} investigation. Stop working on it now — do not retry and do not start another repo agent run.`;
           }
-          return (rr as Record<string, string>).content;
+          const out = rr as Record<string, unknown>;
+          if (typeof out.content === "string" && out.content.trim()) {
+            return out.content;
+          }
+          // Unexpected result shape (no `content` key) — surface whatever
+          // came back rather than returning `undefined` (which the model
+          // reads as "no output" and treats as a failure to retry).
+          const fallback = JSON.stringify(out);
+          return fallback && fallback !== "{}"
+            ? fallback
+            : `The repo agent for ${ws.slug} finished without returning any content.`;
         } catch (e) {
           console.error(`Error executing repo agent for ${ws.slug}:`, e);
           return `Could not execute repo agent for ${ws.slug}`;

--- a/src/lib/ai/runCanvasAgent.ts
+++ b/src/lib/ai/runCanvasAgent.ts
@@ -639,6 +639,13 @@ export async function runCanvasAgent(
   // (and unused) when no org-tool branch is built.
   const capturedWebSearchResults: CapturedSearchResult[] = [];
 
+  // Turn-level cancellation flag, shared with the repo_agent tool
+  // executes (via AskToolsContext). When the user stops a run, the
+  // execute sets `requested: true` and the `stopWhen` condition below
+  // ends the agent loop after the current step — otherwise the model
+  // treats the cancellation as a tool failure and starts another run.
+  const cancellation = { requested: false };
+
   // Capability composition inputs, shared by both branches below.
   // `orgCapabilities` is the `includes`-expanded selection in canonical
   // order, with org-gated capabilities (e.g. `prompts`, restricted to the
@@ -671,6 +678,7 @@ export async function runCanvasAgent(
     tools = askToolsMulti(workspaceConfigs, apiKey, conceptsByWorkspace, {
       conversationId: currentCanvasConversationId,
       turnId,
+      cancellation,
     });
 
     if (orgId) {
@@ -764,6 +772,7 @@ export async function runCanvasAgent(
     }, {
       conversationId: currentCanvasConversationId,
       turnId: opts.turnId,
+      cancellation,
     });
 
     // Best-effort: a swarm timeout/outage here must NOT kill the whole
@@ -968,6 +977,9 @@ export async function runCanvasAgent(
     providerOptions,
     stopWhen: [
       createHasEndMarkerCondition(),
+      // User pressed Stop on a repo_agent run — end the whole turn after
+      // the current step instead of letting the model retry the tool.
+      () => cancellation.requested,
       ...(extraStopConditions
         ? Array.isArray(extraStopConditions)
           ? extraStopConditions

--- a/src/services/canvas-active-runs-hooks.ts
+++ b/src/services/canvas-active-runs-hooks.ts
@@ -30,26 +30,17 @@ export async function setActiveRun(
   entry: ActiveRunEntry,
   turnId: string,
 ): Promise<{ abortSelf: boolean }> {
-  // Import here to access the pending-abort intent helper.
-  const { setPendingAbortIntent: _s, ...rest } = await import("./canvas-active-runs");
-  void rest;
-
-  // Use the core setActiveRun — it encodes turnId inside the key via a
-  // convention: the entry's requestId is the actual swarm request_id; the
-  // turnId is threaded via the `onRequestId` hook's closure, not stored in
-  // the entry key.  We pass turnId as a prefix so `setActiveRun` can match
-  // the pending-abort intent.
+  // Stamp the turnId onto the entry — the core `setActiveRun` matches it
+  // against a pending-abort intent (Stop pressed before this run had a
+  // request_id to abort) and returns the consumed intent on a match.
   const result = await setActiveRunCore(conversationId, {
     ...entry,
-    // Encode turnId in the run's key for pending-abort matching.
-    // Convention: requestId key in activeRuns map is the real swarm requestId.
-    // The turnId is passed separately.
-    requestId: entry.requestId,
+    turnId,
   });
 
-  // If the pending-abort intent was consumed (turnId match), auto-flag abortRequested.
+  // Intent consumed (turnId match) → flag this run abortRequested so the
+  // poll loop cancels it on its next cycle.
   if (result.pendingAbortIntent && result.pendingAbortIntent.turnId === turnId) {
-    // Mark this run as abortRequested atomically.
     const { requestAbortForAllRuns } = await import("./canvas-active-runs");
     await requestAbortForAllRuns(conversationId);
     return { abortSelf: true };

--- a/src/services/canvas-active-runs.ts
+++ b/src/services/canvas-active-runs.ts
@@ -25,8 +25,15 @@ import type { Prisma } from "@prisma/client";
 // Constants
 // ---------------------------------------------------------------------------
 
-/** Max age of an activeRun entry before we treat it as a crashed/dead run. */
-export const ACTIVE_RUN_TTL_MS = 10 * 60 * 1000; // 10 minutes
+/**
+ * Max age of an activeRun entry before we treat it as a crashed/dead run.
+ * Must comfortably exceed the longest legitimate run: repoAgent polls up
+ * to 10 min (120 × 5 s) and `/api/ask/quick` allows 800 s total — at the
+ * old 10-min TTL a still-running long poll went "stale", which made
+ * `isAbortRequestedForRun` return false and `requestAbortForAllRuns`
+ * prune it, so Stop silently no-oped on exactly the longest runs.
+ */
+export const ACTIVE_RUN_TTL_MS = 15 * 60 * 1000; // 15 minutes
 
 /** Max age of a pending-abort intent before it expires (avoids cancelling future turns). */
 export const PENDING_ABORT_TTL_MS = 60 * 1000; // 1 minute
@@ -39,6 +46,8 @@ export interface ActiveRunEntry {
   requestId: string;
   workspaceId: string;
   startedAt: string; // ISO timestamp
+  /** Client turn id this run belongs to — matched against pending-abort intents. */
+  turnId?: string;
   abortRequested?: boolean;
 }
 
@@ -103,12 +112,16 @@ export async function setActiveRun(
     const runs = liveEntries(doc.runs ?? {});
     runs[entry.requestId] = entry;
 
-    // Check for (and atomically consume) a pending-abort intent for this turnId.
+    // Check for (and atomically consume) a pending-abort intent for this
+    // turnId. Match on the entry's own `turnId` (set by the hooks wrapper);
+    // the `requestId.split(":")` form is a legacy fallback for entries
+    // whose key encodes the turn as a `<turnId>:<requestId>` prefix.
     let consumedIntent: PendingAbortIntent | undefined;
     if (doc.pendingAbortIntent) {
       const intent = doc.pendingAbortIntent;
       const expired = new Date(intent.expiresAt) < new Date();
-      if (!expired && intent.turnId === entry.requestId.split(":")[0]) {
+      const entryTurnId = entry.turnId ?? entry.requestId.split(":")[0];
+      if (!expired && intent.turnId === entryTurnId) {
         // The intent matches this run's turn — consume it.
         consumedIntent = intent;
         // Clear it so later runs in the same turn don't re-consume.


### PR DESCRIPTION
## Summary

Follow-ups to #4880 (Stop control) plus two streaming-UI fixes, prompted by testing Stop in the canvas chat: pressing Stop made the model say *"The repo_agent returned no output. Let me try a more targeted search…"* and start **another** run, and every tool call showed a "Complete" mark the moment it started.

### Stop now stops the whole turn
- repo_agent executes share a turn-level `cancellation` flag with `runCanvasAgent` (`AskToolsContext.cancellation`); a new `stopWhen` condition ends the agent loop after the step containing the cancelled tool result. Previously the model treated the cancellation as a transient tool failure and immediately retried.
- The cancelled tool result now reads "do not retry", so future turns reading this history don't re-run the investigation either.

### Why the model saw "no output" after Stop
An aborted swarm run reports `status: "completed"` with an **empty result object** on the next poll. The "completed with a real result even after abort" branch accepted any truthy result — `{}` included — and the execute unwrapped `.content` → `undefined`, so the model received a tool call with no output at all. Now:
- empty objects fall through to the cancelled marker,
- bare-string results are normalized to `{ content }`,
- unexpected result shapes are surfaced as JSON instead of `undefined`.

### Stop reliability
- `ACTIVE_RUN_TTL_MS` 10 → 15 min: a run still inside its 10-min poll window went "stale" at exactly 10 min, making `isAbortRequestedForRun` return false and `requestAbortForAllRuns` prune it — Stop silently no-oped on the longest runs.
- Pending-abort intent matching fixed: the intent's `turnId` was compared against `requestId.split(":")[0]`, but requestIds are opaque swarm ids, so the start-race Stop (pressed before the run registered) never matched. Run entries now store the real `turnId`.

### Streaming UI
- Removed the "✓ Complete" footer `StreamingMessage` picked up as a side effect of the token-usage display (#4856); `TurnTokenUsage` is kept.
- `SidebarChat` derives `isMessageStreaming` from `isStreaming` (true until the stream settles) instead of `isLoading` (cleared on the first chunk) — the old flag marked every row as done the instant anything streamed in, which is why the false "Complete" appeared immediately.

## Testing
- `repoAgentCancel`, `canvas-active-runs`, and `useSendCanvasChatMessage` unit suites pass (42 tests).
- `tsc --noEmit` clean on source files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)