### PR TITLE
Make Concepts pills on agent log details clickable links to the Learn page

### DIFF
--- a/src/__tests__/unit/components/ConceptsPanel.test.tsx
+++ b/src/__tests__/unit/components/ConceptsPanel.test.tsx
@@ -55,4 +55,49 @@ describe("ConceptsPanel", () => {
     render(<ConceptsPanel reflection={{ concepts: [{ ref_id: "ref-42", rank: null }] }} />);
     expect(screen.getByText("ref-42")).toBeTruthy();
   });
+
+  it("links concepts with a gitree id to the Learn page in a new tab", () => {
+    render(
+      <ConceptsPanel
+        workspaceSlug="openlaw"
+        reflection={{
+          concepts: [
+            {
+              id: "stakwork/claude-for-legal/legal-document-type-review-memo",
+              ref_id: "a4903a86",
+              name: "Review Memo",
+              rank: null,
+            },
+          ],
+        }}
+      />,
+    );
+    const link = screen.getByText("Review Memo").closest("a");
+    expect(link).toBeTruthy();
+    // Double-encoded: the Learn page decodes the param twice (searchParams.get
+    // + decodeURIComponent) before matching against concept ids.
+    expect(link?.getAttribute("href")).toBe(
+      "/w/openlaw/learn?concept=stakwork%252Fclaude-for-legal%252Flegal-document-type-review-memo",
+    );
+    expect(link?.getAttribute("target")).toBe("_blank");
+  });
+
+  it("does not link concepts without a gitree id, even with a slug", () => {
+    render(
+      <ConceptsPanel
+        workspaceSlug="openlaw"
+        reflection={{ concepts: [{ ref_id: "graph-only", name: "Graph only", rank: null }] }}
+      />,
+    );
+    expect(screen.getByText("Graph only").closest("a")).toBeNull();
+  });
+
+  it("does not link concepts when no workspace slug is provided", () => {
+    render(
+      <ConceptsPanel
+        reflection={{ concepts: [{ id: "org/repo/thing", name: "Thing", rank: null }] }}
+      />,
+    );
+    expect(screen.getByText("Thing").closest("a")).toBeNull();
+  });
 });

--- a/src/app/w/[slug]/agent-logs/[logId]/page.tsx
+++ b/src/app/w/[slug]/agent-logs/[logId]/page.tsx
@@ -136,6 +136,7 @@ export default function AgentLogDetailPage() {
         rawContent={rawContent}
         loading={loading}
         error={error}
+        workspaceSlug={slug}
         onFlagTurn={isEvalCaptureEnabled(slug) ? (i) => { setCaptureTurnIndex(i); setCaptureOpen(true); } : undefined}
       />
 

--- a/src/components/agent-logs/LogDetailContent.tsx
+++ b/src/components/agent-logs/LogDetailContent.tsx
@@ -729,10 +729,23 @@ export function RunConfigPanel({ config }: { config: AgentRunConfig }) {
 // ConceptsPanel — gitree Concepts the session read, from the reflection sidecar
 // ---------------------------------------------------------------------------
 
-function ConceptChip({ concept }: { concept: ReflectedConcept }) {
+function ConceptChip({
+  concept,
+  workspaceSlug,
+}: {
+  concept: ReflectedConcept;
+  workspaceSlug?: string;
+}) {
   const name = concept.name || concept.ref_id || concept.id || "";
   const isRanked = typeof concept.rank === "number";
   const hasContradiction = !!concept.contradicts;
+
+  // Deep link to the Learn page, which double-decodes its `concept` param
+  // (searchParams.get + decodeURIComponent), hence the double encode here.
+  const href =
+    workspaceSlug && concept.id
+      ? `/w/${workspaceSlug}/learn?concept=${encodeURIComponent(encodeURIComponent(concept.id))}`
+      : null;
 
   const detailLines: string[] = [];
   if (concept.repo) detailLines.push(concept.repo);
@@ -740,7 +753,7 @@ function ConceptChip({ concept }: { concept: ReflectedConcept }) {
   if (isRanked) detailLines.push(`Ranked #${concept.rank}`);
   const hasTooltip = detailLines.length > 0 || !!concept.evidence || hasContradiction;
 
-  const chip = (
+  const badge = (
     <Badge
       variant={isRanked ? "default" : "outline"}
       className={cn(
@@ -748,6 +761,10 @@ function ConceptChip({ concept }: { concept: ReflectedConcept }) {
         isRanked
           ? "bg-primary/10 text-primary border border-primary/20 hover:bg-primary/10"
           : "text-muted-foreground",
+        href &&
+          (isRanked
+            ? "cursor-pointer hover:bg-primary/20"
+            : "cursor-pointer hover:bg-muted hover:text-foreground"),
       )}
     >
       {isRanked && <span className="font-semibold">{concept.rank}</span>}
@@ -756,6 +773,14 @@ function ConceptChip({ concept }: { concept: ReflectedConcept }) {
         <AlertTriangle className="w-3 h-3 shrink-0 text-amber-500" />
       )}
     </Badge>
+  );
+
+  const chip = href ? (
+    <a href={href} target="_blank" rel="noopener noreferrer">
+      {badge}
+    </a>
+  ) : (
+    badge
   );
 
   if (!hasTooltip) return chip;
@@ -776,7 +801,13 @@ function ConceptChip({ concept }: { concept: ReflectedConcept }) {
   );
 }
 
-export function ConceptsPanel({ reflection }: { reflection: SessionReflection }) {
+export function ConceptsPanel({
+  reflection,
+  workspaceSlug,
+}: {
+  reflection: SessionReflection;
+  workspaceSlug?: string;
+}) {
   // Skip entries with no displayable identity; hide the panel entirely when
   // nothing remains (including raw-only reflections that didn't parse upstream).
   const concepts = (reflection.concepts ?? []).filter(
@@ -798,7 +829,7 @@ export function ConceptsPanel({ reflection }: { reflection: SessionReflection })
       </div>
       <div className="flex flex-wrap gap-1.5">
         {concepts.map((c, i) => (
-          <ConceptChip key={c.ref_id || c.id || i} concept={c} />
+          <ConceptChip key={c.ref_id || c.id || i} concept={c} workspaceSlug={workspaceSlug} />
         ))}
       </div>
       {reflection.gap && (
@@ -931,7 +962,7 @@ export function LogDetailContent({
       {!loading && !error && hasContent && (
         <>
           {config && <RunConfigPanel config={config} />}
-          {reflection && <ConceptsPanel reflection={reflection} />}
+          {reflection && <ConceptsPanel reflection={reflection} workspaceSlug={workspaceSlug} />}
           {stats && <StatsBar stats={stats} />}
           <ScrollArea
             className={cn(

--- a/src/components/agent-logs/LogDetailDialog.tsx
+++ b/src/components/agent-logs/LogDetailDialog.tsx
@@ -20,9 +20,10 @@ interface LogDetailDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   logId: string | null;
+  workspaceSlug?: string;
 }
 
-export function LogDetailDialog({ open, onOpenChange, logId }: LogDetailDialogProps) {
+export function LogDetailDialog({ open, onOpenChange, logId, workspaceSlug }: LogDetailDialogProps) {
   const [conversation, setConversation] = useState<ParsedMessage[] | null>(null);
   const [stats, setStats] = useState<AgentLogStats | null>(null);
   const [reflection, setReflection] = useState<SessionReflection | null>(null);
@@ -85,6 +86,7 @@ export function LogDetailDialog({ open, onOpenChange, logId }: LogDetailDialogPr
           rawContent={rawContent}
           loading={loading}
           error={error}
+          workspaceSlug={workspaceSlug}
         />
 
         <DialogFooter>

--- a/src/components/legal/BenchmarkRunAgentLogs.tsx
+++ b/src/components/legal/BenchmarkRunAgentLogs.tsx
@@ -129,7 +129,7 @@ export function BenchmarkRunAgentLogs({ runId }: { runId: string }) {
               </div>
               {isExpanded && log.reflection && (
                 <div className="mt-2">
-                  <ConceptsPanel reflection={log.reflection} />
+                  <ConceptsPanel reflection={log.reflection} workspaceSlug={workspace?.slug} />
                 </div>
               )}
             </div>
@@ -142,6 +142,7 @@ export function BenchmarkRunAgentLogs({ runId }: { runId: string }) {
           if (!open) setDialogLogId(null);
         }}
         logId={dialogLogId}
+        workspaceSlug={workspace?.slug}
       />
     </div>
   );


### PR DESCRIPTION
## What changed

Concept chips rendered by `ConceptsPanel` are now clickable pills that open the concept's Learn page in a new tab: `/w/{slug}/learn?concept=<id>`. This applies everywhere the panel renders — the Agent Log Details page, the log detail dialog, and the expanded agent rows on the legal benchmarks page.

## Why

The Concepts strip on log details showed which gitree concepts a session read, but there was no way to jump to the actual concept text. Each pill now deep-links to the Learn page entry.

## Notes for reviewers

- The concept id in the URL is **double-encoded** (`stakwork%252Fclaude-for-legal%252F...`) on purpose: the Learn page decodes twice — once via `searchParams.get` and once via its own `decodeURIComponent` (see `LearnViewer.tsx`), matching the URLs its own `setUrlParam` produces.
- Only concepts carrying a gitree `id` (e.g. `stakwork/claude-for-legal/legal-document-type-review-memo`) become links; graph-only concepts with just a `ref_id` stay as plain chips, since the Learn page matches on `id` and can't resolve a graph ref.
- `workspaceSlug` is now wired through the call sites: the agent log details page (wasn't passing it before), `LogDetailDialog` (new optional prop), and `BenchmarkRunAgentLogs` (passes `workspace?.slug` to both the inline panel and the dialog). The prop is optional, so the panel degrades to non-clickable chips when no slug is available.
- Existing pill tooltips (repo, read order, rank, evidence) are unchanged.

## Testing

Three new unit tests in `ConceptsPanel.test.tsx`: exact double-encoded href + `target="_blank"`, no link for ref_id-only concepts, no link without a slug. All 9 tests pass; tsc and eslint show no new issues in touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)