### PR TITLE
Make canvas workflow-explorer runs dispatch-only: webhook replaces polling

### DIFF
--- a/src/__tests__/unit/lib/ai/workflowExplorerTools.test.ts
+++ b/src/__tests__/unit/lib/ai/workflowExplorerTools.test.ts
@@ -2,40 +2,41 @@
  * Unit tests for buildWorkflowExplorerTools
  *
  * Coverage:
- *   - Isolation: no-context callers (no ctx) create no row and pass no webhookUrl.
- *   - Isolation: callers with ctx but no currentCanvasConversationId create no row.
- *   - User cancellation: REPO_AGENT_CANCELLED_MARKER → row claimed FAILED.
- *   - Initiation failure (throws before request_id) → row claimed FAILED.
- *   - Inline success: row claimed DELIVERED_INLINE; content returned.
- *   - Inline race (webhook claimed first): "already posted" note returned.
- *   - Poll timeout with request_id: row stays PENDING; "still running" message.
- *   - Tool signature / schema sanity.
+ *   - Isolation: no-context callers use the inline poll path (no row, no webhookUrl).
+ *   - Ctx without currentCanvasConversationId / publicBaseUrl / ownership: same fallback.
+ *   - Dispatch path (canvas): row created, dispatchRepoAgent called with a tokenized
+ *     webhookUrl, requestId saved, dispatch message returned, row left PENDING
+ *     (the webhook is the sole delivery path — no poll, no inline claim).
+ *   - Fan-back setup failure: degrades to the inline poll path.
+ *   - Initiation failure (dispatch throws before a request_id) → row claimed FAILED.
+ *   - Inline poll path: content return, cancellation marker, and error behavior unchanged.
+ *   - Token security: the bearer token rides in the webhookUrl; only its SHA-256 is stored.
  */
 
 import { describe, test, expect, vi, beforeEach } from "vitest";
+import crypto from "crypto";
 
 // ── Hoisted mock factories ────────────────────────────────────────────────────
 
 const {
   mockRepoAgent,
-  mockResolveWorkflowLibrarySwarm,
+  mockDispatchRepoAgent,
   mockResolveOrgConversationRowId,
   mockAgentRunCreate,
   mockAgentRunUpdate,
   mockAgentRunUpdateMany,
-  mockRandomBytes,
 } = vi.hoisted(() => ({
   mockRepoAgent: vi.fn(),
-  mockResolveWorkflowLibrarySwarm: vi.fn(),
+  mockDispatchRepoAgent: vi.fn(),
   mockResolveOrgConversationRowId: vi.fn(),
   mockAgentRunCreate: vi.fn(),
   mockAgentRunUpdate: vi.fn(),
   mockAgentRunUpdateMany: vi.fn(),
-  mockRandomBytes: vi.fn(),
 }));
 
 vi.mock("@/lib/ai/askTools", () => ({
   repoAgent: mockRepoAgent,
+  dispatchRepoAgent: mockDispatchRepoAgent,
   REPO_AGENT_CANCELLED_MARKER: "__repo_agent_user_cancelled__",
 }));
 
@@ -72,23 +73,6 @@ vi.mock("@/services/org-canvas-conversation", () => ({
   resolveOrgConversationRowId: mockResolveOrgConversationRowId,
 }));
 
-// Intercept crypto.randomBytes
-vi.mock("crypto", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("crypto")>();
-  return {
-    ...actual,
-    default: {
-      ...actual,
-      randomBytes: (n: number) => {
-        const result = mockRandomBytes(n);
-        if (result) return result;
-        return actual.randomBytes(n);
-      },
-      createHash: actual.createHash, // keep real SHA-256 for tokenHash
-    },
-  };
-});
-
 import { buildWorkflowExplorerTools } from "@/lib/ai/workflowExplorerTools";
 import type { CapabilityContext } from "@/lib/ai/capabilities";
 
@@ -101,6 +85,14 @@ function makeCtx(overrides: Partial<CapabilityContext> = {}): CapabilityContext 
     capturedWebSearchResults: [],
     ...overrides,
   };
+}
+
+/** Ctx with both fan-back prerequisites (conversation + public base URL). */
+function makeCanvasCtx(): CapabilityContext {
+  return makeCtx({
+    currentCanvasConversationId: "conv-1",
+    publicBaseUrl: "https://hive.example.com",
+  });
 }
 
 function getExecute(ctx?: CapabilityContext) {
@@ -116,8 +108,8 @@ function getExecute(ctx?: CapabilityContext) {
 describe("buildWorkflowExplorerTools", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockRandomBytes.mockReturnValue(null); // fall through to real crypto by default
     mockRepoAgent.mockResolvedValue({ content: "workflow research result" });
+    mockDispatchRepoAgent.mockResolvedValue("req-123");
     mockAgentRunCreate.mockResolvedValue({ id: "run-test-1" });
     mockAgentRunUpdateMany.mockResolvedValue({ count: 1 });
     mockAgentRunUpdate.mockResolvedValue({});
@@ -131,108 +123,130 @@ describe("buildWorkflowExplorerTools", () => {
     expect(tools).toHaveProperty("workflow_explorer_agent");
   });
 
-  // ── Isolation: no-context callers ────────────────────────────────────────────
+  // ── Isolation: no-context callers use the inline poll path ───────────────────
 
-  test("no ctx: does NOT create an AgentRun row or pass webhookUrl", async () => {
+  test("no ctx: polls inline — no AgentRun row, no dispatch, no webhookUrl", async () => {
     const execute = getExecute(/* no ctx */);
-    await execute({ prompt: "find transcription skills" });
+    const result = await execute({ prompt: "find transcription skills" });
 
     expect(mockAgentRunCreate).not.toHaveBeenCalled();
-    // repoAgent called without webhookUrl
-    const call = mockRepoAgent.mock.calls[0];
-    expect(call[2]).not.toHaveProperty("webhookUrl");
+    expect(mockDispatchRepoAgent).not.toHaveBeenCalled();
+    expect(mockRepoAgent).toHaveBeenCalledOnce();
+    expect(mockRepoAgent.mock.calls[0][2]).not.toHaveProperty("webhookUrl");
+    expect(result).toBe("workflow research result");
   });
 
-  test("ctx without currentCanvasConversationId: does NOT create row", async () => {
+  test("ctx without currentCanvasConversationId: polls inline, no row", async () => {
     const execute = getExecute(makeCtx({ publicBaseUrl: "https://hive.example.com" }));
     await execute({ prompt: "find transcription skills" });
 
     expect(mockAgentRunCreate).not.toHaveBeenCalled();
+    expect(mockDispatchRepoAgent).not.toHaveBeenCalled();
+    expect(mockRepoAgent).toHaveBeenCalledOnce();
   });
 
-  test("ctx without publicBaseUrl: does NOT create row", async () => {
+  test("ctx without publicBaseUrl: polls inline, no row", async () => {
     const execute = getExecute(makeCtx({ currentCanvasConversationId: "conv-1" }));
     await execute({ prompt: "find transcription skills" });
 
     expect(mockAgentRunCreate).not.toHaveBeenCalled();
+    expect(mockDispatchRepoAgent).not.toHaveBeenCalled();
+    expect(mockRepoAgent).toHaveBeenCalledOnce();
   });
 
-  test("ctx with conversation that fails ownership check: does NOT create row", async () => {
+  test("ctx with conversation that fails ownership check: polls inline, no row", async () => {
     mockResolveOrgConversationRowId.mockResolvedValue(null); // IDOR check fails
-    const execute = getExecute(
-      makeCtx({ currentCanvasConversationId: "conv-1", publicBaseUrl: "https://hive.example.com" }),
-    );
+    const execute = getExecute(makeCanvasCtx());
     await execute({ prompt: "find transcription skills" });
 
     expect(mockAgentRunCreate).not.toHaveBeenCalled();
+    expect(mockDispatchRepoAgent).not.toHaveBeenCalled();
+    expect(mockRepoAgent).toHaveBeenCalledOnce();
   });
 
-  // ── Inline success path ───────────────────────────────────────────────────────
+  // ── Dispatch path (canvas conversation) ──────────────────────────────────────
 
-  test("inline success: creates row, claims DELIVERED_INLINE, returns content", async () => {
-    const execute = getExecute(
-      makeCtx({ currentCanvasConversationId: "conv-1", publicBaseUrl: "https://hive.example.com" }),
-    );
+  test("canvas ctx: creates row, dispatches with webhookUrl, returns background message", async () => {
+    const execute = getExecute(makeCanvasCtx());
     const result = await execute({ prompt: "find transcription skills" });
 
+    // Row created with validated ownership fields and a hashed token
     expect(mockAgentRunCreate).toHaveBeenCalledOnce();
     const createArgs = mockAgentRunCreate.mock.calls[0][0].data;
     expect(createArgs.conversationId).toBe("validated-conv-id");
     expect(createArgs.orgId).toBe("org-1");
     expect(createArgs.userId).toBe("user-1");
-    expect(typeof createArgs.tokenHash).toBe("string");
     expect(createArgs.tokenHash).toHaveLength(64); // SHA-256 hex
 
-    // webhookUrl passed to repoAgent — id and bearer token both ride in the
-    // query string (stakgraph POSTs the URL verbatim with no custom headers)
-    const repoAgentParams = mockRepoAgent.mock.calls[0][2];
-    expect(repoAgentParams.webhookUrl).toContain("/api/agent-runs/webhook?id=");
-    expect(repoAgentParams.webhookUrl).toMatch(/&token=[0-9a-f]{64}$/i);
+    // Dispatch-only: no poll loop
+    expect(mockDispatchRepoAgent).toHaveBeenCalledOnce();
+    expect(mockRepoAgent).not.toHaveBeenCalled();
 
-    // Claimed DELIVERED_INLINE
-    expect(mockAgentRunUpdateMany).toHaveBeenCalledWith(
+    // webhookUrl carries id + bearer token in the query string (stakgraph
+    // POSTs the URL verbatim with no custom headers)
+    const dispatchParams = mockDispatchRepoAgent.mock.calls[0][2];
+    expect(dispatchParams.webhookUrl).toContain("/api/agent-runs/webhook?id=");
+    expect(dispatchParams.webhookUrl).toMatch(/&token=[0-9a-f]{64}$/i);
+
+    // requestId saved; row NOT claimed (stays PENDING for the webhook)
+    expect(mockAgentRunUpdate).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({ status: "PENDING" }),
-        data: expect.objectContaining({ status: "DELIVERED_INLINE" }),
+        where: { id: "run-test-1" },
+        data: expect.objectContaining({ requestId: "req-123" }),
       }),
     );
+    expect(mockAgentRunUpdateMany).not.toHaveBeenCalled();
 
-    // Content returned
+    expect(result).toContain("researching in the background");
+  });
+
+  test("requestId save failure is non-fatal — dispatch message still returned", async () => {
+    mockAgentRunUpdate.mockRejectedValue(new Error("db write failed"));
+    const execute = getExecute(makeCanvasCtx());
+    const result = await execute({ prompt: "find transcription skills" });
+
+    expect(result).toContain("researching in the background");
+  });
+
+  test("fan-back setup failure degrades to the inline poll path", async () => {
+    mockAgentRunCreate.mockRejectedValue(new Error("db down"));
+    const execute = getExecute(makeCanvasCtx());
+    const result = await execute({ prompt: "find transcription skills" });
+
+    expect(mockDispatchRepoAgent).not.toHaveBeenCalled();
+    expect(mockRepoAgent).toHaveBeenCalledOnce();
     expect(result).toBe("workflow research result");
   });
 
-  test("inline race (webhook won first): returns 'already posted' note", async () => {
-    // Simulate webhook claimed first — updateMany returns count=0
-    mockAgentRunUpdateMany.mockResolvedValue({ count: 0 });
+  // ── Initiation failure ────────────────────────────────────────────────────────
 
-    const execute = getExecute(
-      makeCtx({ currentCanvasConversationId: "conv-1", publicBaseUrl: "https://hive.example.com" }),
-    );
+  test("dispatch failure: claims row FAILED, returns error message", async () => {
+    mockDispatchRepoAgent.mockRejectedValue(new Error("Failed to initiate repo agent"));
+
+    const execute = getExecute(makeCanvasCtx());
     const result = await execute({ prompt: "find transcription skills" });
 
-    expect(result).toContain("already been posted");
-  });
-
-  // ── User cancellation ─────────────────────────────────────────────────────────
-
-  test("user cancellation: claims row FAILED, returns cancelled message", async () => {
-    mockRepoAgent.mockResolvedValue("__repo_agent_user_cancelled__");
-
-    const execute = getExecute(
-      makeCtx({ currentCanvasConversationId: "conv-1", publicBaseUrl: "https://hive.example.com" }),
-    );
-    const result = await execute({ prompt: "find transcription skills" });
-
-    // Row claimed FAILED
     expect(mockAgentRunUpdateMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({ status: "PENDING" }),
         data: expect.objectContaining({ status: "FAILED" }),
       }),
     );
-
-    expect(result).toContain("cancelled");
+    expect(result).toContain("Could not execute");
   });
+
+  test("inline poll failure with no ctx: no row interaction, returns error message", async () => {
+    mockRepoAgent.mockRejectedValue(new Error("swarm error"));
+
+    const execute = getExecute(/* no ctx */);
+    const result = await execute({ prompt: "find transcription skills" });
+
+    expect(mockAgentRunCreate).not.toHaveBeenCalled();
+    expect(mockAgentRunUpdateMany).not.toHaveBeenCalled();
+    expect(result).toContain("Could not execute");
+  });
+
+  // ── Cancellation (inline poll path only) ─────────────────────────────────────
 
   test("no-context cancellation: no row interaction, returns cancelled message", async () => {
     mockRepoAgent.mockResolvedValue("__repo_agent_user_cancelled__");
@@ -245,90 +259,20 @@ describe("buildWorkflowExplorerTools", () => {
     expect(result).toContain("cancelled");
   });
 
-  // ── Initiation failure ────────────────────────────────────────────────────────
-
-  test("initiation failure (throws before request_id): claims row FAILED immediately", async () => {
-    mockRepoAgent.mockRejectedValue(new Error("Failed to initiate repo agent"));
-
-    const execute = getExecute(
-      makeCtx({ currentCanvasConversationId: "conv-1", publicBaseUrl: "https://hive.example.com" }),
-    );
-    const result = await execute({ prompt: "find transcription skills" });
-
-    // hasRequestId is false → initiation failure path
-    expect(mockAgentRunUpdateMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({ status: "FAILED" }),
-      }),
-    );
-    // Not the poll-timeout message
-    expect(result).not.toContain("still running");
-    expect(result).toContain("Could not execute");
-  });
-
-  test("initiation failure with no ctx: no row interaction, returns error message", async () => {
-    mockRepoAgent.mockRejectedValue(new Error("swarm error"));
-
-    const execute = getExecute(/* no ctx */);
-    const result = await execute({ prompt: "find transcription skills" });
-
-    expect(mockAgentRunCreate).not.toHaveBeenCalled();
-    expect(mockAgentRunUpdateMany).not.toHaveBeenCalled();
-    expect(result).toContain("Could not execute");
-  });
-
-  // ── Poll timeout after genuine start ─────────────────────────────────────────
-
-  test("poll timeout after genuine start: row stays PENDING, returns 'still running' message", async () => {
-    // Simulate: onRequestId fires first (setting hasRequestId = true), then repoAgent throws
-    let onRequestIdHook: ((id: string) => Promise<void>) | undefined;
-    mockRepoAgent.mockImplementation(
-      async (_url: unknown, _key: unknown, _params: unknown, _bifrost: unknown, hooks: { onRequestId?: (id: string) => Promise<void> }) => {
-        onRequestIdHook = hooks?.onRequestId;
-        if (onRequestIdHook) await onRequestIdHook("req-123");
-        throw new Error("Repo agent execution timed out. Please try again.");
-      },
-    );
-
-    const execute = getExecute(
-      makeCtx({ currentCanvasConversationId: "conv-1", publicBaseUrl: "https://hive.example.com" }),
-    );
-    const result = await execute({ prompt: "find transcription skills" });
-
-    // Row NOT claimed (stays PENDING)
-    expect(mockAgentRunUpdateMany).not.toHaveBeenCalled();
-
-    // requestId saved to the row
-    expect(mockAgentRunUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({ requestId: "req-123" }),
-      }),
-    );
-
-    // "still running" message
-    expect(result).toContain("still running");
-    expect(result).not.toContain("Could not execute");
-  });
-
   // ── Token security ────────────────────────────────────────────────────────────
 
   test("stored tokenHash is SHA-256 of the URL-borne raw token, not the raw token itself", async () => {
-    const execute = getExecute(
-      makeCtx({ currentCanvasConversationId: "conv-1", publicBaseUrl: "https://hive.example.com" }),
-    );
+    const execute = getExecute(makeCanvasCtx());
     await execute({ prompt: "find transcription skills" });
 
     const createArgs = mockAgentRunCreate.mock.calls[0][0].data;
     // The raw token rides in the webhookUrl query string (stakgraph relays
     // no headers) — extract it and verify only its hash was persisted.
-    const url: string = mockRepoAgent.mock.calls[0][2].webhookUrl;
+    const url: string = mockDispatchRepoAgent.mock.calls[0][2].webhookUrl;
     const rawToken = new URL(url).searchParams.get("token") as string;
     expect(rawToken).toMatch(/^[0-9a-f]{64}$/i);
 
-    const expectedHash = require("crypto")
-      .createHash("sha256")
-      .update(rawToken)
-      .digest("hex");
+    const expectedHash = crypto.createHash("sha256").update(rawToken).digest("hex");
     expect(createArgs.tokenHash).toBe(expectedHash);
     expect(createArgs.tokenHash).not.toBe(rawToken);
   });

--- a/src/app/api/mock/stakgraph/repo/agent/route.ts
+++ b/src/app/api/mock/stakgraph/repo/agent/route.ts
@@ -28,10 +28,12 @@ export const dynamic = "force-dynamic";
  * to simulate a swarm failure. Set `webhookMode` in the body:
  *   - `"success"` (default) — fires a completed callback after 500 ms
  *   - `"fail"` — fires a failed/aborted callback after 500 ms
- *   - `"inline"` — fires NO callback (the inline poll path should catch it)
+ *   - `"inline"` — fires NO callback. For canvas dispatch-only runs this
+ *     simulates a lost webhook (row stays PENDING); for non-canvas callers
+ *     the inline poll path picks the result up from the progress route.
  *
- * The inline short-run path continues to be exercised by the existing mock
- * progress route (`/api/mock/stakgraph/progress/route.ts`).
+ * The poll path continues to be exercised by the existing mock progress
+ * route (`/api/mock/stakgraph/progress/route.ts`).
  */
 export async function POST(request: NextRequest) {
   try {

--- a/src/lib/ai/askTools.ts
+++ b/src/lib/ai/askTools.ts
@@ -80,6 +80,55 @@ export function isCancelledMarker(v: unknown): v is RepoCancelledMarker {
  */
 const ABORT_GRACE_CYCLES = 3;
 
+/** Shared initiate POST to the swarm's /repo/agent. Returns the request_id. */
+async function initiateRun(
+  swarmUrl: string,
+  swarmApiKey: string,
+  body: Record<string, unknown>,
+): Promise<string> {
+  const initiateResponse = await fetch(`${swarmUrl}/repo/agent`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-token": swarmApiKey,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!initiateResponse.ok) {
+    const errorText = await initiateResponse.text();
+    console.error(`[repoAgent] Repo agent initiation error: ${initiateResponse.status} - ${errorText}`);
+    throw new Error("Failed to initiate repo agent");
+  }
+
+  const initiateData = await initiateResponse.json();
+  const requestId = initiateData.request_id;
+
+  if (!requestId) {
+    throw new Error("No request_id returned from repo agent");
+  }
+
+  return requestId;
+}
+
+/**
+ * Dispatch-only variant of `repoAgent`: initiate the run on the swarm and
+ * return its request_id WITHOUT polling for the result.
+ *
+ * For callers that register a `webhookUrl` in `params` — the swarm's
+ * terminal webhook is then the sole delivery path, so holding a poll loop
+ * open for the life of the run would be redundant (and an inline-vs-webhook
+ * delivery race the receiver would have to arbitrate). See
+ * `workflowExplorerTools.ts` for the canonical caller.
+ */
+export async function dispatchRepoAgent(
+  swarmUrl: string,
+  swarmApiKey: string,
+  params: { prompt: string; [key: string]: unknown },
+): Promise<string> {
+  return initiateRun(swarmUrl, swarmApiKey, { ...params });
+}
+
 export async function repoAgent(
   swarmUrl: string,
   swarmApiKey: string,
@@ -178,27 +227,7 @@ export async function repoAgent(
     body.headers = bifrost.headers ?? {};
   }
 
-  const initiateResponse = await fetch(`${swarmUrl}/repo/agent`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "x-api-token": swarmApiKey,
-    },
-    body: JSON.stringify(body),
-  });
-
-  if (!initiateResponse.ok) {
-    const errorText = await initiateResponse.text();
-    console.error(`[repoAgent] Repo agent initiation error: ${initiateResponse.status} - ${errorText}`);
-    throw new Error("Failed to initiate repo agent");
-  }
-
-  const initiateData = await initiateResponse.json();
-  const requestId = initiateData.request_id;
-
-  if (!requestId) {
-    throw new Error("No request_id returned from repo agent");
-  }
+  const requestId = await initiateRun(swarmUrl, swarmApiKey, body);
 
   // Fire the onRequestId hook so the caller can register the run atomically.
   if (hooks?.onRequestId) {

--- a/src/lib/ai/workflowExplorerTools.ts
+++ b/src/lib/ai/workflowExplorerTools.ts
@@ -15,23 +15,29 @@
  * Stakwork source-control org (see `capabilities.ts`) — other orgs' agents
  * never see this tool.
  *
- * ## Webhook fan-back safety net
+ * ## Webhook delivery (canvas conversations)
  *
- * When a canvas conversation is active (`ctx.currentCanvasConversationId`),
- * the tool creates a `PENDING` `AgentRun` arbitration row and passes a
- * `webhookUrl` to the swarm so long runs (that outlive the Vercel lambda)
- * are delivered exactly once into the conversation via the callback path.
+ * When a canvas conversation is active (`ctx.currentCanvasConversationId` +
+ * `ctx.publicBaseUrl`), the tool is DISPATCH-ONLY: it creates a `PENDING`
+ * `AgentRun` row, initiates the run with a `webhookUrl`, and returns
+ * immediately. The swarm's terminal webhook is the sole delivery path — the
+ * result is fanned into the conversation by `/api/agent-runs/webhook` when
+ * the run finishes. No poll loop, no inline-vs-webhook race, and the lambda
+ * is never pinned for the life of a long run.
  *
  * Delivery state machine:
- *   - **Inline success**: claim PENDING → DELIVERED_INLINE, return content to the model.
- *   - **Inline race** (webhook claimed first): return a short "already posted" note.
- *   - **Initiation failure** (repoAgent throws before a request_id): claim PENDING → FAILED
+ *   - **Dispatch success**: row stays PENDING; the webhook later claims it to
+ *     DELIVERED_WEBHOOK (result posted) or FAILED (failure note posted).
+ *   - **Initiation failure** (dispatch throws — no request_id): claim PENDING → FAILED
  *     immediately (no callback can ever arrive — avoids orphaned PENDING rows).
- *   - **User cancellation / abort** (REPO_AGENT_CANCELLED_MARKER): claim PENDING → FAILED
- *     so a late "completed despite abort" webhook no-ops the claim.
- *   - **Poll timeout after genuine start** (has request_id): leave PENDING; tell the model
- *     the run is still running and its result will post to the conversation when done.
- *   - **No ctx / no conversation**: behave exactly as before — no row, no webhookUrl.
+ *   - **No ctx / no conversation / no publicBaseUrl**: no delivery target exists, so
+ *     the tool falls back to the classic inline poll path — no row, no webhookUrl,
+ *     result returned to the model in-turn.
+ *
+ * RESIDUAL GAP: if the swarm process dies mid-run (webhook never fires and
+ * retries exhaust), the row stays PENDING forever. A stale-row sweep that
+ * re-polls /progress with the saved requestId is deferred to a follow-up
+ * (add @@index([status, createdAt]) alongside it).
  *
  * NEVER log the raw token or full webhookUrl. Log only runId and status.
  */
@@ -42,7 +48,7 @@ import crypto from "crypto";
 import { db } from "@/lib/db";
 import { EncryptionService } from "@/lib/encryption";
 import { config } from "@/config/env";
-import { repoAgent } from "./askTools";
+import { repoAgent, dispatchRepoAgent } from "./askTools";
 import type { CapabilityContext } from "./capabilities";
 import { resolveOrgConversationRowId } from "@/services/org-canvas-conversation";
 
@@ -100,21 +106,14 @@ function hashToken(token: string): string {
 }
 
 /**
- * Attempt to atomically claim a `PENDING` AgentRun row to `newStatus`.
- * Returns `true` when this caller won the claim, `false` when the row was
- * already claimed (exactly-once: the other path already won).
+ * Atomically claim a `PENDING` AgentRun row to FAILED (initiation failure —
+ * no webhook can ever arrive for it). Returns `true` when this caller won
+ * the claim, `false` when the row was already claimed.
  */
-async function claimAgentRun(
-  runId: string,
-  newStatus: "DELIVERED_INLINE" | "FAILED",
-  error?: string,
-): Promise<boolean> {
+async function markAgentRunFailed(runId: string, error: string): Promise<boolean> {
   const { count } = await db.agentRun.updateMany({
     where: { id: runId, status: "PENDING" },
-    data: {
-      status: newStatus,
-      ...(error ? { error } : {}),
-    },
+    data: { status: "FAILED", error },
   });
   return count > 0;
 }
@@ -188,7 +187,8 @@ export function buildWorkflowExplorerTools(ctx?: CapabilityContext): ToolSet {
         "It can also pull ground-truth run data from the Stakwork API: which workflows invoke a skill (with real use counts), recent runs and their success/error states, and the actual params and outputs each step sent — useful for citing working configurations (exact URL formats, variable interpolations) or diagnosing why a similar workflow failed. " +
         "Use it when designing or discussing a NEW Stakwork workflow: e.g. 'what existing skills take a video url as input?', 'is there already a transcription workflow, and how does it compose its steps?', 'show me real params from a successful run that uses AzureOCR'. " +
         "READ-ONLY by default — it cannot create or modify workflows. Pass run_step: true (ONLY when the user explicitly asks to run/execute/test a specific step) to additionally let it execute one workflow step with supplied inputs and report the output. " +
-        "Heavy/slow (minutes): call it ONCE with a complete, self-contained prompt rather than several times.",
+        "Heavy/slow (minutes): call it ONCE with a complete, self-contained prompt rather than several times. " +
+        "In a canvas conversation this tool runs in the BACKGROUND: it returns immediately with a dispatch confirmation (no findings), and the explorer's full report is posted directly into the conversation when it finishes. Tell the user it's underway — do NOT re-call the tool to fetch results and do NOT invent findings.",
       inputSchema: z.object({
         prompt: z
           .string()
@@ -208,21 +208,17 @@ export function buildWorkflowExplorerTools(ctx?: CapabilityContext): ToolSet {
       execute: async ({ prompt, run_step }: { prompt: string; run_step?: boolean }) => {
         // ── Webhook fan-back setup ────────────────────────────────────────
         // Only activated when a canvas conversation is present and we have a
-        // public base URL. When absent, the tool behaves exactly as before.
+        // public base URL. When absent, the tool falls back to the classic
+        // inline poll path (there is no delivery target for a webhook).
         const title = prompt.slice(0, 120) + (prompt.length > 120 ? "…" : "");
         const fanBack = ctx ? await setupFanBack(ctx, title).catch((e) => {
-          // Non-fatal: if row creation fails, degrade gracefully (no safety net
-          // for this run, but the inline path still works).
+          // Non-fatal: if row creation fails, degrade gracefully to the
+          // inline poll path for this run.
           console.error("[workflow_explorer_agent] fan-back setup failed (non-fatal)", {
             error: e instanceof Error ? e.message : String(e),
           });
           return null;
         }) : null;
-
-        // Tracks whether the swarm returned a request_id (= run started).
-        // Affects the poll-timeout handling: a timeout *before* a request_id
-        // means initiation failed; *after* means the run is still in progress.
-        let hasRequestId = false;
 
         try {
           const { swarmUrl, swarmApiKey } = await resolveWorkflowLibrarySwarm();
@@ -231,127 +227,65 @@ export function buildWorkflowExplorerTools(ctx?: CapabilityContext): ToolSet {
             console.log("[workflow_explorer_agent] step execution enabled for this call");
           }
 
-          const rr = await repoAgent(
-            swarmUrl,
-            swarmApiKey,
-            {
-              prompt,
-              mode: "workflow",
-              stakworkApiKey: config.STAKWORK_API_KEY || undefined,
-              ...(run_step ? { toolsConfig: { stakwork_run_step: true } } : {}),
-              // Fan-back field — only sent when the safety net is active.
-              // stakgraph reads `webhookUrl` off the body and POSTs the
-              // terminal payload to it verbatim (id + bearer token both in
-              // the query string; the swarm attaches no custom headers).
-              ...(fanBack ? { webhookUrl: fanBack.webhookUrl } : {}),
-            },
-            /* bifrost */ undefined,
-            /* hooks */ fanBack
-              ? {
-                  onRequestId: async (requestId: string) => {
-                    hasRequestId = true;
-                    console.log("[workflow_explorer_agent] run started", {
-                      runId: fanBack.runId,
-                      requestId,
-                    });
-                    // Save requestId for observability / log-correlation.
-                    // NOT part of the arbitration key — a secondary best-effort write.
-                    await db.agentRun.update({
-                      where: { id: fanBack.runId },
-                      data: { requestId },
-                    }).catch((e) =>
-                      console.warn("[workflow_explorer_agent] requestId save failed (non-fatal)", {
-                        runId: fanBack.runId,
-                        error: e instanceof Error ? e.message : String(e),
-                      }),
-                    );
-                  },
-                }
-              : undefined,
-          );
-
-          // ── User cancellation ──────────────────────────────────────────
-          // `repoAgent` returns the REPO_AGENT_CANCELLED_MARKER string when the
-          // user hit Stop. Claim PENDING → FAILED so a late "completed despite
-          // abort" webhook finds zero PENDING rows and no-ops — satisfying the
-          // "aborts read as failures" requirement.
-          if (typeof rr === "string") {
-            if (fanBack) {
-              const claimed = await claimAgentRun(fanBack.runId, "FAILED", "user_cancelled");
-              console.log("[workflow_explorer_agent] cancelled — row FAILED", {
-                runId: fanBack.runId,
-                claimed,
-              });
-            }
-            return "Workflow explorer agent was cancelled";
-          }
-
-          // ── Inline success ─────────────────────────────────────────────
-          const content = (rr as Record<string, string>).content;
+          const baseParams = {
+            prompt,
+            mode: "workflow" as const,
+            stakworkApiKey: config.STAKWORK_API_KEY || undefined,
+            ...(run_step ? { toolsConfig: { stakwork_run_step: true } } : {}),
+          };
 
           if (fanBack) {
-            // Claim PENDING → DELIVERED_INLINE.
-            //
-            // ORDERING: we claim BEFORE returning the content to the model.
-            // If the lambda crashes between this claim and the model seeing the
-            // content, the webhook will no-op (row no longer PENDING) and that
-            // single result is lost. This is the same failure mode as any inline
-            // tool result today (short-run behavior is unchanged — req #1). The
-            // alternative (claim after) risks double-delivery if the webhook
-            // beats us to the fan-out. Accept the crash-loss; eliminate it only
-            // with a distributed transaction (out of scope).
-            const claimed = await claimAgentRun(fanBack.runId, "DELIVERED_INLINE");
-            console.log("[workflow_explorer_agent] inline result", {
-              runId: fanBack.runId,
-              claimed,
+            // ── Dispatch-only: the webhook is the sole delivery path ─────
+            // Initiate the run and return immediately — no poll loop. The
+            // swarm POSTs the terminal payload to webhookUrl (id + bearer
+            // token in its query string) and /api/agent-runs/webhook fans
+            // the result into the conversation.
+            const requestId = await dispatchRepoAgent(swarmUrl, swarmApiKey, {
+              ...baseParams,
+              webhookUrl: fanBack.webhookUrl,
             });
-            if (!claimed) {
-              // The webhook already claimed and fanned out — exactly-once: no-op.
-              return "The workflow explorer result has already been posted to this conversation.";
-            }
+            console.log("[workflow_explorer_agent] dispatched", {
+              runId: fanBack.runId,
+              requestId,
+            });
+            // Save requestId for observability and the future stale-row
+            // sweep. NOT part of the arbitration key — best-effort write.
+            await db.agentRun.update({
+              where: { id: fanBack.runId },
+              data: { requestId },
+            }).catch((e) =>
+              console.warn("[workflow_explorer_agent] requestId save failed (non-fatal)", {
+                runId: fanBack.runId,
+                error: e instanceof Error ? e.message : String(e),
+              }),
+            );
+            return (
+              "The workflow explorer is researching in the background — its findings will be " +
+              "posted directly to this conversation when ready (typically within a few minutes). " +
+              "Let the user know it's underway; do not call this tool again for the same request."
+            );
           }
 
-          return content;
+          // ── Inline poll path (no canvas delivery target) ───────────────
+          const rr = await repoAgent(swarmUrl, swarmApiKey, baseParams);
+          if (typeof rr === "string") return "Workflow explorer agent was cancelled";
+          return (rr as Record<string, string>).content;
         } catch (e) {
           console.error("Error executing workflow explorer agent:", e);
 
           if (fanBack) {
-            if (!hasRequestId) {
-              // ── Initiation failure ────────────────────────────────────
-              // repoAgent threw before the swarm returned a request_id, so no
-              // callback can ever arrive. Claim PENDING → FAILED immediately to
-              // avoid an orphaned-forever PENDING row (closing the window the raw
-              // draft left open).
-              const claimed = await claimAgentRun(
-                fanBack.runId,
-                "FAILED",
-                e instanceof Error ? e.message : "initiation_failed",
-              );
-              console.log("[workflow_explorer_agent] initiation failure — row FAILED", {
-                runId: fanBack.runId,
-                claimed,
-              });
-              return "Could not execute workflow explorer agent";
-            } else {
-              // ── Poll timeout after genuine start ──────────────────────
-              // The swarm accepted the run (request_id was received) but it
-              // outlived the inline poll budget. The row stays PENDING — the
-              // swarm will call back via the webhook when done. Tell the model
-              // the run is still in progress so the user knows to wait and a
-              // later successful webhook doesn't contradict what they were told.
-              // NEVER say "could not execute" here — the run IS running.
-              //
-              // RESIDUAL GAP: if the swarm process dies mid-run, this row stays
-              // PENDING forever. A stale-row sweep is deferred to a follow-up
-              // (at which point @@index([status, createdAt]) should be added).
-              console.log("[workflow_explorer_agent] poll timeout — run in progress (PENDING)", {
-                runId: fanBack.runId,
-              });
-              return (
-                "The workflow explorer is still running — it will post its result to this " +
-                "conversation when it finishes. No further action is needed from you."
-              );
-            }
+            // ── Initiation failure ────────────────────────────────────────
+            // Dispatch threw, so the swarm never accepted the run and no
+            // callback can ever arrive. Claim PENDING → FAILED immediately
+            // to avoid an orphaned-forever PENDING row.
+            const claimed = await markAgentRunFailed(
+              fanBack.runId,
+              e instanceof Error ? e.message : "initiation_failed",
+            );
+            console.log("[workflow_explorer_agent] initiation failure — row FAILED", {
+              runId: fanBack.runId,
+              claimed,
+            });
           }
 
           return "Could not execute workflow explorer agent";


### PR DESCRIPTION
## Problem

Follow-up to #4905. The inline poll (5s interval) and the swarm's terminal webhook (fires instantly on completion) raced to deliver the workflow-explorer result — and the webhook nearly always won. The raw sub-agent output got posted directly to the conversation while the canvas agent received only *"The workflow explorer result has already been posted"*, so it could never read, summarize, or act on the findings.

## Approach

Remove the race instead of arbitrating it. When a canvas conversation is active, the tool is now **dispatch-only**:

1. Create the `PENDING` `AgentRun` row, initiate the run with the tokenized `webhookUrl`, save the `request_id` — and return immediately with a dispatch confirmation.
2. The swarm's terminal webhook is the **sole delivery path**: `/api/agent-runs/webhook` claims the row and fans the result into the conversation.

No poll loop, no inline claim, no `DELIVERED_INLINE` race branches, and the lambda is never pinned for the life of a long run.

Callers with no delivery target (no ctx / no conversation / no `publicBaseUrl`, or fan-back setup failure) fall back to the classic inline poll path unchanged.

## Changes

- `askTools.ts`: new `dispatchRepoAgent` (initiate-only), sharing the initiate POST with the polling `repoAgent`
- `workflowExplorerTools.ts`: dispatch path for canvas ctx; removed inline claim / lost-race note / cancellation claim / poll-timeout branches; initiation failure still claims the row `FAILED` so no `PENDING` row is orphaned
- Tool description tells the model results post to the conversation in the background (don't re-call, don't invent findings)
- Webhook route, fan-out service, and `AgentRun` schema untouched

## Known gap (deferred, now load-bearing)

If the swarm process dies mid-run and webhook retries exhaust (~35s window), the row stays `PENDING` forever and nothing is delivered. A stale-row sweep that re-polls `/progress` with the saved `requestId` is the planned follow-up (add `@@index([status, createdAt])` alongside it).

## Testing

- 12/12 unit tests (`workflowExplorerTools.test.ts`, rewritten for dispatch-only)
- 19/19 integration tests (`agent-runs/webhook.test.ts`, unchanged route)
- `askTools` + fan-out unit suites green (91 tests total); typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)