### PR TITLE
Add task filter and hill-climb chart to benchmark Runs tab

### DIFF
--- a/src/__tests__/unit/components/BenchmarkRunsHistory.test.tsx
+++ b/src/__tests__/unit/components/BenchmarkRunsHistory.test.tsx
@@ -54,7 +54,7 @@ const makeRun = (overrides: Partial<{
 const mockSetExpandedId = vi.fn();
 const mockRefetch = vi.fn();
 
-const mockUseList = vi.fn(() => ({
+const mockUseList = vi.fn((_workspaceId: string | undefined) => ({
   runs: [makeRun()],
   total: 1,
   isLoading: false,
@@ -97,6 +97,50 @@ vi.mock("@/components/legal/StakworkRunLink", () => ({
       { href: `https://jobs.stakwork.com/admin/projects/${projectId}`, "data-testid": "stakwork-link" },
       "View on Stakwork",
     ),
+}));
+
+// Radix Select doesn't work in jsdom — minimal clickable stand-in
+let selectOnValueChange: ((value: string) => void) | null = null;
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value: string;
+    onValueChange: (v: string) => void;
+    children?: React.ReactNode;
+  }) => {
+    selectOnValueChange = onValueChange;
+    return React.createElement("div", { "data-testid": "task-filter", "data-value": value }, children);
+  },
+  SelectTrigger: ({ children, ...props }: { children?: React.ReactNode }) =>
+    React.createElement("div", props, children),
+  SelectValue: ({ placeholder }: { placeholder?: string }) =>
+    React.createElement("span", null, placeholder),
+  SelectContent: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement("div", null, children),
+  SelectItem: ({ value, children }: { value: string; children?: React.ReactNode }) =>
+    React.createElement(
+      "button",
+      { "data-testid": `task-filter-option-${value}`, onClick: () => selectOnValueChange?.(value) },
+      children,
+    ),
+}));
+
+vi.mock("@/components/legal/HillClimbChart", () => ({
+  HillClimbChart: ({
+    attempts,
+  }: {
+    attempts: Array<{ n_passed?: number; n_total?: number; label?: string }>;
+  }) =>
+    React.createElement("div", {
+      "data-testid": "hill-climb-chart",
+      "data-labels": attempts.map((a) => a.label).join(","),
+      "data-passed": attempts.map((a) => a.n_passed).join(","),
+      "data-totals": attempts.map((a) => a.n_total).join(","),
+    }),
 }));
 
 vi.mock("@/components/ui/badge", () => ({
@@ -671,5 +715,141 @@ describe("BenchmarkRunsHistory", () => {
 
     const scoreDiv = screen.getByText("5/5").closest("div")!;
     expect(scoreDiv.getAttribute("title")).toBe(judgeNotes);
+  });
+
+  // ─── Task filter + hill-climb chart tests ─────────────────────────────────
+
+  const TASK_A = { taskSlug: "antitrust/task-1", taskTitle: "Analyze Antitrust Strategy" };
+  const TASK_B = { taskSlug: "tax/task-2", taskTitle: "Tax Structuring Memo" };
+
+  // Newest-first, matching the API ordering
+  const multiTaskRuns = [
+    makeRun({ id: "a3", ...TASK_A, status: "COMPLETED", n_passed: 9, n_total: 12, all_pass: false, createdAt: new Date("2025-06-03T09:00:00Z").toISOString() }),
+    makeRun({ id: "b1", ...TASK_B, status: "COMPLETED", n_passed: 5, n_total: 5, all_pass: true, createdAt: new Date("2025-06-02T12:00:00Z").toISOString() }),
+    makeRun({ id: "a2", ...TASK_A, status: "IN_PROGRESS", createdAt: new Date("2025-06-02T09:00:00Z").toISOString() }),
+    makeRun({ id: "a1", ...TASK_A, status: "COMPLETED", n_passed: 7, n_total: 12, all_pass: false, createdAt: new Date("2025-06-01T09:00:00Z").toISOString() }),
+  ];
+
+  const mockMultiTaskRuns = (runs = multiTaskRuns) => {
+    mockUseList.mockReturnValue({
+      runs,
+      total: runs.length,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+      setExpandedId: mockSetExpandedId,
+    });
+  };
+
+  it("renders task filter with 'All tasks' plus one option per unique task with run counts", () => {
+    mockMultiTaskRuns();
+    render(React.createElement(BenchmarkRunsHistory));
+
+    expect(screen.getByTestId("task-filter-option-all")).toHaveTextContent("All tasks");
+    expect(screen.getByTestId(`task-filter-option-${TASK_A.taskSlug}`)).toHaveTextContent(
+      "Analyze Antitrust Strategy (3)",
+    );
+    expect(screen.getByTestId(`task-filter-option-${TASK_B.taskSlug}`)).toHaveTextContent(
+      "Tax Structuring Memo (1)",
+    );
+  });
+
+  it("does NOT render the progress card or chart when 'All tasks' is selected", () => {
+    mockMultiTaskRuns();
+    render(React.createElement(BenchmarkRunsHistory));
+
+    expect(screen.queryByTestId("task-progress-card")).toBeNull();
+    expect(screen.queryByTestId("hill-climb-chart")).toBeNull();
+  });
+
+  it("selecting a task filters the table to that task's runs and shows the count", async () => {
+    mockMultiTaskRuns();
+    const user = userEvent.setup();
+    render(React.createElement(BenchmarkRunsHistory));
+
+    await user.click(screen.getByTestId(`task-filter-option-${TASK_A.taskSlug}`));
+
+    // Task B's row is gone; all three task A rows remain (slug renders once per row)
+    expect(screen.queryByText(TASK_B.taskSlug)).toBeNull();
+    expect(screen.getAllByText(TASK_A.taskSlug).length).toBe(3);
+    expect(screen.getByText("3 of 4 runs")).toBeInTheDocument();
+  });
+
+  it("selecting a task shows the chart with scored runs oldest → newest, skipping unscored", async () => {
+    mockMultiTaskRuns();
+    const user = userEvent.setup();
+    render(React.createElement(BenchmarkRunsHistory));
+
+    await user.click(screen.getByTestId(`task-filter-option-${TASK_A.taskSlug}`));
+
+    const chart = screen.getByTestId("hill-climb-chart");
+    // a1 (7) then a3 (9); a2 has no score and is excluded
+    expect(chart.getAttribute("data-passed")).toBe("7,9");
+    expect(chart.getAttribute("data-labels")).toBe("#1,#2");
+  });
+
+  it("progress card shows best score and scored-run count", async () => {
+    mockMultiTaskRuns();
+    const user = userEvent.setup();
+    render(React.createElement(BenchmarkRunsHistory));
+
+    await user.click(screen.getByTestId(`task-filter-option-${TASK_A.taskSlug}`));
+
+    const card = screen.getByTestId("task-progress-card");
+    expect(card.textContent).toContain("Best: 9/12");
+    expect(card.textContent).toContain("2 scored runs");
+  });
+
+  it("normalizes drifted n_total to the max across the task's runs", async () => {
+    mockMultiTaskRuns([
+      makeRun({ id: "a2", ...TASK_A, status: "COMPLETED", n_passed: 10, n_total: 14, all_pass: false, createdAt: new Date("2025-06-02T09:00:00Z").toISOString() }),
+      makeRun({ id: "a1", ...TASK_A, status: "COMPLETED", n_passed: 7, n_total: 12, all_pass: false, createdAt: new Date("2025-06-01T09:00:00Z").toISOString() }),
+    ]);
+    const user = userEvent.setup();
+    render(React.createElement(BenchmarkRunsHistory));
+
+    await user.click(screen.getByTestId(`task-filter-option-${TASK_A.taskSlug}`));
+
+    expect(screen.getByTestId("hill-climb-chart").getAttribute("data-totals")).toBe("14,14");
+  });
+
+  it("shows a 'no scored runs' note instead of the chart when the task has no scores", async () => {
+    mockMultiTaskRuns([
+      makeRun({ id: "a1", ...TASK_A, status: "IN_PROGRESS" }),
+    ]);
+    const user = userEvent.setup();
+    render(React.createElement(BenchmarkRunsHistory));
+
+    await user.click(screen.getByTestId(`task-filter-option-${TASK_A.taskSlug}`));
+
+    expect(screen.getByText("No scored runs yet for this task.")).toBeInTheDocument();
+    expect(screen.queryByTestId("hill-climb-chart")).toBeNull();
+  });
+
+  it("selecting 'All tasks' again restores all rows and hides the chart", async () => {
+    mockMultiTaskRuns();
+    const user = userEvent.setup();
+    render(React.createElement(BenchmarkRunsHistory));
+
+    await user.click(screen.getByTestId(`task-filter-option-${TASK_A.taskSlug}`));
+    expect(screen.queryByText(TASK_B.taskSlug)).toBeNull();
+
+    await user.click(screen.getByTestId("task-filter-option-all"));
+    expect(screen.getByText(TASK_B.taskSlug)).toBeInTheDocument();
+    expect(screen.queryByTestId("task-progress-card")).toBeNull();
+  });
+
+  it("changing the filter collapses an expanded row", async () => {
+    mockMultiTaskRuns();
+    const user = userEvent.setup();
+    render(React.createElement(BenchmarkRunsHistory));
+
+    const row = screen.getByText(TASK_B.taskSlug).closest("tr")!;
+    await user.click(row);
+    expect(screen.getByTestId("results-b1")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId(`task-filter-option-${TASK_A.taskSlug}`));
+    expect(screen.queryByTestId("results-b1")).toBeNull();
+    expect(mockSetExpandedId).toHaveBeenLastCalledWith(null);
   });
 });

--- a/src/__tests__/unit/hooks/useLegalBenchmarkRunList.test.ts
+++ b/src/__tests__/unit/hooks/useLegalBenchmarkRunList.test.ts
@@ -87,7 +87,7 @@ describe("useLegalBenchmarkRunList", () => {
     expect(url).not.toContain("workspaceId=openlaw");
   });
 
-  it("includes type=LEGAL_BENCHMARK_RUNNER and limit=20 in query params", async () => {
+  it("includes type=LEGAL_BENCHMARK_RUNNER and limit=100 in query params", async () => {
     mockFetchOk([makeRow()]);
 
     const { result } = renderHook(() => useLegalBenchmarkRunList("ws-cuid-123"));
@@ -95,7 +95,7 @@ describe("useLegalBenchmarkRunList", () => {
 
     const url = String(vi.mocked(global.fetch).mock.calls[0][0]);
     expect(url).toContain("type=LEGAL_BENCHMARK_RUNNER");
-    expect(url).toContain("limit=20");
+    expect(url).toContain("limit=100");
     expect(url).toContain("includeResult=true");
   });
 

--- a/src/components/legal/BenchmarkRunsHistory.tsx
+++ b/src/components/legal/BenchmarkRunsHistory.tsx
@@ -1,15 +1,75 @@
 "use client";
 
-import { useState } from "react";
+import { Fragment, useMemo, useState } from "react";
 import { formatDistanceToNow } from "date-fns";
 import { ExternalLink, Loader2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { useLegalBenchmarkRunList } from "@/hooks/useLegalBenchmarkRunList";
 import { LegalBenchmarkResults } from "@/components/legal/LegalBenchmarkResults";
 import { StakworkRunLink } from "@/components/legal/StakworkRunLink";
+import { HillClimbChart } from "@/components/legal/HillClimbChart";
 import { WorkflowStatus } from "@prisma/client";
 import type { BenchmarkRunListRow } from "@/hooks/useLegalBenchmarkRunList";
+import type { EvalTriggerOutput } from "@/lib/harvey-lab/eval-normalizers";
+
+const ALL_TASKS = "all";
+
+interface TaskOption {
+  slug: string;
+  title: string;
+  count: number;
+}
+
+/** Unique tasks across the loaded runs, preserving most-recent-first order */
+function buildTaskOptions(runs: BenchmarkRunListRow[]): TaskOption[] {
+  const map = new Map<string, TaskOption>();
+  for (const run of runs) {
+    if (!run.taskSlug) continue;
+    const existing = map.get(run.taskSlug);
+    if (existing) {
+      existing.count += 1;
+    } else {
+      map.set(run.taskSlug, {
+        slug: run.taskSlug,
+        title: run.taskTitle || run.taskSlug,
+        count: 1,
+      });
+    }
+  }
+  return Array.from(map.values());
+}
+
+/**
+ * Map one task's scored runs (oldest → newest) into HillClimbChart input.
+ * The chart's legacy path derives the monotonic best-so-far line from n_passed.
+ * If n_total drifted between runs (criteria edited), the max is used as target.
+ */
+function toChartAttempts(taskRuns: BenchmarkRunListRow[]): EvalTriggerOutput[] {
+  const scored = taskRuns
+    .filter((r) => typeof r.n_passed === "number" && typeof r.n_total === "number")
+    .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+
+  const maxTotal = scored.reduce((max, r) => Math.max(max, r.n_total ?? 0), 0);
+
+  return scored.map((r, i) => ({
+    ref_id: r.id,
+    attempt_number: i + 1,
+    result: "",
+    score: r.n_passed ?? 0,
+    n_passed: r.n_passed,
+    n_total: maxTotal,
+    isBaseline: false,
+    label: `#${i + 1}`,
+  }));
+}
 
 /** Strip provider prefix for display, e.g. "anthropic/claude-sonnet-5" → "claude-sonnet-5" */
 function displayModelName(value: string | undefined): string {
@@ -33,6 +93,22 @@ export function BenchmarkRunsHistory() {
 
   const { runs, total, isLoading, error, setExpandedId } = useLegalBenchmarkRunList(workspaceId);
   const [expandedRunId, setExpandedRunId] = useState<string | null>(null);
+  const [taskFilter, setTaskFilter] = useState<string>(ALL_TASKS);
+
+  const taskOptions = useMemo(() => buildTaskOptions(runs), [runs]);
+
+  const selectedTask =
+    taskFilter === ALL_TASKS ? null : taskOptions.find((t) => t.slug === taskFilter) ?? null;
+
+  const filteredRuns = useMemo(
+    () => (selectedTask ? runs.filter((r) => r.taskSlug === selectedTask.slug) : runs),
+    [runs, selectedTask],
+  );
+
+  const chartAttempts = useMemo(
+    () => (selectedTask ? toChartAttempts(filteredRuns) : []),
+    [selectedTask, filteredRuns],
+  );
 
   const handleToggleExpand = (runId: string) => {
     const next = expandedRunId === runId ? null : runId;
@@ -43,6 +119,11 @@ export function BenchmarkRunsHistory() {
   const handleReset = () => {
     setExpandedRunId(null);
     setExpandedId(null);
+  };
+
+  const handleFilterChange = (value: string) => {
+    setTaskFilter(value);
+    if (expandedRunId) handleReset();
   };
 
   if (isLoading) {
@@ -75,6 +156,31 @@ export function BenchmarkRunsHistory() {
 
   return (
     <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <Select value={taskFilter} onValueChange={handleFilterChange}>
+          <SelectTrigger className="w-[340px]" data-testid="task-filter-trigger">
+            <SelectValue placeholder="Filter by task" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL_TASKS}>All tasks</SelectItem>
+            {taskOptions.map((t) => (
+              <SelectItem key={t.slug} value={t.slug}>
+                {t.title} ({t.count})
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {selectedTask && (
+          <span className="text-xs text-muted-foreground">
+            {filteredRuns.length} of {runs.length} runs
+          </span>
+        )}
+      </div>
+
+      {selectedTask && (
+        <TaskProgressCard task={selectedTask} attempts={chartAttempts} />
+      )}
+
       {total > 100 && (
         <div className="text-xs text-muted-foreground bg-muted rounded-md px-3 py-2">
           Showing the most recent 100 runs.
@@ -96,10 +202,9 @@ export function BenchmarkRunsHistory() {
             </tr>
           </thead>
           <tbody>
-            {runs.map((run) => (
-              <>
+            {filteredRuns.map((run) => (
+              <Fragment key={run.id}>
                 <tr
-                  key={run.id}
                   className="border-b last:border-0 cursor-pointer hover:bg-muted/30 transition-colors"
                   onClick={() => handleToggleExpand(run.id)}
                 >
@@ -144,7 +249,7 @@ export function BenchmarkRunsHistory() {
                   )}
                 </tr>
                 {expandedRunId === run.id && (
-                  <tr key={`${run.id}-expanded`} className="border-b last:border-0 bg-muted/10">
+                  <tr className="border-b last:border-0 bg-muted/10">
                     <td colSpan={colSpan} className="px-4 pb-4">
                       <LegalBenchmarkResults
                         runId={run.id}
@@ -154,11 +259,43 @@ export function BenchmarkRunsHistory() {
                     </td>
                   </tr>
                 )}
-              </>
+              </Fragment>
             ))}
           </tbody>
         </table>
       </div>
+    </div>
+  );
+}
+
+function TaskProgressCard({
+  task,
+  attempts,
+}: {
+  task: TaskOption;
+  attempts: EvalTriggerOutput[];
+}) {
+  const best = attempts.reduce((max, a) => Math.max(max, a.n_passed ?? 0), 0);
+  const target = attempts[0]?.n_total ?? 0;
+
+  return (
+    <div className="rounded-lg border bg-card p-4" data-testid="task-progress-card">
+      <div className="flex items-baseline justify-between gap-4 mb-1">
+        <div className="font-medium text-sm leading-tight truncate">{task.title}</div>
+        {attempts.length > 0 && (
+          <div className="text-xs text-muted-foreground whitespace-nowrap tabular-nums">
+            Best: {best}/{target} · {attempts.length} scored{" "}
+            {attempts.length === 1 ? "run" : "runs"}
+          </div>
+        )}
+      </div>
+      {attempts.length > 0 ? (
+        <HillClimbChart attempts={attempts} height={160} />
+      ) : (
+        <div className="text-sm text-muted-foreground py-6 text-center">
+          No scored runs yet for this task.
+        </div>
+      )}
     </div>
   );
 }

--- a/src/hooks/useLegalBenchmarkRunList.ts
+++ b/src/hooks/useLegalBenchmarkRunList.ts
@@ -61,7 +61,7 @@ export function useLegalBenchmarkRunList(
     if (!workspaceId) return;
     try {
       const res = await fetch(
-        `/api/stakwork/runs?type=${StakworkRunType.LEGAL_BENCHMARK_RUNNER}&workspaceId=${workspaceId}&limit=20&includeResult=true`,
+        `/api/stakwork/runs?type=${StakworkRunType.LEGAL_BENCHMARK_RUNNER}&workspaceId=${workspaceId}&limit=100&includeResult=true`,
       );
       if (!res.ok) throw new Error("Failed to fetch runs");
       const data = await res.json();


### PR DESCRIPTION
## Summary
- Adds a task filter to the Legal Benchmarks **Runs** tab: a Select listing every unique task in the loaded runs with per-task run counts, plus "All tasks"
- When a single task is selected, a progress card renders above the table reusing the existing `HillClimbChart` (same d3 chart as the Recursion tab): dots for each scored run oldest → newest, monotonic best-so-far line, dashed target line, tooltips, and a "Best: X/Y · N scored runs" summary
- Table narrows to the selected task with an "N of M runs" count; unscored runs (in-progress / failed-before-scoring) stay in the table but are excluded from the chart; tasks with no scored runs get a friendly note instead of an empty chart
- If `n_total` drifted between runs (criteria edited), the max is used as the chart target
- Bumps `useLegalBenchmarkRunList` fetch limit 20 → 100 (API max) so per-task history is complete — also makes the existing "showing the most recent 100 runs" banner truthful
- Fixes in passing: missing React `key` on the per-run fragment, and a pre-existing TS error in the test's `mockUseList` signature

No changes to `HillClimbChart` itself — its legacy input path (plain `n_passed`/`n_total`) computes the running best internally.

## Test plan
- [x] 9 new unit tests in `BenchmarkRunsHistory.test.tsx`: filter options/counts, table narrowing, chart chronological ordering + unscored exclusion, best-score summary, `n_total` drift normalization, no-scores state, filter reset, expanded-row collapse on filter change
- [x] Full suite for `BenchmarkRunsHistory` (48) and `HillClimbChart` (33) passing
- [x] `tsc --noEmit` and ESLint clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)