### PR TITLE
Tighten isScoredRun to completed-only and update documentation in benchmark-summary utils

### DIFF
--- a/src/__tests__/unit/lib/harvey-lab/benchmark-summary.test.ts
+++ b/src/__tests__/unit/lib/harvey-lab/benchmark-summary.test.ts
@@ -2,7 +2,8 @@
  * Unit tests for src/lib/harvey-lab/benchmark-summary.ts
  *
  * Covers:
- *   - isScoredRun: PENDING/IN_PROGRESS excluded; ERROR/HALTED included with score;
+ *   - isScoredRun: PENDING/IN_PROGRESS excluded; COMPLETED-only rule;
+ *     FAILED/HALTED excluded even when they carry a score;
  *     terminal runs without all_pass excluded
  *   - selectScoredRuns: ordering by updatedAt (primary), createdAt (secondary), id
  *     (tiebreaker); window slicing; fewer than SUMMARY_WINDOW runs
@@ -86,17 +87,26 @@ describe("isScoredRun", () => {
     expect(isScoredRun(makeRun({ status: WorkflowStatus.COMPLETED, all_pass: false }))).toBe(true);
   });
 
-  it("returns true for ERROR run with a score (terminal but not COMPLETED)", () => {
-    expect(isScoredRun(makeRun({ status: WorkflowStatus.ERROR, all_pass: false }))).toBe(true);
+  // COMPLETED-only rule: FAILED and HALTED are excluded even when they carry a score.
+  // These are the assertions most likely to be regressed — named explicitly.
+  it("returns false for FAILED run even when it carries a valid score (COMPLETED-only rule)", () => {
+    expect(
+      isScoredRun(
+        makeRun({ status: WorkflowStatus.FAILED, all_pass: false, n_passed: 3, n_total: 5 }),
+      ),
+    ).toBe(false);
   });
 
-  it("returns true for HALTED run with a score", () => {
-    expect(isScoredRun(makeRun({ status: WorkflowStatus.HALTED, all_pass: true }))).toBe(true);
+  it("returns false for HALTED run even when it carries a valid score (COMPLETED-only rule)", () => {
+    expect(
+      isScoredRun(
+        makeRun({ status: WorkflowStatus.HALTED, all_pass: true, n_passed: 5, n_total: 5 }),
+      ),
+    ).toBe(false);
   });
 
   it("returns false for FAILED run with no all_pass (no score data)", () => {
     const run = makeRun({ status: WorkflowStatus.FAILED });
-    delete (run as Partial<BenchmarkRunListRow>).all_pass;
     expect(isScoredRun({ ...run, all_pass: undefined as unknown as boolean })).toBe(false);
   });
 
@@ -123,12 +133,12 @@ describe("selectScoredRuns", () => {
     expect(selectScoredRuns(runs)).toHaveLength(1);
   });
 
-  it("includes ERROR and HALTED runs that carry a score", () => {
+  it("excludes FAILED and HALTED runs even when they carry a score (COMPLETED-only rule)", () => {
     const runs = [
-      makeRun({ status: WorkflowStatus.ERROR, all_pass: false }),
-      makeRun({ status: WorkflowStatus.HALTED, all_pass: true }),
+      makeRun({ status: WorkflowStatus.FAILED, all_pass: false, n_passed: 2, n_total: 5 }),
+      makeRun({ status: WorkflowStatus.HALTED, all_pass: true, n_passed: 5, n_total: 5 }),
     ];
-    expect(selectScoredRuns(runs)).toHaveLength(2);
+    expect(selectScoredRuns(runs)).toHaveLength(0);
   });
 
   it("excludes terminal runs with no all_pass", () => {

--- a/src/lib/harvey-lab/benchmark-summary.ts
+++ b/src/lib/harvey-lab/benchmark-summary.ts
@@ -21,26 +21,28 @@ export const FAIL_BADGE_CLASS =
   "border-0 bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300";
 
 /**
- * Returns true when a run has a definitive score that should appear in the
- * summary strip and Runs table score column.
+ * Returns true when a run should appear as a pip in the rolling summary strip.
+ * COMPLETED-only — the strip is a clean-runs-only quality signal.
  *
- * Matches the predicate used by ScoreCell in BenchmarkRunsHistory.tsx:
- * - Excludes active (PENDING / IN_PROGRESS) runs — they haven't scored yet.
- * - Requires all_pass to be a boolean — terminal runs without score data are excluded.
- * - Intentionally INCLUDES ERROR and HALTED runs that carried a score in their
- *   result payload, because the workflow can emit scores even in non-COMPLETED
- *   terminal states.
+ * Intentional divergences (do NOT "fix" one to match the other):
  *
- * NOTE: toChartAttempts in BenchmarkRunsHistory.tsx uses a different, looser
- * predicate (checks for presence of n_passed/n_total, no status gate) for the
- * hill-climb chart. That divergence is pre-existing and intentionally NOT
- * unified here — the two predicates serve different purposes.
+ * 1. ScoreCell in BenchmarkRunsHistory.tsx uses a LOOSER predicate: it excludes
+ *    only PENDING/IN_PROGRESS, then requires a boolean all_pass. Consequence: a
+ *    FAILED or HALTED run that was judged before it died will still show a
+ *    PASS/FAIL badge in the Runs table but will NOT appear as a pip here. This
+ *    is intentional — the strip counts clean completions only.
+ *
+ * 2. toChartAttempts in BenchmarkRunsHistory.tsx uses a THIRD, even looser
+ *    predicate (counts present, no status check) for the hill-climb chart.
+ *    Also pre-existing and out of scope.
+ *
+ * Note: WorkflowStatus.ERROR is never assigned to a StakworkRun — mapStakworkStatus
+ * in src/utils/conversions.ts maps Stakwork "error"/"failed" → FAILED and
+ * "halted"/"paused"/"stopped" → HALTED — so no ERROR branch is needed.
  */
 export function isScoredRun(run: BenchmarkRunListRow): boolean {
   return (
-    run.status !== WorkflowStatus.PENDING &&
-    run.status !== WorkflowStatus.IN_PROGRESS &&
-    typeof run.all_pass === "boolean"
+    run.status === WorkflowStatus.COMPLETED && typeof run.all_pass === "boolean"
   );
 }
 


### PR DESCRIPTION
Generated with Hive: Tighten isScoredRun to completed-only and update documentation in benchmark-summary utils