### PR TITLE
Persist canvas turn mid-stream errors and harden streamText retries

### DIFF
--- a/src/app/api/ask/quick/route.ts
+++ b/src/app/api/ask/quick/route.ts
@@ -487,6 +487,12 @@ export async function POST(request: NextRequest) {
       // internally-wired dispatch_graph_walk tool; consumed in after()
       // to schedule one graph-walk sub-agent worker per dispatched intent.
       const dispatchedGraphWalks: DispatchedGraphWalkIntent[] = [];
+      // Set when the stream errors mid-generation (via the onError hook).
+      // Mid-stream errors do NOT reject `consumeStream()`/`result.steps`
+      // — they resolve with the completed steps — so without this flag
+      // the turn-persist block writes a silently truncated transcript
+      // and the failure is invisible after a reload.
+      let midStreamError: string | null = null;
 
       const tAgent = Date.now();
       const {
@@ -592,6 +598,9 @@ export async function POST(request: NextRequest) {
                 outputTokens,
               });
             },
+            onError: ({ message }) => {
+              midStreamError = message;
+            },
           },
         });
 
@@ -669,6 +678,23 @@ export async function POST(request: NextRequest) {
               steps as Parameters<typeof messagesFromSteps>[0],
               assistantPrefix,
             );
+            // A mid-stream error resolves (not rejects) the awaits above,
+            // leaving a truncated transcript. Persist a trailing error row
+            // — in the SAME append, since `appendTurnMessages` is
+            // idempotent on the prefix and would no-op a second call — so
+            // a reload shows why the turn stopped (mirrors the client's
+            // inline error message). Also covers turns that died before
+            // producing any step: `rows` is empty, and without the error
+            // row the turn would persist nothing at all.
+            const errMsg: string | null = midStreamError;
+            if (errMsg !== null) {
+              rows.push({
+                id: `${assistantPrefix}error`,
+                role: "assistant",
+                content: `I'm sorry — this turn hit an error before completing: ${errMsg.slice(0, 300)}. Please try again.`,
+                timestamp: new Date().toISOString(),
+              });
+            }
             await appendTurnMessages({
               conversationId: rowId,
               rows,

--- a/src/lib/ai/runCanvasAgent.ts
+++ b/src/lib/ai/runCanvasAgent.ts
@@ -153,6 +153,15 @@ export interface CanvasAgentHooks {
    * final `usage` so the caller can record token spend.
    */
   onFinish?: (args: { usage: unknown }) => void | Promise<void>;
+  /**
+   * Called when the stream errors mid-generation, after the internal
+   * error logging. Mid-stream errors do NOT reject `consumeStream()`
+   * or `result.steps` — they resolve with the steps completed so far —
+   * so this hook is the only way a caller can learn the turn died
+   * (e.g. to persist a visible error row instead of a silently
+   * truncated transcript). Must not throw; exceptions are swallowed.
+   */
+  onError?: (args: { error: unknown; message: string }) => void;
 }
 
 /**
@@ -1056,6 +1065,13 @@ export async function runCanvasAgent(
     tools,
     messages: modelMessages,
     providerOptions,
+    // The SDK default (2 retries, quick backoff) is easily exhausted by a
+    // transient network flake (e.g. ECONNRESET to the provider) or a
+    // rate-limit window, which silently ends the turn after the current
+    // step — observed in prod as the agent "going quiet" right before
+    // proposing. 5 retries with the SDK's exponential backoff rides out
+    // short incidents while staying well inside the route's maxDuration.
+    maxRetries: 5,
     stopWhen: [
       createHasEndMarkerCondition(),
       // User pressed Stop on a repo_agent run — end the whole turn after
@@ -1124,14 +1140,22 @@ export async function runCanvasAgent(
     // via `toUIMessageStreamResponse({ onError })` in the HTTP route.
     onError: (event) => {
       const err = (event as { error?: unknown })?.error ?? event;
+      const message = err instanceof Error ? err.message : String(err);
       console.error("[runCanvasAgent] streamText error:", {
         workspaces: workspaceSlugs,
         orgId: orgId ?? null,
-        message: err instanceof Error ? err.message : String(err),
+        message,
         name: err instanceof Error ? err.name : undefined,
         stack: err instanceof Error ? err.stack : undefined,
         error: err,
       });
+      // Caller hook runs last; its failures must not disturb the
+      // stream's own error handling.
+      try {
+        hooks?.onError?.({ error: err, message });
+      } catch {
+        // swallowed by contract (see CanvasAgentHooks.onError)
+      }
     },
   });
 


### PR DESCRIPTION
## What

Two fixes for canvas-agent turns that die mid-stream and look "completely stuck":

1. **Persist a visible error row when a turn errors mid-generation.** New optional `onError` hook on `CanvasAgentHooks`, fired from `runCanvasAgent`'s existing `streamText` onError logging. `/api/ask/quick` uses it to append a trailing assistant row ("I'm sorry — this turn hit an error before completing: <reason>. Please try again.") to the persisted transcript.
2. **`maxRetries: 5`** (SDK default is 2) on the `streamText` call, so transient network flakes (ECONNRESET to the provider) and rate-limit blips get ridden out with exponential backoff instead of silently ending the turn. Applies to all `runCanvasAgent` callers (quick, sync, auto-turn, research/graph-walk workers).

## Why

Debugging a prod report ("canvas hangs whenever it's about to propose a prompt update"), the conversation export showed the real failure mode: a turn ended 53s in, right after its tool results, with no text and no error — and the next two user messages persisted **zero** assistant rows. Prod logs showed outbound `ECONNRESET` (socket hang up) from the same box.

The root gap: a mid-stream error does **not** reject `consumeStream()`/`result.steps` — they resolve with the steps completed so far. So the turn-persist block's success path wrote a silently truncated transcript, and the existing catch-path error row never fired. From the user's perspective the agent just went quiet forever.

## Reviewer notes

- The error row rides in the **same** `appendTurnMessages` call as the step rows — the helper is idempotent on the id prefix, so a second call would no-op. This also covers turns that died before producing any step: `rows` is empty and the error row alone gets appended (previously those turns persisted nothing at all).
- The error row shares the turn's `-a` id prefix (`${turnId}-aerror`), so the authoring tab's live-sync filter excludes it (it already shows the inline stream error) — no duplicate; other viewers and reloads see it via the normal text-row render path. No client changes needed.
- The hook invocation is wrapped in try/catch so a hook failure can't disturb stream error handling; the hook is documented as must-not-throw.
- SDK retries cover failures initiating a step's model call; a stream dying halfway through a response still errors — but now it errors visibly.

## Testing

- `tsc --noEmit` clean on touched files; ESLint clean (one pre-existing warning on master).
- Unit: full suite 13,664 passed. Targeted: `runCanvasAgent-timing` (10) and `canvas-turn-persistence` (20).
- Integration: `api/ask/quick` 34/34 against the Docker test DB.
- Unrelated pre-existing issue found while testing: `scripts/setup-test-db.js` references the removed `VerificationToken` model and crashes; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)