### PR TITLE
Generated with Hive: Namespace cross-workspace sub-agents as slug_repo_agent and wrap description with fallback

### DIFF
--- a/src/__tests__/integration/api/learnings/diagrams/create.test.ts
+++ b/src/__tests__/integration/api/learnings/diagrams/create.test.ts
@@ -330,7 +330,7 @@ describe("POST /api/learnings/diagrams/create", () => {
     const callArg = vi.mocked(repoAgent).mock.calls[0][2];
     expect(callArg.subAgents).toBeDefined();
     expect(callArg.subAgents).toHaveLength(1);
-    expect(callArg.subAgents![0].name).toBe(workspace2.slug);
+    expect(callArg.subAgents![0].name).toBe(`${workspace2.slug}_repo_agent`);
     expect(callArg.subAgents![0].url).toContain("second-ws.sphinx.chat");
     expect(callArg.subAgents![0].repoUrl).toBe("https://github.com/test-owner/second-ws-repo");
   });

--- a/src/__tests__/integration/api/learnings/diagrams/edit.test.ts
+++ b/src/__tests__/integration/api/learnings/diagrams/edit.test.ts
@@ -344,7 +344,7 @@ describe("POST /api/learnings/diagrams/edit", () => {
     const callArg = vi.mocked(repoAgent).mock.calls[0][2];
     expect(callArg.subAgents).toBeDefined();
     expect(callArg.subAgents).toHaveLength(1);
-    expect(callArg.subAgents![0].name).toBe(workspace2.slug);
+    expect(callArg.subAgents![0].name).toBe(`${workspace2.slug}_repo_agent`);
     expect(callArg.subAgents![0].url).toContain("second-ws-edit.sphinx.chat");
     expect(callArg.subAgents![0].repoUrl).toBe("https://github.com/test-owner/second-ws-edit-repo");
   });

--- a/src/__tests__/unit/services/feature-chat-plan.test.ts
+++ b/src/__tests__/unit/services/feature-chat-plan.test.ts
@@ -252,7 +252,7 @@ describe("sendFeatureChatMessage — plan_mode subAgents auto-attach", () => {
 
     expect(mockedCallStakwork).toHaveBeenCalledWith(
       expect.objectContaining({
-        subAgents: expect.arrayContaining([expect.objectContaining({ name: "org-ws-1" })]),
+        subAgents: expect.arrayContaining([expect.objectContaining({ name: "org-ws-1_repo_agent" })]),
       }),
     );
   });
@@ -271,7 +271,7 @@ describe("sendFeatureChatMessage — plan_mode subAgents auto-attach", () => {
 
     expect(mockedCallStakwork).toHaveBeenCalledWith(
       expect.objectContaining({
-        subAgents: expect.arrayContaining([expect.objectContaining({ name: "org-ws-dev" })]),
+        subAgents: expect.arrayContaining([expect.objectContaining({ name: "org-ws-dev_repo_agent" })]),
       }),
     );
   });
@@ -319,9 +319,9 @@ describe("sendFeatureChatMessage — plan_mode subAgents auto-attach", () => {
     const callArgs = mockedCallStakwork.mock.calls[0][0] as { subAgents: { name: string }[] };
     const names = callArgs.subAgents.map((a) => a.name);
     // Both present, no duplicates
-    expect(names).toContain("shared-ws");
-    expect(names).toContain("auto-ws");
-    expect(names.filter((n) => n === "shared-ws")).toHaveLength(1);
+    expect(names).toContain("shared-ws_repo_agent");
+    expect(names).toContain("auto-ws_repo_agent");
+    expect(names.filter((n) => n === "shared-ws_repo_agent")).toHaveLength(1);
   });
 
   test("passes empty subAgents when org has no accessible workspaces and no mentions (single-ws org)", async () => {

--- a/src/__tests__/unit/services/roadmap/resolve-extra-swarms.test.ts
+++ b/src/__tests__/unit/services/roadmap/resolve-extra-swarms.test.ts
@@ -64,8 +64,8 @@ describe("resolveExtraSwarms", () => {
 
     expect(result).toHaveLength(1);
     expect(result[0]).toEqual({
-      name: "my-workspace",
-      description: "My workspace description",
+      name: "my-workspace_repo_agent",
+      description: "This is a repo agent in a different workspace. Workspace description: My workspace description",
       url: "https://swarm.example.com:3355",
       apiKey: "decrypted:encrypted-key",
       repoUrls: "https://github.com/org/repo1,https://github.com/org/repo2",
@@ -75,13 +75,13 @@ describe("resolveExtraSwarms", () => {
     });
   });
 
-  it("omits description when the workspace has none", async () => {
+  it("falls back when the workspace has no description", async () => {
     mockFindFirst.mockResolvedValueOnce(makeWorkspace({ description: null }));
 
     const result = await resolveExtraSwarms("hello @my-workspace", "user-1");
 
     expect(result).toHaveLength(1);
-    expect(result[0].description).toBeUndefined();
+    expect(result[0].description).toBe("This is a repo agent in a different workspace.");
   });
 
   it("skips a slug the user is not a member of (workspace not found)", async () => {
@@ -159,7 +159,7 @@ describe("resolveExtraSwarms", () => {
     );
 
     expect(result).toHaveLength(2);
-    expect(result.map((r) => r.name)).toEqual(["ws-a", "ws-b"]);
+    expect(result.map((r) => r.name)).toEqual(["ws-a_repo_agent", "ws-b_repo_agent"]);
   });
 
   it("deduplicates a slug repeated across multiple messages", async () => {

--- a/src/__tests__/unit/services/roadmap/resolve-sub-agents.test.ts
+++ b/src/__tests__/unit/services/roadmap/resolve-sub-agents.test.ts
@@ -75,8 +75,8 @@ describe("workspaceToSubAgent", () => {
     const ws = makeWorkspace();
     const agent = workspaceToSubAgent(ws);
     expect(agent).toEqual({
-      name: "my-workspace",
-      description: "My workspace",
+      name: "my-workspace_repo_agent",
+      description: "This is a repo agent in a different workspace. Workspace description: My workspace",
       url: "https://swarm.example.com:3355",
       apiKey: "decrypted:encrypted-key",
       repoUrls: "https://github.com/org/repo1,https://github.com/org/repo2",
@@ -99,11 +99,18 @@ describe("workspaceToSubAgent", () => {
     expect(workspaceToSubAgent(ws)).toBeNull();
   });
 
-  it("omits description when workspace.description is null", () => {
+  it("falls back when description is null", () => {
     const ws = makeWorkspace({ description: null });
     const agent = workspaceToSubAgent(ws);
     expect(agent).not.toBeNull();
-    expect(agent!.description).toBeUndefined();
+    expect(agent!.description).toBe("This is a repo agent in a different workspace.");
+  });
+
+  it("falls back when description is empty string", () => {
+    const ws = makeWorkspace({ description: "" });
+    const agent = workspaceToSubAgent(ws);
+    expect(agent).not.toBeNull();
+    expect(agent!.description).toBe("This is a repo agent in a different workspace.");
   });
 });
 
@@ -153,8 +160,8 @@ describe("resolveOrgMemberSwarms", () => {
     const result = await resolveOrgMemberSwarms("user-1", "org-1");
 
     expect(result).toHaveLength(2);
-    expect(result[0].name).toBe("ws-a");
-    expect(result[1].name).toBe("ws-b");
+    expect(result[0].name).toBe("ws-a_repo_agent");
+    expect(result[1].name).toBe("ws-b_repo_agent");
   });
 
   it("silently skips workspaces with no swarm", async () => {
@@ -166,7 +173,7 @@ describe("resolveOrgMemberSwarms", () => {
     const result = await resolveOrgMemberSwarms("user-1", "org-1");
 
     expect(result).toHaveLength(1);
-    expect(result[0].name).toBe("ok-ws");
+    expect(result[0].name).toBe("ok-ws_repo_agent");
   });
 
   it("silently skips workspaces with no repositories", async () => {
@@ -178,7 +185,7 @@ describe("resolveOrgMemberSwarms", () => {
     const result = await resolveOrgMemberSwarms("user-1", "org-1");
 
     expect(result).toHaveLength(1);
-    expect(result[0].name).toBe("ok-ws");
+    expect(result[0].name).toBe("ok-ws_repo_agent");
   });
 
   it("returns empty array for an org with no accessible workspaces", async () => {
@@ -214,9 +221,9 @@ describe("resolveSubAgents", () => {
     });
 
     expect(result).toHaveLength(3);
-    expect(result.map((a) => a.name)).toContain("mentioned-ws");
-    expect(result.map((a) => a.name)).toContain("org-ws-1");
-    expect(result.map((a) => a.name)).toContain("org-ws-2");
+    expect(result.map((a) => a.name)).toContain("mentioned-ws_repo_agent");
+    expect(result.map((a) => a.name)).toContain("org-ws-1_repo_agent");
+    expect(result.map((a) => a.name)).toContain("org-ws-2_repo_agent");
   });
 
   it("deduplicates by slug — manual @mention wins over org auto-attach", async () => {
@@ -235,7 +242,8 @@ describe("resolveSubAgents", () => {
 
     expect(result).toHaveLength(1);
     // Manual mention entry is preserved (comes first, org duplicate dropped)
-    expect(result[0].description).toBe("from-mention");
+    expect(result[0].name).toBe("shared-ws_repo_agent");
+    expect(result[0].description).toBe("This is a repo agent in a different workspace. Workspace description: from-mention");
   });
 
   it("returns only mention agents when org returns nothing new", async () => {
@@ -249,7 +257,7 @@ describe("resolveSubAgents", () => {
     });
 
     expect(result).toHaveLength(1);
-    expect(result[0].name).toBe("mention-ws");
+    expect(result[0].name).toBe("mention-ws_repo_agent");
   });
 
   it("returns only org agents when no @mentions in message", async () => {
@@ -262,7 +270,7 @@ describe("resolveSubAgents", () => {
     });
 
     expect(result).toHaveLength(1);
-    expect(result[0].name).toBe("org-ws");
+    expect(result[0].name).toBe("org-ws_repo_agent");
   });
 
   it("returns empty array when both resolvers find nothing", async () => {
@@ -290,7 +298,7 @@ describe("resolveSubAgents", () => {
     });
 
     expect(result).toHaveLength(2);
-    expect(result.map((a) => a.name)).toContain("ws-a");
-    expect(result.map((a) => a.name)).toContain("ws-b");
+    expect(result.map((a) => a.name)).toContain("ws-a_repo_agent");
+    expect(result.map((a) => a.name)).toContain("ws-b_repo_agent");
   });
 });

--- a/src/services/roadmap/feature-chat.ts
+++ b/src/services/roadmap/feature-chat.ts
@@ -212,8 +212,10 @@ export function workspaceToSubAgent(
   );
   const repoUrls = workspace.repositories.map((r) => r.repositoryUrl).join(",");
   return {
-    name: workspace.slug,
-    description: workspace.description ?? undefined,
+    name: `${workspace.slug}_repo_agent`,
+    description: workspace.description
+      ? `This is a repo agent in a different workspace. Workspace description: ${workspace.description}`
+      : "This is a repo agent in a different workspace.",
     url,
     apiKey,
     repoUrls,
@@ -568,7 +570,7 @@ export async function sendFeatureChatMessage({
         sourceControlOrgId,
       });
       console.log(
-        `[feature-chat] subAgents: ${extraSwarms.filter((a) => allMessages.some((m) => m?.includes(`@${a.name}`))).length} from @-mentions, ${extraSwarms.length} total (org auto-attach)`,
+        `[feature-chat] subAgents: ${extraSwarms.filter((a) => allMessages.some((m) => m?.includes(`@${a.name.replace(/_repo_agent$/, "")}`))).length} from @-mentions, ${extraSwarms.length} total (org auto-attach)`,
       );
     } else {
       extraSwarms = await resolveExtraSwarms(allMessages, userId);


### PR DESCRIPTION
Namespace cross-workspace sub-agents as slug_repo_agent and wrap description with fallback