### PR TITLE
Accept find/replace edits on the prompt update tools

### DIFF
--- a/src/__tests__/unit/lib/ai/promptTools-edits.test.ts
+++ b/src/__tests__/unit/lib/ai/promptTools-edits.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+const { mockGetRawPromptValue, mockGetResolvedPrompt } = vi.hoisted(() => ({
+  mockGetRawPromptValue: vi.fn(),
+  mockGetResolvedPrompt: vi.fn(),
+}));
+
+vi.mock("@/services/prompts/prompt-read", () => ({
+  getRawPromptValue: mockGetRawPromptValue,
+  getResolvedPrompt: mockGetResolvedPrompt,
+}));
+
+vi.mock("nanoid", () => ({ nanoid: () => "proposal-1" }));
+
+// ── Imports ────────────────────────────────────────────────────────────────
+import { buildPromptTools } from "@/lib/ai/promptTools";
+import {
+  PROPOSE_PROMPT_UPDATE_TOOL,
+} from "@/lib/proposals/types";
+
+const RAW = ["You are a helpful assistant.", "", "Rules:", "- Be concise."].join("\n");
+
+function rawValue(value = RAW) {
+  return {
+    id: "prompt-1",
+    name: "MY_PROMPT",
+    versionId: "version-2",
+    versionNumber: 2,
+    value,
+  };
+}
+
+type ToolExecute = (input: Record<string, unknown>) => Promise<Record<string, unknown>>;
+
+function proposeUpdate(): ToolExecute {
+  const tools = buildPromptTools("user-1");
+  return (tools[PROPOSE_PROMPT_UPDATE_TOOL] as unknown as { execute: ToolExecute }).execute;
+}
+
+function getPrompt(): ToolExecute {
+  const tools = buildPromptTools("user-1");
+  return (tools.get_prompt as unknown as { execute: ToolExecute }).execute;
+}
+
+describe("propose_prompt_update — edits resolve to a full value", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetRawPromptValue.mockResolvedValue(rawValue());
+  });
+
+  it("stores the complete edited value in the payload, not the edit list", async () => {
+    const result = await proposeUpdate()({
+      prompt_id: "prompt-1",
+      edits: [{ oldStr: "- Be concise.", newStr: "- Be extremely concise." }],
+    });
+
+    const expected = RAW.replace("- Be concise.", "- Be extremely concise.");
+    expect(result.kind).toBe("promptUpdate");
+    expect((result.payload as { value: string }).value).toBe(expected);
+    expect(result.payload).not.toHaveProperty("edits");
+  });
+
+  it("diffs the edited value against the raw base", async () => {
+    const result = await proposeUpdate()({
+      prompt_id: "prompt-1",
+      edits: [{ oldStr: "Rules:", newStr: "Guidelines:" }],
+    });
+
+    const meta = result.meta as { oldStr: string; newStr: string };
+    expect(meta.oldStr).toBe(RAW);
+    expect(meta.newStr).toBe(RAW.replace("Rules:", "Guidelines:"));
+  });
+
+  it("still accepts a full value for a wholesale rewrite", async () => {
+    const result = await proposeUpdate()({
+      prompt_id: "prompt-1",
+      value: "Totally new prompt.",
+    });
+
+    expect((result.payload as { value: string }).value).toBe("Totally new prompt.");
+    expect((result.meta as { newStr: string }).newStr).toBe("Totally new prompt.");
+  });
+
+  it("rejects an edit whose oldStr does not match, without emitting a proposal", async () => {
+    const result = await proposeUpdate()({
+      prompt_id: "prompt-1",
+      edits: [{ oldStr: "- Be terse.", newStr: "x" }],
+    });
+
+    expect(result.error).toMatch(/not found/i);
+    expect(result.error).toContain("MY_PROMPT v2");
+    expect(result.kind).toBeUndefined();
+  });
+
+  it("rejects passing both value and edits", async () => {
+    const result = await proposeUpdate()({
+      prompt_id: "prompt-1",
+      value: "whole thing",
+      edits: [{ oldStr: "Rules:", newStr: "Guidelines:" }],
+    });
+
+    expect(result.error).toMatch(/not both/i);
+    expect(result.kind).toBeUndefined();
+  });
+
+  it("rejects passing neither value nor edits", async () => {
+    const result = await proposeUpdate()({ prompt_id: "prompt-1" });
+
+    expect(result.error).toMatch(/required/i);
+    expect(result.kind).toBeUndefined();
+  });
+
+  it("reports a missing prompt before applying edits", async () => {
+    mockGetRawPromptValue.mockResolvedValue({ notFound: true });
+
+    const result = await proposeUpdate()({
+      prompt_id: "nope",
+      edits: [{ oldStr: "a", newStr: "b" }],
+    });
+
+    expect(result.error).toMatch(/not found/i);
+  });
+});
+
+describe("get_prompt — raw mode feeds the edit path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the verbatim stored value with raw: true", async () => {
+    mockGetRawPromptValue.mockResolvedValue(rawValue("Hello {{NAME}}"));
+
+    const result = await getPrompt()({ id_or_name: "MY_PROMPT", raw: true });
+
+    expect(result.value).toBe("Hello {{NAME}}");
+    expect(result.raw).toBe(true);
+    expect(result.versionId).toBe("version-2");
+    expect(mockGetResolvedPrompt).not.toHaveBeenCalled();
+  });
+
+  it("returns resolved text by default", async () => {
+    mockGetResolvedPrompt.mockResolvedValue({
+      id: "prompt-1",
+      name: "MY_PROMPT",
+      versionId: "version-2",
+      versionNumber: 2,
+      resolvedText: "Hello Evan",
+      missingVariables: [],
+    });
+
+    const result = await getPrompt()({ id_or_name: "MY_PROMPT" });
+
+    expect(result.resolvedText).toBe("Hello Evan");
+    expect(result.value).toBeUndefined();
+    expect(mockGetRawPromptValue).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a not-found in raw mode", async () => {
+    mockGetRawPromptValue.mockResolvedValue({ notFound: true });
+
+    const result = await getPrompt()({ id_or_name: "NOPE", raw: true });
+
+    expect(result.error).toMatch(/not found/i);
+  });
+});

--- a/src/__tests__/unit/lib/mcp/mcpUpdatePromptEdits.test.ts
+++ b/src/__tests__/unit/lib/mcp/mcpUpdatePromptEdits.test.ts
@@ -83,27 +83,10 @@ describe("mcpUpdatePromptEdits — resolves edits to a full value", () => {
     );
   });
 
-  it("reads the raw base value, so edits are not built against resolved text", async () => {
+  it("reads the raw current value, so edits are not built against resolved text", async () => {
     await mcpUpdatePromptEdits(AUTH, "prompt-1", [{ oldStr: "Rules:", newStr: "Guidelines:" }]);
 
-    expect(mockGetRawPromptValue).toHaveBeenCalledWith("prompt-1", undefined);
-  });
-
-  it("uses baseVersionId as the base when supplied", async () => {
-    mockGetRawPromptValue.mockResolvedValue({ ...rawValue("old text"), versionId: "version-1" });
-
-    await mcpUpdatePromptEdits(
-      AUTH,
-      "prompt-1",
-      [{ oldStr: "old", newStr: "new" }],
-      undefined,
-      "version-1",
-    );
-
-    expect(mockGetRawPromptValue).toHaveBeenCalledWith("prompt-1", "version-1");
-    expect(mockWritePromptThrough).toHaveBeenCalledWith(
-      expect.objectContaining({ value: "new text" }),
-    );
+    expect(mockGetRawPromptValue).toHaveBeenCalledWith("prompt-1");
   });
 
   it("forwards description when provided", async () => {
@@ -193,21 +176,6 @@ describe("mcpUpdatePromptEdits — base lookup failures", () => {
     expect(result.isError).toBe(true);
     expect(text(result)).toMatch(/prompt not found/i);
     expect(mockWritePromptThrough).not.toHaveBeenCalled();
-  });
-
-  it("names the version when an explicit baseVersionId does not resolve", async () => {
-    mockGetRawPromptValue.mockResolvedValue({ notFound: true });
-
-    const result = await mcpUpdatePromptEdits(
-      AUTH,
-      "prompt-1",
-      [{ oldStr: "a", newStr: "b" }],
-      undefined,
-      "version-99",
-    );
-
-    expect(result.isError).toBe(true);
-    expect(text(result)).toContain("version-99");
   });
 
   it("surfaces a read error without writing", async () => {

--- a/src/__tests__/unit/lib/mcp/mcpUpdatePromptEdits.test.ts
+++ b/src/__tests__/unit/lib/mcp/mcpUpdatePromptEdits.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+const { mockWritePromptThrough, mockGetRawPromptValue } = vi.hoisted(() => ({
+  mockWritePromptThrough: vi.fn(),
+  mockGetRawPromptValue: vi.fn(),
+}));
+
+vi.mock("@/services/prompts/prompt-sync", () => ({
+  writePromptThrough: mockWritePromptThrough,
+}));
+
+vi.mock("@/services/prompts/prompt-read", () => ({
+  getRawPromptValue: mockGetRawPromptValue,
+  getResolvedPrompt: vi.fn(),
+  getResolvedPromptVersion: vi.fn(),
+  listPromptVersions: vi.fn(),
+}));
+
+// ── Imports ────────────────────────────────────────────────────────────────
+import { mcpUpdatePromptEdits } from "@/lib/mcp/mcpTools";
+
+const AUTH = {
+  userId: "user-1",
+  workspaceId: "ws-1",
+  workspaceSlug: "stakwork",
+};
+
+const RAW = [
+  "You are a helpful assistant.",
+  "",
+  "Rules:",
+  "- Be concise.",
+].join("\n");
+
+function rawValue(value = RAW) {
+  return {
+    id: "prompt-1",
+    name: "MY_PROMPT",
+    versionId: "version-2",
+    versionNumber: 2,
+    value,
+  };
+}
+
+function writeResult() {
+  return {
+    prompt: { id: "prompt-1", name: "MY_PROMPT" },
+    version: {
+      id: "version-3",
+      versionNumber: 3,
+      value: "written",
+      description: null,
+      published: false,
+    },
+  };
+}
+
+function text(result: { content: { text: string }[] }): string {
+  return (result.content[0] as { text: string }).text;
+}
+
+describe("mcpUpdatePromptEdits — resolves edits to a full value", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetRawPromptValue.mockResolvedValue(rawValue());
+    mockWritePromptThrough.mockResolvedValue(writeResult());
+  });
+
+  it("writes the complete edited value, not the edit list", async () => {
+    const result = await mcpUpdatePromptEdits(AUTH, "prompt-1", [
+      { oldStr: "- Be concise.", newStr: "- Be extremely concise." },
+    ]);
+
+    expect(result.isError).toBeFalsy();
+    expect(mockWritePromptThrough).toHaveBeenCalledWith(
+      expect.objectContaining({
+        promptId: "prompt-1",
+        value: RAW.replace("- Be concise.", "- Be extremely concise."),
+        userId: "user-1",
+        source: "MCP",
+      }),
+    );
+  });
+
+  it("reads the raw base value, so edits are not built against resolved text", async () => {
+    await mcpUpdatePromptEdits(AUTH, "prompt-1", [{ oldStr: "Rules:", newStr: "Guidelines:" }]);
+
+    expect(mockGetRawPromptValue).toHaveBeenCalledWith("prompt-1", undefined);
+  });
+
+  it("uses baseVersionId as the base when supplied", async () => {
+    mockGetRawPromptValue.mockResolvedValue({ ...rawValue("old text"), versionId: "version-1" });
+
+    await mcpUpdatePromptEdits(
+      AUTH,
+      "prompt-1",
+      [{ oldStr: "old", newStr: "new" }],
+      undefined,
+      "version-1",
+    );
+
+    expect(mockGetRawPromptValue).toHaveBeenCalledWith("prompt-1", "version-1");
+    expect(mockWritePromptThrough).toHaveBeenCalledWith(
+      expect.objectContaining({ value: "new text" }),
+    );
+  });
+
+  it("forwards description when provided", async () => {
+    await mcpUpdatePromptEdits(
+      AUTH,
+      "prompt-1",
+      [{ oldStr: "Rules:", newStr: "Guidelines:" }],
+      "New desc",
+    );
+
+    expect(mockWritePromptThrough).toHaveBeenCalledWith(
+      expect.objectContaining({ description: "New desc" }),
+    );
+  });
+
+  it("applies multiple edits in order", async () => {
+    await mcpUpdatePromptEdits(AUTH, "prompt-1", [
+      { oldStr: "helpful", newStr: "terse" },
+      { oldStr: "- Be concise.", newStr: "- Be brief." },
+    ]);
+
+    const written = mockWritePromptThrough.mock.calls[0][0].value;
+    expect(written).toContain("You are a terse assistant.");
+    expect(written).toContain("- Be brief.");
+  });
+});
+
+describe("mcpUpdatePromptEdits — refuses to write on a bad edit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetRawPromptValue.mockResolvedValue(rawValue());
+    mockWritePromptThrough.mockResolvedValue(writeResult());
+  });
+
+  it("fails without writing when oldStr does not match (stale read)", async () => {
+    const result = await mcpUpdatePromptEdits(AUTH, "prompt-1", [
+      { oldStr: "- Be terse.", newStr: "- Be brief." },
+    ]);
+
+    expect(result.isError).toBe(true);
+    expect(text(result)).toMatch(/not found/i);
+    expect(mockWritePromptThrough).not.toHaveBeenCalled();
+  });
+
+  it("reports the base prompt name and version in the failure", async () => {
+    const result = await mcpUpdatePromptEdits(AUTH, "prompt-1", [
+      { oldStr: "nope", newStr: "x" },
+    ]);
+
+    expect(text(result)).toContain("MY_PROMPT v2");
+  });
+
+  it("fails without writing when an edit is ambiguous", async () => {
+    mockGetRawPromptValue.mockResolvedValue(rawValue("foo bar foo"));
+
+    const result = await mcpUpdatePromptEdits(AUTH, "prompt-1", [
+      { oldStr: "foo", newStr: "qux" },
+    ]);
+
+    expect(result.isError).toBe(true);
+    expect(text(result)).toMatch(/matched 2 times/i);
+    expect(mockWritePromptThrough).not.toHaveBeenCalled();
+  });
+
+  it("does not write any earlier edit when a later one fails", async () => {
+    const result = await mcpUpdatePromptEdits(AUTH, "prompt-1", [
+      { oldStr: "- Be concise.", newStr: "- Be brief." },
+      { oldStr: "missing", newStr: "x" },
+    ]);
+
+    expect(result.isError).toBe(true);
+    expect(mockWritePromptThrough).not.toHaveBeenCalled();
+  });
+});
+
+describe("mcpUpdatePromptEdits — base lookup failures", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWritePromptThrough.mockResolvedValue(writeResult());
+  });
+
+  it("maps a missing prompt to a not-found error", async () => {
+    mockGetRawPromptValue.mockResolvedValue({ notFound: true });
+
+    const result = await mcpUpdatePromptEdits(AUTH, "nope", [{ oldStr: "a", newStr: "b" }]);
+
+    expect(result.isError).toBe(true);
+    expect(text(result)).toMatch(/prompt not found/i);
+    expect(mockWritePromptThrough).not.toHaveBeenCalled();
+  });
+
+  it("names the version when an explicit baseVersionId does not resolve", async () => {
+    mockGetRawPromptValue.mockResolvedValue({ notFound: true });
+
+    const result = await mcpUpdatePromptEdits(
+      AUTH,
+      "prompt-1",
+      [{ oldStr: "a", newStr: "b" }],
+      undefined,
+      "version-99",
+    );
+
+    expect(result.isError).toBe(true);
+    expect(text(result)).toContain("version-99");
+  });
+
+  it("surfaces a read error without writing", async () => {
+    mockGetRawPromptValue.mockResolvedValue({ error: "DB is down" });
+
+    const result = await mcpUpdatePromptEdits(AUTH, "prompt-1", [{ oldStr: "a", newStr: "b" }]);
+
+    expect(result.isError).toBe(true);
+    expect(text(result)).toMatch(/DB is down/);
+    expect(mockWritePromptThrough).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/unit/services/prompts/prompt-edits.test.ts
+++ b/src/__tests__/unit/services/prompts/prompt-edits.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  applyPromptEdits,
+  MAX_PROMPT_EDITS,
+} from "@/services/prompts/prompt-edits";
+
+const BASE = [
+  "You are a helpful assistant.",
+  "",
+  "Rules:",
+  "- Be concise.",
+  "- Cite sources.",
+].join("\n");
+
+function ok(result: ReturnType<typeof applyPromptEdits>): string {
+  if (!result.ok) throw new Error(`expected ok, got: ${result.error}`);
+  return result.value;
+}
+
+function err(result: ReturnType<typeof applyPromptEdits>): string {
+  if (result.ok) throw new Error("expected failure, got ok");
+  return result.error;
+}
+
+describe("applyPromptEdits — happy path", () => {
+  it("replaces a unique occurrence and leaves the rest byte-identical", () => {
+    const value = ok(
+      applyPromptEdits(BASE, [{ oldStr: "- Be concise.", newStr: "- Be extremely concise." }]),
+    );
+
+    expect(value).toBe(BASE.replace("- Be concise.", "- Be extremely concise."));
+    expect(value).toContain("You are a helpful assistant.");
+    expect(value).toContain("- Cite sources.");
+  });
+
+  it("preserves whitespace and line breaks outside the matched region", () => {
+    const base = "line one\n\n  indented\ttab\n";
+    const value = ok(applyPromptEdits(base, [{ oldStr: "indented", newStr: "shifted" }]));
+
+    expect(value).toBe("line one\n\n  shifted\ttab\n");
+  });
+
+  it("applies multiple edits in order", () => {
+    const value = ok(
+      applyPromptEdits(BASE, [
+        { oldStr: "helpful assistant", newStr: "terse assistant" },
+        { oldStr: "- Cite sources.", newStr: "- Cite sources inline." },
+      ]),
+    );
+
+    expect(value).toContain("You are a terse assistant.");
+    expect(value).toContain("- Cite sources inline.");
+  });
+
+  it("applies each edit to the result of the previous one", () => {
+    const value = ok(
+      applyPromptEdits("aaa", [
+        { oldStr: "aaa", newStr: "bbb" },
+        { oldStr: "bbb", newStr: "ccc" },
+      ]),
+    );
+
+    expect(value).toBe("ccc");
+  });
+
+  it("deletes matched text when newStr is empty", () => {
+    const value = ok(applyPromptEdits(BASE, [{ oldStr: "\n- Cite sources.", newStr: "" }]));
+
+    expect(value).not.toContain("Cite sources");
+    expect(value).toContain("- Be concise.");
+  });
+
+  it("replaces every occurrence with replaceAll", () => {
+    const value = ok(
+      applyPromptEdits("foo bar foo baz foo", [
+        { oldStr: "foo", newStr: "qux", replaceAll: true },
+      ]),
+    );
+
+    expect(value).toBe("qux bar qux baz qux");
+  });
+
+  it("treats oldStr literally, not as a regex", () => {
+    const value = ok(
+      applyPromptEdits("cost is $1.00 (approx)", [
+        { oldStr: "$1.00 (approx)", newStr: "$2.00 (exact)" },
+      ]),
+    );
+
+    expect(value).toBe("cost is $2.00 (exact)");
+  });
+
+  it("does not treat $& in newStr as a substitution pattern", () => {
+    const value = ok(applyPromptEdits("hello world", [{ oldStr: "world", newStr: "$& there" }]));
+
+    expect(value).toBe("hello $& there");
+  });
+
+  it("handles a multi-line oldStr spanning the whole prompt", () => {
+    const value = ok(applyPromptEdits(BASE, [{ oldStr: BASE, newStr: "Replaced wholesale." }]));
+
+    expect(value).toBe("Replaced wholesale.");
+  });
+});
+
+describe("applyPromptEdits — rejects ambiguous or stale edits", () => {
+  it("fails when oldStr is not found", () => {
+    const message = err(applyPromptEdits(BASE, [{ oldStr: "- Be terse.", newStr: "x" }]));
+
+    expect(message).toMatch(/not found/i);
+    expect(message).toMatch(/edit 1 of 1/);
+  });
+
+  it("names the failing edit's position in a multi-edit call", () => {
+    const message = err(
+      applyPromptEdits(BASE, [
+        { oldStr: "- Be concise.", newStr: "- Be brief." },
+        { oldStr: "nope", newStr: "x" },
+      ]),
+    );
+
+    expect(message).toMatch(/edit 2 of 2/);
+  });
+
+  it("fails when oldStr matches more than once without replaceAll", () => {
+    const message = err(applyPromptEdits("foo bar foo", [{ oldStr: "foo", newStr: "qux" }]));
+
+    expect(message).toMatch(/matched 2 times/i);
+    expect(message).toMatch(/replaceAll/);
+  });
+
+  it("fails when a later edit becomes ambiguous after an earlier one", () => {
+    // The first edit introduces a second "beta", making edit 2 non-unique.
+    const message = err(
+      applyPromptEdits("alpha beta", [
+        { oldStr: "alpha", newStr: "beta" },
+        { oldStr: "beta", newStr: "gamma" },
+      ]),
+    );
+
+    expect(message).toMatch(/edit 2 of 2/);
+    expect(message).toMatch(/matched 2 times/i);
+  });
+
+  it("rejects an empty oldStr", () => {
+    const message = err(applyPromptEdits(BASE, [{ oldStr: "", newStr: "x" }]));
+
+    expect(message).toMatch(/non-empty/i);
+  });
+
+  it("rejects a no-op edit where oldStr equals newStr", () => {
+    const message = err(
+      applyPromptEdits(BASE, [{ oldStr: "- Be concise.", newStr: "- Be concise." }]),
+    );
+
+    expect(message).toMatch(/identical/i);
+  });
+
+  it("rejects an empty edit list", () => {
+    expect(err(applyPromptEdits(BASE, []))).toMatch(/at least one edit/i);
+  });
+
+  it("rejects more than MAX_PROMPT_EDITS edits", () => {
+    const edits = Array.from({ length: MAX_PROMPT_EDITS + 1 }, (_, i) => ({
+      oldStr: `x${i}`,
+      newStr: `y${i}`,
+    }));
+
+    expect(err(applyPromptEdits(BASE, edits))).toMatch(/too many edits/i);
+  });
+
+  it("truncates a long oldStr in the error message", () => {
+    const long = "z".repeat(500);
+    const message = err(applyPromptEdits(BASE, [{ oldStr: long, newStr: "x" }]));
+
+    expect(message).toContain("…");
+    expect(message.length).toBeLessThan(long.length);
+  });
+
+  it("does not partially apply edits when a later one fails", () => {
+    const result = applyPromptEdits(BASE, [
+      { oldStr: "- Be concise.", newStr: "- Be brief." },
+      { oldStr: "missing", newStr: "x" },
+    ]);
+
+    // Failure returns no value at all — the caller cannot accidentally write a
+    // half-applied prompt.
+    expect(result.ok).toBe(false);
+    expect(result).not.toHaveProperty("value");
+  });
+});

--- a/src/lib/ai/promptTools.ts
+++ b/src/lib/ai/promptTools.ts
@@ -5,7 +5,8 @@
  *   - `get_prompt`           — fetch a prompt's resolved content by id or name (read, no approval)
  *   - `list_prompts`         — list prompts with latest/published version number (read, no approval)
  *   - `propose_new_prompt`   — emit an approvable card to create a new prompt (write via approval)
- *   - `propose_prompt_update`— emit an approvable card with before/after diff (write via approval)
+ *   - `propose_prompt_update`— emit an approvable card with before/after diff (write via approval),
+ *                              from either a full value or exact-match find/replace edits
  *
  * The `Prompt` model is globally scoped (no org/workspace FK), so the builder
  * takes only `userId` — no `orgId` param. The MCP write fns resolve the shared
@@ -27,6 +28,11 @@ import { nanoid } from "nanoid";
 import { db } from "@/lib/db";
 import { getResolvedPrompt, getRawPromptValue } from "@/services/prompts/prompt-read";
 import {
+  applyPromptEdits,
+  MAX_PROMPT_EDITS,
+  type PromptEdit,
+} from "@/services/prompts/prompt-edits";
+import {
   PROPOSE_NEW_PROMPT_TOOL,
   PROPOSE_PROMPT_UPDATE_TOOL,
 } from "@/lib/proposals/types";
@@ -37,9 +43,10 @@ export function buildPromptTools(userId: string): ToolSet {
   return {
     get_prompt: tool({
       description:
-        "Fetch a prompt's fully resolved content by id or name. " +
-        "Returns the published version's text (with nested references expanded and variables substituted). " +
-        "Use this to read an existing prompt before reasoning about or proposing an update to it. " +
+        "Fetch a prompt's content by id or name. " +
+        "By default returns the published version's fully resolved text (nested references expanded, variables substituted). " +
+        "Pass raw: true to get the verbatim stored value instead, with {{VARIABLE}} tokens and nested prompt references intact — " +
+        "do that whenever you intend to propose an update, since `edits` are matched against the raw value, not the resolved one. " +
         "No approval required — this is a read-only operation.",
       inputSchema: z.object({
         id_or_name: z
@@ -51,16 +58,43 @@ export function buildPromptTools(userId: string): ToolSet {
           .record(z.string(), z.string())
           .optional()
           .describe(
-            "Optional key/value map of variables to substitute into {{PLACEHOLDER}} tokens in the prompt text.",
+            "Optional key/value map of variables to substitute into {{PLACEHOLDER}} tokens in the prompt text. Ignored when raw is true.",
+          ),
+        raw: z
+          .boolean()
+          .optional()
+          .describe(
+            "Return the verbatim stored value (no variable substitution, no nested-prompt expansion) in `value` instead of `resolvedText`. " +
+            "Use this to build `edits` for propose_prompt_update.",
           ),
       }),
       execute: async ({
         id_or_name,
         variables,
+        raw,
       }: {
         id_or_name: string;
         variables?: Record<string, string>;
+        raw?: boolean;
       }) => {
+        if (raw) {
+          const rawResult = await getRawPromptValue(id_or_name);
+          if ("notFound" in rawResult) {
+            return { error: `Prompt '${id_or_name}' not found.` };
+          }
+          if ("error" in rawResult) {
+            return { error: rawResult.error };
+          }
+          return {
+            id: rawResult.id,
+            name: rawResult.name,
+            versionId: rawResult.versionId,
+            versionNumber: rawResult.versionNumber,
+            raw: true as const,
+            value: rawResult.value,
+          };
+        }
+
         const result = await getResolvedPrompt(id_or_name, variables ?? {});
         if ("notFound" in result) {
           return { error: `Prompt '${id_or_name}' not found.` };
@@ -212,16 +246,48 @@ export function buildPromptTools(userId: string): ToolSet {
         "Propose updating the value and/or description of an existing prompt. " +
         "Emits an approvable card with a before/after diff — no new version is written until the user approves. " +
         "The approved update creates a new DRAFT version; it does NOT auto-publish. " +
-        "Use `get_prompt` or `list_prompts` first to obtain the prompt's id.",
+        "Use `get_prompt` or `list_prompts` first to obtain the prompt's id. " +
+        "Supply EITHER `edits` (targeted find/replace — prefer this for anything short of a rewrite) " +
+        "OR `value` (the complete new text), never both.",
       inputSchema: z.object({
         prompt_id: z
           .string()
           .describe("The cuid id of the prompt to update (obtain via list_prompts or get_prompt)."),
         value: z
           .string()
+          .optional()
           .describe(
-            "The full proposed new value for the prompt. " +
-            "Even for a description-only change, supply the current value unchanged here.",
+            "The full proposed new value for the prompt. Omit when using `edits`. " +
+            "For a description-only change, supply the current value unchanged here.",
+          ),
+        edits: z
+          .array(
+            z.object({
+              oldStr: z
+                .string()
+                .min(1)
+                .describe(
+                  "Exact text to find in the prompt's current raw value — must match verbatim, " +
+                  "including whitespace. Note the raw value still contains {{VARIABLE}} tokens and " +
+                  "nested prompt references, which get_prompt's resolved text does not.",
+                ),
+              newStr: z
+                .string()
+                .describe("Replacement text. Pass an empty string to delete the matched text."),
+              replaceAll: z
+                .boolean()
+                .optional()
+                .describe(
+                  "Replace every occurrence. Omit to require oldStr to appear exactly once.",
+                ),
+            }),
+          )
+          .min(1)
+          .max(MAX_PROMPT_EDITS)
+          .optional()
+          .describe(
+            "Targeted find/replace edits, applied in order to the prompt's current value. " +
+            "Omit when using `value`. If an oldStr does not match, the proposal is rejected.",
           ),
         description: z
           .string()
@@ -235,14 +301,29 @@ export function buildPromptTools(userId: string): ToolSet {
       execute: async ({
         prompt_id,
         value,
+        edits,
         description,
         rationale,
       }: {
         prompt_id: string;
-        value: string;
+        value?: string;
+        edits?: PromptEdit[];
         description?: string;
         rationale?: string;
       }) => {
+        if (value !== undefined && edits !== undefined) {
+          return {
+            error:
+              "Pass either `value` or `edits`, not both. Use `edits` for targeted changes and `value` only for a full rewrite.",
+          };
+        }
+        if (value === undefined && (edits === undefined || edits.length === 0)) {
+          return {
+            error:
+              "One of `value` (complete new text) or `edits` (targeted find/replace) is required.",
+          };
+        }
+
         // Fetch the raw value of the version `get_prompt` would resolve
         // (published if set, else latest) so the diff "before" is consistent
         // with what the read tool reports. We intentionally do NOT use
@@ -256,14 +337,28 @@ export function buildPromptTools(userId: string): ToolSet {
           return { error: raw.error };
         }
 
+        // Resolve edits to a complete value here, so the proposal payload and the
+        // approval path keep working on whole values — an edit list stored on a
+        // card and replayed days later would apply to a prompt that has since moved.
+        let newValue: string;
+        if (edits) {
+          const applied = applyPromptEdits(raw.value, edits);
+          if (!applied.ok) {
+            return { error: `${applied.error} (base: ${raw.name} v${raw.versionNumber})` };
+          }
+          newValue = applied.value;
+        } else {
+          newValue = value!;
+        }
+
         const proposalId = nanoid();
         return {
           kind: "promptUpdate" as const,
           proposalId,
-          payload: { promptId: prompt_id, value, description },
+          payload: { promptId: prompt_id, value: newValue, description },
           meta: {
             oldStr: raw.value,
-            newStr: value,
+            newStr: newValue,
             promptName: raw.name,
             versionNumber: raw.versionNumber,
           },

--- a/src/lib/constants/prompt.ts
+++ b/src/lib/constants/prompt.ts
@@ -1143,13 +1143,15 @@ You have four tools for **Prompt** management — reading and proposing changes 
 
 ### Read tools (no approval required)
 
-- **\`get_prompt({ id_or_name, variables? })\`** — Fetch a prompt's fully resolved content by id or UPPERCASE_UNDERSCORE name. Returns the published version's text with nested references expanded and variables substituted. Use this before reasoning about or proposing an update to an existing prompt.
+- **\`get_prompt({ id_or_name, variables?, raw? })\`** — Fetch a prompt's content by id or UPPERCASE_UNDERSCORE name. By default returns the published version's text with nested references expanded and variables substituted. Pass \`raw: true\` for the verbatim stored value (\`{{VARIABLE}}\` tokens and nested prompt references left intact) — always do this before proposing an update, since \`edits\` match against the raw value.
 - **\`list_prompts({ search?, limit? })\`** — List prompts (id, name, description, updatedAt, latestVersionNumber, isLatestPublished). Use this to discover a prompt's id before calling \`get_prompt\` or \`propose_prompt_update\`.
 
 ### Write tools (require user approval)
 
 - **\`propose_new_prompt({ name, value, description?, rationale? })\`** — Propose creating a new prompt. Emits an approvable card; nothing is written until the user approves. Name must be UPPERCASE_UNDERSCORE (e.g. \`MY_PROMPT_NAME\`). Call \`list_prompts\` first to verify the name doesn't already exist.
-- **\`propose_prompt_update({ prompt_id, value, description?, rationale? })\`** — Propose updating an existing prompt's value and/or description. Emits an approvable card with a before/after diff. The approved update creates a new DRAFT version (does NOT auto-publish). Use \`list_prompts\` or \`get_prompt\` to obtain the \`prompt_id\` first.
+- **\`propose_prompt_update({ prompt_id, edits? | value?, description?, rationale? })\`** — Propose updating an existing prompt's value and/or description. Emits an approvable card with a before/after diff. The approved update creates a new DRAFT version (does NOT auto-publish). Use \`list_prompts\` or \`get_prompt\` to obtain the \`prompt_id\` first. Supply EITHER \`edits\` or \`value\`, never both:
+  - \`edits: [{ oldStr, newStr, replaceAll? }]\` — targeted find/replace, applied in order. **Prefer this for anything short of a full rewrite.** Each \`oldStr\` must match the raw stored value exactly (whitespace and line breaks included) and must be unique unless you pass \`replaceAll: true\`.
+  - \`value\` — the complete new text. Use only when rewriting the prompt wholesale.
 
 ### Important rules
 
@@ -1157,7 +1159,9 @@ You have four tools for **Prompt** management — reading and proposing changes 
 - Never fabricate prompt ids — use the ids returned by \`list_prompts\`.
 - Prompt writes go through approval; they are NOT direct writes. Nothing is saved until the user clicks Approve.
 - After approval, a new DRAFT version is created. It is NOT published automatically — the user must publish from the Prompts management page.
-- For description-only changes, still supply the full current \`value\` unchanged in \`propose_prompt_update\` (the tool has no partial-update path).
+- Build \`edits\` from \`get_prompt({ raw: true })\` output, never from resolved text — the resolved text has variables substituted and nested prompts inlined, so edits derived from it will not match and the proposal will be rejected.
+- If an edit is rejected as "not found", the prompt changed since you read it. Re-read it raw and rebuild the edit; do not switch to sending the whole \`value\` to work around a failed match.
+- For description-only changes, supply the full current \`value\` unchanged (\`edits\` cannot express a no-op).
 `;
 }
 

--- a/src/lib/mcp/handler.ts
+++ b/src/lib/mcp/handler.ts
@@ -826,13 +826,7 @@ function createServer(
           .max(MAX_PROMPT_EDITS)
           .optional()
           .describe(
-            "Targeted find/replace edits applied to the base version. Omit when using `value`.",
-          ),
-        baseVersionId: z
-          .string()
-          .optional()
-          .describe(
-            "Version the `edits` apply to. Omit to use the same version `get_prompt` returns (published if set, else latest). Supply the versionId you actually read to make a concurrent change fail loudly instead of rebasing silently. Ignored when using `value`.",
+            "Targeted find/replace edits applied to the current version (published if set, else latest — the same version `get_prompt` returns). Omit when using `value`.",
           ),
         description: z
           .string()
@@ -845,13 +839,11 @@ function createServer(
         promptId,
         value,
         edits,
-        baseVersionId,
         description,
       }: {
         promptId: string;
         value?: string;
         edits?: PromptEdit[];
-        baseVersionId?: string;
         description?: string;
       },
       extra,
@@ -872,7 +864,7 @@ function createServer(
       if (result.error) return result.error;
 
       return edits
-        ? mcpUpdatePromptEdits(result.auth!, promptId, edits, description, baseVersionId)
+        ? mcpUpdatePromptEdits(result.auth!, promptId, edits, description)
         : mcpUpdatePrompt(result.auth!, promptId, value!, description);
     },
   );

--- a/src/lib/mcp/handler.ts
+++ b/src/lib/mcp/handler.ts
@@ -18,6 +18,8 @@ import {
   mcpCreateFeatureTask,
   mcpCreatePrompt,
   mcpUpdatePrompt,
+  mcpUpdatePromptEdits,
+  mcpError,
   mcpGetPrompt,
   mcpGetPromptVersions,
   mcpGetPromptVersion,
@@ -38,6 +40,10 @@ import {
   registerOrgTools,
   type OrgMcpAuthExtra,
 } from "@/lib/mcp/orgMcpTools";
+import {
+  MAX_PROMPT_EDITS,
+  type PromptEdit,
+} from "@/services/prompts/prompt-edits";
 import {
   mcpVerifyCitations,
   mcpSearchCaseLaw,
@@ -780,15 +786,54 @@ function createServer(
     {
       title: "Update Prompt",
       description: [
-        "Push a new version of an existing prompt. The prior versions are preserved — this does NOT overwrite history.",
+        "Push a new version of an existing prompt. The prior versions are preserved — this does NOT overwrite history, and the new version is an unpublished DRAFT.",
         "",
-        "Pass the prompt `id` (not name) and the new `value`. Optionally update `description`. The prompt name cannot be changed via this tool.",
+        "Pass the prompt `id` (not name) and EITHER `value` (the complete new content) OR `edits` (targeted find/replace) — exactly one, never both. Optionally update `description`. The prompt name cannot be changed via this tool.",
+        "",
+        "**Prefer `edits` for anything short of a rewrite.** Each edit's `oldStr` must match the stored value exactly — whitespace and line breaks included — and must be unique unless you pass `replaceAll: true`. Read the base first with `get_prompt` and `raw: true`: the raw value is what edits apply to, whereas the resolved text has variables substituted and nested prompts inlined, so edits built from it will not match.",
+        "",
+        "Edits apply in order, each to the result of the previous one. If an `oldStr` does not match, the whole call fails and nothing is written — that usually means the prompt changed since you read it, so re-read and rebuild the edit.",
       ].join("\n"),
       inputSchema: {
         promptId: z.string().describe("ID of the prompt to update."),
         value: z
           .string()
-          .describe("New prompt content — creates a new PromptVersion."),
+          .optional()
+          .describe(
+            "Complete new prompt content — replaces the whole value. Omit when using `edits`.",
+          ),
+        edits: z
+          .array(
+            z.object({
+              oldStr: z
+                .string()
+                .min(1)
+                .describe(
+                  "Exact text to find in the current value — must match verbatim, including whitespace.",
+                ),
+              newStr: z
+                .string()
+                .describe("Replacement text. Pass an empty string to delete the matched text."),
+              replaceAll: z
+                .boolean()
+                .optional()
+                .describe(
+                  "Replace every occurrence. Omit to require oldStr to appear exactly once.",
+                ),
+            }),
+          )
+          .min(1)
+          .max(MAX_PROMPT_EDITS)
+          .optional()
+          .describe(
+            "Targeted find/replace edits applied to the base version. Omit when using `value`.",
+          ),
+        baseVersionId: z
+          .string()
+          .optional()
+          .describe(
+            "Version the `edits` apply to. Omit to use the same version `get_prompt` returns (published if set, else latest). Supply the versionId you actually read to make a concurrent change fail loudly instead of rebasing silently. Ignored when using `value`.",
+          ),
         description: z
           .string()
           .optional()
@@ -796,13 +841,39 @@ function createServer(
       },
     },
     async (
-      { promptId, value, description }: { promptId: string; value: string; description?: string },
+      {
+        promptId,
+        value,
+        edits,
+        baseVersionId,
+        description,
+      }: {
+        promptId: string;
+        value?: string;
+        edits?: PromptEdit[];
+        baseVersionId?: string;
+        description?: string;
+      },
       extra,
     ) => {
+      if (value !== undefined && edits !== undefined) {
+        return mcpError(
+          "Error: pass either `value` or `edits`, not both. Use `edits` for targeted changes and `value` only for a full rewrite.",
+        );
+      }
+      if (value === undefined && (edits === undefined || edits.length === 0)) {
+        return mcpError(
+          "Error: one of `value` (complete new content) or `edits` (targeted find/replace) is required.",
+        );
+      }
+
       const authExtra = extra.authInfo?.extra as McpAuthExtra | undefined;
       const result = await getWorkspaceAuth(authExtra, "update_prompt");
       if (result.error) return result.error;
-      return mcpUpdatePrompt(result.auth!, promptId, value, description);
+
+      return edits
+        ? mcpUpdatePromptEdits(result.auth!, promptId, edits, description, baseVersionId)
+        : mcpUpdatePrompt(result.auth!, promptId, value!, description);
     },
   );
 

--- a/src/lib/mcp/mcpTools.ts
+++ b/src/lib/mcp/mcpTools.ts
@@ -5,6 +5,7 @@ import { sendFeatureChatMessage } from "@/services/roadmap/feature-chat";
 import { createTicket } from "@/services/roadmap/tickets";
 import { sendMessageToStakwork } from "@/services/task-workflow";
 import { writePromptThrough } from "@/services/prompts/prompt-sync";
+import { applyPromptEdits, type PromptEdit } from "@/services/prompts/prompt-edits";
 import {
   getResolvedPrompt,
   listPromptVersions,
@@ -1324,6 +1325,49 @@ export async function mcpCreatePrompt(
       error instanceof Error ? error.message : "Could not create prompt";
     return mcpError(`Error: ${msg}`);
   }
+}
+
+/**
+ * Push a new version of an existing prompt from a list of exact-match edits
+ * instead of a full value.
+ *
+ * The edits are resolved to a complete value here, at tool-call time, and handed
+ * to `mcpUpdatePrompt` — so the stored version, the proposal payload and the
+ * approval path all keep working on whole values. See `prompt-edits.ts`.
+ *
+ * The base is the version the caller read: `baseVersionId` when supplied,
+ * otherwise the same anchor `get_prompt` uses (published if set, else latest).
+ * Passing `baseVersionId` explicitly turns a stale read into a failed match
+ * rather than a silent rebase onto whatever is current.
+ */
+export async function mcpUpdatePromptEdits(
+  auth: WorkspaceAuth,
+  promptId: string,
+  edits: PromptEdit[],
+  description?: string,
+  baseVersionId?: string,
+): Promise<McpToolResult> {
+  const base = await getRawPromptValue(promptId, baseVersionId);
+
+  if ("notFound" in base) {
+    return mcpError(
+      baseVersionId
+        ? `Error: prompt '${promptId}' has no version '${baseVersionId}'`
+        : "Error: prompt not found",
+    );
+  }
+  if ("error" in base) {
+    return mcpError(`Error: ${base.error}`);
+  }
+
+  const applied = applyPromptEdits(base.value, edits);
+  if (!applied.ok) {
+    return mcpError(
+      `Error: ${applied.error} (base: ${base.name} v${base.versionNumber})`,
+    );
+  }
+
+  return mcpUpdatePrompt(auth, promptId, applied.value, description);
 }
 
 /**

--- a/src/lib/mcp/mcpTools.ts
+++ b/src/lib/mcp/mcpTools.ts
@@ -1335,26 +1335,21 @@ export async function mcpCreatePrompt(
  * to `mcpUpdatePrompt` — so the stored version, the proposal payload and the
  * approval path all keep working on whole values. See `prompt-edits.ts`.
  *
- * The base is the version the caller read: `baseVersionId` when supplied,
- * otherwise the same anchor `get_prompt` uses (published if set, else latest).
- * Passing `baseVersionId` explicitly turns a stale read into a failed match
- * rather than a silent rebase onto whatever is current.
+ * The base is always the current version — the same anchor `get_prompt` uses
+ * (published if set, else latest). If the prompt changed since the caller read
+ * it, the edit either still applies cleanly or fails the exact match; there is
+ * no way to pin an older base and silently revert a concurrent change.
  */
 export async function mcpUpdatePromptEdits(
   auth: WorkspaceAuth,
   promptId: string,
   edits: PromptEdit[],
   description?: string,
-  baseVersionId?: string,
 ): Promise<McpToolResult> {
-  const base = await getRawPromptValue(promptId, baseVersionId);
+  const base = await getRawPromptValue(promptId);
 
   if ("notFound" in base) {
-    return mcpError(
-      baseVersionId
-        ? `Error: prompt '${promptId}' has no version '${baseVersionId}'`
-        : "Error: prompt not found",
-    );
+    return mcpError("Error: prompt not found");
   }
   if ("error" in base) {
     return mcpError(`Error: ${base.error}`);

--- a/src/lib/proposals/types.ts
+++ b/src/lib/proposals/types.ts
@@ -345,9 +345,12 @@ export interface PromptCreateProposalPayload {
 
 /**
  * Payload the agent fills in for a prompt update proposal.
- * `value` is required (mcpUpdatePrompt has no partial-update path).
- * A description-only change must still send the current raw value as `value`
- * so `oldStr === newStr` for value but description changes.
+ * `value` is required and always a complete snapshot: the agent may express the
+ * change as find/replace edits, but `propose_prompt_update` resolves those to a
+ * full value at tool-call time (an edit list replayed at approval time would
+ * apply to a prompt that has since moved). A description-only change must still
+ * send the current raw value as `value` so `oldStr === newStr` for value but
+ * description changes.
  */
 export interface PromptUpdateProposalPayload {
   promptId: string;

--- a/src/services/prompts/prompt-edits.ts
+++ b/src/services/prompts/prompt-edits.ts
@@ -1,0 +1,121 @@
+/**
+ * Exact-match find/replace edits for prompt values.
+ *
+ * Prompts are stored as whole values and every write path (`writePromptThrough`,
+ * the `promptUpdate` proposal payload, `PromptVersion.value`) keeps a complete
+ * snapshot. Edits are purely a *wire format* on the agent-facing edge: an agent
+ * sends only the fragments it wants changed, and we resolve them to a full value
+ * immediately, at tool-call time. Nothing downstream ever sees an edit list.
+ *
+ * That buys two things over having the agent re-emit the whole prompt:
+ *   - a long prompt is not round-tripped through the model, so it cannot silently
+ *     drift (dropped section, normalized whitespace, "helpfully" reworded para);
+ *   - a stale read fails loudly — if `oldStr` no longer matches, someone changed
+ *     the prompt since the agent read it, and we reject instead of clobbering.
+ */
+
+export interface PromptEdit {
+  /** Exact text to find in the current value. Must match verbatim, whitespace included. */
+  oldStr: string;
+  /** Replacement text. May be empty to delete. */
+  newStr: string;
+  /** Replace every occurrence instead of requiring `oldStr` to be unique. */
+  replaceAll?: boolean;
+}
+
+export type ApplyPromptEditsResult =
+  | { ok: true; value: string }
+  | { ok: false; error: string };
+
+/** Cap on edits per call — a sanity bound, not a meaningful workflow limit. */
+export const MAX_PROMPT_EDITS = 50;
+
+/** Keep `oldStr` echoes in error messages readable. */
+const SNIPPET_LIMIT = 80;
+
+function snippet(str: string): string {
+  const oneLine = str.replace(/\n/g, "\\n");
+  return oneLine.length <= SNIPPET_LIMIT
+    ? oneLine
+    : `${oneLine.slice(0, SNIPPET_LIMIT)}…`;
+}
+
+/** Literal (non-regex) occurrence count. */
+function countOccurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+function replaceFirst(haystack: string, needle: string, replacement: string): string {
+  const idx = haystack.indexOf(needle);
+  return haystack.slice(0, idx) + replacement + haystack.slice(idx + needle.length);
+}
+
+/**
+ * Apply `edits` to `base` in order, each against the result of the previous one.
+ *
+ * Fails (rather than guessing) when an edit does not match exactly once:
+ * a zero-match edit means the caller's copy of the prompt is stale, and an
+ * ambiguous multi-match edit means the caller has not said which occurrence
+ * it meant. Both are conditions the caller must resolve, not us.
+ */
+export function applyPromptEdits(
+  base: string,
+  edits: PromptEdit[],
+): ApplyPromptEditsResult {
+  if (!Array.isArray(edits) || edits.length === 0) {
+    return { ok: false, error: "edits must contain at least one edit." };
+  }
+  if (edits.length > MAX_PROMPT_EDITS) {
+    return {
+      ok: false,
+      error: `Too many edits (${edits.length}); the maximum is ${MAX_PROMPT_EDITS}.`,
+    };
+  }
+
+  let current = base;
+
+  for (let i = 0; i < edits.length; i++) {
+    const { oldStr, newStr, replaceAll } = edits[i];
+    const label = `edit ${i + 1} of ${edits.length}`;
+
+    if (typeof oldStr !== "string" || oldStr.length === 0) {
+      return { ok: false, error: `${label}: oldStr must be a non-empty string.` };
+    }
+    if (typeof newStr !== "string") {
+      return { ok: false, error: `${label}: newStr must be a string.` };
+    }
+    if (oldStr === newStr) {
+      return {
+        ok: false,
+        error: `${label}: oldStr and newStr are identical — the edit would change nothing.`,
+      };
+    }
+
+    const matches = countOccurrences(current, oldStr);
+
+    if (matches === 0) {
+      return {
+        ok: false,
+        error:
+          `${label}: oldStr not found in the prompt: "${snippet(oldStr)}". ` +
+          "It must match the stored value exactly, including whitespace and line breaks. " +
+          "Re-read the current value with raw: true and build the edit from that text " +
+          "(note that earlier edits in this same call have already been applied).",
+      };
+    }
+    if (matches > 1 && !replaceAll) {
+      return {
+        ok: false,
+        error:
+          `${label}: oldStr matched ${matches} times: "${snippet(oldStr)}". ` +
+          "Extend oldStr with surrounding context to make it unique, or pass replaceAll: true.",
+      };
+    }
+
+    current = replaceAll
+      ? current.split(oldStr).join(newStr)
+      : replaceFirst(current, oldStr, newStr);
+  }
+
+  return { ok: true, value: current };
+}


### PR DESCRIPTION
## Problem

`update_prompt` (MCP) and `propose_prompt_update` (canvas agent) both required the complete new prompt text. For a targeted change — tweak one rule, reword a paragraph — that means an agent must re-emit the whole prompt, which:

- pays for a long prompt twice (read + write);
- invites silent drift, since nothing in the write path compares against what was read (a dropped section or normalized whitespace lands as a new version);
- cannot detect a stale read at all. `mcpUpdatePrompt` is last-writer-wins on content, so a concurrent edit is silently reverted.

## What changed

Both tools now accept `edits: [{ oldStr, newStr, replaceAll? }]` as an alternative to `value` — exactly one, never both.

**Edits are a wire format only.** They're resolved to a complete value at tool-call time; `writePromptThrough`, the `promptUpdate` proposal payload, `PromptVersion.value` and the approval path all still work on whole values. That's deliberate: an edit list stored on an approval card and replayed days later would apply to a prompt that has since moved, and the diff card would lose its before/after preview.

- **`src/services/prompts/prompt-edits.ts`** (new) — `applyPromptEdits(base, edits)`. Literal (non-regex) matching, edits applied in order each against the previous result. Fails rather than guessing: zero matches (stale read), multiple matches without `replaceAll` (ambiguous), empty `oldStr`, or `oldStr === newStr`. On failure it returns no value at all, so a half-applied prompt can't be written.
- **`update_prompt`** — routes to `mcpUpdatePromptEdits`, which reads the base, applies the edits, and delegates to the unchanged `mcpUpdatePrompt`. The base is always the current version — the same anchor `get_prompt` uses (published, else latest) — so a concurrent change either merges cleanly or fails the exact match loudly; there is no way to pin an older base and silently revert it.
- **`propose_prompt_update`** — already fetched the raw value for the diff, so edits apply to that. The resolved full value goes into `payload.value` and `meta.newStr`; the approval handler and diff card are untouched.
- **Canvas `get_prompt` gains `raw: true`**, mirroring the MCP tool. Without it that edge could only return resolved text — variables substituted, nested prompts inlined — so edits built from it could never match. The canvas system-prompt snippet now tells the agent to read raw before proposing, and to re-read rather than fall back to a full `value` when a match fails.

## Compatibility

Additive. `value` still works everywhere it did; no schema, migration, or approval-path changes.

## Testing

39 new tests across the applier, the MCP path, and the canvas tool — including that a failed edit writes nothing, that a later edit made ambiguous by an earlier one is rejected, and that `$&` in `newStr` isn't treated as a substitution pattern.

Full `lib/mcp`, `lib/ai`, `lib/proposals`, `services/prompts`, `lib/constants` unit suites pass (846). Typecheck and lint clean on changed files; the one remaining `prompt.ts` lint warning (unused eslint-disable, line 1021) is pre-existing — confirmed with these changes stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
