### PR TITLE
Add opt-in run_step param to workflow_explorer_agent for single-step execution

### DIFF
--- a/src/lib/ai/capabilities.ts
+++ b/src/lib/ai/capabilities.ts
@@ -419,9 +419,13 @@ export const CAPABILITY_REGISTRY: Record<OrgCapability, CapabilityDefinition> =
         "**workflows** — research the Stakwork workflow library via " +
         "`workflow_explorer_agent`: find existing Workflows/Skills/Scripts " +
         "by what they take as input and produce as output, read proven step " +
-        "orderings, and spot gaps. Load when designing or discussing a new " +
-        "Stakwork workflow.",
-      // Read-only research tool — nothing to strip in readonly mode.
+        "orderings, and spot gaps; on explicit user request it can also " +
+        "test-run a single workflow step. Load when designing or discussing " +
+        "a new Stakwork workflow.",
+      // Research tool, read-only by default. Its `run_step` param can launch
+      // a single (billable) step execution, but only on explicit user
+      // request per the prompt policy — not listed in writeToolNames because
+      // stripping it in readonly mode would also remove all research.
       writeToolNames: [],
       // Org-gated to the Stakwork source-control org: the tool exposes the
       // stakwork workspace's workflow graph, so it reuses the same allow-list

--- a/src/lib/ai/workflowExplorerTools.ts
+++ b/src/lib/ai/workflowExplorerTools.ts
@@ -79,15 +79,25 @@ export function buildWorkflowExplorerTools(): ToolSet {
         "It searches components semantically by what they take as input and produce as output, reads full workflow recipes (step orderings + the skills each step uses), and reports proven, reusable building blocks with usage statistics — plus gaps where nothing exists yet. " +
         "It can also pull ground-truth run data from the Stakwork API: which workflows invoke a skill (with real use counts), recent runs and their success/error states, and the actual params and outputs each step sent — useful for citing working configurations (exact URL formats, variable interpolations) or diagnosing why a similar workflow failed. " +
         "Use it when designing or discussing a NEW Stakwork workflow: e.g. 'what existing skills take a video url as input?', 'is there already a transcription workflow, and how does it compose its steps?', 'show me real params from a successful run that uses AzureOCR'. " +
-        "STRICTLY READ-ONLY research — it cannot create or modify workflows. Heavy/slow (minutes): call it ONCE with a complete, self-contained prompt rather than several times.",
+        "READ-ONLY by default — it cannot create or modify workflows. Pass run_step: true (ONLY when the user explicitly asks to run/execute/test a specific step) to additionally let it execute one workflow step with supplied inputs and report the output. " +
+        "Heavy/slow (minutes): call it ONCE with a complete, self-contained prompt rather than several times.",
       inputSchema: z.object({
         prompt: z
           .string()
           .describe(
-            "Self-contained research task for the workflow explorer. State the goal of the workflow being designed, the input/output shapes if known (e.g. 'takes a video url, produces a transcript with timestamps'), and ask for reusable building blocks and gaps.",
+            "Self-contained research task for the workflow explorer. State the goal of the workflow being designed, the input/output shapes if known (e.g. 'takes a video url, produces a transcript with timestamps'), and ask for reusable building blocks and gaps. " +
+              "When run_step is true, also name the workflow (id if known) and step id, give the input values the user supplied (or tell it to discover required inputs and use stated test values / mock_mode), and ask for the step's resolved inputs and outputs.",
+          ),
+        run_step: z
+          .boolean()
+          .optional()
+          .describe(
+            "Enable single-step EXECUTION (stakwork_run_step) on the explorer for this call. " +
+              "Set true ONLY when the user has explicitly asked to run/execute/test a workflow step — never for ordinary research. " +
+              "Executions are real and billable.",
           ),
       }),
-      execute: async ({ prompt }: { prompt: string }) => {
+      execute: async ({ prompt, run_step }: { prompt: string; run_step?: boolean }) => {
         try {
           const { swarmUrl, swarmApiKey } = await resolveWorkflowLibrarySwarm();
           // No repo_url: workflow mode works entirely off the swarm's graph.
@@ -102,10 +112,19 @@ export function buildWorkflowExplorerTools(): ToolSet {
           // library workflows — per-customer keys 404 on workflows they don't
           // own. Optional: without it the explorer still works, minus the
           // run-research tools.
+          // run_step is a per-call opt-in: it flips the swarm-side
+          // toolsConfig.stakwork_run_step gate that registers the (billable)
+          // single-step execution tool. Omitted entirely otherwise — absence
+          // is the swarm's off state, so ordinary research calls stay
+          // strictly read-only.
+          if (run_step) {
+            console.log("[workflow_explorer_agent] step execution enabled for this call");
+          }
           const rr = await repoAgent(swarmUrl, swarmApiKey, {
             prompt,
             mode: "workflow",
             stakworkApiKey: config.STAKWORK_API_KEY || undefined,
+            ...(run_step ? { toolsConfig: { stakwork_run_step: true } } : {}),
           });
           if (typeof rr === "string") return "Workflow explorer agent was cancelled";
           return (rr as Record<string, string>).content;

--- a/src/lib/constants/prompt.ts
+++ b/src/lib/constants/prompt.ts
@@ -745,11 +745,11 @@ export function getWorkflowsCapabilitySnippet(): string {
 
 ## Workflow Explorer
 
-You have one **read-only** sub-agent tool for researching the Stakwork workflow library — the canonical catalog of existing Workflows (complete automation recipes), Skills (reusable steps), and Scripts (code snippets).
+You have one sub-agent tool for researching the Stakwork workflow library — the canonical catalog of existing Workflows (complete automation recipes), Skills (reusable steps), and Scripts (code snippets). It is **read-only by default**; single-step execution can be enabled per call (see Running a step below).
 
 ### Tool
 
-- **\`workflow_explorer_agent({ prompt })\`** — Dispatch a research agent over the workflow library's knowledge graph. It searches components semantically by their input/output schemas, reads full workflow recipes (the ordered steps and the skill each step invokes), weighs usage statistics, and reports back concrete reusable building blocks plus gaps where no existing component covers a needed capability.
+- **\`workflow_explorer_agent({ prompt, run_step? })\`** — Dispatch a research agent over the workflow library's knowledge graph. It searches components semantically by their input/output schemas, reads full workflow recipes (the ordered steps and the skill each step invokes), weighs usage statistics, and reports back concrete reusable building blocks plus gaps where no existing component covers a needed capability.
 
 ### When to use
 
@@ -763,10 +763,16 @@ You have one **read-only** sub-agent tool for researching the Stakwork workflow 
 - State the goal of the workflow being designed, and the input/output shapes if known (e.g. "takes a video url, produces a transcript with word-level timestamps").
 - Ask for reusable building blocks (with usage stats) AND gaps, not just a yes/no.
 
+### Running a step (\`run_step: true\`)
+
+- Set \`run_step: true\` ONLY when the user **explicitly asks to run, execute, or test a workflow step** ("run that step", "test call_swarm_agent with these inputs"). Questions like "what params does step X take" or "why did that step fail" are research — leave it unset.
+- Never set it proactively. If actually executing a step would help but the user hasn't asked, propose it and wait for their go-ahead. Executions are real and billable.
+- When set, make the prompt self-contained about the execution: name the workflow (id if known) and the step id, give the input values the user supplied — or tell the explorer to discover the step's required inputs first and use the user's stated test values (or \`mock_mode\` for a dry run) — and ask it to report the step's resolved inputs and outputs. One dispatch should carry the whole discover → fill → run → report loop.
+
 ### Caveats
 
 - **Heavy/slow** (an agentic loop on the swarm; can take minutes). Call it ONCE with a complete prompt rather than iterating.
-- **Strictly read-only research** — it cannot create, modify, or run workflows. Actual workflow creation happens elsewhere.
+- **Read-only by default** — it cannot create or modify workflows, and without \`run_step: true\` it cannot execute anything. Actual workflow creation happens elsewhere.
 `;
 }
 


### PR DESCRIPTION
## What

Lets the canvas agent's `workflow_explorer_agent` execute ONE Stakwork workflow step — but only when the user explicitly asks for it. Completes the chain built in stakwork/senza-lnd#7949–#7955 (the `run_step_from_template` endpoint) and stakwork/stakgraph#1478/#1479 (the swarm-side `stakwork_run_step` tool, gated on `toolsConfig.stakwork_run_step`).

## How

- **`workflowExplorerTools.ts`** — new optional `run_step: boolean` on the tool schema. When true, the call forwards `toolsConfig: { stakwork_run_step: true }` to the swarm agent, flipping its opt-in gate for that one dispatch. When absent, nothing is sent — omission is the swarm's off state, so ordinary research calls stay strictly read-only. Tool + prompt-param descriptions carry the consent rule ("set true ONLY when the user has explicitly asked to run/execute/test a workflow step — never for ordinary research; executions are real and billable").
- **`prompt.ts`** (`getWorkflowsCapabilitySnippet`) — new "Running a step" section: when to set the flag (explicit user request only, never proactively — propose and wait otherwise), and how to phrase the execution prompt (self-contained: workflow + step id, user-supplied inputs or discover-then-fill with test values / `mock_mode`, one dispatch carrying the whole discover → fill → run → report loop). "Strictly read-only" caveats updated to "read-only by default".
- **`capabilities.ts`** — menuBlurb mentions the on-request step execution. Deliberately NOT added to `writeToolNames`: readonly mode strips whole tools by name, which would also remove all research; the comment documents this trade-off.

## Why per-call rather than session-level

A session- or capability-level toggle would let one approval bleed into later unrelated calls. A per-call boolean means each execution window is opened by exactly one user request and closes immediately after — layered on top of the existing gates (org-gated `workflows` capability, server-side Stakwork API key, swarm-side `toolsConfig` opt-in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)