### PR TITLE
Replace benchmark P/F pips with a rolling pass rate in the Runs tab

### DIFF
--- a/src/__tests__/unit/components/BenchmarkRunsHistory-focus.test.tsx
+++ b/src/__tests__/unit/components/BenchmarkRunsHistory-focus.test.tsx
@@ -132,6 +132,16 @@ vi.mock("date-fns", () => ({
   formatDistanceToNow: () => "about 1 month ago",
 }));
 
+// The summary strip owns a second Select; stub it so the shared select mock
+// below stays bound to the task filter.
+vi.mock("@/components/legal/BenchmarkSummaryStrip", () => ({
+  BenchmarkSummaryStrip: ({ windowSize }: { windowSize: number }) =>
+    React.createElement("div", {
+      "data-testid": "summary-strip",
+      "data-window": String(windowSize),
+    }),
+}));
+
 let selectOnValueChange: ((value: string) => void) | null = null;
 
 vi.mock("@/components/ui/select", () => ({

--- a/src/__tests__/unit/components/BenchmarkRunsHistory.test.tsx
+++ b/src/__tests__/unit/components/BenchmarkRunsHistory.test.tsx
@@ -129,6 +129,33 @@ vi.mock("@/components/ui/select", () => ({
     ),
 }));
 
+// The summary strip owns a second Select; stub it so the shared select mock
+// above stays bound to the task filter. Exposes what the table hands down.
+vi.mock("@/components/legal/BenchmarkSummaryStrip", () => ({
+  BenchmarkSummaryStrip: ({
+    runs,
+    windowSize,
+    onWindowChange,
+  }: {
+    runs: Array<{ id: string }>;
+    windowSize: number;
+    onWindowChange: (size: number) => void;
+  }) =>
+    React.createElement(
+      "div",
+      {
+        "data-testid": "summary-strip",
+        "data-window": String(windowSize),
+        "data-rows": String(runs.length),
+      },
+      React.createElement(
+        "button",
+        { "data-testid": "set-window-25", onClick: () => onWindowChange(25) },
+        "Last 25",
+      ),
+    ),
+}));
+
 vi.mock("@/components/legal/HillClimbChart", () => ({
   HillClimbChart: ({
     attempts,
@@ -457,9 +484,12 @@ describe("BenchmarkRunsHistory", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows 'Showing the most recent 100 runs' banner when total > 100", () => {
+  it("shows the window banner when the window holds rows back, including the fetch cap", () => {
+    // 12 scored runs, default window of 10 → 2 rows held back
     mockUseList.mockReturnValue({
-      runs: Array.from({ length: 5 }, (_, i) => makeRun({ id: `run-${i}` })),
+      runs: Array.from({ length: 12 }, (_, i) =>
+        makeRun({ id: `run-${i}`, status: "COMPLETED", all_pass: true }),
+      ),
       total: 150,
       isLoading: false,
       error: null,
@@ -467,12 +497,109 @@ describe("BenchmarkRunsHistory", () => {
       setExpandedId: mockSetExpandedId,
     });
     render(React.createElement(BenchmarkRunsHistory));
-    expect(screen.getByText("Showing the most recent 100 runs.")).toBeInTheDocument();
+    const note = screen.getByTestId("window-note");
+    expect(note.textContent).toContain("Showing 10 of 12 loaded runs");
+    expect(note.textContent).toContain("back to the 10 most recent scored runs");
+    // The fetch cap is disclosed too, rather than silently truncating
+    expect(note.textContent).toContain("Only the latest 100 of 150 runs are loaded");
   });
 
-  it("does NOT show the banner when total <= 100", () => {
+  it("does NOT show the window banner when every loaded run is on screen", () => {
     render(React.createElement(BenchmarkRunsHistory));
-    expect(screen.queryByText(/Showing the most recent 100 runs/)).toBeNull();
+    expect(screen.queryByTestId("window-note")).toBeNull();
+  });
+
+  // ── Window: counted in scored runs, rendered across all states ─────────────
+
+  it("keeps unscored rows that fall inside the window span", () => {
+    // 10 scored runs with a FAILED and a PENDING run interleaved: the window is
+    // 10 SCORED runs, so all 12 rows render.
+    const runs = [
+      makeRun({ id: "s-0", status: "COMPLETED", all_pass: true }),
+      makeRun({ id: "failed-1", status: "FAILED" }),
+      ...Array.from({ length: 8 }, (_, i) =>
+        makeRun({ id: `s-${i + 1}`, status: "COMPLETED", all_pass: false }),
+      ),
+      makeRun({ id: "pending-1", status: "PENDING" }),
+      makeRun({ id: "s-9", status: "COMPLETED", all_pass: true }),
+    ];
+    mockUseList.mockReturnValue({
+      runs,
+      total: runs.length,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+      setExpandedId: mockSetExpandedId,
+    });
+    render(React.createElement(BenchmarkRunsHistory));
+
+    expect(screen.getAllByTestId(/^run-row-/)).toHaveLength(12);
+    expect(screen.getByTestId("run-row-failed-1")).toBeInTheDocument();
+    expect(screen.getByTestId("run-row-pending-1")).toBeInTheDocument();
+  });
+
+  it("cuts the table at the Nth most recent scored run", () => {
+    // 12 scored runs, window of 10 → the 2 oldest rows are dropped
+    const runs = Array.from({ length: 12 }, (_, i) =>
+      makeRun({ id: `s-${i}`, status: "COMPLETED", all_pass: true }),
+    );
+    mockUseList.mockReturnValue({
+      runs,
+      total: runs.length,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+      setExpandedId: mockSetExpandedId,
+    });
+    render(React.createElement(BenchmarkRunsHistory));
+
+    expect(screen.getAllByTestId(/^run-row-/)).toHaveLength(10);
+    expect(screen.getByTestId("run-row-s-9")).toBeInTheDocument();
+    expect(screen.queryByTestId("run-row-s-10")).toBeNull();
+  });
+
+  it("hands the strip exactly the rows the table is showing", () => {
+    const runs = Array.from({ length: 12 }, (_, i) =>
+      makeRun({ id: `s-${i}`, status: "COMPLETED", all_pass: true }),
+    );
+    mockUseList.mockReturnValue({
+      runs,
+      total: runs.length,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+      setExpandedId: mockSetExpandedId,
+    });
+    render(React.createElement(BenchmarkRunsHistory));
+
+    const strip = screen.getByTestId("summary-strip");
+    expect(strip.getAttribute("data-window")).toBe("10");
+    expect(strip.getAttribute("data-rows")).toBe(
+      String(screen.getAllByTestId(/^run-row-/).length),
+    );
+  });
+
+  it("widening the window from the strip grows the table", async () => {
+    const user = userEvent.setup();
+    const runs = Array.from({ length: 12 }, (_, i) =>
+      makeRun({ id: `s-${i}`, status: "COMPLETED", all_pass: true }),
+    );
+    mockUseList.mockReturnValue({
+      runs,
+      total: runs.length,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+      setExpandedId: mockSetExpandedId,
+    });
+    render(React.createElement(BenchmarkRunsHistory));
+
+    expect(screen.getAllByTestId(/^run-row-/)).toHaveLength(10);
+
+    await user.click(screen.getByTestId("set-window-25"));
+
+    expect(screen.getAllByTestId(/^run-row-/)).toHaveLength(12);
+    expect(screen.getByTestId("summary-strip").getAttribute("data-window")).toBe("25");
   });
 
   it("shows loading state", () => {

--- a/src/__tests__/unit/components/BenchmarkSummaryStrip.test.tsx
+++ b/src/__tests__/unit/components/BenchmarkSummaryStrip.test.tsx
@@ -3,381 +3,198 @@
  */
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { WorkflowStatus } from "@prisma/client";
+import type { BenchmarkRunListRow } from "@/hooks/useLegalBenchmarkRunList";
 
 globalThis.React = React;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
+let _seq = 0;
 const makeRun = (
-  overrides: Partial<{
-    id: string;
-    workspaceId: string;
-    status: string;
-    taskSlug: string;
-    taskTitle: string;
-    createdAt: string;
-    updatedAt: string;
-    n_passed: number;
-    n_total: number;
-    all_pass: boolean;
-  }> = {},
-) => ({
-  id: "run-1",
-  workspaceId: "ws-1",
-  status: "COMPLETED",
-  projectId: null,
-  taskSlug: "antitrust/task-1",
-  taskTitle: "Analyze Antitrust Strategy",
-  createdAt: new Date("2025-06-01T09:00:00Z").toISOString(),
-  updatedAt: new Date("2025-06-01T09:05:00Z").toISOString(),
-  n_passed: 8,
-  n_total: 10,
-  all_pass: true,
-  ...overrides,
-});
+  overrides: Partial<BenchmarkRunListRow> = {},
+): BenchmarkRunListRow => {
+  _seq += 1;
+  return {
+    id: `run-${_seq}`,
+    workspaceId: "ws-1",
+    status: WorkflowStatus.COMPLETED,
+    projectId: null,
+    taskSlug: "antitrust/task-1",
+    taskTitle: "Analyze Antitrust Strategy",
+    createdAt: new Date(1_700_000_000_000 + _seq * 1000).toISOString(),
+    updatedAt: new Date(1_700_000_000_000 + _seq * 1000).toISOString(),
+    n_passed: 8,
+    n_total: 10,
+    all_pass: true,
+    ...overrides,
+  };
+};
 
-// ─── Module mocks ─────────────────────────────────────────────────────────────
-
-// Default: legal slug, so gate passes
-const mockUseWorkspace = vi.fn(() => ({
-  workspace: { id: "ws-1", slug: "openlaw" },
-  isSuperAdmin: false,
-}));
-
-vi.mock("@/hooks/useWorkspace", () => ({
-  useWorkspace: () => mockUseWorkspace(),
-}));
-
-vi.mock("date-fns", () => ({
-  formatDistanceToNow: (_date: Date, _opts?: { addSuffix?: boolean }) =>
-    "2 months ago",
-}));
-
-// ─── Import after mocks ───────────────────────────────────────────────────────
+/** One run per supplied pass flag. */
+const makeRuns = (passFlags: boolean[]) =>
+  passFlags.map((all_pass) => makeRun({ all_pass }));
 
 const { BenchmarkSummaryStrip } = await import(
   "@/components/legal/BenchmarkSummaryStrip"
 );
 
+const renderStrip = (
+  runs: BenchmarkRunListRow[],
+  onWindowChange = vi.fn(),
+  windowSize: 10 | 25 | 50 | 100 = 10,
+) => {
+  render(
+    React.createElement(BenchmarkSummaryStrip, {
+      runs,
+      windowSize,
+      onWindowChange,
+    }),
+  );
+  return onWindowChange;
+};
+
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe("BenchmarkSummaryStrip", () => {
-  const onSelectRun = vi.fn();
-
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUseWorkspace.mockReturnValue({
-      workspace: { id: "ws-1", slug: "openlaw" },
-      isSuperAdmin: false,
-    });
+
+    // Radix Select needs these APIs, which jsdom does not implement
+    if (!HTMLElement.prototype.hasPointerCapture) {
+      HTMLElement.prototype.hasPointerCapture = vi.fn(() => false);
+    }
+    if (!HTMLElement.prototype.setPointerCapture) {
+      HTMLElement.prototype.setPointerCapture = vi.fn();
+    }
+    if (!HTMLElement.prototype.releasePointerCapture) {
+      HTMLElement.prototype.releasePointerCapture = vi.fn();
+    }
+    if (!HTMLElement.prototype.scrollIntoView) {
+      HTMLElement.prototype.scrollIntoView = vi.fn();
+    }
   });
 
-  // ── Gate tests ─────────────────────────────────────────────────────────────
+  // ── No P/F pips ─────────────────────────────────────────────────────────────
 
-  it("renders content for a legal slug (openlaw)", () => {
-    render(
-      React.createElement(BenchmarkSummaryStrip, {
-        runs: [makeRun()],
-        isLoading: false,
-        error: null,
-        onSelectRun,
-      }),
-    );
-    // strip or empty state — either way, it renders something (not null)
-    expect(document.body.textContent).not.toBe("");
-  });
-
-  it("renders null for a non-legal, non-dev slug", () => {
-    mockUseWorkspace.mockReturnValue({
-      workspace: { id: "ws-2", slug: "some-other-workspace" },
-      isSuperAdmin: false,
-    });
+  it("renders no per-run P/F pips", () => {
     const { container } = render(
       React.createElement(BenchmarkSummaryStrip, {
-        runs: [makeRun()],
-        isLoading: false,
-        error: null,
-        onSelectRun,
+        runs: makeRuns([true, false, false]),
+        windowSize: 10 as const,
+        onWindowChange: vi.fn(),
       }),
     );
-    expect(container.firstChild).toBeNull();
+    expect(container.querySelector('[data-testid^="pip-"]')).toBeNull();
+    expect(screen.queryByText("P")).toBeNull();
+    expect(screen.queryByText("F")).toBeNull();
   });
 
-  // ── Loading skeleton ────────────────────────────────────────────────────────
+  // ── Rolling pass rate ───────────────────────────────────────────────────────
 
-  it("shows skeleton pips while isLoading and runs is empty", () => {
-    render(
-      React.createElement(BenchmarkSummaryStrip, {
-        runs: [],
-        isLoading: true,
-        error: null,
-        onSelectRun,
-      }),
-    );
-    expect(screen.getByTestId("benchmark-strip-skeleton")).toBeInTheDocument();
-    expect(screen.queryByTestId("benchmark-strip")).toBeNull();
-    expect(screen.queryByTestId("benchmark-strip-empty")).toBeNull();
+  it("shows the run-level pass rate, not the criteria average", () => {
+    // 2 of 8 runs fully passed → 25%
+    renderStrip(makeRuns([true, true, false, false, false, false, false, false]));
+    expect(screen.getByTestId("strip-pass-rate")).toHaveTextContent("25%");
+    expect(screen.getByText("rolling pass rate")).toBeInTheDocument();
   });
 
-  it("does NOT show skeleton when runs are already loaded (even if isLoading=true)", () => {
-    render(
-      React.createElement(BenchmarkSummaryStrip, {
-        runs: [makeRun()],
-        isLoading: true,
-        error: null,
-        onSelectRun,
-      }),
-    );
-    expect(screen.queryByTestId("benchmark-strip-skeleton")).toBeNull();
-    expect(screen.getByTestId("benchmark-strip")).toBeInTheDocument();
+  it("shows 100% when every scored run passed", () => {
+    renderStrip(makeRuns([true, true, true]));
+    expect(screen.getByTestId("strip-pass-rate")).toHaveTextContent("100%");
   });
 
-  // ── Error state ─────────────────────────────────────────────────────────────
-
-  it("shows error affordance when error is set (and not loading)", () => {
-    render(
-      React.createElement(BenchmarkSummaryStrip, {
-        runs: [],
-        isLoading: false,
-        error: "Network error",
-        onSelectRun,
-      }),
-    );
-    const errorEl = screen.getByTestId("benchmark-strip-error");
-    expect(errorEl).toBeInTheDocument();
-    expect(screen.queryByTestId("benchmark-strip-empty")).toBeNull();
-    expect(screen.queryByTestId("benchmark-strip")).toBeNull();
+  it("shows 0% when no scored run passed", () => {
+    renderStrip(makeRuns([false, false]));
+    expect(screen.getByTestId("strip-pass-rate")).toHaveTextContent("0%");
   });
 
-  it("error state is visually distinct from empty state (different testids)", () => {
-    const { unmount } = render(
-      React.createElement(BenchmarkSummaryStrip, {
-        runs: [],
-        isLoading: false,
-        error: "err",
-        onSelectRun,
-      }),
-    );
-    expect(screen.getByTestId("benchmark-strip-error")).toBeInTheDocument();
-    expect(screen.queryByTestId("benchmark-strip-empty")).toBeNull();
-    unmount();
-
-    render(
-      React.createElement(BenchmarkSummaryStrip, {
-        runs: [],
-        isLoading: false,
-        error: null,
-        onSelectRun,
-      }),
-    );
-    expect(screen.getByTestId("benchmark-strip-empty")).toBeInTheDocument();
-    expect(screen.queryByTestId("benchmark-strip-error")).toBeNull();
-  });
-
-  it("calls onRetry when the Retry button is clicked (error state)", () => {
-    const onRetry = vi.fn();
-    render(
-      React.createElement(BenchmarkSummaryStrip, {
-        runs: [],
-        isLoading: false,
-        error: "err",
-        onSelectRun,
-        onRetry,
-      }),
-    );
-    fireEvent.click(screen.getByText("Retry"));
-    expect(onRetry).toHaveBeenCalledTimes(1);
-  });
-
-  // ── Empty state ─────────────────────────────────────────────────────────────
-
-  it("shows empty state when loaded with no scored runs", () => {
-    // Unscored runs (PENDING) should produce empty state
-    render(
-      React.createElement(BenchmarkSummaryStrip, {
-        runs: [makeRun({ status: "PENDING", all_pass: undefined })],
-        isLoading: false,
-        error: null,
-        onSelectRun,
-      }),
-    );
-    expect(screen.getByTestId("benchmark-strip-empty")).toBeInTheDocument();
-    expect(screen.queryByTestId("benchmark-strip")).toBeNull();
-  });
-
-  it("shows 'No scored runs yet' text in empty state", () => {
-    render(
-      React.createElement(BenchmarkSummaryStrip, {
-        runs: [],
-        isLoading: false,
-        error: null,
-        onSelectRun,
-      }),
-    );
-    expect(screen.getByText("No scored runs yet")).toBeInTheDocument();
-  });
-
-  // ── Pip rendering ───────────────────────────────────────────────────────────
-
-  it("renders the strip with pips for scored runs", () => {
-    render(
-      React.createElement(BenchmarkSummaryStrip, {
-        runs: [makeRun({ id: "r1", all_pass: true }), makeRun({ id: "r2", all_pass: false })],
-        isLoading: false,
-        error: null,
-        onSelectRun,
-      }),
-    );
-    expect(screen.getByTestId("benchmark-strip")).toBeInTheDocument();
-    expect(screen.getByTestId("pip-r1")).toBeInTheDocument();
-    expect(screen.getByTestId("pip-r2")).toBeInTheDocument();
-  });
-
-  it("pip title includes task title, score, and date", () => {
-    render(
-      React.createElement(BenchmarkSummaryStrip, {
-        runs: [
-          makeRun({
-            id: "r1",
-            taskTitle: "Analyze Antitrust Strategy",
-            n_passed: 8,
-            n_total: 10,
-            all_pass: true,
-          }),
-        ],
-        isLoading: false,
-        error: null,
-        onSelectRun,
-      }),
-    );
-    const pip = screen.getByTestId("pip-r1");
-    expect(pip.getAttribute("title")).toContain("Analyze Antitrust Strategy");
-    expect(pip.getAttribute("title")).toContain("8/10");
-    expect(pip.getAttribute("title")).toContain("2 months ago");
-  });
-
-  it("pip aria-label matches title", () => {
-    render(
-      React.createElement(BenchmarkSummaryStrip, {
-        runs: [makeRun({ id: "r1", all_pass: true })],
-        isLoading: false,
-        error: null,
-        onSelectRun,
-      }),
-    );
-    const pip = screen.getByTestId("pip-r1");
-    expect(pip.getAttribute("aria-label")).toBe(pip.getAttribute("title"));
-  });
-
-  it("pip omits score from title when n_passed/n_total absent", () => {
-    render(
-      React.createElement(BenchmarkSummaryStrip, {
-        runs: [
-          makeRun({
-            id: "r1",
-            all_pass: true,
-            n_passed: undefined,
-            n_total: undefined,
-          }),
-        ],
-        isLoading: false,
-        error: null,
-        onSelectRun,
-      }),
-    );
-    const pip = screen.getByTestId("pip-r1");
-    expect(pip.getAttribute("title")).not.toContain("/");
-  });
-
-  it("clicking a pip calls onSelectRun with the correct run id", () => {
-    render(
-      React.createElement(BenchmarkSummaryStrip, {
-        runs: [makeRun({ id: "run-abc" })],
-        isLoading: false,
-        error: null,
-        onSelectRun,
-      }),
-    );
-    fireEvent.click(screen.getByTestId("pip-run-abc"));
-    expect(onSelectRun).toHaveBeenCalledWith("run-abc");
-  });
-
-  it("pips are <button> elements (keyboard reachable)", () => {
-    render(
-      React.createElement(BenchmarkSummaryStrip, {
-        runs: [makeRun({ id: "r1" })],
-        isLoading: false,
-        error: null,
-        onSelectRun,
-      }),
-    );
-    expect(screen.getByTestId("pip-r1").tagName).toBe("BUTTON");
-  });
-
-  // ── Average + sub-label ─────────────────────────────────────────────────────
-
-  it("renders avg criteria pass rate label", () => {
-    render(
-      React.createElement(BenchmarkSummaryStrip, {
-        runs: [makeRun({ n_passed: 8, n_total: 10, all_pass: true })],
-        isLoading: false,
-        error: null,
-        onSelectRun,
-      }),
-    );
-    expect(screen.getByText("avg criteria pass rate")).toBeInTheDocument();
-  });
-
-  it("renders '—' for average when no runs qualify for rating", () => {
-    // all_pass present (pip) but n_total is missing (no rating)
-    render(
-      React.createElement(BenchmarkSummaryStrip, {
-        runs: [makeRun({ all_pass: true, n_passed: undefined, n_total: undefined })],
-        isLoading: false,
-        error: null,
-        onSelectRun,
-      }),
-    );
-    expect(screen.getByText("—")).toBeInTheDocument();
-  });
-
-  it("sub-label reflects scoredCount and ratedCount when they differ", () => {
-    // 2 scored, 1 rated (second run has all_pass but no counts)
-    render(
-      React.createElement(BenchmarkSummaryStrip, {
-        runs: [
-          makeRun({ id: "r1", all_pass: true, n_passed: 8, n_total: 10 }),
-          makeRun({
-            id: "r2",
-            all_pass: false,
-            n_passed: undefined,
-            n_total: undefined,
-            updatedAt: new Date("2025-06-02T09:00:00Z").toISOString(),
-          }),
-        ],
-        isLoading: false,
-        error: null,
-        onSelectRun,
-      }),
-    );
+  it("sub-label reports passed-of-scored and the criteria average", () => {
+    renderStrip([
+      makeRun({ all_pass: true, n_passed: 10, n_total: 10 }),
+      makeRun({ all_pass: false, n_passed: 8, n_total: 10 }),
+    ]);
     const subLabel = screen.getByTestId("strip-sub-label");
-    // 2 scored, 1 rated
-    expect(subLabel.textContent).toContain("2 scored");
-    expect(subLabel.textContent).toContain("1 rated");
+    expect(subLabel.textContent).toContain("1/2 scored runs passed");
+    // mean(1.0, 0.8) = 0.9
+    expect(subLabel.textContent).toContain("90% avg criteria");
   });
 
-  it("sub-label scoredCount and ratedCount are equal when all runs have counts", () => {
-    render(
-      React.createElement(BenchmarkSummaryStrip, {
-        runs: [makeRun({ id: "r1", all_pass: true, n_passed: 5, n_total: 5 })],
-        isLoading: false,
-        error: null,
-        onSelectRun,
-      }),
-    );
+  it("omits the criteria average when no run carries counts", () => {
+    renderStrip([
+      makeRun({ all_pass: true, n_passed: undefined, n_total: undefined }),
+    ]);
     const subLabel = screen.getByTestId("strip-sub-label");
-    expect(subLabel.textContent).toContain("1 scored");
-    expect(subLabel.textContent).toContain("1 rated");
+    expect(subLabel.textContent).toContain("1/1 scored runs passed");
+    expect(subLabel.textContent).not.toContain("avg criteria");
+    expect(screen.getByTestId("strip-pass-rate")).toHaveTextContent("100%");
+  });
+
+  // ── Unscored rows are shown by the table but never move the rate ────────────
+
+  it("ignores unscored rows handed in alongside scored ones", () => {
+    // The table passes every row in the window, whatever its state
+    renderStrip([
+      makeRun({ all_pass: true }),
+      makeRun({ status: WorkflowStatus.FAILED, all_pass: false }),
+      makeRun({ status: WorkflowStatus.PENDING, all_pass: undefined }),
+      makeRun({ status: WorkflowStatus.IN_PROGRESS, all_pass: undefined }),
+    ]);
+    expect(screen.getByTestId("strip-pass-rate")).toHaveTextContent("100%");
+    expect(screen.getByTestId("strip-sub-label").textContent).toContain(
+      "1/1 scored runs passed",
+    );
+  });
+
+  it("shows the empty message when no row in view is scored", () => {
+    renderStrip([
+      makeRun({ status: WorkflowStatus.PENDING, all_pass: undefined }),
+      makeRun({ status: WorkflowStatus.FAILED, all_pass: undefined }),
+    ]);
+    expect(screen.getByTestId("benchmark-strip-empty")).toBeInTheDocument();
+    expect(screen.queryByTestId("strip-pass-rate")).toBeNull();
+  });
+
+  it("keeps the window dropdown available even with nothing scored", () => {
+    // The dropdown drives the table too, so it must never disappear
+    renderStrip([makeRun({ status: WorkflowStatus.PENDING, all_pass: undefined })]);
+    expect(screen.getByTestId("summary-window-trigger")).toBeInTheDocument();
+  });
+
+  // ── Window dropdown ─────────────────────────────────────────────────────────
+
+  it("renders the window it was given", () => {
+    renderStrip(makeRuns([true]), vi.fn(), 25);
+    expect(screen.getByTestId("summary-window-trigger")).toHaveTextContent(
+      "Last 25",
+    );
+  });
+
+  it("reports the chosen window to the parent instead of self-managing", async () => {
+    const user = userEvent.setup();
+    const onWindowChange = renderStrip(makeRuns([true, false]));
+
+    await user.click(screen.getByTestId("summary-window-trigger"));
+    await user.click(await screen.findByRole("option", { name: "Last 50" }));
+
+    expect(onWindowChange).toHaveBeenCalledWith(50);
+    // Still displays the prop value — the table owns the state
+    expect(screen.getByTestId("summary-window-trigger")).toHaveTextContent(
+      "Last 10",
+    );
+  });
+
+  it("offers 10 / 25 / 50 / 100 as window options", async () => {
+    const user = userEvent.setup();
+    renderStrip(makeRuns([true, false]));
+
+    await user.click(screen.getByTestId("summary-window-trigger"));
+    for (const size of [10, 25, 50, 100]) {
+      expect(
+        await screen.findByRole("option", { name: `Last ${size}` }),
+      ).toBeInTheDocument();
+    }
   });
 });

--- a/src/__tests__/unit/components/LegalBenchmarksPage.test.tsx
+++ b/src/__tests__/unit/components/LegalBenchmarksPage.test.tsx
@@ -3,7 +3,7 @@
  *
  * Integration tests for the Legal Benchmarks page:
  * - Exactly one /api/stakwork/runs request fires on load (shared hook instance)
- * - Clicking a pip switches to the Runs tab and expands the corresponding row
+ * - Header summary strip and tab switching render off the shared run list
  */
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -170,7 +170,7 @@ const LegalBenchmarksPage = (await import(
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
-describe("LegalBenchmarksPage — shared run-list", () => {
+describe("LegalBenchmarksPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRunListHook.mockReturnValue({
@@ -183,82 +183,36 @@ describe("LegalBenchmarksPage — shared run-list", () => {
     });
   });
 
-  it("calls useLegalBenchmarkRunList exactly once at page level with the workspace id", () => {
+  it("does not fetch runs at page level — the Runs tab owns the list now", () => {
     render(React.createElement(LegalBenchmarksPage));
-    // The page-level shared instance fires with the real workspace id
-    const calls = mockRunListHook.mock.calls;
-    const realCalls = calls.filter(([id]) => id === WORKSPACE_ID);
-    expect(realCalls).toHaveLength(1);
-    // BenchmarkRunsHistory (rendered inside an inactive Radix TabsContent) is
-    // deferred by Radix Presence and does not mount until the tab first becomes
-    // active — so we only assert the page-level call here rather than counting
-    // a noop call that depends on Radix internals.
-    // The unit tests in BenchmarkRunsHistory-focus.test.tsx independently verify
-    // that when runList prop is supplied the internal hook is called with undefined.
+    // Radix defers the inactive Runs tab, so nothing requests the run list
+    // until the user opens it.
+    expect(
+      mockRunListHook.mock.calls.filter(([id]) => id === WORKSPACE_ID),
+    ).toHaveLength(0);
   });
 
-  it("renders both the summary strip and the runs tab", () => {
+  it("keeps the header free of the summary strip", () => {
     render(React.createElement(LegalBenchmarksPage));
-    // Summary strip is visible in the header
-    expect(screen.getByTestId("benchmark-strip")).toBeInTheDocument();
-    // Benchmark tab (default) is shown
+    expect(screen.getByTestId("page-header")).toBeInTheDocument();
+    expect(screen.queryByTestId("benchmark-strip")).toBeNull();
     expect(screen.getByTestId("benchmarks-panel")).toBeInTheDocument();
   });
 
-  it("pip click switches to the Runs tab", async () => {
+  it("shows the summary strip inside the Runs tab, with no P/F pips", async () => {
     // Use real timers — fake timers + userEvent.click + Radix UI Tabs deadlock
     // because Radix's Presence animation callbacks call setTimeout/rAF
     // which userEvent's advanceTimers intercepts, causing an infinite loop.
     const user = userEvent.setup();
-    render(React.createElement(LegalBenchmarksPage));
+    const { container } = render(React.createElement(LegalBenchmarksPage));
 
-    // Strip is visible
-    const pip = screen.getByTestId("pip-run-page-1");
-    await user.click(pip);
+    await user.click(screen.getByText("Runs"));
 
-    // Runs tab content should now be rendered
     await waitFor(() => {
-      expect(screen.getByText("Antitrust Strategy")).toBeInTheDocument();
+      expect(screen.getByTestId("benchmark-strip")).toBeInTheDocument();
     });
-  });
-
-  it("pip click expands the corresponding row in BenchmarkRunsHistory", async () => {
-    const user = userEvent.setup();
-    render(React.createElement(LegalBenchmarksPage));
-
-    const pip = screen.getByTestId("pip-run-page-1");
-    await user.click(pip);
-
-    // After switching tabs and focus effect fires, the row should be expanded
-    await waitFor(() => {
-      expect(screen.getByTestId("results-run-page-1")).toBeInTheDocument();
-    });
-  });
-
-  it("clicking a pip twice with different nonces re-fires focus", async () => {
-    const user = userEvent.setup();
-    render(React.createElement(LegalBenchmarksPage));
-
-    const pip = screen.getByTestId("pip-run-page-1");
-
-    // First click — expand row
-    await user.click(pip);
-    await waitFor(() => {
-      expect(screen.getByTestId("results-run-page-1")).toBeInTheDocument();
-    });
-
-    // Collapse via reset button
-    await act(async () => {
-      const resetBtn = screen.getByTestId("reset-btn");
-      await user.click(resetBtn);
-    });
-    expect(screen.queryByTestId("results-run-page-1")).toBeNull();
-
-    // Second click — expand again
-    await user.click(pip);
-    await waitFor(() => {
-      expect(screen.getByTestId("results-run-page-1")).toBeInTheDocument();
-    });
+    expect(screen.getByText("Antitrust Strategy")).toBeInTheDocument();
+    expect(container.querySelector('[data-testid^="pip-"]')).toBeNull();
   });
 
   it("renders the Recursion tab when its trigger is clicked", async () => {

--- a/src/__tests__/unit/lib/harvey-lab/benchmark-summary.test.ts
+++ b/src/__tests__/unit/lib/harvey-lab/benchmark-summary.test.ts
@@ -5,25 +5,32 @@
  *   - isScoredRun: PENDING/IN_PROGRESS excluded; COMPLETED-only rule;
  *     FAILED/HALTED excluded even when they carry a score;
  *     terminal runs without all_pass excluded
- *   - selectScoredRuns: ordering by updatedAt (primary), createdAt (secondary), id
- *     (tiebreaker); window slicing; fewer than SUMMARY_WINDOW runs
+ *   - selectWindowRows: window counted in scored runs, unscored rows carried
+ *     along, cut position, fewer scored runs than the window
  *   - averagePassRate: missing counts excluded; n_total=0 guard; null on empty;
  *     correct mean
+ *   - passRate: run-level P/F rate over the supplied rows; null on empty
  *   - summarize: scoredCount / ratedCount split; correct aggregation
- *   - Constants: PASS_BADGE_CLASS / FAIL_BADGE_CLASS are non-empty strings
+ *   - Constants: WINDOW_OPTIONS, PASS_BADGE_CLASS / FAIL_BADGE_CLASS
  */
 import { describe, it, expect } from "vitest";
 import { WorkflowStatus } from "@prisma/client";
 import {
   SUMMARY_WINDOW,
+  WINDOW_OPTIONS,
   PASS_BADGE_CLASS,
   FAIL_BADGE_CLASS,
   isScoredRun,
-  selectScoredRuns,
+  selectWindowRows,
   averagePassRate,
+  passRate,
   summarize,
 } from "@/lib/harvey-lab/benchmark-summary";
 import type { BenchmarkRunListRow } from "@/hooks/useLegalBenchmarkRunList";
+
+/** Mirrors RUN_LIST_LIMIT in useLegalBenchmarkRunList (type-only import here to
+ *  keep this suite free of the hook's React/Pusher module graph). */
+const RUN_LIST_LIMIT = 100;
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -53,6 +60,20 @@ function makeRun(
 describe("constants", () => {
   it("SUMMARY_WINDOW is 10", () => {
     expect(SUMMARY_WINDOW).toBe(10);
+  });
+
+  it("WINDOW_OPTIONS offers 10/25/50/100 in ascending order", () => {
+    expect([...WINDOW_OPTIONS]).toEqual([10, 25, 50, 100]);
+  });
+
+  it("SUMMARY_WINDOW is one of WINDOW_OPTIONS", () => {
+    expect(WINDOW_OPTIONS).toContain(SUMMARY_WINDOW);
+  });
+
+  // Guards the "no refetch on window change" contract: every option must be
+  // servable from the single already-fetched payload.
+  it("largest window does not exceed the run-list fetch limit", () => {
+    expect(Math.max(...WINDOW_OPTIONS)).toBeLessThanOrEqual(RUN_LIST_LIMIT);
   });
 
   it("PASS_BADGE_CLASS is a non-empty string containing green", () => {
@@ -121,135 +142,73 @@ describe("isScoredRun", () => {
   });
 });
 
-// ─── selectScoredRuns ─────────────────────────────────────────────────────────
+// ─── selectWindowRows ─────────────────────────────────────────────────────────
 
-describe("selectScoredRuns", () => {
-  it("filters out PENDING and IN_PROGRESS runs", () => {
+describe("selectWindowRows", () => {
+  const scored = (id: string) => makeRun({ id, all_pass: true });
+  const unscored = (id: string) =>
+    makeRun({ id, status: WorkflowStatus.FAILED, all_pass: undefined });
+
+  it("returns every row when fewer scored runs than the window exist", () => {
+    const runs = [scored("a"), unscored("b"), scored("c")];
+    expect(selectWindowRows(runs, 10).map((r) => r.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("returns an empty array for an empty input", () => {
+    expect(selectWindowRows([], 10)).toEqual([]);
+  });
+
+  it("cuts at the Nth scored run, counting only scored runs", () => {
+    const runs = [scored("s1"), scored("s2"), scored("s3"), scored("s4")];
+    expect(selectWindowRows(runs, 2).map((r) => r.id)).toEqual(["s1", "s2"]);
+  });
+
+  // The point of the whole design: the table shows every state, the rate doesn't.
+  it("carries unscored rows that sit inside the span", () => {
     const runs = [
-      makeRun({ status: WorkflowStatus.PENDING, all_pass: true }),
-      makeRun({ status: WorkflowStatus.IN_PROGRESS, all_pass: false }),
-      makeRun({ status: WorkflowStatus.COMPLETED, all_pass: true }),
+      scored("s1"),
+      unscored("f1"),
+      unscored("f2"),
+      scored("s2"),
+      scored("s3"),
     ];
-    expect(selectScoredRuns(runs)).toHaveLength(1);
+    // Window of 2 scored runs reaches s2, dragging f1/f2 along
+    expect(selectWindowRows(runs, 2).map((r) => r.id)).toEqual([
+      "s1",
+      "f1",
+      "f2",
+      "s2",
+    ]);
   });
 
-  it("excludes FAILED and HALTED runs even when they carry a score (COMPLETED-only rule)", () => {
+  it("excludes unscored rows that trail past the cut", () => {
+    const runs = [scored("s1"), scored("s2"), unscored("f1"), scored("s3")];
+    // The cut lands on s2 — f1 is older than the window and stays out
+    expect(selectWindowRows(runs, 2).map((r) => r.id)).toEqual(["s1", "s2"]);
+  });
+
+  it("counts PENDING and IN_PROGRESS rows as unscored", () => {
     const runs = [
-      makeRun({ status: WorkflowStatus.FAILED, all_pass: false, n_passed: 2, n_total: 5 }),
-      makeRun({ status: WorkflowStatus.HALTED, all_pass: true, n_passed: 5, n_total: 5 }),
+      makeRun({ id: "p1", status: WorkflowStatus.PENDING, all_pass: undefined }),
+      makeRun({ id: "i1", status: WorkflowStatus.IN_PROGRESS, all_pass: undefined }),
+      scored("s1"),
     ];
-    expect(selectScoredRuns(runs)).toHaveLength(0);
+    expect(selectWindowRows(runs, 1).map((r) => r.id)).toEqual(["p1", "i1", "s1"]);
   });
 
-  it("excludes terminal runs with no all_pass", () => {
-    const runs = [
-      makeRun({ status: WorkflowStatus.FAILED, all_pass: undefined as unknown as boolean }),
-      makeRun({ status: WorkflowStatus.COMPLETED, all_pass: true }),
-    ];
-    const result = selectScoredRuns(runs);
-    expect(result).toHaveLength(1);
-    expect(result[0].status).toBe(WorkflowStatus.COMPLETED);
+  it("defaults to SUMMARY_WINDOW scored runs", () => {
+    const runs = Array.from({ length: 15 }, (_, i) => scored(`s${i}`));
+    expect(selectWindowRows(runs)).toHaveLength(SUMMARY_WINDOW);
   });
 
-  it("returns runs oldest → newest (ascending updatedAt)", () => {
-    const older = makeRun({
-      updatedAt: new Date("2025-01-01T10:00:00Z").toISOString(),
-      createdAt: new Date("2025-01-01T09:00:00Z").toISOString(),
-    });
-    const newer = makeRun({
-      updatedAt: new Date("2025-01-02T10:00:00Z").toISOString(),
-      createdAt: new Date("2025-01-02T09:00:00Z").toISOString(),
-    });
-    // Supply newer first
-    const result = selectScoredRuns([newer, older]);
-    expect(result[0].id).toBe(older.id);
-    expect(result[1].id).toBe(newer.id);
+  it("returns an empty array for a non-positive window", () => {
+    expect(selectWindowRows([scored("s1")], 0)).toEqual([]);
   });
 
-  it("orders by updatedAt even when createdAt diverges in opposite direction", () => {
-    // run A created first but updated last → should appear later in the strip
-    const runA = makeRun({
-      createdAt: new Date("2025-01-01T08:00:00Z").toISOString(),
-      updatedAt: new Date("2025-01-03T12:00:00Z").toISOString(),
-    });
-    // run B created later but updated earlier → should appear first in the strip
-    const runB = makeRun({
-      createdAt: new Date("2025-01-02T08:00:00Z").toISOString(),
-      updatedAt: new Date("2025-01-02T12:00:00Z").toISOString(),
-    });
-    const result = selectScoredRuns([runA, runB]);
-    expect(result[0].id).toBe(runB.id);
-    expect(result[1].id).toBe(runA.id);
-  });
-
-  it("uses createdAt as secondary sort key when updatedAt is identical", () => {
-    const sharedUpdatedAt = new Date("2025-01-05T10:00:00Z").toISOString();
-    const earlier = makeRun({
-      updatedAt: sharedUpdatedAt,
-      createdAt: new Date("2025-01-04T10:00:00Z").toISOString(),
-    });
-    const later = makeRun({
-      updatedAt: sharedUpdatedAt,
-      createdAt: new Date("2025-01-05T09:00:00Z").toISOString(),
-    });
-    const result = selectScoredRuns([later, earlier]);
-    expect(result[0].id).toBe(earlier.id);
-    expect(result[1].id).toBe(later.id);
-  });
-
-  it("uses id as final tiebreaker for determinism when both timestamps are identical", () => {
-    const sharedTs = new Date("2025-01-05T10:00:00Z").toISOString();
-    const runA = makeRun({ id: "aaa-run", updatedAt: sharedTs, createdAt: sharedTs });
-    const runB = makeRun({ id: "zzz-run", updatedAt: sharedTs, createdAt: sharedTs });
-    // Supply in reverse alphabetical order
-    const result1 = selectScoredRuns([runB, runA]);
-    const result2 = selectScoredRuns([runA, runB]);
-    // Both orderings must yield the same deterministic result
-    expect(result1.map((r) => r.id)).toEqual(result2.map((r) => r.id));
-    // aaa < zzz alphabetically → aaa is the older position
-    expect(result1[0].id).toBe("aaa-run");
-    expect(result1[1].id).toBe("zzz-run");
-  });
-
-  it("returns at most SUMMARY_WINDOW runs", () => {
-    const runs = Array.from({ length: 15 }, (_, i) =>
-      makeRun({
-        updatedAt: new Date(1_700_000_000_000 + i * 1000).toISOString(),
-      }),
-    );
-    expect(selectScoredRuns(runs)).toHaveLength(SUMMARY_WINDOW);
-  });
-
-  it("returns the LAST N (most recent) when more than window exist", () => {
-    const base = 1_700_000_000_000;
-    const runs = Array.from({ length: 15 }, (_, i) =>
-      makeRun({
-        id: `ordered-${i}`,
-        updatedAt: new Date(base + i * 1000).toISOString(),
-      }),
-    );
-    const result = selectScoredRuns(runs);
-    // Should include runs 5..14 (the 10 newest), still oldest-first
-    expect(result[0].id).toBe("ordered-5");
-    expect(result[result.length - 1].id).toBe("ordered-14");
-  });
-
-  it("returns fewer than SUMMARY_WINDOW when not enough scored runs exist", () => {
-    const runs = [makeRun(), makeRun()];
-    expect(selectScoredRuns(runs)).toHaveLength(2);
-  });
-
-  it("returns empty array when no scored runs exist", () => {
-    const runs = [
-      makeRun({ status: WorkflowStatus.PENDING, all_pass: true }),
-      makeRun({ status: WorkflowStatus.IN_PROGRESS, all_pass: false }),
-    ];
-    expect(selectScoredRuns(runs)).toHaveLength(0);
-  });
-
-  it("respects a custom windowSize argument", () => {
-    const runs = Array.from({ length: 8 }, () => makeRun());
-    expect(selectScoredRuns(runs, 3)).toHaveLength(3);
+  it("leaves the input array untouched", () => {
+    const runs = [scored("s1"), scored("s2"), scored("s3")];
+    selectWindowRows(runs, 1);
+    expect(runs.map((r) => r.id)).toEqual(["s1", "s2", "s3"]);
   });
 });
 
@@ -319,15 +278,93 @@ describe("averagePassRate", () => {
   });
 });
 
+// ─── passRate ─────────────────────────────────────────────────────────────────
+
+describe("passRate", () => {
+  it("returns null for an empty array", () => {
+    expect(passRate([])).toBeNull();
+  });
+
+  it("returns 1 when every run fully passed", () => {
+    expect(passRate([makeRun({ all_pass: true }), makeRun({ all_pass: true })])).toBe(1);
+  });
+
+  it("returns 0 when no run fully passed", () => {
+    expect(passRate([makeRun({ all_pass: false }), makeRun({ all_pass: false })])).toBe(0);
+  });
+
+  it("computes the run-level fraction (2 of 5 passed → 0.4)", () => {
+    const runs = [
+      makeRun({ all_pass: true }),
+      makeRun({ all_pass: true }),
+      makeRun({ all_pass: false }),
+      makeRun({ all_pass: false }),
+      makeRun({ all_pass: false }),
+    ];
+    expect(passRate(runs)).toBeCloseTo(0.4);
+  });
+
+  it("ignores criteria counts entirely (a near-miss run counts as a fail)", () => {
+    // 9/10 criteria passed but all_pass=false → contributes 0 to the run-level rate
+    const runs = [makeRun({ all_pass: false, n_passed: 9, n_total: 10 })];
+    expect(passRate(runs)).toBe(0);
+  });
+
+  it("treats a non-boolean all_pass as a fail rather than counting it as a pass", () => {
+    const runs = [
+      { ...makeRun(), all_pass: undefined } as BenchmarkRunListRow,
+      makeRun({ all_pass: true }),
+    ];
+    expect(passRate(runs)).toBeCloseTo(0.5);
+  });
+});
+
 // ─── summarize ────────────────────────────────────────────────────────────────
 
 describe("summarize", () => {
-  it("returns zero counts and null averagePassRate for empty runs", () => {
+  it("returns zero counts and null rates for empty runs", () => {
     const result = summarize([]);
-    expect(result.pips).toHaveLength(0);
+    expect(result.scoredRuns).toHaveLength(0);
     expect(result.scoredCount).toBe(0);
     expect(result.ratedCount).toBe(0);
+    expect(result.passCount).toBe(0);
+    expect(result.passRate).toBeNull();
     expect(result.averagePassRate).toBeNull();
+  });
+
+  it("reports passCount and passRate over the supplied rows", () => {
+    const runs = [
+      makeRun({ all_pass: true }),
+      makeRun({ all_pass: false }),
+      makeRun({ all_pass: false }),
+      makeRun({ all_pass: false }),
+    ];
+    const result = summarize(runs);
+    expect(result.passCount).toBe(1);
+    expect(result.scoredCount).toBe(4);
+    expect(result.passRate).toBeCloseTo(0.25);
+  });
+
+  it("measures exactly the rows handed in — windowing is the caller's job", () => {
+    // Newest-first: 2 recent fails, then 2 older passes
+    const runs = [
+      makeRun({ all_pass: false }),
+      makeRun({ all_pass: false }),
+      makeRun({ all_pass: true }),
+      makeRun({ all_pass: true }),
+    ];
+    expect(summarize(selectWindowRows(runs, 2)).passRate).toBe(0);
+    expect(summarize(selectWindowRows(runs, 4)).passRate).toBeCloseTo(0.5);
+  });
+
+  it("passRate and averagePassRate are independent measures", () => {
+    // Every run misses exactly one criterion: 0% run-level, 90% criteria-level
+    const runs = Array.from({ length: 3 }, () =>
+      makeRun({ all_pass: false, n_passed: 9, n_total: 10 }),
+    );
+    const result = summarize(runs);
+    expect(result.passRate).toBe(0);
+    expect(result.averagePassRate).toBeCloseTo(0.9);
   });
 
   it("returns zero counts and null averagePassRate for only PENDING/IN_PROGRESS runs", () => {
@@ -336,21 +373,21 @@ describe("summarize", () => {
       makeRun({ status: WorkflowStatus.IN_PROGRESS, all_pass: false }),
     ];
     const result = summarize(runs);
-    expect(result.pips).toHaveLength(0);
+    expect(result.scoredRuns).toHaveLength(0);
     expect(result.scoredCount).toBe(0);
     expect(result.averagePassRate).toBeNull();
   });
 
-  it("scoredCount equals pips.length", () => {
+  it("scoredCount equals scoredRuns.length", () => {
     const runs = [makeRun(), makeRun(), makeRun()];
     const result = summarize(runs);
-    expect(result.scoredCount).toBe(result.pips.length);
+    expect(result.scoredCount).toBe(result.scoredRuns.length);
   });
 
   it("ratedCount reflects only runs with valid n_passed/n_total", () => {
     const runs = [
       makeRun({ n_passed: 5, n_total: 10 }),               // rated
-      makeRun({ n_passed: undefined, n_total: undefined, all_pass: true }), // pips but not rated
+      makeRun({ n_passed: undefined, n_total: undefined, all_pass: true }), // counted but not rated
       makeRun({ n_passed: 0, n_total: 0, all_pass: false }), // not rated (n_total=0)
     ];
     const result = summarize(runs);
@@ -361,7 +398,7 @@ describe("summarize", () => {
   it("averagePassRate is computed from rated runs only", () => {
     const runs = [
       makeRun({ n_passed: 4, n_total: 8 }),   // 0.5
-      makeRun({ n_passed: undefined, n_total: undefined, all_pass: true }), // pips only
+      makeRun({ n_passed: undefined, n_total: undefined, all_pass: true }), // counted only
     ];
     const result = summarize(runs);
     expect(result.averagePassRate).toBeCloseTo(0.5);
@@ -369,20 +406,13 @@ describe("summarize", () => {
     expect(result.scoredCount).toBe(2);
   });
 
-  it("passes custom windowSize to selectScoredRuns", () => {
-    const runs = Array.from({ length: 8 }, () => makeRun());
-    const result = summarize(runs, 3);
-    expect(result.pips).toHaveLength(3);
-    expect(result.scoredCount).toBe(3);
-  });
-
-  it("pips are in oldest-to-newest order", () => {
+  it("drops unscored rows from scoredRuns but keeps the given order", () => {
     const runs = [
-      makeRun({ id: "new-run", updatedAt: new Date("2025-02-01T00:00:00Z").toISOString() }),
-      makeRun({ id: "old-run", updatedAt: new Date("2025-01-01T00:00:00Z").toISOString() }),
+      makeRun({ id: "newest" }),
+      makeRun({ id: "failed", status: WorkflowStatus.FAILED, all_pass: undefined }),
+      makeRun({ id: "oldest" }),
     ];
     const result = summarize(runs);
-    expect(result.pips[0].id).toBe("old-run");
-    expect(result.pips[1].id).toBe("new-run");
+    expect(result.scoredRuns.map((r) => r.id)).toEqual(["newest", "oldest"]);
   });
 });

--- a/src/__tests__/unit/lib/harvey-lab/benchmark-summary.test.ts
+++ b/src/__tests__/unit/lib/harvey-lab/benchmark-summary.test.ts
@@ -16,6 +16,7 @@
 import { describe, it, expect } from "vitest";
 import { WorkflowStatus } from "@prisma/client";
 import {
+  RUN_LIST_LIMIT,
   SUMMARY_WINDOW,
   WINDOW_OPTIONS,
   PASS_BADGE_CLASS,
@@ -27,10 +28,6 @@ import {
   summarize,
 } from "@/lib/harvey-lab/benchmark-summary";
 import type { BenchmarkRunListRow } from "@/hooks/useLegalBenchmarkRunList";
-
-/** Mirrors RUN_LIST_LIMIT in useLegalBenchmarkRunList (type-only import here to
- *  keep this suite free of the hook's React/Pusher module graph). */
-const RUN_LIST_LIMIT = 100;
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 

--- a/src/app/w/[slug]/legal/benchmarks/page.tsx
+++ b/src/app/w/[slug]/legal/benchmarks/page.tsx
@@ -5,11 +5,8 @@ import { Scale } from "lucide-react";
 import { PageHeader } from "@/components/ui/page-header";
 import { LegalBenchmarksPanel } from "@/components/legal/LegalBenchmarksPanel";
 import { BenchmarkRunsHistory } from "@/components/legal/BenchmarkRunsHistory";
-import { BenchmarkSummaryStrip } from "@/components/legal/BenchmarkSummaryStrip";
 import { RecursionList } from "@/components/legal/RecursionBox";
 import { useLegalBenchmarkRecursionList } from "@/hooks/useLegalBenchmarkRecursionList";
-import { useLegalBenchmarkRunList } from "@/hooks/useLegalBenchmarkRunList";
-import { useWorkspace } from "@/hooks/useWorkspace";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 
 type TabValue = "benchmark" | "runs" | "recursion";
@@ -28,25 +25,7 @@ function RecursionTab() {
 }
 
 export default function LegalBenchmarksPage() {
-  const { workspace } = useWorkspace();
-
-  // Single run-list instance shared between BenchmarkSummaryStrip (header)
-  // and BenchmarkRunsHistory (Runs tab) — avoids double fetch/poll/Pusher.
-  const runList = useLegalBenchmarkRunList(workspace?.id);
-
   const [activeTab, setActiveTab] = useState<TabValue>("benchmark");
-
-  // Token-based focus request: nonce ensures clicking the same pip twice
-  // re-fires the effect even if the runId hasn't changed.
-  const [focusRequest, setFocusRequest] = useState<{
-    runId: string;
-    nonce: number;
-  } | null>(null);
-
-  const handleSelectRun = (runId: string) => {
-    setActiveTab("runs");
-    setFocusRequest({ runId, nonce: Date.now() });
-  };
 
   return (
     <div className="flex flex-col h-full">
@@ -54,22 +33,13 @@ export default function LegalBenchmarksPage() {
         icon={Scale}
         title="Legal Benchmarks"
         description="Harvey LAB — 1,749 real legal tasks across 25 practice areas"
-        actions={
-          <BenchmarkSummaryStrip
-            runs={runList.runs}
-            isLoading={runList.isLoading}
-            error={runList.error}
-            onSelectRun={handleSelectRun}
-            onRetry={runList.refetch}
-          />
-        }
       />
       <Tabs
         value={activeTab}
         onValueChange={(v) => setActiveTab(v as TabValue)}
         className="flex flex-col flex-1 min-h-0"
       >
-        <div className="px-4 border-b">
+        <div className="px-4 pb-3">
           <TabsList>
             <TabsTrigger value="benchmark">Benchmark</TabsTrigger>
             <TabsTrigger value="runs">Runs</TabsTrigger>
@@ -80,11 +50,7 @@ export default function LegalBenchmarksPage() {
           <LegalBenchmarksPanel className="h-full" />
         </TabsContent>
         <TabsContent value="runs" className="flex-1 min-h-0 overflow-auto p-4">
-          <BenchmarkRunsHistory
-            runList={runList}
-            focusRequest={focusRequest}
-            onFocusHandled={() => setFocusRequest(null)}
-          />
+          <BenchmarkRunsHistory />
         </TabsContent>
         <TabsContent value="recursion" className="flex-1 min-h-0 overflow-auto p-4">
           <RecursionTab />

--- a/src/components/legal/BenchmarkRunsHistory.tsx
+++ b/src/components/legal/BenchmarkRunsHistory.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import {
   PASS_BADGE_CLASS,
   FAIL_BADGE_CLASS,
+  RUN_LIST_LIMIT,
   SUMMARY_WINDOW,
   WINDOW_OPTIONS,
   isScoredRun,
@@ -24,7 +25,6 @@ import {
 import { useWorkspace } from "@/hooks/useWorkspace";
 import {
   useLegalBenchmarkRunList,
-  RUN_LIST_LIMIT,
   type BenchmarkRunListRow,
 } from "@/hooks/useLegalBenchmarkRunList";
 import { LegalBenchmarkResults } from "@/components/legal/LegalBenchmarkResults";

--- a/src/components/legal/BenchmarkRunsHistory.tsx
+++ b/src/components/legal/BenchmarkRunsHistory.tsx
@@ -4,7 +4,16 @@ import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { formatDistanceToNow } from "date-fns";
 import { ExternalLink, Loader2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { PASS_BADGE_CLASS, FAIL_BADGE_CLASS } from "@/lib/harvey-lab/benchmark-summary";
+import {
+  PASS_BADGE_CLASS,
+  FAIL_BADGE_CLASS,
+  SUMMARY_WINDOW,
+  WINDOW_OPTIONS,
+  isScoredRun,
+  selectWindowRows,
+  type SummaryWindow,
+} from "@/lib/harvey-lab/benchmark-summary";
+import { BenchmarkSummaryStrip } from "@/components/legal/BenchmarkSummaryStrip";
 import {
   Select,
   SelectContent,
@@ -15,6 +24,7 @@ import {
 import { useWorkspace } from "@/hooks/useWorkspace";
 import {
   useLegalBenchmarkRunList,
+  RUN_LIST_LIMIT,
   type BenchmarkRunListRow,
 } from "@/hooks/useLegalBenchmarkRunList";
 import { LegalBenchmarkResults } from "@/components/legal/LegalBenchmarkResults";
@@ -98,7 +108,7 @@ interface BenchmarkRunsHistoryProps {
    *  share a single fetch/poll/Pusher subscription across the header strip
    *  and this table. When omitted, the component self-manages as before. */
   runList?: RunListHookResult;
-  /** Token from a pip click — triggers auto-scroll + expand of the target row. */
+  /** Deep-link token — triggers auto-scroll + expand of the target row. */
   focusRequest?: { runId: string; nonce: number } | null;
   /** Called once the focus effect has handled (or no-op'd) the request so the
    *  parent can clear the token. */
@@ -123,6 +133,7 @@ export function BenchmarkRunsHistory({
 
   const [expandedRunId, setExpandedRunId] = useState<string | null>(null);
   const [taskFilter, setTaskFilter] = useState<string>(ALL_TASKS);
+  const [windowSize, setWindowSize] = useState<SummaryWindow>(SUMMARY_WINDOW);
 
   // ── Row refs for focus/scroll ────────────────────────────────────────────
   const rowRefs = useRef<Map<string, HTMLTableRowElement>>(new Map());
@@ -145,6 +156,21 @@ export function BenchmarkRunsHistory({
     //     because handleReset calls setExpandedId(null), which triggers an
     //     unwanted refetch and would immediately collapse the row we're opening.
     setTaskFilter(ALL_TASKS);
+
+    // (a2) The window caps which rows are rendered, so a run older than the
+    //      current window has no row to expand or scroll to. Widen to the
+    //      smallest option whose scored-run count reaches it — an unscored
+    //      target needs one more, since the cut lands on a scored run.
+    const index = runs.findIndex((r) => r.id === runId);
+    const scoredThrough = runs.slice(0, index + 1).filter(isScoredRun).length;
+    const needed = scoredThrough + (isScoredRun(runs[index]) ? 0 : 1);
+    setWindowSize(
+      (current) =>
+        needed > current
+          ? WINDOW_OPTIONS.find((size) => size >= needed) ??
+            WINDOW_OPTIONS[WINDOW_OPTIONS.length - 1]
+          : current,
+    );
 
     // (b) Expand the target row
     setExpandedRunId(runId);
@@ -190,9 +216,18 @@ export function BenchmarkRunsHistory({
     [runs, selectedTask],
   );
 
+  // The window is measured in SCORED runs: the rows span back to the Nth most
+  // recent completed run, carrying the PENDING/FAILED rows in between so the
+  // table still shows every state. Chart and summary read from here, so what is
+  // measured is always what is listed.
+  const visibleRuns = useMemo(
+    () => selectWindowRows(filteredRuns, windowSize),
+    [filteredRuns, windowSize],
+  );
+
   const chartAttempts = useMemo(
-    () => (selectedTask ? toChartAttempts(filteredRuns) : []),
-    [selectedTask, filteredRuns],
+    () => (selectedTask ? toChartAttempts(visibleRuns) : []),
+    [selectedTask, visibleRuns],
   );
 
   const handleToggleExpand = (runId: string) => {
@@ -241,7 +276,7 @@ export function BenchmarkRunsHistory({
 
   return (
     <div className="space-y-3">
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-2 flex-wrap">
         <Select value={taskFilter} onValueChange={handleFilterChange}>
           <SelectTrigger className="w-[340px]" data-testid="task-filter-trigger">
             <SelectValue placeholder="Filter by task" />
@@ -260,15 +295,28 @@ export function BenchmarkRunsHistory({
             {filteredRuns.length} of {runs.length} runs
           </span>
         )}
+        <div className="ml-auto">
+          <BenchmarkSummaryStrip
+            runs={visibleRuns}
+            windowSize={windowSize}
+            onWindowChange={setWindowSize}
+          />
+        </div>
       </div>
 
       {selectedTask && (
         <TaskProgressCard task={selectedTask} attempts={chartAttempts} />
       )}
 
-      {total > 100 && (
-        <div className="text-xs text-muted-foreground bg-muted rounded-md px-3 py-2">
-          Showing the most recent 100 runs.
+      {visibleRuns.length < filteredRuns.length && (
+        <div
+          className="text-xs text-muted-foreground bg-muted rounded-md px-3 py-2"
+          data-testid="window-note"
+        >
+          Showing {visibleRuns.length} of {filteredRuns.length} loaded runs —
+          back to the {windowSize} most recent scored runs.
+          {total > RUN_LIST_LIMIT &&
+            ` Only the latest ${RUN_LIST_LIMIT} of ${total} runs are loaded.`}
         </div>
       )}
 
@@ -287,7 +335,7 @@ export function BenchmarkRunsHistory({
             </tr>
           </thead>
           <tbody>
-            {filteredRuns.map((run) => (
+            {visibleRuns.map((run) => (
               <Fragment key={run.id}>
                 <tr
                   ref={(el) => {

--- a/src/components/legal/BenchmarkSummaryStrip.tsx
+++ b/src/components/legal/BenchmarkSummaryStrip.tsx
@@ -1,165 +1,85 @@
 "use client";
 
-import { AlertCircle } from "lucide-react";
-import { useWorkspace } from "@/hooks/useWorkspace";
-import { LEGAL_SLUGS } from "@/lib/eval-capture-slugs";
-import { isDevelopmentMode } from "@/lib/runtime";
 import {
   summarize,
-  SUMMARY_WINDOW,
-  PASS_BADGE_CLASS,
-  FAIL_BADGE_CLASS,
+  WINDOW_OPTIONS,
+  type SummaryWindow,
 } from "@/lib/harvey-lab/benchmark-summary";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import type { BenchmarkRunListRow } from "@/hooks/useLegalBenchmarkRunList";
-import { formatDistanceToNow } from "date-fns";
 
 interface BenchmarkSummaryStripProps {
+  /** The rows the table is currently showing — the summary measures these only. */
   runs: BenchmarkRunListRow[];
-  isLoading: boolean;
-  error: string | null;
-  onSelectRun: (runId: string) => void;
-  onRetry?: () => void;
+  windowSize: SummaryWindow;
+  onWindowChange: (size: SummaryWindow) => void;
 }
 
-function pipLabel(run: BenchmarkRunListRow): string {
-  const title = run.taskTitle || run.taskSlug || "Unknown task";
-  const score =
-    typeof run.n_passed === "number" && typeof run.n_total === "number"
-      ? ` · ${run.n_passed}/${run.n_total}`
-      : "";
-  const date = run.createdAt
-    ? ` · ${formatDistanceToNow(new Date(run.createdAt), { addSuffix: true })}`
-    : "";
-  return `${title}${score}${date}`;
+function formatPercent(value: number | null): string {
+  return value !== null ? `${Math.round(value * 100)}%` : "—";
 }
 
 export function BenchmarkSummaryStrip({
   runs,
-  isLoading,
-  error,
-  onSelectRun,
-  onRetry,
+  windowSize,
+  onWindowChange,
 }: BenchmarkSummaryStripProps) {
-  const { workspace } = useWorkspace();
-
-  const isAllowed =
-    LEGAL_SLUGS.includes(workspace?.slug ?? "") || isDevelopmentMode();
-
-  if (!isAllowed) return null;
-
-  // ── Skeleton while first load ────────────────────────────────────────────
-  if (isLoading && runs.length === 0) {
-    return (
-      <div
-        className="flex items-center gap-3 min-w-0"
-        data-testid="benchmark-strip-skeleton"
-        aria-label="Loading benchmark summary"
-      >
-        <div className="flex gap-1">
-          {Array.from({ length: SUMMARY_WINDOW }).map((_, i) => (
-            <div
-              key={i}
-              className="h-5 w-5 rounded-sm bg-muted animate-pulse"
-              aria-hidden="true"
-            />
-          ))}
-        </div>
-        <div className="h-4 w-16 rounded bg-muted animate-pulse" aria-hidden="true" />
-      </div>
-    );
-  }
-
-  // ── Error state ──────────────────────────────────────────────────────────
-  if (error && !isLoading) {
-    return (
-      <div
-        className="flex items-center gap-1.5 text-xs text-muted-foreground min-w-0"
-        data-testid="benchmark-strip-error"
-      >
-        <AlertCircle className="h-3.5 w-3.5 shrink-0 text-destructive" />
-        <span>Could not load benchmark summary</span>
-        {onRetry && (
-          <button
-            onClick={onRetry}
-            className="underline hover:text-foreground transition-colors"
-          >
-            Retry
-          </button>
-        )}
-      </div>
-    );
-  }
-
-  const { pips, averagePassRate, scoredCount, ratedCount } = summarize(runs);
-
-  // ── Empty state ──────────────────────────────────────────────────────────
-  if (scoredCount === 0) {
-    return (
-      <div
-        className="text-xs text-muted-foreground min-w-0"
-        data-testid="benchmark-strip-empty"
-      >
-        No scored runs yet
-      </div>
-    );
-  }
-
-  const avgDisplay =
-    averagePassRate !== null
-      ? `${Math.round(averagePassRate * 100)}%`
-      : "—";
+  const { passRate, passCount, averagePassRate, scoredCount, ratedCount } =
+    summarize(runs);
 
   return (
     <div
-      className="flex items-center gap-3 min-w-0 overflow-x-auto"
+      className="flex items-center gap-2 text-xs"
       data-testid="benchmark-strip"
     >
-      {/* Pip strip */}
-      <div className="flex gap-1 shrink-0" role="group" aria-label="Recent benchmark runs">
-        {pips.map((run) => {
-          const label = pipLabel(run);
-          const passClass = run.all_pass ? PASS_BADGE_CLASS : FAIL_BADGE_CLASS;
-          return (
-            <button
-              key={run.id}
-              onClick={() => onSelectRun(run.id)}
-              title={label}
-              aria-label={label}
-              className={[
-                "h-5 w-5 rounded-sm text-[9px] font-bold transition-opacity hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1",
-                passClass,
-              ].join(" ")}
-              data-testid={`pip-${run.id}`}
-            >
-              {run.all_pass ? "P" : "F"}
-            </button>
-          );
-        })}
-        {/* Ghost pips to keep fixed width when fewer than SUMMARY_WINDOW scored runs */}
-        {Array.from({ length: SUMMARY_WINDOW - pips.length }).map((_, i) => (
-          <div
-            key={`ghost-${i}`}
-            className="h-5 w-5 rounded-sm bg-muted/30"
-            aria-hidden="true"
-          />
-        ))}
-      </div>
-
-      {/* Average + sub-label */}
-      <div className="shrink-0 text-right">
-        <div className="text-sm font-semibold tabular-nums leading-none">
-          {avgDisplay}
-        </div>
-        <div className="text-[10px] text-muted-foreground leading-tight mt-0.5">
-          avg criteria pass rate
-        </div>
-        <div
-          className="text-[10px] text-muted-foreground leading-tight"
-          data-testid="strip-sub-label"
+      <Select
+        value={String(windowSize)}
+        onValueChange={(v) => onWindowChange(Number(v) as SummaryWindow)}
+      >
+        <SelectTrigger
+          className="h-8 w-[110px] text-xs"
+          aria-label="Number of runs to show"
+          data-testid="summary-window-trigger"
         >
-          {scoredCount} scored · {ratedCount} rated
-        </div>
-      </div>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {WINDOW_OPTIONS.map((size) => (
+            <SelectItem key={size} value={String(size)} className="text-xs">
+              Last {size}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {scoredCount === 0 ? (
+        <span className="text-muted-foreground" data-testid="benchmark-strip-empty">
+          No scored runs in view
+        </span>
+      ) : (
+        <>
+          <span
+            className="text-sm font-semibold tabular-nums"
+            data-testid="strip-pass-rate"
+          >
+            {formatPercent(passRate)}
+          </span>
+          <span className="text-muted-foreground">rolling pass rate</span>
+          <span
+            className="text-muted-foreground tabular-nums"
+            data-testid="strip-sub-label"
+          >
+            · {passCount}/{scoredCount} scored runs passed
+            {ratedCount > 0 && ` · ${formatPercent(averagePassRate)} avg criteria`}
+          </span>
+        </>
+      )}
     </div>
   );
 }

--- a/src/hooks/useLegalBenchmarkRunList.ts
+++ b/src/hooks/useLegalBenchmarkRunList.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback, useRef } from "react";
 import { StakworkRunType, WorkflowStatus } from "@prisma/client";
 import { parseBenchmarkRunResult } from "@/types/legal";
+import { RUN_LIST_LIMIT } from "@/lib/harvey-lab/benchmark-summary";
 import { usePusherChannel } from "@/hooks/usePusherChannel";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { getWorkspaceChannelName, PUSHER_EVENTS } from "@/lib/pusher";
@@ -41,14 +42,6 @@ interface UseLegalBenchmarkRunListResult {
 }
 
 const POLL_INTERVAL_MS = 15_000;
-
-/**
- * How many runs one fetch pulls. 100 is the hard server cap in
- * /api/stakwork/runs, so this is also the widest rolling window the summary
- * strip can offer (see WINDOW_OPTIONS) — every window option is served from
- * this single payload, no refetch on window change.
- */
-export const RUN_LIST_LIMIT = 100;
 
 export function useLegalBenchmarkRunList(
   workspaceId: string | undefined,

--- a/src/hooks/useLegalBenchmarkRunList.ts
+++ b/src/hooks/useLegalBenchmarkRunList.ts
@@ -42,6 +42,14 @@ interface UseLegalBenchmarkRunListResult {
 
 const POLL_INTERVAL_MS = 15_000;
 
+/**
+ * How many runs one fetch pulls. 100 is the hard server cap in
+ * /api/stakwork/runs, so this is also the widest rolling window the summary
+ * strip can offer (see WINDOW_OPTIONS) — every window option is served from
+ * this single payload, no refetch on window change.
+ */
+export const RUN_LIST_LIMIT = 100;
+
 export function useLegalBenchmarkRunList(
   workspaceId: string | undefined,
 ): UseLegalBenchmarkRunListResult {
@@ -62,7 +70,7 @@ export function useLegalBenchmarkRunList(
     if (!workspaceId) return;
     try {
       const res = await fetch(
-        `/api/stakwork/runs?type=${StakworkRunType.LEGAL_BENCHMARK_RUNNER}&workspaceId=${workspaceId}&limit=100&includeResult=true`,
+        `/api/stakwork/runs?type=${StakworkRunType.LEGAL_BENCHMARK_RUNNER}&workspaceId=${workspaceId}&limit=${RUN_LIST_LIMIT}&includeResult=true`,
       );
       if (!res.ok) throw new Error("Failed to fetch runs");
       const data = await res.json();

--- a/src/lib/harvey-lab/benchmark-summary.ts
+++ b/src/lib/harvey-lab/benchmark-summary.ts
@@ -1,12 +1,27 @@
 import { WorkflowStatus } from "@prisma/client";
 import type { BenchmarkRunListRow } from "@/hooks/useLegalBenchmarkRunList";
 
-/** Fixed window size for the rolling summary strip — always the last 10 scored runs. */
-export const SUMMARY_WINDOW = 10;
+/**
+ * Window sizes offered in the Runs-tab dropdown, in display order.
+ * The window counts SCORED runs: "Last 25" means the 25 most recent completed,
+ * judged runs. The table then lists every run in that span whatever its state —
+ * PENDING and FAILED rows stay visible for context, they just don't move the
+ * rate. See selectWindowRows.
+ *
+ * The largest option must stay <= RUN_LIST_LIMIT (the run-list fetch size, and
+ * the hard cap of /api/stakwork/runs) — every option is served from the single
+ * already-loaded payload, so changing the window never triggers a refetch.
+ */
+export const WINDOW_OPTIONS = [10, 25, 50, 100] as const;
+
+export type SummaryWindow = (typeof WINDOW_OPTIONS)[number];
+
+/** Default window — the 10 most recent scored runs. */
+export const SUMMARY_WINDOW: SummaryWindow = 10;
 
 /**
  * Tailwind class string for a passing score badge.
- * Lifted from ScoreCell in BenchmarkRunsHistory.tsx so both the pip strip and
+ * Shared with ScoreCell in BenchmarkRunsHistory.tsx so the summary strip and
  * the Runs table use exactly the same colour language.
  */
 export const PASS_BADGE_CLASS =
@@ -14,14 +29,14 @@ export const PASS_BADGE_CLASS =
 
 /**
  * Tailwind class string for a failing score badge.
- * Lifted from ScoreCell in BenchmarkRunsHistory.tsx so both the pip strip and
+ * Shared with ScoreCell in BenchmarkRunsHistory.tsx so the summary strip and
  * the Runs table use exactly the same colour language.
  */
 export const FAIL_BADGE_CLASS =
   "border-0 bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300";
 
 /**
- * Returns true when a run should appear as a pip in the rolling summary strip.
+ * Returns true when a run counts toward the rolling summary.
  * COMPLETED-only — the strip is a clean-runs-only quality signal.
  *
  * Intentional divergences (do NOT "fix" one to match the other):
@@ -29,8 +44,8 @@ export const FAIL_BADGE_CLASS =
  * 1. ScoreCell in BenchmarkRunsHistory.tsx uses a LOOSER predicate: it excludes
  *    only PENDING/IN_PROGRESS, then requires a boolean all_pass. Consequence: a
  *    FAILED or HALTED run that was judged before it died will still show a
- *    PASS/FAIL badge in the Runs table but will NOT appear as a pip here. This
- *    is intentional — the strip counts clean completions only.
+ *    PASS/FAIL badge in the Runs table but will NOT be counted here. This is
+ *    intentional — the strip counts clean completions only.
  *
  * 2. toChartAttempts in BenchmarkRunsHistory.tsx uses a THIRD, even looser
  *    predicate (counts present, no status check) for the hill-climb chart.
@@ -47,37 +62,32 @@ export function isScoredRun(run: BenchmarkRunListRow): boolean {
 }
 
 /**
- * Filter to only scored runs, sort oldest → newest, and return the last
- * `windowSize` entries (preserving oldest-first order within the window).
+ * Rows the Runs table should list for a window of `windowSize` scored runs.
  *
- * Sort key priority:
- *   1. updatedAt (primary) — closest proxy for completion time; runs finish
- *      out-of-order so createdAt would mis-place a newly-scored older run.
- *   2. createdAt (secondary) — stable fallback when updatedAt is identical.
- *   3. id (final tiebreaker) — required for determinism when batch-launched
- *      runs share near-identical timestamps; without it pip order is
- *      nondeterministic across refetches.
+ * `runs` must be newest-first (the order /api/stakwork/runs returns). Walks
+ * from the newest until it has seen `windowSize` scored runs, then cuts — so
+ * the slice contains exactly that many scored runs plus every unscored run
+ * (PENDING, FAILED, judged-but-dead) interleaved among them. That keeps the
+ * table honest about what happened while the rate stays over completed runs
+ * only.
+ *
+ * Returns every run when fewer than `windowSize` scored runs exist: there is
+ * no older data to hold back.
  */
-export function selectScoredRuns(
+export function selectWindowRows(
   runs: BenchmarkRunListRow[],
-  windowSize = SUMMARY_WINDOW,
+  windowSize: number = SUMMARY_WINDOW,
 ): BenchmarkRunListRow[] {
-  const scored = runs.filter(isScoredRun);
+  if (windowSize <= 0) return [];
 
-  scored.sort((a, b) => {
-    const updatedDiff =
-      new Date(a.updatedAt).getTime() - new Date(b.updatedAt).getTime();
-    if (updatedDiff !== 0) return updatedDiff;
-
-    const createdDiff =
-      new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
-    if (createdDiff !== 0) return createdDiff;
-
-    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
-  });
-
-  // Return the last windowSize entries, preserving oldest → newest order.
-  return scored.slice(-windowSize);
+  let scoredSeen = 0;
+  for (let i = 0; i < runs.length; i++) {
+    if (isScoredRun(runs[i])) {
+      scoredSeen += 1;
+      if (scoredSeen === windowSize) return runs.slice(0, i + 1);
+    }
+  }
+  return runs;
 }
 
 /**
@@ -104,31 +114,48 @@ export function averagePassRate(scored: BenchmarkRunListRow[]): number | null {
   return sum / qualifying.length;
 }
 
+/**
+ * Fraction of scored runs that passed every criterion (all_pass === true).
+ * This is the headline "rolling pass rate" — a run-level P/F rate, distinct
+ * from averagePassRate above, which is criteria-level.
+ *
+ * Returns null for an empty window (avoids 0/0 reaching the rendered label).
+ */
+export function passRate(scored: BenchmarkRunListRow[]): number | null {
+  if (scored.length === 0) return null;
+  return scored.filter((r) => r.all_pass === true).length / scored.length;
+}
+
 export interface BenchmarkSummary {
-  /** The up-to-SUMMARY_WINDOW most-recent scored runs, oldest → newest. */
-  pips: BenchmarkRunListRow[];
+  /** The scored subset of the supplied rows, in the order they were given. */
+  scoredRuns: BenchmarkRunListRow[];
+  /** Fraction of those scored runs that fully passed; null when none are scored. */
+  passRate: number | null;
+  /** Number of scored runs that fully passed. */
+  passCount: number;
   /** Mean of n_passed/n_total across rated runs; null when no run qualifies. */
   averagePassRate: number | null;
-  /** Number of scored runs in the window (= pips.length). */
+  /** Number of scored runs (= scoredRuns.length). */
   scoredCount: number;
-  /** Number of pips that also qualify for the pass-rate average (n_total > 0). */
+  /** Number of scored runs that also qualify for the criteria average (n_total > 0). */
   ratedCount: number;
 }
 
 /**
- * Single entry-point for the summary strip component.
+ * Summarise exactly the rows handed in — the caller (the Runs table) has already
+ * applied the task filter and the window, so what is measured is always what is
+ * on screen. Rows that never got a score (PENDING, FAILED-before-judging) drop
+ * out here, which is why scoredCount is usually smaller than the row count.
+ *
  * Separates the two populations so the component never has to reconcile them:
- * - pips/scoredCount derive from all_pass (boolean gate)
+ * - passRate/scoredCount derive from all_pass (boolean gate)
  * - averagePassRate/ratedCount derive from n_passed/n_total (numeric gate)
- * A run with missing counts pips without contributing to the average — that is
- * a legitimate, intentional state.
+ * A run with missing counts still contributes to the pass rate without
+ * contributing to the criteria average — that is a legitimate, intentional state.
  */
-export function summarize(
-  runs: BenchmarkRunListRow[],
-  windowSize = SUMMARY_WINDOW,
-): BenchmarkSummary {
-  const pips = selectScoredRuns(runs, windowSize);
-  const ratedCount = pips.filter(
+export function summarize(runs: BenchmarkRunListRow[]): BenchmarkSummary {
+  const scoredRuns = runs.filter(isScoredRun);
+  const ratedCount = scoredRuns.filter(
     (r) =>
       typeof r.n_passed === "number" &&
       typeof r.n_total === "number" &&
@@ -136,9 +163,11 @@ export function summarize(
   ).length;
 
   return {
-    pips,
-    averagePassRate: averagePassRate(pips),
-    scoredCount: pips.length,
+    scoredRuns,
+    passRate: passRate(scoredRuns),
+    passCount: scoredRuns.filter((r) => r.all_pass === true).length,
+    averagePassRate: averagePassRate(scoredRuns),
+    scoredCount: scoredRuns.length,
     ratedCount,
   };
 }

--- a/src/lib/harvey-lab/benchmark-summary.ts
+++ b/src/lib/harvey-lab/benchmark-summary.ts
@@ -2,6 +2,16 @@ import { WorkflowStatus } from "@prisma/client";
 import type { BenchmarkRunListRow } from "@/hooks/useLegalBenchmarkRunList";
 
 /**
+ * How many runs one run-list fetch pulls. 100 is the hard server cap in
+ * /api/stakwork/runs, so it is also the widest window the dropdown can offer.
+ *
+ * Lives here rather than beside the fetch in useLegalBenchmarkRunList because
+ * it is half of the WINDOW_OPTIONS contract below — and because test suites
+ * routinely mock the hook module, which would leave this undefined.
+ */
+export const RUN_LIST_LIMIT = 100;
+
+/**
  * Window sizes offered in the Runs-tab dropdown, in display order.
  * The window counts SCORED runs: "Last 25" means the 25 most recent completed,
  * judged runs. The table then lists every run in that span whatever its state —


### PR DESCRIPTION
The header strip showed ten per-run P/F squares next to an average that measured something else (criteria pass rate), so a 96% could sit beside eight failures. Drop the pips and show the run-level rate instead.

- Add passRate() and selectWindowRows(); drop selectScoredRuns(), whose ordering only existed to sequence pips. The window counts scored runs, so "Last 25" means the 25 most recent completed runs while PENDING and FAILED rows still render in the table.
- Move the summary out of the page header into the Runs toolbar. One dropdown (10/25/50/100) drives the table, the hill-climb chart and the rate; all four windows are served from the existing 100-run fetch.
- The page no longer fetches at page level - the table self-manages again.
- Remove the tab-row border that sat flush against the tab pill.