### PR TITLE
Fix prompt-cache breakers in the canvas agent (Jamie)

### DIFF
--- a/src/__tests__/integration/api/ask/quick.test.ts
+++ b/src/__tests__/integration/api/ask/quick.test.ts
@@ -50,6 +50,9 @@ vi.mock('@/lib/ai/askTools', () => ({
 vi.mock('@/lib/constants/prompt', () => ({
   getQuickAskPrefixMessages: vi.fn(() => []),
   getMultiWorkspacePrefixMessages: vi.fn(() => []),
+  // Trailing `<canvas-scope>` message builder. `null` = no scope block,
+  // which keeps the assembled message array equal to the history.
+  buildCanvasScopeMessage: vi.fn(() => null),
   // Per-capability snippets consumed by the capability registry
   // (@/lib/ai/capabilities), reached transitively via runCanvasAgent.
   getRoadmapCapabilitySnippet: vi.fn(() => ''),

--- a/src/__tests__/integration/api/ask/sync.test.ts
+++ b/src/__tests__/integration/api/ask/sync.test.ts
@@ -45,6 +45,9 @@ vi.mock('@/lib/ai/askTools', () => ({
 vi.mock('@/lib/constants/prompt', () => ({
   getQuickAskPrefixMessages: vi.fn(() => []),
   getMultiWorkspacePrefixMessages: vi.fn(() => []),
+  // Trailing `<canvas-scope>` message builder. `null` = no scope block,
+  // which keeps the assembled message array equal to the history.
+  buildCanvasScopeMessage: vi.fn(() => null),
   getRoadmapCapabilitySnippet: vi.fn(() => ''),
   getWhiteboardCapabilitySnippet: vi.fn(() => ''),
   getPlannerCapabilitySnippet: vi.fn(() => ''),

--- a/src/__tests__/unit/lib/ai/runCanvasAgent-timing.test.ts
+++ b/src/__tests__/unit/lib/ai/runCanvasAgent-timing.test.ts
@@ -79,6 +79,7 @@ vi.mock("@/lib/ai/capabilityGates", () => ({
 vi.mock("@/lib/constants/prompt", () => ({
   getMultiWorkspacePrefixMessages: vi.fn(() => []),
   getQuickAskPrefixMessages: vi.fn(() => []),
+  buildCanvasScopeMessage: vi.fn(() => null),
   getRoadmapCapabilitySnippet: vi.fn(() => ""),
   getWhiteboardCapabilitySnippet: vi.fn(() => ""),
   getPlannerCapabilitySnippet: vi.fn(() => ""),

--- a/src/__tests__/unit/lib/canvas/canvas-scope-hint.test.ts
+++ b/src/__tests__/unit/lib/canvas/canvas-scope-hint.test.ts
@@ -1,32 +1,27 @@
 import { describe, it, expect } from "vitest";
 import type { CanvasScopeHint } from "@/lib/constants/prompt";
-import { getQuickAskPrefixMessages } from "@/lib/constants/prompt";
+import { buildCanvasScopeMessage } from "@/lib/constants/prompt";
 
-// Helper: invoke the exported function and extract the system message content.
-function getSystemContent(scope?: CanvasScopeHint): string {
-  const msgs = getQuickAskPrefixMessages(
-    [],       // concepts
-    [],       // repoUrls
-    null,     // clueMsgs
-    undefined, // description
-    undefined, // members
-    scope !== undefined ? { orgId: "org-test", scope } : { orgId: "org-test" },
-  );
-  const system = msgs.find((m) => m.role === "system");
-  return typeof system?.content === "string" ? system.content : "";
+// Helper: render the trailing `<canvas-scope>` message for a scope.
+// (The hint deliberately no longer lives in the system prompt — it's a
+// tail message so the cached prefix survives canvas navigation.)
+function getScopeContent(scope?: CanvasScopeHint): string {
+  const msg = buildCanvasScopeMessage(scope);
+  if (!msg) return "";
+  return typeof msg.content === "string" ? msg.content : "";
 }
 
-// Helper: pull the canvas scope section out of a system prompt string.
+// Helper: pull the canvas scope section out of the rendered block.
 function getScopeSection(content: string): string {
   const idx = content.indexOf("## Current canvas scope");
   if (idx === -1) return "";
   return content.slice(idx);
 }
 
-describe("getCanvasScopeHint — selectedNodeIds (via getQuickAskPrefixMessages)", () => {
+describe("getCanvasScopeHint — selectedNodeIds (via buildCanvasScopeMessage)", () => {
   it("emits nothing for selectedNodeIds: [] (empty array)", () => {
     const section = getScopeSection(
-      getSystemContent({ currentCanvasRef: "", selectedNodeIds: [] }),
+      getScopeContent({ currentCanvasRef: "", selectedNodeIds: [] }),
     );
     // The section exists (ref is provided) but no multi-node hint.
     expect(section).not.toContain("They have selected");
@@ -35,14 +30,14 @@ describe("getCanvasScopeHint — selectedNodeIds (via getQuickAskPrefixMessages)
 
   it("emits nothing for selectedNodeIds: undefined", () => {
     const section = getScopeSection(
-      getSystemContent({ currentCanvasRef: "", selectedNodeIds: undefined }),
+      getScopeContent({ currentCanvasRef: "", selectedNodeIds: undefined }),
     );
     expect(section).not.toContain("They have selected");
   });
 
   it("emits hint for selectedNodeIds with 1 entry", () => {
     const section = getScopeSection(
-      getSystemContent({
+      getScopeContent({
         currentCanvasRef: "",
         selectedNodeIds: ["initiative:abc123"],
       }),
@@ -56,7 +51,7 @@ describe("getCanvasScopeHint — selectedNodeIds (via getQuickAskPrefixMessages)
 
   it("emits hint listing all IDs for selectedNodeIds with N entries", () => {
     const section = getScopeSection(
-      getSystemContent({
+      getScopeContent({
         currentCanvasRef: "",
         selectedNodeIds: ["initiative:aaa", "ws:bbb", "note:ccc"],
       }),
@@ -70,7 +65,7 @@ describe("getCanvasScopeHint — selectedNodeIds (via getQuickAskPrefixMessages)
   it("does NOT emit multi hint when selectedNodeId (single) is also set", () => {
     // Single-node selection takes priority; `!selected` guard suppresses multi hint.
     const section = getScopeSection(
-      getSystemContent({
+      getScopeContent({
         currentCanvasRef: "",
         selectedNodeId: "initiative:solo",
         selectedNodeIds: ["initiative:solo", "ws:other"],
@@ -84,7 +79,7 @@ describe("getCanvasScopeHint — selectedNodeIds (via getQuickAskPrefixMessages)
 
   it("single-node selectedNodeId path is unaffected when selectedNodeIds absent", () => {
     const section = getScopeSection(
-      getSystemContent({
+      getScopeContent({
         currentCanvasRef: "",
         selectedNodeId: "ws:xyz",
       }),
@@ -102,14 +97,14 @@ describe("getCanvasScopeHint — selectedNodeIds (via getQuickAskPrefixMessages)
 describe("getCanvasScopeHint — early-return guard", () => {
   it("returns empty scope section when no ref and no selected node(s)", () => {
     // No currentCanvasRef means refProvided=false; no selectedNodeId; no selectedNodeIds.
-    const content = getSystemContent({});
+    const content = getScopeContent({});
     expect(getScopeSection(content)).toBe("");
   });
 
   it("does NOT bail early when selectedNodeIds has entries (even without a ref)", () => {
     // selectedNodeIds alone bypasses the `!refProvided && !selected && !(selectedNodeIds?.length)` guard.
     const section = getScopeSection(
-      getSystemContent({ selectedNodeIds: ["note:hello"] }),
+      getScopeContent({ selectedNodeIds: ["note:hello"] }),
     );
     // The section should be rendered with the multi-node hint.
     expect(section).toContain("They have selected 1 nodes");

--- a/src/__tests__/unit/lib/constants/canvas-scope-hint.test.ts
+++ b/src/__tests__/unit/lib/constants/canvas-scope-hint.test.ts
@@ -1,15 +1,22 @@
 import { describe, it, expect } from "vitest";
-import { getMultiWorkspacePrefixMessages } from "@/lib/constants/prompt";
+import {
+  buildCanvasScopeMessage,
+  getMultiWorkspacePrefixMessages,
+} from "@/lib/constants/prompt";
+import type { CanvasScopeHint } from "@/lib/constants/prompt";
 import type { WorkspaceConfig } from "@/lib/ai/workspaceConfig";
 
 /**
  * Lock the contract that the canvas scope hint is:
- *   1. emitted into the system prompt only when `orgId` is set
- *      (otherwise canvas tools aren't loaded and the hint would be noise),
- *   2. names the current canvas ref so the agent defaults tool calls
+ *   1. rendered into a TRAILING `<canvas-scope>` message — never inlined
+ *      into the system prompt, which must stay byte-stable turn-to-turn
+ *      so Anthropic prompt caching survives the user clicking around the
+ *      canvas (see `CANVAS_SCOPE_POINTER`),
+ *   2. omitted entirely when there's no scope to describe,
+ *   3. names the current canvas ref so the agent defaults tool calls
  *      there, and
- *   3. includes the selected node id when one is provided, and
- *   4. surfaces a human-readable breadcrumb (org name on root, parent ›
+ *   4. includes the selected node id when one is provided, and
+ *   5. surfaces a human-readable breadcrumb (org name on root, parent ›
  *      child on a sub-canvas) so the agent can refer to the scope by
  *      name in replies instead of echoing an opaque ref id.
  */
@@ -33,129 +40,139 @@ function systemContent(messages: ReturnType<typeof getMultiWorkspacePrefixMessag
   return typeof sys.content === "string" ? sys.content : "";
 }
 
-describe("canvas scope hint in system prompt", () => {
-  it("does NOT include the hint when orgId is absent", () => {
+/** The rendered `<canvas-scope>` block, or "" when none was emitted. */
+function scopeBlock(scope?: CanvasScopeHint): string {
+  const msg = buildCanvasScopeMessage(scope);
+  if (!msg) return "";
+  return typeof msg.content === "string" ? msg.content : "";
+}
+
+// ─── The system prompt must NOT carry volatile scope data ────────────────────
+// This is the cache contract: the scope changes on every canvas click, and
+// the system message is a single content block. Inlining the hint there
+// invalidated the persona preamble + every capability snippet above it.
+
+describe("system prompt stays scope-free (prompt-cache contract)", () => {
+  it("carries only the static pointer, never the rendered scope", () => {
+    const messages = getMultiWorkspacePrefixMessages(
+      [makeWs("alpha"), makeWs("beta")],
+      { alpha: [], beta: [] },
+      [],
+      "org-1",
+    );
+    const sys = systemContent(messages);
+    // Static pointer telling the agent where to look.
+    expect(sys).toContain("<canvas-scope>");
+    expect(sys).toContain("Current canvas scope");
+    // …but none of the per-turn-volatile rendered values. (`initiative:`
+    // on its own is fine — the capability snippets document the node-id
+    // format; what must never appear is the rendered scope text.)
+    expect(sys).not.toContain("They have selected node");
+    expect(sys).not.toContain("They have selected 1 nodes");
+    expect(sys).not.toContain("The user is viewing");
+    expect(sys).not.toContain("linked on the org root canvas");
+  });
+
+  it("is byte-identical regardless of the user's canvas position", () => {
+    const build = () =>
+      systemContent(
+        getMultiWorkspacePrefixMessages(
+          [makeWs("alpha"), makeWs("beta")],
+          { alpha: [], beta: [] },
+          [],
+          "org-1",
+        ),
+      );
+    expect(build()).toBe(build());
+  });
+
+  it("omits the pointer entirely when orgId is absent (no canvas tools)", () => {
     const messages = getMultiWorkspacePrefixMessages(
       [makeWs("alpha"), makeWs("beta")],
       { alpha: [], beta: [] },
       [],
       undefined,
-      { currentCanvasRef: "initiative:abc", selectedNodeId: "ws:xyz" },
     );
-    const sys = systemContent(messages);
-    expect(sys).not.toContain("Current canvas scope");
+    expect(systemContent(messages)).not.toContain("<canvas-scope>");
+  });
+});
+
+describe("canvas scope message", () => {
+  it("emits no message when no scope is provided", () => {
+    expect(buildCanvasScopeMessage(undefined)).toBeNull();
   });
 
-  it("does NOT include the hint when no scope info is provided", () => {
-    const messages = getMultiWorkspacePrefixMessages(
-      [makeWs("alpha"), makeWs("beta")],
-      { alpha: [], beta: [] },
-      [],
-      "org-1",
-    );
-    const sys = systemContent(messages);
-    expect(sys).not.toContain("Current canvas scope");
+  it("emits no message when the scope has no usable fields", () => {
+    expect(buildCanvasScopeMessage({})).toBeNull();
+  });
+
+  it("is a user-role message wrapped in a <canvas-scope> tag", () => {
+    const msg = buildCanvasScopeMessage({ currentCanvasRef: "" });
+    expect(msg).not.toBeNull();
+    expect(msg!.role).toBe("user");
+    const content = typeof msg!.content === "string" ? msg!.content : "";
+    expect(content.startsWith("<canvas-scope>")).toBe(true);
+    expect(content.trimEnd().endsWith("</canvas-scope>")).toBe(true);
+    // The agent must not mistake it for something the human typed.
+    expect(content).toContain("the user did not type this");
   });
 
   it("describes the org root when ref is empty", () => {
-    const messages = getMultiWorkspacePrefixMessages(
-      [makeWs("alpha"), makeWs("beta")],
-      { alpha: [], beta: [] },
-      [],
-      "org-1",
-      { currentCanvasRef: "" },
-    );
-    const sys = systemContent(messages);
-    expect(sys).toContain("Current canvas scope");
-    expect(sys).toContain("the org root canvas");
-    expect(sys).toContain('ref: ""');
+    const block = scopeBlock({ currentCanvasRef: "" });
+    expect(block).toContain("Current canvas scope");
+    expect(block).toContain("the org root canvas");
+    expect(block).toContain('ref: ""');
   });
 
   it("names the sub-canvas ref when one is provided", () => {
-    const messages = getMultiWorkspacePrefixMessages(
-      [makeWs("alpha"), makeWs("beta")],
-      { alpha: [], beta: [] },
-      [],
-      "org-1",
-      { currentCanvasRef: "initiative:abc" },
-    );
-    const sys = systemContent(messages);
-    expect(sys).toContain("`initiative:abc` sub-canvas");
-    expect(sys).toContain('ref: "initiative:abc"');
+    const block = scopeBlock({ currentCanvasRef: "initiative:abc" });
+    expect(block).toContain("`initiative:abc` sub-canvas");
+    expect(block).toContain('ref: "initiative:abc"');
   });
 
   it("mentions the selected node when provided", () => {
-    const messages = getMultiWorkspacePrefixMessages(
-      [makeWs("alpha"), makeWs("beta")],
-      { alpha: [], beta: [] },
-      [],
-      "org-1",
-      { currentCanvasRef: "", selectedNodeId: "initiative:def" },
-    );
-    const sys = systemContent(messages);
-    expect(sys).toContain("`initiative:def`");
-    expect(sys).toContain("this initiative/workspace/milestone");
+    const block = scopeBlock({
+      currentCanvasRef: "",
+      selectedNodeId: "initiative:def",
+    });
+    expect(block).toContain("`initiative:def`");
+    expect(block).toContain("this initiative/workspace/milestone");
   });
 
-  it("emits hint when only selectedNodeId is set", () => {
-    const messages = getMultiWorkspacePrefixMessages(
-      [makeWs("alpha"), makeWs("beta")],
-      { alpha: [], beta: [] },
-      [],
-      "org-1",
-      { selectedNodeId: "ws:zzz" },
-    );
-    const sys = systemContent(messages);
-    expect(sys).toContain("Current canvas scope");
-    expect(sys).toContain("`ws:zzz`");
+  it("emits the block when only selectedNodeId is set", () => {
+    const block = scopeBlock({ selectedNodeId: "ws:zzz" });
+    expect(block).toContain("Current canvas scope");
+    expect(block).toContain("`ws:zzz`");
   });
 
   it("includes the breadcrumb name on the root canvas", () => {
-    const messages = getMultiWorkspacePrefixMessages(
-      [makeWs("alpha"), makeWs("beta")],
-      { alpha: [], beta: [] },
-      [],
-      "org-1",
-      { currentCanvasRef: "", currentCanvasBreadcrumb: "Acme" },
-    );
-    const sys = systemContent(messages);
-    expect(sys).toContain("**Acme**");
-    expect(sys).toContain("the org root canvas");
+    const block = scopeBlock({
+      currentCanvasRef: "",
+      currentCanvasBreadcrumb: "Acme",
+    });
+    expect(block).toContain("**Acme**");
+    expect(block).toContain("the org root canvas");
     // The agent should be told to refer to the scope by name, not ref id.
-    expect(sys).toContain('use the name "Acme"');
+    expect(block).toContain('use the name "Acme"');
   });
 
   it("includes a parent › child breadcrumb on a sub-canvas", () => {
-    const messages = getMultiWorkspacePrefixMessages(
-      [makeWs("alpha"), makeWs("beta")],
-      { alpha: [], beta: [] },
-      [],
-      "org-1",
-      {
-        currentCanvasRef: "initiative:abc",
-        currentCanvasBreadcrumb: "Acme › Auth Refactor",
-      },
-    );
-    const sys = systemContent(messages);
-    expect(sys).toContain("**Acme › Auth Refactor**");
+    const block = scopeBlock({
+      currentCanvasRef: "initiative:abc",
+      currentCanvasBreadcrumb: "Acme › Auth Refactor",
+    });
+    expect(block).toContain("**Acme › Auth Refactor**");
     // Ref id is still surfaced for tool calls.
-    expect(sys).toContain("`initiative:abc` sub-canvas");
-    expect(sys).toContain('ref: "initiative:abc"');
-    expect(sys).toContain('use the name "Acme › Auth Refactor"');
+    expect(block).toContain("`initiative:abc` sub-canvas");
+    expect(block).toContain('ref: "initiative:abc"');
+    expect(block).toContain('use the name "Acme › Auth Refactor"');
   });
 
   it("falls back to ref-only when no breadcrumb is provided", () => {
-    const messages = getMultiWorkspacePrefixMessages(
-      [makeWs("alpha"), makeWs("beta")],
-      { alpha: [], beta: [] },
-      [],
-      "org-1",
-      { currentCanvasRef: "initiative:abc" },
-    );
-    const sys = systemContent(messages);
-    expect(sys).toContain("`initiative:abc` sub-canvas");
+    const block = scopeBlock({ currentCanvasRef: "initiative:abc" });
+    expect(block).toContain("`initiative:abc` sub-canvas");
     // No name-based instruction when there's no name.
-    expect(sys).not.toContain('use the name "');
+    expect(block).not.toContain('use the name "');
   });
 
   // ─── Linked-workspace hint (initiative-scoped) ─────────────────────────────
@@ -165,83 +182,51 @@ describe("canvas scope hint in system prompt", () => {
   // belong to. These tests lock the prompt-side surfacing of that hint.
 
   it("surfaces a single linked workspace as a strong slug directive (no cuid)", () => {
-    const messages = getMultiWorkspacePrefixMessages(
-      [makeWs("alpha"), makeWs("beta")],
-      { alpha: [], beta: [] },
-      [],
-      "org-1",
-      {
-        currentCanvasRef: "initiative:abc",
-        linkedWorkspaces: [
-          { id: "ws-hive", slug: "hive", name: "Hive" },
-        ],
-      },
-    );
-    const sys = systemContent(messages);
-    expect(sys).toContain("**Hive**");
-    expect(sys).toContain("slug `hive`");
-    expect(sys).toContain('workspaceSlug: "hive"');
-    expect(sys).toContain("propose_feature");
+    const block = scopeBlock({
+      currentCanvasRef: "initiative:abc",
+      linkedWorkspaces: [{ id: "ws-hive", slug: "hive", name: "Hive" }],
+    });
+    expect(block).toContain("**Hive**");
+    expect(block).toContain("slug `hive`");
+    expect(block).toContain('workspaceSlug: "hive"');
+    expect(block).toContain("propose_feature");
     // The id must not leak into the prompt — that's the failure mode
     // we're protecting against. Tools resolve slug → id internally.
-    expect(sys).not.toContain("ws-hive");
-    expect(sys).not.toContain("workspaceId:");
+    expect(block).not.toContain("ws-hive");
+    expect(block).not.toContain("workspaceId:");
   });
 
   it("surfaces multiple linked workspaces as a list with an ask-the-user nudge", () => {
-    const messages = getMultiWorkspacePrefixMessages(
-      [makeWs("alpha"), makeWs("beta")],
-      { alpha: [], beta: [] },
-      [],
-      "org-1",
-      {
-        currentCanvasRef: "initiative:abc",
-        linkedWorkspaces: [
-          { id: "ws-hive", slug: "hive", name: "Hive" },
-          { id: "ws-sg", slug: "stakgraph", name: "Stakgraph" },
-        ],
-      },
-    );
-    const sys = systemContent(messages);
-    expect(sys).toContain("**Hive**");
-    expect(sys).toContain("**Stakgraph**");
-    expect(sys).toContain("ask them before calling `propose_feature`");
+    const block = scopeBlock({
+      currentCanvasRef: "initiative:abc",
+      linkedWorkspaces: [
+        { id: "ws-hive", slug: "hive", name: "Hive" },
+        { id: "ws-sg", slug: "stakgraph", name: "Stakgraph" },
+      ],
+    });
+    expect(block).toContain("**Hive**");
+    expect(block).toContain("**Stakgraph**");
+    expect(block).toContain("ask them before calling `propose_feature`");
     // No cuids in the multi-linked branch either.
-    expect(sys).not.toContain("ws-hive");
-    expect(sys).not.toContain("ws-sg");
+    expect(block).not.toContain("ws-hive");
+    expect(block).not.toContain("ws-sg");
   });
 
   it("does NOT surface the linked-workspace hint outside initiative scopes", () => {
-    const messages = getMultiWorkspacePrefixMessages(
-      [makeWs("alpha"), makeWs("beta")],
-      { alpha: [], beta: [] },
-      [],
-      "org-1",
-      {
-        currentCanvasRef: "ws:zzz",
-        // Non-initiative scope — even if linkedWorkspaces is set
-        // somehow, the prompt branch should not fire.
-        linkedWorkspaces: [
-          { id: "ws-hive", slug: "hive", name: "Hive" },
-        ],
-      },
-    );
-    const sys = systemContent(messages);
-    expect(sys).not.toContain("linked on the org root canvas");
-    expect(sys).not.toContain('workspaceSlug: "hive"');
+    const block = scopeBlock({
+      currentCanvasRef: "ws:zzz",
+      // Non-initiative scope — even if linkedWorkspaces is set
+      // somehow, the prompt branch should not fire.
+      linkedWorkspaces: [{ id: "ws-hive", slug: "hive", name: "Hive" }],
+    });
+    expect(block).not.toContain("linked on the org root canvas");
+    expect(block).not.toContain('workspaceSlug: "hive"');
   });
 
   it("omits the hint when linkedWorkspaces is empty/undefined on an initiative scope", () => {
-    const messages = getMultiWorkspacePrefixMessages(
-      [makeWs("alpha"), makeWs("beta")],
-      { alpha: [], beta: [] },
-      [],
-      "org-1",
-      { currentCanvasRef: "initiative:abc" },
-    );
-    const sys = systemContent(messages);
+    const block = scopeBlock({ currentCanvasRef: "initiative:abc" });
     // Existing behaviour preserved — no linked-workspace section.
-    expect(sys).not.toContain("linked on the org root canvas");
+    expect(block).not.toContain("linked on the org root canvas");
   });
 });
 
@@ -256,7 +241,6 @@ describe("reply style + no-id-leak rules", () => {
       { alpha: [], beta: [] },
       [],
       "org-1",
-      { currentCanvasRef: "" },
     );
     const sys = systemContent(messages);
     // Section header.
@@ -276,7 +260,6 @@ describe("reply style + no-id-leak rules", () => {
       { alpha: [], beta: [] },
       [],
       "org-1",
-      { currentCanvasRef: "" },
     );
     const sys = systemContent(messages);
     // The mock workspaces have id `ws-alpha` / `ws-beta`. Those must

--- a/src/lib/ai/runCanvasAgent.ts
+++ b/src/lib/ai/runCanvasAgent.ts
@@ -44,6 +44,7 @@ import type {
   PrepareStepFunction,
 } from "ai";
 import {
+  buildCanvasScopeMessage,
   getMultiWorkspacePrefixMessages,
   getQuickAskPrefixMessages,
 } from "@/lib/constants/prompt";
@@ -378,10 +379,14 @@ export interface RunCanvasAgentResult {
    */
   readonly: boolean;
   /**
-   * The prefix messages actually used this turn (system prompt + seeded
-   * concepts), rebuilt fresh every turn with the current scope. Surfaced
-   * so the caller can persist a snapshot for the Agent Logs detail view
-   * ("what the model saw").
+   * The non-history context used this turn: the prefix messages (system
+   * prompt + seeded concepts) plus the trailing `<canvas-scope>` block
+   * when one was injected. Surfaced so the caller can persist a snapshot
+   * for the Agent Logs detail view ("what the model saw").
+   *
+   * Note the ordering here is the *log* ordering, not the request
+   * ordering — the scope block is actually sent after the conversation
+   * history (see the append site in the body for why).
    */
   assembledPrefix: ModelMessage[];
   /**
@@ -615,6 +620,10 @@ export async function runCanvasAgent(
   let tools: ToolSet;
   let prefixMessages: ModelMessage[];
   let features: Record<string, unknown>[];
+  // The user's current canvas scope, resolved per branch below. Rendered
+  // into a TRAILING message (not the system prompt) — see the append
+  // site further down for why.
+  let canvasScope: CanvasScopeHint | undefined;
   // Concept-cache bookkeeping, assigned per branch below.
   let cacheHit = false;
   let cacheableConcepts: CachedConcepts = {};
@@ -764,15 +773,19 @@ export async function runCanvasAgent(
       };
     }
 
-    // Always rebuilt fresh (cheap string work) so the scope hint reflects
-    // the user's CURRENT canvas/selection, even on a concept-cache hit.
+    // Canvas tools only exist on org-scope calls, so the scope block is
+    // only meaningful there.
+    canvasScope = orgId ? buildScopeHint(scope, linkedWorkspaces) : undefined;
+
+    // Rebuilt fresh each turn (cheap string work), but deliberately
+    // scope-FREE: every input here is stable turn-to-turn for a given
+    // conversation, which is what keeps the system block cacheable.
     const tPrefixMessages = Date.now();
     prefixMessages = getMultiWorkspacePrefixMessages(
       workspaceConfigs,
       conceptsByWorkspace,
       [],
       orgId,
-      buildScopeHint(scope, linkedWorkspaces),
       orgPromptSuffix,
       canvasSystemPrompt.value,
       userTimezone,
@@ -861,7 +874,9 @@ export async function runCanvasAgent(
       };
     }
 
-    // Always rebuilt fresh so the scope hint stays current on cache hits.
+    canvasScope = orgId ? buildScopeHint(scope, []) : undefined;
+
+    // Scope-free by design — see the multi-workspace branch above.
     const tPrefixMessagesSingle = Date.now();
     prefixMessages = getQuickAskPrefixMessages(
       features,
@@ -872,7 +887,6 @@ export async function runCanvasAgent(
       orgId
         ? {
             orgId,
-            scope: buildScopeHint(scope, []),
             promptSuffix: orgPromptSuffix,
           }
         : undefined,
@@ -910,7 +924,26 @@ export async function runCanvasAgent(
   // ------------------------------------------------------------------
   // Assemble final message list + sanitize
   // ------------------------------------------------------------------
-  const rawMessages: ModelMessage[] = [...prefixMessages, ...messages];
+  // The canvas scope block goes LAST — after the full history, not in
+  // the system prompt.
+  //
+  // Anthropic prompt caching is longest-common-prefix. The scope
+  // (current canvas ref, breadcrumb, selected node ids) changes every
+  // time the user clicks a node or opens a sub-canvas, so while it lived
+  // in the system message — one content block — a single click rewrote
+  // that block and invalidated the cache for the persona preamble and
+  // every capability snippet above it. Parked at the tail, the volatile
+  // bytes are the last thing in the request and everything before them
+  // (tools → system → seeded concepts → history) stays cacheable.
+  //
+  // Keep this the final append. Anything inserted after it re-creates
+  // the exact problem this fixes.
+  const canvasScopeMessage = buildCanvasScopeMessage(canvasScope);
+  const rawMessages: ModelMessage[] = [
+    ...prefixMessages,
+    ...messages,
+    ...(canvasScopeMessage ? [canvasScopeMessage] : []),
+  ];
   const tSanitize = Date.now();
   const modelMessages = await sanitizeAndCompleteToolCalls(
     rawMessages,
@@ -1113,7 +1146,12 @@ export async function runCanvasAgent(
     primaryWorkspaceId: primaryWorkspaceId!,
     primaryUserId: primaryUserId!,
     readonly,
-    assembledPrefix: prefixMessages,
+    // The scope block is appended for the log snapshot even though the
+    // model sees it at the tail — it's non-history context the Agent
+    // Logs view should still show under "what the model saw".
+    assembledPrefix: canvasScopeMessage
+      ? [...prefixMessages, canvasScopeMessage]
+      : prefixMessages,
     cacheableConcepts,
     cacheHit,
     promptResolutions,

--- a/src/lib/ai/workspaceConfig.ts
+++ b/src/lib/ai/workspaceConfig.ts
@@ -55,9 +55,14 @@ export async function buildWorkspaceConfigs(
       throw notFoundError(`GitHub PAT not found for workspace: ${slug}`);
     }
 
-    // Fetch workspace members (name, github username, role, description)
+    // Fetch workspace members (name, github username, role, description).
+    // `orderBy` is load-bearing: this roster is rendered near the top of
+    // the cached system prompt, and `lastAccessedAt` writes churn these
+    // rows — without a stable sort the heap order shifts and busts the
+    // Anthropic prompt cache for the whole request.
     const memberships = await db.workspaceMember.findMany({
       where: { workspaceId: access.workspace.id, leftAt: null },
+      orderBy: [{ joinedAt: "asc" }, { id: "asc" }],
       select: {
         role: true,
         description: true,
@@ -159,8 +164,13 @@ export async function buildPublicWorkspaceConfig(
   // Members list is used in the prompt so the agent can refer to
   // contributors by name. Public viewers see it too — names are
   // public knowledge for an isPublicViewable workspace.
+  //
+  // Stable `orderBy` for the same reason as `buildWorkspaceConfigs`:
+  // an unordered roster reshuffles under row churn and busts the
+  // cached system prompt.
   const memberships = await db.workspaceMember.findMany({
     where: { workspaceId: workspace.id, leftAt: null },
+    orderBy: [{ joinedAt: "asc" }, { id: "asc" }],
     select: {
       role: true,
       description: true,

--- a/src/lib/constants/prompt.ts
+++ b/src/lib/constants/prompt.ts
@@ -102,7 +102,6 @@ When you are done print "[END_OF_ANSWER]"`;
  */
 export interface SingleWorkspaceOrgContext {
   orgId: string;
-  scope?: CanvasScopeHint;
   /**
    * Pre-composed org prompt suffix for the caller's selected
    * capabilities (see `composeCapabilityPromptSuffix`). Omitted →
@@ -125,7 +124,7 @@ export function getQuickAskPrefixMessages(
   const systemContent = orgContext
     ? baseSystem +
       (orgContext.promptSuffix ?? getCanvasPromptSuffix()) +
-      getCanvasScopeHint(orgContext.scope)
+      CANVAS_SCOPE_POINTER
     : baseSystem;
 
   return [
@@ -971,7 +970,6 @@ export function getMultiWorkspacePrefixMessages(
   conceptsByWorkspace: Record<string, Record<string, unknown>[]>,
   clueMsgs: ModelMessage[] | null,
   orgId?: string,
-  scope?: CanvasScopeHint,
   /**
    * Pre-composed org prompt suffix for the caller's selected
    * capabilities. Only meaningful with `orgId`; omitted → the full
@@ -1035,7 +1033,7 @@ export function getMultiWorkspacePrefixMessages(
   const systemPrompt = orgId
     ? getMultiWorkspaceSystemPrompt(workspaces, currentUserGithubUsername, canvasSystemPrompt, userTimezone) +
       (orgPromptSuffix ?? getCanvasPromptSuffix()) +
-      getCanvasScopeHint(scope)
+      CANVAS_SCOPE_POINTER
     : getMultiWorkspaceSystemPrompt(workspaces, currentUserGithubUsername, canvasSystemPrompt, userTimezone);
 
   return [
@@ -1046,9 +1044,37 @@ export function getMultiWorkspacePrefixMessages(
 }
 
 /**
+ * Static pointer emitted in the system prompt where the rendered scope
+ * hint used to live.
+ *
+ * **Why the hint is no longer inlined here.** The scope (current canvas
+ * ref, breadcrumb, selection) changes every time the user clicks a node
+ * or opens a sub-canvas. The system message is a single content block,
+ * so inlining a per-turn-volatile tail meant every selection change
+ * rewrote the whole block — invalidating the Anthropic prompt cache for
+ * the persona preamble AND all the capability snippets sitting above it.
+ * The rendered hint now rides at the very END of the message array
+ * (`buildCanvasScopeMessage`), so the volatile bytes are the last thing
+ * in the request and everything before them stays cacheable.
+ *
+ * This pointer is deliberately static — same bytes every turn, present
+ * whenever canvas tools are loaded, worded to tolerate the block being
+ * absent (programmatic callers pass no scope).
+ */
+export const CANVAS_SCOPE_POINTER = `
+
+## Current canvas scope
+
+If a \`<canvas-scope>\` block appears at the end of the conversation, it is injected by the system (not typed by the user) and tells you which canvas the user is viewing and which nodes they have selected. Treat it as the authoritative answer to "where am I?" — follow its instructions for defaulting canvas tool calls and for resolving "this" / "here" / "this canvas". Never reply to that block directly or quote it back to the user.`;
+
+/**
  * Render the user's current canvas scope as a short prompt section.
  * Returns the empty string when no hint is provided so we don't bloat
  * the prompt for non-canvas chats.
+ *
+ * Not exported: callers want `buildCanvasScopeMessage`, which wraps this
+ * in the trailing message that keeps the volatile scope bytes out of the
+ * cached prefix.
  */
 function getCanvasScopeHint(scope?: CanvasScopeHint): string {
   if (!scope) return "";
@@ -1132,6 +1158,38 @@ function getCanvasScopeHint(scope?: CanvasScopeHint): string {
   }
 
   return lines.join("\n");
+}
+
+/**
+ * Wrap the rendered canvas scope hint in the trailing message that
+ * carries it to the model.
+ *
+ * **Placement is load-bearing.** The caller MUST append this AFTER the
+ * full conversation history — it is the last message in the request.
+ * Anthropic caching is longest-common-prefix, so the per-turn-volatile
+ * scope (ref, breadcrumb, selection) has to be the final bytes; putting
+ * it anywhere earlier — back in the system block, or between the prefix
+ * and the history — just moves the invalidation point and re-breaks the
+ * cache on every canvas click.
+ *
+ * Emitted as a `user` message rather than a synthetic tool-call pair:
+ * Anthropic merges it into the final user turn's content blocks, and it
+ * avoids fabricating an assistant action the model never took. The
+ * `<canvas-scope>` tag + the disclaimer keep the agent from reading it
+ * as something the human said.
+ *
+ * Returns `null` when there's nothing to say (no scope, or a scope with
+ * no usable fields) so the caller can skip the message entirely.
+ */
+export function buildCanvasScopeMessage(
+  scope?: CanvasScopeHint,
+): ModelMessage | null {
+  const hint = getCanvasScopeHint(scope).trim();
+  if (!hint) return null;
+  return {
+    role: "user",
+    content: `<canvas-scope>\nSystem-injected context — the user did not type this. Do not reply to it directly or quote it back.\n\n${hint}\n</canvas-scope>`,
+  };
 }
 
 export function getPromptsCapabilitySnippet(): string {


### PR DESCRIPTION
Two fixes for prompt-cache invalidation in Jamie's prompt assembly. Anthropic caching (top-level `cache_control: ephemeral` via `getProviderOptions`) is longest-common-prefix, so anything that mutates early bytes throws away everything after it.

## 1. Canvas scope hint moved out of the system prompt

`getCanvasScopeHint(scope)` was concatenated onto the end of the system prompt string. The system message is a single content block, and the scope (current canvas ref, breadcrumb, selected node ids) changes every time the user clicks a node or opens a sub-canvas — so a single click rewrote that block and invalidated the cache for the persona preamble and every capability snippet above it.

The hint now renders into a trailing `<canvas-scope>` **user message** appended after the full history (`buildCanvasScopeMessage`), so the volatile bytes are the last thing in the request. A static `CANVAS_SCOPE_POINTER` stays in the system prompt to tell the agent where to look.

A user message rather than a synthetic tool-call pair: Anthropic merges it into the final user turn's content blocks, and it avoids fabricating an assistant action the model never took. The tag plus an explicit "the user did not type this" disclaimer keep the agent from reading it as human speech.

`scope` drops out of both prefix builders' signatures. `assembledPrefix` still carries the block so the Agent Logs "what the model saw" view is unchanged.

**Known residual:** the block isn't persisted into conversation history, so it leaves a wall at its position — the prior turn's assistant/tool output gets re-processed on the next turn. Net effect vs. before: a large win whenever the user moves around the canvas between messages, a modest regression when they don't. Persisting it as a hidden row, emitted only when the scope actually changes, would make the prefix fully append-only; happy to do that as a follow-up.

## 2. Stable ordering for the member roster

`workspaceMember.findMany` had no `orderBy`, so Postgres returned rows in unspecified heap order. That roster renders near the top of the system prompt, and row churn can reshuffle it between turns, silently rewriting the cached prefix. Now ordered by `joinedAt, id` in both config builders.

## Testing

- Full unit suite passes (13,504 tests). New assertions lock the contract that the system block is byte-identical regardless of canvas position, and the scope-hint tests now exercise `buildCanvasScopeMessage` directly.
- Integration tests not run — they need the Docker test DB, which isn't up locally.

## Not addressed here

From the same audit, still open: presigned S3 image URLs re-signed every request (`resolveMessageImages.ts`), the sub-agent `[TIME BUDGET]` note churn in the research/graph-walk `prepareStep` hooks, `getCurrentDateSnippet()` sitting at byte 0 of the system prompt, and the system prompt potentially flipping between the DB value and the in-repo default across serverless instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)