### PR TITLE
Pin keyv family to safe versions (Shai-Hulud supply chain attack)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -169,35 +169,6 @@
         "wouter": "^3.10.0"
       }
     },
-    "../graph-viz": {
-      "version": "0.0.0",
-      "extraneous": true,
-      "dependencies": {
-        "@react-three/drei": "^10.7.7",
-        "@react-three/fiber": "^9.5.0",
-        "@react-three/postprocessing": "^3.0.4",
-        "react": "^19.2.0",
-        "react-dom": "^19.2.0",
-        "react-router-dom": "^7.13.1",
-        "three": "^0.183.1"
-      },
-      "devDependencies": {
-        "@eslint/js": "^9.39.1",
-        "@types/node": "^24.10.1",
-        "@types/react": "^19.2.7",
-        "@types/react-dom": "^19.2.3",
-        "@types/three": "^0.183.1",
-        "@vitejs/plugin-basic-ssl": "^2.2.0",
-        "@vitejs/plugin-react": "^5.1.1",
-        "eslint": "^9.39.1",
-        "eslint-plugin-react-hooks": "^7.0.1",
-        "eslint-plugin-react-refresh": "^0.4.24",
-        "globals": "^16.5.0",
-        "typescript": "~5.9.3",
-        "typescript-eslint": "^8.48.0",
-        "vite": "^7.3.1"
-      }
-    },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",

--- a/package.json
+++ b/package.json
@@ -201,5 +201,15 @@
     "wait-on": "8.0.4",
     "wouter": "^3.10.0"
   },
+  "overrides": {
+    "keyv": "4.5.4",
+    "flat-cache": "4.0.1",
+    "file-entry-cache": "8.0.0"
+  },
+  "resolutions": {
+    "keyv": "4.5.4",
+    "flat-cache": "4.0.1",
+    "file-entry-cache": "8.0.0"
+  },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
## What

Adds `overrides` (npm) and `resolutions` (yarn classic) to `package.json` pinning:

- `keyv@4.5.4`
- `flat-cache@4.0.1`
- `file-entry-cache@8.0.0`

## Why

The keyv/cacheable package family was compromised today (Aug 4, 2026) in the Shai-Hulud supply chain attack — a credential-stealing worm injected via a malicious `preinstall` hook in `keyv@6.0.0`, `flat-cache@6.1.24`, `file-entry-cache@11.1.6`, and related packages.

**Hive is not currently affected.** Our only exposure is the transitive chain `eslint → file-entry-cache@8.0.0 → flat-cache@4.0.1 → keyv@4.5.4` — all older majors than the compromised releases, and the installed copies were verified clean (no preinstall hooks, no `setup.mjs`, no Bun payload). None of the other compromised packages (`cacheable`, `cache-manager`, `cacheable-request`, `@cacheable/*`, `ecto`) appear in the lockfile.

These pins ensure a lockfile regeneration or future dependency bump cannot pull the trojaned versions. Both override styles are included because `packageManager` declares yarn but the repo actually uses npm/`package-lock.json`.

## Reviewer notes

- Lockfile was synced with `npm install --package-lock-only --ignore-scripts` — nothing was downloaded or executed, and no resolved versions changed. npm also dropped a stale extraneous `../graph-viz` sibling-project entry from the lockfile (the 29 removed lines).
- The exact-version pins will block legitimate future majors of these packages too; relax or remove the overrides once npm removes the malicious releases and the maintainer regains control of the account.
- CI already uses `npm ci` everywhere, so it installs exactly what the lockfile specifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)