### PR TITLE
perf: parallelize buildWorkspaceConfigs (42.5s → ~8s on multi-workspace canvas turns)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "@vercel/functions": "^3.1.4",
         "@xyflow/react": "^12.8.6",
         "ai": "^6.0.72",
-        "aieo": "^0.1.33",
+        "aieo": "^0.1.34",
         "autoprefixer": "^10.4.21",
         "axios": "1.10.0",
         "bcryptjs": "^3.0.2",
@@ -243,13 +243,13 @@
       }
     },
     "node_modules/@ai-sdk/anthropic": {
-      "version": "3.0.85",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.85.tgz",
-      "integrity": "sha512-fNeDB644l5wbRNQU0FnI+F7UTtOenMnPtACfMPUJaS2zJfuBlseEa1TMg+otHkETZgaJB+6Na51NQEv0+m7czw==",
+      "version": "3.0.105",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.105.tgz",
+      "integrity": "sha512-6B9UjgK14JwG4PtyhHKMQrqg49s90FClsreNZ9HmMdSWZ9tJFHuYmy4cauS/BqO/6rKC+qcNEXTP45+qivdypA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.30"
+        "@ai-sdk/provider": "3.0.14",
+        "@ai-sdk/provider-utils": "4.0.41"
       },
       "engines": {
         "node": ">=18"
@@ -259,9 +259,9 @@
       }
     },
     "node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.14.tgz",
+      "integrity": "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -271,20 +271,33 @@
       }
     },
     "node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.30",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.30.tgz",
-      "integrity": "sha512-VO7I+vPffqI5sMnPoUq5DCSqKIgQIk/naJWRdQVpz2ma2zoprC/lqiJiUEl2s6DfvTD76TbhD3q39ROjlA6rGw==",
+      "version": "4.0.41",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.41.tgz",
+      "integrity": "sha512-I7hhjfw01yEI8NkuAsT8Mv6xbWFr/lqLXMdaJQ2zWfXEpxog1eT7skDcv1+RY29/+5btzH8wD+vVvy48bk9oNQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider": "3.0.14",
         "@standard-schema/spec": "^1.1.0",
-        "eventsource-parser": "^3.0.8"
+        "eventsource-parser": "^3.0.8",
+        "undici": "^5.29.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic/node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@ai-sdk/azure": {
@@ -5587,6 +5600,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
@@ -7930,29 +7952,15 @@
       }
     },
     "node_modules/@openrouter/ai-sdk-provider": {
-      "version": "6.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@openrouter/ai-sdk-provider/-/ai-sdk-provider-6.0.0-alpha.1.tgz",
-      "integrity": "sha512-N91glWtq6XFl8Kvgft14BiDeCLABHatylAVKHOWMRJHnBl6iKblI4iZgcipnF9Pj8ZRUO752qpPoZVC+L2C6tA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@openrouter/ai-sdk-provider/-/ai-sdk-provider-2.10.0.tgz",
+      "integrity": "sha512-FMsAEjLUt5pWuRE2LDC/LCvVrFjLlrEzUITH5+5SZtfq7KZ2wrOHjQVxzz92sju8S9ltpzW87CLW8/b0oBXVCw==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "^3.0.0",
-        "@ai-sdk/provider-utils": "^4.0.0",
-        "@openrouter/sdk": "^0.3.11"
-      },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "zod": "^4.3.5"
-      }
-    },
-    "node_modules/@openrouter/sdk": {
-      "version": "0.3.16",
-      "resolved": "https://registry.npmjs.org/@openrouter/sdk/-/sdk-0.3.16.tgz",
-      "integrity": "sha512-WEBlrXdc5R8I7o2temkMV65tIRGkzg9ct4DMNZ/FHS/hiRscLRS5EpcuORnAgjzZAh9X2dSsBpgygM8T7KiNAw==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
+        "ai": "^6.0.0",
         "zod": "^3.25.0 || ^4.0.0"
       }
     },
@@ -15547,50 +15555,17 @@
       }
     },
     "node_modules/aieo": {
-      "version": "0.1.33",
-      "resolved": "https://registry.npmjs.org/aieo/-/aieo-0.1.33.tgz",
-      "integrity": "sha512-0b4LaUim5rucDf28aXl7WO5K/J9bLja0IxtcnnWbhdr/B56Qr2JHjVtG93p182lUtt8zJyT1JZYplX6sFWHJ/w==",
+      "version": "0.1.34",
+      "resolved": "https://registry.npmjs.org/aieo/-/aieo-0.1.34.tgz",
+      "integrity": "sha512-0ZV2LvbBd5N1pc69EYzrnSF5dfX517n4CFITOM08K/+QkpWNBquGnJIpGTz7SN1Xa2CdQ/YPNs94rRTyF4q7qw==",
       "license": "ISC",
       "dependencies": {
-        "@ai-sdk/anthropic": "3.0.75",
+        "@ai-sdk/anthropic": "3.0.105",
         "@ai-sdk/google": "3.0.67",
         "@ai-sdk/openai": "3.0.61",
-        "@openrouter/ai-sdk-provider": "6.0.0-alpha.1",
+        "@openrouter/ai-sdk-provider": "2.10.0",
         "ai": "6.0.175",
         "zod": "4.3.6"
-      }
-    },
-    "node_modules/aieo/node_modules/@ai-sdk/anthropic": {
-      "version": "3.0.75",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.75.tgz",
-      "integrity": "sha512-5AV3CKwaOJFdGXhihVgvRLNrjwRn2Xmy71YygT8DYOA+5zTx93Seg2QSIS8b3tJxzZ7X4H84pEtrE8VZKBCZGA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.26"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/aieo/node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.26",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.26.tgz",
-      "integrity": "sha512-CsKNLKsOpvPujRlIYvoz+Ybw+kGn7J4/fIZa/58+R7iWLLfwn6ifE2G6Yq8K9XvH/I/3bzaDAJ3NhRwEMsLBKQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
-        "@standard-schema/spec": "^1.1.0",
-        "eventsource-parser": "^3.0.8"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/aieo/node_modules/@ai-sdk/google": {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@vercel/functions": "^3.1.4",
     "@xyflow/react": "^12.8.6",
     "ai": "^6.0.72",
-    "aieo": "^0.1.33",
+    "aieo": "^0.1.34",
     "autoprefixer": "^10.4.21",
     "axios": "1.10.0",
     "bcryptjs": "^3.0.2",

--- a/src/__tests__/unit/lib/ai/workspaceConfig.test.ts
+++ b/src/__tests__/unit/lib/ai/workspaceConfig.test.ts
@@ -9,6 +9,7 @@ const {
   mockDbWorkspaceMemberFindMany,
   mockDbWorkspaceFindFirst,
   mockGetGithubUsernameAndPAT,
+  mockResolveGithubIdentity,
   mockDecryptField,
 } = vi.hoisted(() => ({
   mockValidateWorkspaceAccess: vi.fn(),
@@ -17,6 +18,7 @@ const {
   mockDbWorkspaceMemberFindMany: vi.fn(),
   mockDbWorkspaceFindFirst: vi.fn(),
   mockGetGithubUsernameAndPAT: vi.fn(),
+  mockResolveGithubIdentity: vi.fn(),
   mockDecryptField: vi.fn(),
 }));
 
@@ -35,6 +37,7 @@ vi.mock("@/lib/db", () => ({
 
 vi.mock("@/lib/auth/nextauth", () => ({
   getGithubUsernameAndPAT: mockGetGithubUsernameAndPAT,
+  resolveGithubIdentity: mockResolveGithubIdentity,
 }));
 
 vi.mock("@/lib/encryption", () => ({
@@ -76,6 +79,8 @@ function setupDefaultMocks(githubUsername = "alice", swarmName: string | null = 
   ]);
 
   mockDbWorkspaceMemberFindMany.mockResolvedValue([]);
+
+  mockResolveGithubIdentity.mockResolvedValue({ username: githubUsername });
 
   mockGetGithubUsernameAndPAT.mockResolvedValue({
     token: "ghp_test",
@@ -166,6 +171,151 @@ describe("buildWorkspaceConfigs", () => {
     const configs = await buildWorkspaceConfigs([SLUG], USER_ID);
 
     expect(configs[0].swarmDomain).toBeUndefined();
+  });
+});
+
+describe("buildWorkspaceConfigs — multi-slug concurrency", () => {
+  const SLUGS = ["alpha", "beta", "gamma"];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves all slugs concurrently rather than one after another", async () => {
+    setupDefaultMocks();
+
+    // Barrier: each call parks until all three have *started*. Under the
+    // old serial loop slug 2 never starts, so this would never settle and
+    // the test times out — which is exactly the regression we're locking.
+    let release!: () => void;
+    const allStarted = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let started = 0;
+
+    mockValidateWorkspaceAccess.mockImplementation(async (slug: string) => {
+      if (++started === SLUGS.length) release();
+      await allStarted;
+      return {
+        hasAccess: true,
+        workspace: { id: `ws-${slug}`, name: slug, description: null },
+      };
+    });
+
+    const configs = await buildWorkspaceConfigs(SLUGS, USER_ID);
+
+    expect(started).toBe(SLUGS.length);
+    expect(configs).toHaveLength(SLUGS.length);
+  });
+
+  it("returns configs in slug order, not completion order", async () => {
+    setupDefaultMocks();
+
+    // Invert the timing: the last slug resolves first.
+    mockValidateWorkspaceAccess.mockImplementation(async (slug: string) => {
+      const delay = (SLUGS.length - SLUGS.indexOf(slug)) * 5;
+      await new Promise((r) => setTimeout(r, delay));
+      return {
+        hasAccess: true,
+        workspace: { id: `ws-${slug}`, name: slug, description: null },
+      };
+    });
+
+    const configs = await buildWorkspaceConfigs(SLUGS, USER_ID);
+
+    expect(configs.map((c) => c.slug)).toEqual(SLUGS);
+    expect(configs.map((c) => c.workspaceId)).toEqual(["ws-alpha", "ws-beta", "ws-gamma"]);
+  });
+
+  it("surfaces the first failure in slug order even when a later slug fails sooner", async () => {
+    setupDefaultMocks();
+
+    // "alpha" (first in order) fails slowly; "beta" fails immediately.
+    // Plain `Promise.all` would surface beta's error; we want alpha's, to
+    // match what the original serial loop reported.
+    mockValidateWorkspaceAccess.mockImplementation(async (slug: string) => {
+      if (slug === "alpha") {
+        await new Promise((r) => setTimeout(r, 20));
+        return { hasAccess: false, workspace: null };
+      }
+      if (slug === "beta") {
+        return { hasAccess: false, workspace: null };
+      }
+      return {
+        hasAccess: true,
+        workspace: { id: `ws-${slug}`, name: slug, description: null },
+      };
+    });
+
+    await expect(buildWorkspaceConfigs(SLUGS, USER_ID)).rejects.toMatchObject({
+      kind: "forbidden",
+      message: "Access denied for workspace: alpha",
+    });
+  });
+
+  it("resolves the user's GitHub identity once for the whole batch", async () => {
+    setupDefaultMocks();
+
+    await buildWorkspaceConfigs(SLUGS, USER_ID);
+
+    // The identity does not vary by workspace; re-reading it per slug was
+    // 2 redundant round-trips each.
+    expect(mockResolveGithubIdentity).toHaveBeenCalledTimes(1);
+    expect(mockResolveGithubIdentity).toHaveBeenCalledWith(USER_ID);
+
+    // ...and it's handed to each per-workspace PAT lookup so those skip
+    // the re-read.
+    expect(mockGetGithubUsernameAndPAT).toHaveBeenCalledTimes(SLUGS.length);
+    for (const slug of SLUGS) {
+      expect(mockGetGithubUsernameAndPAT).toHaveBeenCalledWith(USER_ID, slug, {
+        username: "alice",
+      });
+    }
+  });
+
+  it("issues a workspace's swarm, repo, member and PAT reads concurrently", async () => {
+    setupDefaultMocks();
+
+    // Same barrier idea as above, but within a *single* workspace: each of
+    // the four reads parks until all four have started. Serially chained,
+    // only the first ever starts and this times out.
+    let release!: () => void;
+    const allStarted = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let started = 0;
+    const gate = async <T>(value: T): Promise<T> => {
+      if (++started === 4) release();
+      await allStarted;
+      return value;
+    };
+
+    mockDbSwarmFindFirst.mockImplementation(() =>
+      gate({ swarmUrl: "https://swarm.example.com:3333", swarmApiKey: "k", name: "swarm38" })
+    );
+    mockDbRepositoryFindMany.mockImplementation(() =>
+      gate([{ repositoryUrl: "https://github.com/owner/repo" }])
+    );
+    mockDbWorkspaceMemberFindMany.mockImplementation(() => gate([]));
+    mockGetGithubUsernameAndPAT.mockImplementation(() =>
+      gate({ token: "ghp_test", username: "alice" })
+    );
+
+    const configs = await buildWorkspaceConfigs([SLUG], USER_ID);
+
+    expect(started).toBe(4);
+    expect(configs).toHaveLength(1);
+  });
+
+  it("skips the PAT lookup entirely when the user has no GitHub identity", async () => {
+    setupDefaultMocks();
+    mockResolveGithubIdentity.mockResolvedValue(null);
+
+    await expect(buildWorkspaceConfigs([SLUG], USER_ID)).rejects.toMatchObject({
+      kind: "not_found",
+      message: `GitHub PAT not found for workspace: ${SLUG}`,
+    });
+    expect(mockGetGithubUsernameAndPAT).not.toHaveBeenCalled();
   });
 });
 

--- a/src/lib/ai/workspaceConfig.ts
+++ b/src/lib/ai/workspaceConfig.ts
@@ -1,5 +1,5 @@
 import { forbiddenError, notFoundError } from "@/types/errors";
-import { getGithubUsernameAndPAT } from "@/lib/auth/nextauth";
+import { getGithubUsernameAndPAT, resolveGithubIdentity, type GithubIdentity } from "@/lib/auth/nextauth";
 import { db } from "@/lib/db";
 import { EncryptionService } from "@/lib/encryption";
 import { validateWorkspaceAccess } from "@/services/workspace";
@@ -27,41 +27,103 @@ export async function buildWorkspaceConfigs(
   userId: string
 ): Promise<WorkspaceConfig[]> {
   const encryptionService = EncryptionService.getInstance();
-  const configs: WorkspaceConfig[] = [];
 
-  for (const slug of slugs) {
-    const access = await validateWorkspaceAccess(slug, userId, true);
-    if (!access.hasAccess || !access.workspace) {
+  // Per-slug work runs concurrently: every step below is a read, and the
+  // slugs are independent. Serially this cost ~10 DB round-trips per
+  // workspace *times* the slug count, which on a canvas turn spanning 8
+  // org workspaces dominated the whole request (~35s of a 42s turn).
+  //
+  // The user's GitHub identity is resolved once here rather than inside
+  // each slug's `getGithubUsernameAndPAT` — it does not vary by
+  // workspace, and re-reading it per slug was 2 more round-trips each.
+  // It overlaps with the access checks, so it costs nothing on the wire.
+  //
+  // `allSettled` rather than `Promise.all` so the error we surface is
+  // deterministic: `Promise.all` rejects with whichever slug failed
+  // *first in time*, while the serial loop always reported the first
+  // failure in *slug order*. We reproduce the latter below.
+  const [identity, accessSettled] = await Promise.all([
+    resolveGithubIdentity(userId),
+    Promise.allSettled(
+      slugs.map((slug) => validateWorkspaceAccess(slug, userId, true))
+    ),
+  ]);
+
+  // Phase 2: for every slug that cleared its access check, fan out the
+  // four remaining reads — they only need `workspace.id`, so nothing
+  // among them depends on anything else.
+  const recordsSettled = await Promise.allSettled(
+    slugs.map((slug, i) => {
+      const access = accessSettled[i];
+      if (access.status === "rejected" || !access.value.hasAccess || !access.value.workspace) {
+        return Promise.resolve(null);
+      }
+      return fetchWorkspaceRecords(slug, userId, access.value.workspace.id, identity);
+    })
+  );
+
+  // Guards run per slug in the original nested order (access → swarm →
+  // repos → PAT), so the error that surfaces is the same one the serial
+  // loop produced: an earlier slug's *later* failure still wins over a
+  // later slug's *earlier* failure. `map` also preserves slug order,
+  // which is load-bearing — callers treat `configs[0]` as the primary
+  // workspace, and the rendered system prompt (Anthropic prompt-cached)
+  // must be byte-stable across turns.
+  return slugs.map((slug, i) => {
+    const access = accessSettled[i];
+    if (access.status === "rejected") throw access.reason;
+    if (!access.value.hasAccess || !access.value.workspace) {
       throw forbiddenError(`Access denied for workspace: ${slug}`);
     }
 
-    const swarm = await db.swarm.findFirst({
-      where: { workspaceId: access.workspace.id },
-    });
-    if (!swarm?.swarmUrl) {
-      throw notFoundError(`Swarm not configured for workspace: ${slug}`);
-    }
+    const records = recordsSettled[i];
+    if (records.status === "rejected") throw records.reason;
 
-    const repositories = await db.repository.findMany({
-      where: { workspaceId: access.workspace.id },
+    return assembleWorkspaceConfig(
+      slug,
+      userId,
+      access.value.workspace,
+      records.value!,
+      encryptionService
+    );
+  });
+}
+
+type WorkspaceRecords = Awaited<ReturnType<typeof fetchWorkspaceRecords>>;
+
+async function fetchWorkspaceRecords(
+  slug: string,
+  userId: string,
+  workspaceId: string,
+  identity: GithubIdentity | null
+) {
+  // These re-read rows that `validateWorkspaceAccess` already loaded:
+  // `getWorkspaceBySlug` includes `swarm` and `repositories`, then maps
+  // them away into the narrow `WorkspaceResponse` it returns. Sourcing
+  // them from there instead would cut ~2 queries per workspace, but it
+  // buys no wall-clock (the PAT branch below is the deeper one) and the
+  // fields we need — `swarmApiKey`, `swarm.name` — must NOT be added to
+  // that function's return: `WorkspaceWithAccess` is serialized straight
+  // to the browser by /api/workspaces/[slug], including for anonymous
+  // viewers of public workspaces. Any such reuse has to go through a
+  // separate server-only accessor, not a widened DTO.
+  const [swarm, repositories, githubProfile, memberships] = await Promise.all([
+    db.swarm.findFirst({ where: { workspaceId } }),
+    db.repository.findMany({
+      where: { workspaceId },
       orderBy: { createdAt: "asc" },
-    });
-    if (repositories.length === 0) {
-      throw notFoundError(`No repositories for workspace: ${slug}`);
-    }
-
-    const githubProfile = await getGithubUsernameAndPAT(userId, slug);
-    if (!githubProfile?.token) {
-      throw notFoundError(`GitHub PAT not found for workspace: ${slug}`);
-    }
-
+    }),
+    // A null identity means the user has no GitHub username at all, so
+    // the per-workspace token lookup cannot succeed — skip the query and
+    // let the PAT guard below report it.
+    identity ? getGithubUsernameAndPAT(userId, slug, identity) : Promise.resolve(null),
     // Fetch workspace members (name, github username, role, description).
     // `orderBy` is load-bearing: this roster is rendered near the top of
     // the cached system prompt, and `lastAccessedAt` writes churn these
     // rows — without a stable sort the heap order shifts and busts the
     // Anthropic prompt cache for the whole request.
-    const memberships = await db.workspaceMember.findMany({
-      where: { workspaceId: access.workspace.id, leftAt: null },
+    db.workspaceMember.findMany({
+      where: { workspaceId, leftAt: null },
       orderBy: [{ joinedAt: "asc" }, { id: "asc" }],
       select: {
         role: true,
@@ -73,36 +135,56 @@ export async function buildWorkspaceConfigs(
           },
         },
       },
-    });
+    }),
+  ]);
 
-    const swarmUrlObj = new URL(swarm.swarmUrl);
-    let baseSwarmUrl = `https://${swarmUrlObj.hostname}:3355`;
-    if (swarm.swarmUrl.includes("localhost")) {
-      baseSwarmUrl = "http://localhost:3355";
-    }
+  return { swarm, repositories, githubProfile, memberships };
+}
 
-    configs.push({
-      slug,
-      name: access.workspace.name,
-      description: access.workspace.description ?? undefined,
-      swarmUrl: baseSwarmUrl,
-      swarmApiKey: encryptionService.decryptField("swarmApiKey", swarm.swarmApiKey || ""),
-      swarmDomain: swarm.name ? getSwarmVanityAddress(swarm.name) : undefined,
-      repoUrls: repositories.map((r) => r.repositoryUrl),
-      pat: githubProfile.token,
-      currentUserGithubUsername: githubProfile.username ?? undefined,
-      workspaceId: access.workspace.id,
-      userId,
-      members: memberships.map((m) => ({
-        name: m.user.name,
-        githubUsername: m.user.githubAuth?.githubUsername ?? null,
-        role: m.role,
-        description: m.description,
-      })),
-    });
+function assembleWorkspaceConfig(
+  slug: string,
+  userId: string,
+  workspace: { id: string; name: string; description?: string | null },
+  records: WorkspaceRecords,
+  encryptionService: EncryptionService
+): WorkspaceConfig {
+  const { swarm, repositories, githubProfile, memberships } = records;
+
+  if (!swarm?.swarmUrl) {
+    throw notFoundError(`Swarm not configured for workspace: ${slug}`);
+  }
+  if (repositories.length === 0) {
+    throw notFoundError(`No repositories for workspace: ${slug}`);
+  }
+  if (!githubProfile?.token) {
+    throw notFoundError(`GitHub PAT not found for workspace: ${slug}`);
   }
 
-  return configs;
+  const swarmUrlObj = new URL(swarm.swarmUrl);
+  let baseSwarmUrl = `https://${swarmUrlObj.hostname}:3355`;
+  if (swarm.swarmUrl.includes("localhost")) {
+    baseSwarmUrl = "http://localhost:3355";
+  }
+
+  return {
+    slug,
+    name: workspace.name,
+    description: workspace.description ?? undefined,
+    swarmUrl: baseSwarmUrl,
+    swarmApiKey: encryptionService.decryptField("swarmApiKey", swarm.swarmApiKey || ""),
+    swarmDomain: swarm.name ? getSwarmVanityAddress(swarm.name) : undefined,
+    repoUrls: repositories.map((r) => r.repositoryUrl),
+    pat: githubProfile.token,
+    currentUserGithubUsername: githubProfile.username ?? undefined,
+    workspaceId: workspace.id,
+    userId,
+    members: memberships.map((m) => ({
+      name: m.user.name,
+      githubUsername: m.user.githubAuth?.githubUsername ?? null,
+      role: m.role,
+      description: m.description,
+    })),
+  };
 }
 
 /**

--- a/src/lib/auth/nextauth.ts
+++ b/src/lib/auth/nextauth.ts
@@ -794,18 +794,27 @@ interface GithubUsernameAndPAT {
 }
 
 /**
- * Fetches the GitHub username and token for a given userId.
- * If workspaceSlug is provided, uses workspace-specific app token.
- * If workspaceSlug is omitted, falls back to user's OAuth token from sign-in.
- * Returns { username, token } or null if not found.
+ * The workspace-independent half of a PAT lookup: proof the user exists
+ * plus their GitHub username. See `resolveGithubIdentity`.
  */
-export async function getGithubUsernameAndPAT(
-  userId: string,
-  workspaceSlug?: string,
-): Promise<GithubUsernameAndPAT | null> {
-  console.log(`[getGithubUsernameAndPAT] Starting lookup for userId: ${userId}, workspaceSlug: ${workspaceSlug || 'none'}`);
+export interface GithubIdentity {
+  username: string;
+}
 
-  // Check if this is a mock user
+/**
+ * Resolves the caller's GitHub identity — the two lookups in
+ * `getGithubUsernameAndPAT` that do NOT depend on the workspace.
+ *
+ * Split out so multi-workspace callers can resolve it once and pass it
+ * to `getGithubUsernameAndPAT` via `identity`, instead of re-reading the
+ * same two rows for every slug. On an 8-workspace canvas turn that was
+ * 16 reads returning identical data.
+ */
+export async function resolveGithubIdentity(
+  userId: string,
+): Promise<GithubIdentity | null> {
+  // Deliberately sequential: with no user row there is no GitHubAuth row
+  // to find (FK), so the second query is pure waste on the miss path.
   const user = await db.user.findUnique({ where: { id: userId } });
   if (!user) {
     console.log(`[getGithubUsernameAndPAT] User not found: ${userId}`);
@@ -835,6 +844,31 @@ export async function getGithubUsernameAndPAT(
   }
 
   console.log(`[getGithubUsernameAndPAT] GitHub username found: ${githubAuth.githubUsername}`);
+  return { username: githubAuth.githubUsername };
+}
+
+/**
+ * Fetches the GitHub username and token for a given userId.
+ * If workspaceSlug is provided, uses workspace-specific app token.
+ * If workspaceSlug is omitted, falls back to user's OAuth token from sign-in.
+ * Returns { username, token } or null if not found.
+ *
+ * `identity` lets a caller that already resolved the user's GitHub
+ * identity (via `resolveGithubIdentity`) skip re-reading it. Omit it and
+ * the lookup happens inline, exactly as before.
+ */
+export async function getGithubUsernameAndPAT(
+  userId: string,
+  workspaceSlug?: string,
+  identity?: GithubIdentity,
+): Promise<GithubUsernameAndPAT | null> {
+  console.log(`[getGithubUsernameAndPAT] Starting lookup for userId: ${userId}, workspaceSlug: ${workspaceSlug || 'none'}`);
+
+  const resolvedIdentity = identity ?? (await resolveGithubIdentity(userId));
+  if (!resolvedIdentity) {
+    return null;
+  }
+  const githubUsername = resolvedIdentity.username;
 
   // If no workspace provided, use user's OAuth token from Account table
   if (!workspaceSlug) {
@@ -858,9 +892,9 @@ export async function getGithubUsernameAndPAT(
       const encryptionService = EncryptionService.getInstance();
       const token = encryptionService.decryptField("access_token", account.access_token);
 
-      console.log(`[getGithubUsernameAndPAT] Successfully decrypted OAuth token for user: ${githubAuth.githubUsername}`);
+      console.log(`[getGithubUsernameAndPAT] Successfully decrypted OAuth token for user: ${githubUsername}`);
       return {
-        username: githubAuth.githubUsername,
+        username: githubUsername,
         token: token,
       };
     } catch (error) {
@@ -904,7 +938,7 @@ export async function getGithubUsernameAndPAT(
       const token = encryptionService.decryptField("access_token", account.access_token);
       console.log(`[getGithubUsernameAndPAT] => falling back to personal access token!!! Not good for workspace: ${workspaceSlug}`);
       return {
-        username: githubAuth.githubUsername,
+        username: githubUsername,
         token: token,
       };
     } catch (error) {
@@ -936,9 +970,9 @@ export async function getGithubUsernameAndPAT(
     const encryptionService = EncryptionService.getInstance();
     const token = encryptionService.decryptField("source_control_token", sourceControlToken.token);
 
-    console.log(`[getGithubUsernameAndPAT] Successfully decrypted source control token for user: ${githubAuth.githubUsername}, org: ${workspace.sourceControlOrg.githubLogin}`);
+    console.log(`[getGithubUsernameAndPAT] Successfully decrypted source control token for user: ${githubUsername}, org: ${workspace.sourceControlOrg.githubLogin}`);
     return {
-      username: githubAuth.githubUsername,
+      username: githubUsername,
       token: token,
     };
   } catch (error) {


### PR DESCRIPTION
## Problem

Saying "hi" in the org canvas took **42.5 seconds**. From the request logs:

| Stage | ms |
|---|---|
| `buildWorkspaceConfigs (multi)` | **34,760** |
| `fetchConceptsForWorkspaces` | 901 |
| `getCanvasSystemPrompt` | 527 |
| time-to-first-token | 2,907 |
| streaming total | 4,080 |
| **turn-complete** | **42,551** |

The model did its job in ~4s. The other 38s was setup.

`buildWorkspaceConfigs` looped over slugs serially, and each iteration was a chain of ~10 sequential DB round-trips. Across the 8 workspaces in this org that's ~80 round-trips deep. The log timestamps confirm it exactly: each workspace's PAT lookup started ~4.3s after the previous one, and within each one the four `getGithubUsernameAndPAT` log lines were spaced **377ms apart, every single time**.

That 377ms is uniform per-query network RTT, not query cost — see the note at the bottom.

## Changes

**1. Fan out per slug.** The slugs are independent and every step is a read.

`allSettled` rather than `Promise.all` so the surfaced error stays deterministic: `Promise.all` rejects with whichever slug failed *first in time*, while the serial loop always reported the first failure in slug *order*.

**2. Fan out within each workspace.** `swarm` / `repositories` / `members` / PAT only need `workspace.id`, so nothing among them depends on anything else. Guards are re-applied per slug in the original nested order (access → swarm → repos → PAT), so an earlier slug's *later* failure still wins over a later slug's *earlier* failure — same error a reviewer would get before this PR.

**3. Hoist the GitHub identity.** `resolveGithubIdentity` is split out of `getGithubUsernameAndPAT`, which now accepts it as an optional third argument. The `User` and `GitHubAuth` rows don't vary by workspace, so 8 slugs were issuing 16 reads that returned identical data. Now resolved once, concurrently with the access checks, so it's free on the wire.

## Result

| | Before | After |
|---|---|---|
| `buildWorkspaceConfigs` | 34.8s | ~1.5s |
| Round-trip depth | ~80 | 4 |
| Query count | ~88 | ~50 |
| **Full turn** | **42.5s** | **~8s** |

~4s of the remaining 8s is the model generating, which is the floor.

## Testing

Full unit suite green — **13,834 passed**, lint clean, no new type errors.

`getGithubUsernameAndPAT`'s query *shapes* are deliberately unchanged (still `findUnique`, not batched `findMany`) specifically so its **20 existing tests stay a valid oracle** on the refactor. They pass untouched.

Six new tests in `workspaceConfig.test.ts`:
- both concurrency guarantees, written as start-barriers — each participant parks until all have *started*, so a regression to serial code **hangs** rather than flaking on timing
- slug-order preservation (results ordered by slug, not completion)
- error ordering (earlier slug failing *slower* still wins)
- identity resolved once and threaded into each PAT call
- PAT lookup skipped entirely when the user has no GitHub identity

## Notes for review

**Order preservation is load-bearing**, in two places: callers treat `configs[0]` as the primary workspace, and the rendered system prompt is Anthropic prompt-cached, so it must stay byte-stable across turns.

**Concepts were already fine** and are untouched — `fetchConceptsForWorkspaces` was already `Promise.all` with a cache layer. The 901ms in the log above was a cache *miss* hitting all 8 swarms concurrently.

**A follow-up that looks tempting but isn't.** `validateWorkspaceAccess` → `getWorkspaceBySlug` already loads the `swarm` and `repositories` rows, then maps them away, and we re-query them. Reusing them would cut ~2 queries per workspace — but it buys no wall-clock (the PAT branch is deeper), and the fields needed (`swarmApiKey`, `swarm.name`) **must not** be added to that function's return: `WorkspaceWithAccess` is serialized straight to the browser by `/api/workspaces/[slug]`, including to anonymous viewers of public workspaces, and that function is an intentional sanitization boundary (it already withholds `swarmUrl` and owner email by design). There's a comment at the call site recording this so it doesn't get re-derived.

**The real remaining lever is infrastructure, not code.** Every query costing a uniform ~377ms is network RTT to a remote Postgres over PgBouncer. Parallelism hid it; it didn't fix it. On a local DB the same work would be ~1s end to end.

## Unrelated commit included

`chore: update aieo to 0.1.34` was already in the working tree and is carried here at the author's request. It pulls `@ai-sdk/anthropic` 3.0.85 → 3.0.105 plus provider transitives. Separate commit, easy to drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
