### PR TITLE
Restrict workflow explorer's Stakwork API run tools to run_step calls

### DIFF
--- a/src/lib/ai/workflowExplorerTools.ts
+++ b/src/lib/ai/workflowExplorerTools.ts
@@ -184,8 +184,8 @@ export function buildWorkflowExplorerTools(ctx?: CapabilityContext): ToolSet {
       description:
         "Dispatch a research agent over the Stakwork workflow library (the stakwork workspace's knowledge graph) to find existing Workflows, Skills, and Scripts relevant to a workflow being designed. " +
         "It searches components semantically by what they take as input and produce as output, reads full workflow recipes (step orderings + the skills each step uses), and reports proven, reusable building blocks with usage statistics — plus gaps where nothing exists yet. " +
-        "It can also pull ground-truth run data from the Stakwork API: which workflows invoke a skill (with real use counts), recent runs and their success/error states, and the actual params and outputs each step sent — useful for citing working configurations (exact URL formats, variable interpolations) or diagnosing why a similar workflow failed. " +
-        "Use it when designing or discussing a NEW Stakwork workflow: e.g. 'what existing skills take a video url as input?', 'is there already a transcription workflow, and how does it compose its steps?', 'show me real params from a successful run that uses AzureOCR'. " +
+        "It researches how workflows are DEFINED, not how they ran: for run history, run logs, or diagnosing why a workflow/run failed, use the stakwork workspace's logs_agent (stakwork__logs_agent) instead — it sees the full, untruncated run logs. " +
+        "Use it when designing or discussing a NEW Stakwork workflow: e.g. 'what existing skills take a video url as input?', 'is there already a transcription workflow, and how does it compose its steps?'. " +
         "READ-ONLY by default — it cannot create or modify workflows. Pass run_step: true (ONLY when the user explicitly asks to run/execute/test a specific step) to additionally let it execute one workflow step with supplied inputs and report the output. " +
         "Heavy/slow (minutes): call it ONCE with a complete, self-contained prompt rather than several times. " +
         "In a canvas conversation this tool runs in the BACKGROUND: it returns immediately with a dispatch confirmation (no findings), and the explorer's full report is posted directly into the conversation when it finishes. Tell the user it's underway — do NOT re-call the tool to fetch results and do NOT invent findings.",
@@ -227,11 +227,21 @@ export function buildWorkflowExplorerTools(ctx?: CapabilityContext): ToolSet {
             console.log("[workflow_explorer_agent] step execution enabled for this call");
           }
 
+          // The Stakwork API key is passed ONLY for run_step calls: it gates
+          // registration of the stakwork_* API tools on the swarm side, and
+          // the step-execution flow needs stakwork_inspect_run to copy real
+          // input values. Ordinary research runs stay graph-only — the API's
+          // run logs are heavily truncated; run diagnosis goes through the
+          // stakwork workspace's logs_agent instead.
           const baseParams = {
             prompt,
             mode: "workflow" as const,
-            stakworkApiKey: config.STAKWORK_API_KEY || undefined,
-            ...(run_step ? { toolsConfig: { stakwork_run_step: true } } : {}),
+            ...(run_step
+              ? {
+                  stakworkApiKey: config.STAKWORK_API_KEY || undefined,
+                  toolsConfig: { stakwork_run_step: true },
+                }
+              : {}),
           };
 
           if (fanBack) {

--- a/src/lib/constants/prompt.ts
+++ b/src/lib/constants/prompt.ts
@@ -754,7 +754,7 @@ You have one sub-agent tool for researching the Stakwork workflow library — th
 
 - The user is designing, scoping, or discussing a NEW Stakwork workflow and you need to know what proven components already exist.
 - Questions like: "is there already a workflow that processes video?", "which skills take a video url as input?", "how do the existing transcription workflows compose their steps?"
-- Deep exploration of workflows AND workflow **runs**: it can pull ground-truth run data from the Stakwork API — which workflows invoke a skill (real use counts), recent runs and their success/error states, and the actual params/outputs each step sent. Use it to cite a working configuration (exact URL formats, variable interpolations) or diagnose why a similar workflow failed.
+- It researches how workflows are **defined** (composition, IO schemas, usage stats from the graph) — NOT how they ran. For run history, run logs, or diagnosing why a workflow/run failed, use \`stakwork__logs_agent\` instead: it sees the full, untruncated run logs.
 
 ### Prompting tips
 
@@ -764,7 +764,7 @@ You have one sub-agent tool for researching the Stakwork workflow library — th
 
 ### Running a step (\`run_step: true\`)
 
-- Set \`run_step: true\` ONLY when the user **explicitly asks to run, execute, or test a workflow step** ("run that step", "test call_swarm_agent with these inputs"). Questions like "what params does step X take" or "why did that step fail" are research — leave it unset.
+- Set \`run_step: true\` ONLY when the user **explicitly asks to run, execute, or test a workflow step** ("run that step", "test call_swarm_agent with these inputs"). Questions like "what params does step X take" are research — leave it unset. ("Why did that step fail" is a run-log question — that's \`stakwork__logs_agent\`, not this tool.)
 - Never set it proactively. If actually executing a step would help but the user hasn't asked, propose it and wait for their go-ahead. Executions are real and billable.
 - When set, make the prompt self-contained about the execution: name the workflow (id if known) and the step id, give the input values the user supplied — or tell the explorer to discover the step's required inputs first and use the user's stated test values (or \`mock_mode\` for a dry run) — and ask it to report the step's resolved inputs and outputs. One dispatch should carry the whole discover → fill → run → report loop. By default a run targets the **published** version of the workflow; if the user wants to test a different version (including a **draft/unpublished** one), tell the explorer the target \`workflow_version_id\` and it will run against that version instead.
 


### PR DESCRIPTION
## What changed

- `workflow_explorer_agent` now passes `stakworkApiKey` (and the `stakwork_run_step` toolsConfig opt-in) to the swarm's `/repo/agent` endpoint **only when `run_step: true`**. Ordinary research dispatches become graph-only: stakgraph gates registration of all `stakwork_*` API tools on the key's presence, and its `WORKFLOW_SYSTEM` prompt automatically drops the "Ground-truth run data" section too — so no stakgraph change is needed.
- The tool description and the workflows capability snippet in `prompt.ts` no longer advertise pulling run data from the Stakwork API. They now route run history / run logs / failure diagnosis to `stakwork__logs_agent` instead, matching the existing `logs_agent` routing guidance.

## Why

The Stakwork API truncates run data hard (1.5KB per-step params/output previews, 12KB caps even on single-step IO drill-downs), so run diagnosis through the explorer produced clipped, low-value results. The stakwork workspace's `logs_agent` sees the full untruncated run logs, so the canvas agent (Jamie) should go there for run questions and keep the explorer focused on what the graph is good at: how workflows are defined and composed.

## Notes for reviewers

- Explicit step-testing (`run_step: true`) still gets the API key — the execution flow legitimately needs `stakwork_inspect_run` to copy real input values, and stakgraph's run-step prompt guidance references it.
- Trade-off: research-mode calls also lose `stakwork_skill_usage` (live stats + curated IO examples). Proven-ness signals survive via the graph's denormalized `usage_count` / `usage_count_30d`. If the curated examples turn out to matter, the follow-up is a stakgraph-side toolsConfig gate for just the runs pair.
- Tests: all 12 `workflowExplorerTools` unit tests pass, plus 146 tests across the related capability/prompt suites. ESLint/tsc show nothing new on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)