### PR TITLE
Add Generate Report option to legal benchmark runs

### DIFF
--- a/src/__tests__/unit/components/BenchmarkRunsHistory.test.tsx
+++ b/src/__tests__/unit/components/BenchmarkRunsHistory.test.tsx
@@ -26,6 +26,9 @@ const makeRun = (overrides: Partial<{
   judgeNotes: string;
   requestedModel: string;
   requestedJudgeModel: string;
+  generateReport: boolean;
+  reportStatus: string;
+  reportChatPath: string;
 }> = {}) => ({
   id: "runner-1",
   workspaceId: WORKSPACE_ID,
@@ -40,6 +43,9 @@ const makeRun = (overrides: Partial<{
   judgeNotes: undefined as string | undefined,
   requestedModel: undefined as string | undefined,
   requestedJudgeModel: undefined as string | undefined,
+  generateReport: undefined as boolean | undefined,
+  reportStatus: undefined as string | undefined,
+  reportChatPath: undefined as string | undefined,
   ...overrides,
 });
 
@@ -240,7 +246,8 @@ describe("BenchmarkRunsHistory", () => {
       setExpandedId: mockSetExpandedId,
     });
     render(React.createElement(BenchmarkRunsHistory));
-    expect(screen.getByText("—")).toBeInTheDocument();
+    // Both the Score and Report cells render '—'
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
     expect(screen.queryByText("PASS")).toBeNull();
     expect(screen.queryByText("FAIL")).toBeNull();
   });
@@ -255,7 +262,7 @@ describe("BenchmarkRunsHistory", () => {
       setExpandedId: mockSetExpandedId,
     });
     render(React.createElement(BenchmarkRunsHistory));
-    expect(screen.getByText("—")).toBeInTheDocument();
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
     // Must NOT render a false FAIL badge
     expect(screen.queryByText("FAIL")).toBeNull();
     expect(screen.queryByText("PASS")).toBeNull();
@@ -271,7 +278,7 @@ describe("BenchmarkRunsHistory", () => {
       setExpandedId: mockSetExpandedId,
     });
     render(React.createElement(BenchmarkRunsHistory));
-    expect(screen.getByText("—")).toBeInTheDocument();
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
   });
 
   // ─── judgeNotes / ScoreCell tooltip tests ─────────────────────────────────
@@ -319,10 +326,11 @@ describe("BenchmarkRunsHistory", () => {
       setExpandedId: mockSetExpandedId,
     });
     render(React.createElement(BenchmarkRunsHistory));
-    // PENDING renders '—', no score div to check — just assert no title present on '—' cell
-    const dash = screen.getByText("—");
-    expect(dash.getAttribute("title")).toBeNull();
-    expect(dash.getAttribute("aria-label")).toBeNull();
+    // PENDING renders '—', no score div to check — just assert no title present on any '—' cell
+    for (const dash of screen.getAllByText("—")) {
+      expect(dash.getAttribute("title")).toBeNull();
+      expect(dash.getAttribute("aria-label")).toBeNull();
+    }
   });
 
   it("ScoreCell renders no title or aria-label for IN_PROGRESS run", () => {
@@ -335,14 +343,15 @@ describe("BenchmarkRunsHistory", () => {
       setExpandedId: mockSetExpandedId,
     });
     render(React.createElement(BenchmarkRunsHistory));
-    const dash = screen.getByText("—");
-    expect(dash.getAttribute("title")).toBeNull();
-    expect(dash.getAttribute("aria-label")).toBeNull();
+    for (const dash of screen.getAllByText("—")) {
+      expect(dash.getAttribute("title")).toBeNull();
+      expect(dash.getAttribute("aria-label")).toBeNull();
+    }
   });
 
   // ─── colSpan tests ─────────────────────────────────────────────────────────
 
-  it("expanded row colSpan is 4 for non-super-admin (Task + Started + Runner Status + Score)", async () => {
+  it("expanded row colSpan is 5 for non-super-admin (Task + Started + Runner Status + Score + Report)", async () => {
     const user = userEvent.setup();
     render(React.createElement(BenchmarkRunsHistory));
 
@@ -350,10 +359,10 @@ describe("BenchmarkRunsHistory", () => {
     await user.click(row);
 
     const expandedCell = screen.getByTestId("results-runner-1").closest("td")!;
-    expect(expandedCell.getAttribute("colspan")).toBe("4");
+    expect(expandedCell.getAttribute("colspan")).toBe("5");
   });
 
-  it("expanded row colSpan is 5 for super-admin (adds Stakwork column)", async () => {
+  it("expanded row colSpan is 6 for super-admin (adds Stakwork column)", async () => {
     const { useWorkspace } = await import("@/hooks/useWorkspace");
     (useWorkspace as ReturnType<typeof vi.fn>).mockReturnValue({
       workspace: { id: WORKSPACE_ID, slug: WORKSPACE_SLUG },
@@ -367,7 +376,7 @@ describe("BenchmarkRunsHistory", () => {
     await user.click(row);
 
     const expandedCell = screen.getByTestId("results-runner-1").closest("td")!;
-    expect(expandedCell.getAttribute("colspan")).toBe("5");
+    expect(expandedCell.getAttribute("colspan")).toBe("6");
   });
 
   // ─── Existing interaction tests ────────────────────────────────────────────
@@ -529,7 +538,7 @@ describe("BenchmarkRunsHistory", () => {
     expect(screen.queryByTestId("model-sub-line")).toBeNull();
   });
 
-  it("model sub-line does not affect colSpan (non-super-admin still 4)", async () => {
+  it("model sub-line does not affect colSpan (non-super-admin still 5)", async () => {
     mockUseList.mockReturnValue({
       runs: [makeRun({
         requestedModel: "anthropic/claude-sonnet-5",
@@ -549,7 +558,90 @@ describe("BenchmarkRunsHistory", () => {
     await user.click(row);
 
     const expandedCell = screen.getByTestId("results-runner-1").closest("td")!;
-    expect(expandedCell.getAttribute("colspan")).toBe("4");
+    expect(expandedCell.getAttribute("colspan")).toBe("5");
+  });
+
+  // ─── Report column tests ───────────────────────────────────────────────────
+
+  it("renders Report column header", () => {
+    render(React.createElement(BenchmarkRunsHistory));
+    expect(screen.getByText("Report")).toBeInTheDocument();
+  });
+
+  it("renders 'View Report' link when reportChatPath is present", () => {
+    mockUseList.mockReturnValue({
+      runs: [makeRun({
+        generateReport: true,
+        reportStatus: "completed",
+        reportChatPath: "/org/stakwork?chat=conv-123",
+      })],
+      total: 1,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+      setExpandedId: mockSetExpandedId,
+    });
+    render(React.createElement(BenchmarkRunsHistory));
+    const link = screen.getByTestId("report-chat-link");
+    expect(link).toBeInTheDocument();
+    expect(link.getAttribute("href")).toBe("/org/stakwork?chat=conv-123");
+    expect(link.getAttribute("target")).toBe("_blank");
+  });
+
+  it("shows Pending spinner when report requested but not yet written", () => {
+    mockUseList.mockReturnValue({
+      runs: [makeRun({ status: "IN_PROGRESS", generateReport: true })],
+      total: 1,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+      setExpandedId: mockSetExpandedId,
+    });
+    render(React.createElement(BenchmarkRunsHistory));
+    expect(screen.getByText("Pending")).toBeInTheDocument();
+    expect(screen.queryByTestId("report-chat-link")).toBeNull();
+  });
+
+  it("shows 'Failed' when reportStatus is failed", () => {
+    mockUseList.mockReturnValue({
+      runs: [makeRun({ generateReport: true, reportStatus: "failed" })],
+      total: 1,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+      setExpandedId: mockSetExpandedId,
+    });
+    render(React.createElement(BenchmarkRunsHistory));
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+  });
+
+  it("shows dash (not Pending) for a FAILED run with generateReport (report will never fire)", () => {
+    mockUseList.mockReturnValue({
+      runs: [makeRun({ status: "FAILED", generateReport: true })],
+      total: 1,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+      setExpandedId: mockSetExpandedId,
+    });
+    render(React.createElement(BenchmarkRunsHistory));
+    expect(screen.queryByText("Pending")).toBeNull();
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+  });
+
+  it("shows dash when report was not requested", () => {
+    mockUseList.mockReturnValue({
+      runs: [makeRun({ status: "COMPLETED", n_passed: 5, n_total: 5, all_pass: true })],
+      total: 1,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+      setExpandedId: mockSetExpandedId,
+    });
+    render(React.createElement(BenchmarkRunsHistory));
+    expect(screen.queryByTestId("report-chat-link")).toBeNull();
+    expect(screen.queryByText("Pending")).toBeNull();
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
   });
 
   it("judgeNotes tooltip still reflects judge model (no divergence from sub-line)", () => {

--- a/src/app/api/workspaces/[slug]/legal/benchmarks/run/route.ts
+++ b/src/app/api/workspaces/[slug]/legal/benchmarks/run/route.ts
@@ -94,7 +94,13 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     }
 
     // ── Parse + validate body (BEFORE Bifrost resolution) ─────────────────────
-    let body: { taskSlug?: string; taskTitle?: string; model?: string; judgeModel?: string };
+    let body: {
+      taskSlug?: string;
+      taskTitle?: string;
+      model?: string;
+      judgeModel?: string;
+      generateReport?: boolean;
+    };
     try {
       body = await request.json();
     } catch {
@@ -112,6 +118,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     // Apply defaults for model selection
     const model = body.model ?? DEFAULT_BENCHMARK_MODEL;
     const judgeModel = body.judgeModel ?? DEFAULT_JUDGE_MODEL;
+    const generateReport = body.generateReport === true;
 
     // Validate: isValidModel + Anthropic-only gate + DB catalog membership
     const validateModel = async (m: string, label: string): Promise<NextResponse | null> => {
@@ -276,6 +283,9 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           //  the webhook merge cannot overwrite them).
           requestedModel: bareModel,
           requestedJudgeModel: bareJudgeModel,
+          // Same clobber-proof guarantee: the runner never emits generateReport,
+          // so the completion webhook can read it back and trigger the report.
+          ...(generateReport ? { generateReport: true } : {}),
           // evalTriggerRef will be added later (non-fatal Jarvis step)
         };
 
@@ -285,6 +295,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
             type: StakworkRunType.LEGAL_BENCHMARK_RUNNER,
             status: WorkflowStatus.PENDING,
             webhookUrl: placeholder,
+            userId: userOrResponse.id,
             result: JSON.stringify(runnerResultJson),
           },
           select: { id: true },

--- a/src/components/legal/BenchmarkRunsHistory.tsx
+++ b/src/components/legal/BenchmarkRunsHistory.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { formatDistanceToNow } from "date-fns";
-import { Loader2 } from "lucide-react";
+import { ExternalLink, Loader2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { useLegalBenchmarkRunList } from "@/hooks/useLegalBenchmarkRunList";
@@ -70,8 +70,8 @@ export function BenchmarkRunsHistory() {
     );
   }
 
-  // colSpan: Task + Started + Runner Status + Score + (Stakwork if super admin)
-  const colSpan = isSuperAdmin ? 5 : 4;
+  // colSpan: Task + Started + Runner Status + Score + Report + (Stakwork if super admin)
+  const colSpan = isSuperAdmin ? 6 : 5;
 
   return (
     <div className="space-y-3">
@@ -89,6 +89,7 @@ export function BenchmarkRunsHistory() {
               <th className="text-left px-4 py-3 font-medium text-muted-foreground">Started</th>
               <th className="text-left px-4 py-3 font-medium text-muted-foreground">Runner Status</th>
               <th className="text-left px-4 py-3 font-medium text-muted-foreground">Score</th>
+              <th className="text-left px-4 py-3 font-medium text-muted-foreground">Report</th>
               {isSuperAdmin && (
                 <th className="text-left px-4 py-3 font-medium text-muted-foreground">Stakwork</th>
               )}
@@ -133,6 +134,9 @@ export function BenchmarkRunsHistory() {
                   <td className="px-4 py-3">
                     <ScoreCell run={run} />
                   </td>
+                  <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
+                    <ReportCell run={run} />
+                  </td>
                   {isSuperAdmin && (
                     <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
                       <StakworkRunLink projectId={run.projectId} isSuperAdmin={isSuperAdmin} />
@@ -157,6 +161,41 @@ export function BenchmarkRunsHistory() {
       </div>
     </div>
   );
+}
+
+function ReportCell({ run }: { run: BenchmarkRunListRow }) {
+  if (run.reportChatPath) {
+    return (
+      <a
+        href={run.reportChatPath}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1 text-primary hover:underline whitespace-nowrap"
+        data-testid="report-chat-link"
+      >
+        View Report
+        <ExternalLink className="h-3 w-3" />
+      </a>
+    );
+  }
+
+  if (run.reportStatus === "failed") {
+    return <span className="text-xs text-destructive">Failed</span>;
+  }
+
+  // Requested but not yet started/written (run still executing, or the
+  // completion webhook is generating the report right now). A FAILED run
+  // never triggers a report, so fall through to the dash instead.
+  if (run.generateReport && run.status !== WorkflowStatus.FAILED) {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs text-muted-foreground whitespace-nowrap">
+        <Loader2 className="h-3 w-3 animate-spin" />
+        Pending
+      </span>
+    );
+  }
+
+  return <span className="text-muted-foreground">—</span>;
 }
 
 function ScoreCell({ run }: { run: BenchmarkRunListRow }) {

--- a/src/components/legal/LegalBenchmarksPanel.tsx
+++ b/src/components/legal/LegalBenchmarksPanel.tsx
@@ -202,7 +202,10 @@ export function LegalBenchmarksPanel({ className }: { className?: string }) {
     fetchData();
   }, [slug]);
 
-  const handleSelectTask = async (task: HarveyTask) => {
+  const handleSelectTask = async (
+    task: HarveyTask,
+    options?: { generateReport?: boolean },
+  ) => {
     const res = await fetch(`/api/workspaces/${slug}/legal/benchmarks/run`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -211,6 +214,7 @@ export function LegalBenchmarksPanel({ className }: { className?: string }) {
         taskTitle: task.title,
         model: selectedModel,
         judgeModel: selectedJudgeModel,
+        generateReport: options?.generateReport === true,
       }),
     });
 
@@ -421,7 +425,7 @@ export function LegalBenchmarksPanel({ className }: { className?: string }) {
           onOpenChange={(o) => { if (!o) setDetailsTask(null); }}
           task={detailsTask}
           slug={slug!}
-          onRunTask={() => handleSelectTask(detailsTask)}
+          onRunTask={(options) => handleSelectTask(detailsTask, options)}
         />
       )}
     </div>

--- a/src/components/legal/TaskDetailsModal.tsx
+++ b/src/components/legal/TaskDetailsModal.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from "react";
 import { FileIcon, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
@@ -37,7 +38,7 @@ export interface TaskDetailsModalProps {
   onOpenChange: (open: boolean) => void;
   task: HarveyTask;
   slug: string;
-  onRunTask: () => void;
+  onRunTask: (options: { generateReport: boolean }) => void;
 }
 
 // ─── Loading skeleton ─────────────────────────────────────────────────────────
@@ -86,6 +87,7 @@ export function TaskDetailsModal({
   const [error, setError] = useState<string | null>(null);
   const [sizeData, setSizeData] = useState<FileSizeData | null>(null);
   const [sizeLoading, setSizeLoading] = useState(true);
+  const [generateReport, setGenerateReport] = useState(false);
 
   useEffect(() => {
     if (!open || !task?.slug) {
@@ -232,6 +234,20 @@ export function TaskDetailsModal({
                   ) : (
                     <p className="text-sm text-muted-foreground italic">No instructions available.</p>
                   )}
+                  <div className="flex items-center gap-2 mt-3">
+                    <Checkbox
+                      id="generate-report"
+                      checked={generateReport}
+                      onCheckedChange={(checked) => setGenerateReport(checked === true)}
+                      data-testid="generate-report-checkbox"
+                    />
+                    <label
+                      htmlFor="generate-report"
+                      className="text-sm font-medium cursor-pointer select-none"
+                    >
+                      Generate Report
+                    </label>
+                  </div>
                 </section>
 
                 <Separator className="my-4" />
@@ -315,7 +331,7 @@ export function TaskDetailsModal({
           <Button
             onClick={() => {
               onOpenChange(false);
-              onRunTask();
+              onRunTask({ generateReport });
             }}
           >
             Run Task

--- a/src/hooks/useLegalBenchmarkRunList.ts
+++ b/src/hooks/useLegalBenchmarkRunList.ts
@@ -22,6 +22,12 @@ export interface BenchmarkRunListRow {
   requestedModel?: string;
   /** Operator-chosen judge model (bare name). Absent on legacy runs. */
   requestedJudgeModel?: string;
+  /** Operator checked "Generate Report" at run creation */
+  generateReport?: boolean;
+  /** Report lifecycle: "generating" | "completed" | "failed" */
+  reportStatus?: string;
+  /** Relative link to the report chat, e.g. "/org/<login>?chat=<id>" */
+  reportChatPath?: string;
 }
 
 interface UseLegalBenchmarkRunListResult {
@@ -84,6 +90,9 @@ export function useLegalBenchmarkRunList(
           all_pass: parsed?.all_pass,
           requestedModel: parsed?.requestedModel,
           requestedJudgeModel: parsed?.requestedJudgeModel,
+          generateReport: parsed?.generateReport,
+          reportStatus: parsed?.reportStatus,
+          reportChatPath: parsed?.reportChatPath,
           // Unified judge precedence: operator choice takes priority over runner-echoed value.
           // Format mirrors stakwork-run.ts — if the server-side format string changes, update this line to match.
           judgeNotes:

--- a/src/lib/pusher.ts
+++ b/src/lib/pusher.ts
@@ -143,6 +143,9 @@ export type CanvasConversationUpdateReason =
   // A recurring automation fired: the cron created a fresh org-canvas
   // conversation and appended the agent's response to it.
   | "automation"
+  // A legal benchmark run completed with "Generate Report" checked: the
+  // webhook created a report conversation and appended the agent's analysis.
+  | "benchmark-report"
   // A graph-walk sub-agent completed and fanned its synthesized answer
   // back into the conversation as an assistant bubble.
   | "graph_walk"

--- a/src/services/legal-benchmark-report.ts
+++ b/src/services/legal-benchmark-report.ts
@@ -1,0 +1,268 @@
+/**
+ * Post-run report generation for legal benchmark runs.
+ *
+ * When an operator checks "Generate Report" in the task details modal, the
+ * flag is stored in the runner StakworkRun's `result` JSON. After the final
+ * result webhook merges the scores and marks the run COMPLETED, the webhook
+ * handler calls `generateBenchmarkRunReport` (inside Next's `after()`), which:
+ *   1. Atomically claims the report (`reportStatus: "generating"` in the
+ *      result JSON) so duplicate webhook deliveries can't spawn two reports.
+ *   2. Creates a fresh org-canvas `SharedConversation` seeded with the review
+ *      prompt (same shape as `automation-dispatcher`).
+ *   3. Runs `runCanvasAgent` and appends the assistant turn.
+ *   4. Merges `reportConversationId` / `reportChatPath` back into the run's
+ *      result JSON and broadcasts STAKWORK_RUN_UPDATE so the Runs table
+ *      picks up the link.
+ */
+
+import { db } from "@/lib/db";
+import { type ModelMessage } from "ai";
+import { runCanvasAgent, type CachedConcepts } from "@/lib/ai/runCanvasAgent";
+import {
+  messagesFromSteps,
+  appendTurnMessages,
+  type StoredMessage,
+} from "@/services/canvas-turn-persistence";
+import { resolveOrgWorkspaceSlugs } from "@/services/automation-dispatcher";
+import {
+  pusherServer,
+  getWorkspaceChannelName,
+  PUSHER_EVENTS,
+} from "@/lib/pusher";
+import { logger } from "@/lib/logger";
+import { parseBenchmarkRunResult, type BenchmarkRunResult } from "@/types/legal";
+
+const LOG_SERVICE = "legal-benchmark-report";
+
+function parseResultJson(result: string | null): Record<string, unknown> {
+  if (!result) return {};
+  try {
+    return JSON.parse(result) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Read-merge-write a patch into the run's result JSON. The result column is a
+ * JSON string, so concurrent writers (e.g. the EVAL annotation webhook) are
+ * merged at read time rather than clobbered.
+ */
+async function mergeIntoRunResult(
+  runId: string,
+  patch: Partial<BenchmarkRunResult>,
+): Promise<void> {
+  await db.$transaction(async (tx) => {
+    const row = await tx.stakworkRun.findUnique({
+      where: { id: runId },
+      select: { result: true },
+    });
+    const json = parseResultJson(row?.result ?? null);
+    await tx.stakworkRun.update({
+      where: { id: runId },
+      data: { result: JSON.stringify({ ...json, ...patch }) },
+    });
+  });
+}
+
+/**
+ * Generate the operator-requested post-run report for a completed
+ * LEGAL_BENCHMARK_RUNNER run. No-op when the flag is absent or a report was
+ * already generated/claimed. Errors are recorded on the run
+ * (`reportStatus: "failed"`) and rethrown to the caller's catch.
+ */
+export async function generateBenchmarkRunReport(runId: string): Promise<void> {
+  const run = await db.stakworkRun.findUnique({
+    where: { id: runId },
+    include: {
+      workspace: {
+        select: {
+          slug: true,
+          ownerId: true,
+          sourceControlOrgId: true,
+          sourceControlOrg: { select: { githubLogin: true } },
+        },
+      },
+    },
+  });
+
+  if (!run) {
+    logger.error("[report] Run not found", LOG_SERVICE, { runId });
+    return;
+  }
+
+  // ── Atomic claim — duplicate webhook deliveries bail here ────────────────
+  const claimed = await db.$transaction(async (tx) => {
+    const row = await tx.stakworkRun.findUnique({
+      where: { id: runId },
+      select: { result: true },
+    });
+    const json = parseResultJson(row?.result ?? null);
+    if (json.generateReport !== true) return false;
+    if (json.reportStatus || json.reportConversationId) return false;
+    await tx.stakworkRun.update({
+      where: { id: runId },
+      data: {
+        result: JSON.stringify({ ...json, reportStatus: "generating" }),
+      },
+    });
+    return true;
+  });
+
+  if (!claimed) {
+    logger.info(
+      "[report] Skipping — report not requested or already claimed",
+      LOG_SERVICE,
+      { runId },
+    );
+    return;
+  }
+
+  try {
+    const parsed: Partial<BenchmarkRunResult> = parseBenchmarkRunResult(run.result) ?? {};
+    const orgId = run.workspace.sourceControlOrgId;
+    const githubLogin = run.workspace.sourceControlOrg?.githubLogin;
+    const userId = run.userId ?? run.workspace.ownerId;
+
+    if (!orgId || !githubLogin) {
+      throw new Error(
+        `Workspace ${run.workspace.slug} has no linked SourceControlOrg — cannot create an org-canvas report`,
+      );
+    }
+    if (!run.projectId) {
+      throw new Error("Run has no Stakwork projectId to review");
+    }
+
+    let workspaceSlugs = await resolveOrgWorkspaceSlugs(orgId, userId);
+    if (workspaceSlugs.length === 0) {
+      workspaceSlugs = [run.workspace.slug];
+    }
+
+    const scoreLine =
+      typeof parsed.n_passed === "number" && typeof parsed.n_total === "number"
+        ? ` It scored ${parsed.n_passed}/${parsed.n_total} criteria (${parsed.all_pass ? "PASS" : "FAIL"}).`
+        : "";
+    const prompt = `Review this project run: ${run.projectId}
+
+What were the main reasons this workflow was not as effective as it could have been? Please return a report on the root causes and possible improvements. You can include proposals for Prompt updates, Concept updates, or Features (either code or workflows).
+
+Context: this was a legal benchmark run of the Harvey LAB task "${parsed.taskTitle ?? "unknown"}" (${parsed.taskSlug ?? "unknown"}).${scoreLine}`;
+
+    const now = new Date();
+    const idPrefix = `benchmark-report-${runId}-${now.getTime().toString(36)}-`;
+    const userRow: StoredMessage = {
+      id: `${idPrefix}u`,
+      role: "user",
+      content: prompt,
+      timestamp: now.toISOString(),
+    };
+
+    const conversation = await db.sharedConversation.create({
+      data: {
+        sourceControlOrgId: orgId,
+        userId,
+        workspaceId: null,
+        messages: [userRow] as unknown as never,
+        title: `Benchmark Report: ${parsed.taskTitle ?? runId}`,
+        lastMessageAt: now,
+        source: "org-canvas",
+        settings: {
+          extraWorkspaceSlugs: workspaceSlugs,
+          benchmarkRunId: runId,
+        } as unknown as never,
+        followUpQuestions: [],
+        // Shared so any org member can open the link from the Runs table
+        isShared: true,
+      },
+      select: { id: true },
+    });
+
+    // Persist the link before the (slow) agent run so the Runs table can
+    // surface it while the report is still being written.
+    const reportChatPath = `/org/${githubLogin}?chat=${conversation.id}`;
+    await mergeIntoRunResult(runId, {
+      reportConversationId: conversation.id,
+      reportChatPath,
+    });
+    await broadcastRunUpdate(run.workspace.slug, runId, run.type, run.featureId);
+
+    logger.info("[report] Running canvas agent", LOG_SERVICE, {
+      runId,
+      conversationId: conversation.id,
+      projectId: run.projectId,
+    });
+
+    const messages: ModelMessage[] = [{ role: "user", content: prompt }];
+    const { result: agentResult } = await runCanvasAgent({
+      userId,
+      orgId,
+      workspaceSlugs,
+      messages,
+      cachedConcepts: null as CachedConcepts | null,
+      silentPusher: true,
+      currentCanvasConversationId: conversation.id,
+    });
+
+    await agentResult.text;
+    const steps = await agentResult.steps;
+
+    const assistantPrefix = `${idPrefix}a`;
+    const rows = messagesFromSteps(
+      steps as Parameters<typeof messagesFromSteps>[0],
+      assistantPrefix,
+    );
+    if (rows.length === 0) {
+      rows.push({
+        id: `${assistantPrefix}0`,
+        role: "assistant",
+        content: "(No response generated.)",
+        timestamp: new Date().toISOString(),
+      });
+    }
+
+    await appendTurnMessages({
+      conversationId: conversation.id,
+      rows,
+      idPrefix: assistantPrefix,
+      reason: "benchmark-report",
+    });
+
+    await mergeIntoRunResult(runId, { reportStatus: "completed" });
+    await broadcastRunUpdate(run.workspace.slug, runId, run.type, run.featureId);
+
+    logger.info("[report] Report generated", LOG_SERVICE, {
+      runId,
+      conversationId: conversation.id,
+      messageRows: rows.length,
+    });
+  } catch (err) {
+    await mergeIntoRunResult(runId, { reportStatus: "failed" }).catch(() => {});
+    await broadcastRunUpdate(
+      run.workspace.slug,
+      runId,
+      run.type,
+      run.featureId,
+    ).catch(() => {});
+    throw err;
+  }
+}
+
+async function broadcastRunUpdate(
+  workspaceSlug: string,
+  runId: string,
+  type: string,
+  featureId: string | null,
+): Promise<void> {
+  try {
+    await pusherServer.trigger(
+      getWorkspaceChannelName(workspaceSlug),
+      PUSHER_EVENTS.STAKWORK_RUN_UPDATE,
+      { runId, type, featureId, timestamp: new Date() },
+    );
+  } catch (pusherError) {
+    logger.error("[report] Pusher trigger failed (non-fatal)", LOG_SERVICE, {
+      runId,
+      error: String(pusherError),
+    });
+  }
+}

--- a/src/services/stakwork-run.ts
+++ b/src/services/stakwork-run.ts
@@ -1,4 +1,5 @@
 import { db } from "@/lib/db";
+import { after } from "next/server";
 import {
   WorkflowStatus,
   StakworkRunType,
@@ -1053,6 +1054,32 @@ export async function processStakworkRunWebhook(
       });
     } catch (pusherError) {
       logger.error("[legal-benchmark] Pusher trigger failed (non-fatal)", "stakwork-run", { error: String(pusherError) });
+    }
+
+    // Operator-requested post-run report — fires after the scores were merged
+    // above, so the report agent sees the final result. Scheduled via after()
+    // so the webhook acks immediately (same shape as /api/chat/response).
+    if (status === WorkflowStatus.COMPLETED) {
+      let wantsReport = false;
+      try {
+        const resultJson = serializedResult ?? run.result;
+        wantsReport = resultJson
+          ? (JSON.parse(resultJson) as Record<string, unknown>).generateReport === true
+          : false;
+      } catch { /* ignore malformed result */ }
+      if (wantsReport) {
+        after(async () => {
+          try {
+            const { generateBenchmarkRunReport } = await import("@/services/legal-benchmark-report");
+            await generateBenchmarkRunReport(run.id);
+          } catch (err) {
+            logger.error("[legal-benchmark] Report generation failed (non-fatal)", "stakwork-run", {
+              runId: run.id,
+              error: String(err),
+            });
+          }
+        });
+      }
     }
     return { runId: run.id, status, dataType };
   }

--- a/src/types/legal.ts
+++ b/src/types/legal.ts
@@ -32,6 +32,18 @@ export interface BenchmarkRunResult {
    * Same clobber-proof guarantee as requestedModel.
    */
   requestedJudgeModel?: string;
+  /**
+   * Operator checked "Generate Report" in the task details modal.
+   * Stored at run creation under a clobber-proof key (the runner never
+   * emits it); read by the completion webhook to trigger the report.
+   */
+  generateReport?: boolean;
+  /** Report lifecycle marker — also the idempotency guard against duplicate webhooks */
+  reportStatus?: "generating" | "completed" | "failed";
+  /** SharedConversation id of the generated report chat */
+  reportConversationId?: string;
+  /** Relative link to the report chat, e.g. "/org/<githubLogin>?chat=<conversationId>" */
+  reportChatPath?: string;
   // ── Flat score fields from the runner webhook (workflow 57179 inline eval) ──
   /** Raw score (e.g. 72) */
   score?: number;


### PR DESCRIPTION
## Summary

Adds an operator-requested AI post-run report to the legal benchmarks flow (`/w/[slug]/legal/benchmarks`):

- **Checkbox** — a "Generate Report" checkbox in the Benchmark card Details modal, below the Task instructions. Run Task passes the flag to the run route.
- **Storage** — the flag is stored in the runner `StakworkRun`'s `result` JSON under a clobber-proof key (same pattern as `requestedModel`); the route now also sets `userId` on the row so the report chat is attributed to whoever clicked Run Task.
- **Trigger** — the result webhook's `LEGAL_BENCHMARK_RUNNER` branch checks the flag after scores are merged; on `COMPLETED` it schedules report generation inside Next's `after()` so the webhook acks immediately (same shape as `/api/chat/response`).
- **Report** — new `legal-benchmark-report` service: atomically claims the report (`reportStatus: "generating"`, so duplicate webhook deliveries can't spawn two), creates a shared org-canvas `SharedConversation` seeded with a review prompt referencing the Stakwork project id + task/score context, runs `runCanvasAgent`, persists the assistant turn, then merges `reportConversationId` / `reportChatPath` / `reportStatus` back into the run's result JSON with Pusher broadcasts along the way.
- **Runs table** — new "Report" column: **View Report** link to `/org/<githubLogin>?chat=<conversationId>` (written before the agent runs, so the link appears while the report is being generated), a Pending spinner while in flight, "Failed" on error, dash otherwise (including FAILED workflows, which never trigger a report).

## Notes

- Verified every webhook branch that writes the runner row's `result` merges into the existing JSON rather than replacing it, so the flag and report fields survive the full run lifecycle (including the later EVAL cause-annotation write).
- `processStakworkRunWebhook` has a single caller (the webhook route), so `after()` always runs in request scope; all non-benchmark webhook paths are untouched.

## Test plan

- Full unit suite passes: 13,515 tests (includes updated `BenchmarkRunsHistory` colSpan/dash expectations and new Report-column tests: link, pending, failed, FAILED-run dash, not-requested dash).
- Manual: run a benchmark task with the checkbox checked on `openlaw`, confirm the Report column shows Pending → View Report, and the link opens the org-canvas chat with the generated report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)