### PR TITLE
Fix pool-status polling leak with visibility guard, deduplication, and 30s interval

### DIFF
--- a/src/__tests__/unit/hooks/poolStatusStore.test.ts
+++ b/src/__tests__/unit/hooks/poolStatusStore.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  fetchPoolStatusDeduped,
+  registerResumeCallback,
+  isDocumentVisible,
+} from "@/hooks/poolStatusStore";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeOkResponse(status = { running: 1, total: 2 }) {
+  return {
+    ok: true,
+    json: async () => ({ success: true, data: { status } }),
+  };
+}
+
+function makeErrorResponse(message = "oops") {
+  return {
+    ok: false,
+    json: async () => ({ error: message }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Reset module state between tests by re-importing (vitest module isolation)
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// fetchPoolStatusDeduped
+// ---------------------------------------------------------------------------
+
+describe("fetchPoolStatusDeduped", () => {
+  it("returns null and issues no request when slug is empty", async () => {
+    const mockFetch = vi.fn();
+    global.fetch = mockFetch;
+
+    const result = await fetchPoolStatusDeduped("");
+    expect(result).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns null and issues no request when slug is undefined", async () => {
+    const mockFetch = vi.fn();
+    global.fetch = mockFetch;
+
+    const result = await fetchPoolStatusDeduped(undefined);
+    expect(result).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("fetches pool status for a valid slug", async () => {
+    const mockStatus = { running: 2, total: 5 };
+    global.fetch = vi.fn().mockResolvedValue(makeOkResponse(mockStatus));
+
+    // Re-import to get fresh module state (no stale in-flight map entries)
+    const { fetchPoolStatusDeduped: fresh } = await import(
+      "@/hooks/poolStatusStore"
+    );
+
+    const result = await fresh("my-slug");
+    expect(result).toEqual(mockStatus);
+    expect(global.fetch).toHaveBeenCalledWith("/api/w/my-slug/pool/status");
+  });
+
+  it("deduplicates concurrent calls for the same slug to a single fetch", async () => {
+    const mockStatus = { running: 1, total: 3 };
+    let resolveFirst!: (v: unknown) => void;
+    const blocker = new Promise((res) => {
+      resolveFirst = res;
+    });
+
+    global.fetch = vi.fn().mockReturnValue(
+      blocker.then(() => makeOkResponse(mockStatus))
+    );
+
+    const { fetchPoolStatusDeduped: fresh } = await import(
+      "@/hooks/poolStatusStore"
+    );
+
+    // Fire two concurrent calls before the first resolves
+    const p1 = fresh("dedupe-slug");
+    const p2 = fresh("dedupe-slug");
+
+    resolveFirst(undefined);
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(r1).toEqual(mockStatus);
+    expect(r2).toEqual(mockStatus);
+  });
+
+  it("removes the in-flight entry after resolution so a subsequent call re-fetches", async () => {
+    const mockStatus = { running: 0, total: 1 };
+    global.fetch = vi.fn().mockResolvedValue(makeOkResponse(mockStatus));
+
+    const { fetchPoolStatusDeduped: fresh } = await import(
+      "@/hooks/poolStatusStore"
+    );
+
+    await fresh("slug-reuse");
+    await fresh("slug-reuse");
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws when the response is not ok", async () => {
+    global.fetch = vi.fn().mockResolvedValue(makeErrorResponse("server error"));
+
+    const { fetchPoolStatusDeduped: fresh } = await import(
+      "@/hooks/poolStatusStore"
+    );
+
+    // Attach a no-op rejection handler before the expect call to prevent
+    // vitest from treating the shared in-flight promise as an unhandled rejection
+    const p = fresh("err-slug");
+    p.catch(() => {});
+    await expect(p).rejects.toThrow("server error");
+  });
+
+  it("throws when success is false", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: false, error: "bad data" }),
+    });
+
+    const { fetchPoolStatusDeduped: fresh } = await import(
+      "@/hooks/poolStatusStore"
+    );
+
+    const p = fresh("err-slug2");
+    p.catch(() => {});
+    await expect(p).rejects.toThrow("bad data");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isDocumentVisible
+// ---------------------------------------------------------------------------
+
+describe("isDocumentVisible", () => {
+  it("returns true when visibilityState is visible", () => {
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible",
+    });
+    expect(isDocumentVisible()).toBe(true);
+  });
+
+  it("returns false when visibilityState is hidden", () => {
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "hidden",
+    });
+    expect(isDocumentVisible()).toBe(false);
+
+    // Restore
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// registerResumeCallback / shared visibility manager
+// ---------------------------------------------------------------------------
+
+describe("registerResumeCallback", () => {
+  it("calls the callback when document transitions to visible", () => {
+    const cb = vi.fn();
+    const unregister = registerResumeCallback(cb);
+
+    // Simulate hidden → visible transition
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible",
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(cb).toHaveBeenCalledTimes(1);
+    unregister();
+  });
+
+  it("does not call the callback when document becomes hidden", () => {
+    const cb = vi.fn();
+    const unregister = registerResumeCallback(cb);
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "hidden",
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(cb).not.toHaveBeenCalled();
+    unregister();
+
+    // Restore
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible",
+    });
+  });
+
+  it("fires all registered callbacks on visible transition", () => {
+    const cb1 = vi.fn();
+    const cb2 = vi.fn();
+    const u1 = registerResumeCallback(cb1);
+    const u2 = registerResumeCallback(cb2);
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible",
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(cb1).toHaveBeenCalledTimes(1);
+    expect(cb2).toHaveBeenCalledTimes(1);
+
+    u1();
+    u2();
+  });
+
+  it("stops calling callback after unregistration", () => {
+    const cb = vi.fn();
+    const unregister = registerResumeCallback(cb);
+    unregister();
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible",
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(cb).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/unit/hooks/usePoolStatus.test.ts
+++ b/src/__tests__/unit/hooks/usePoolStatus.test.ts
@@ -1,0 +1,426 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// Mock the store module so tests control fetch / visibility
+// ---------------------------------------------------------------------------
+
+const mockFetchPoolStatusDeduped = vi.fn();
+const mockRegisterResumeCallback = vi.fn();
+const mockIsDocumentVisible = vi.fn(() => true);
+
+vi.mock("@/hooks/poolStatusStore", () => ({
+  fetchPoolStatusDeduped: (...args: unknown[]) =>
+    mockFetchPoolStatusDeduped(...args),
+  registerResumeCallback: (...args: unknown[]) =>
+    mockRegisterResumeCallback(...args),
+  isDocumentVisible: () => mockIsDocumentVisible(),
+}));
+
+import { usePoolStatus } from "@/hooks/usePoolStatus";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeStatus(overrides = {}) {
+  return {
+    availableVms: 2,
+    usedVms: 1,
+    totalVms: 3,
+    queuedCount: 0,
+    ...overrides,
+  };
+}
+
+function makeOkFetch(status = makeStatus()) {
+  return Promise.resolve(status);
+}
+
+// Default: registerResumeCallback returns an unregister no-op and captures cb
+let capturedResumeCallbacks: Array<() => void> = [];
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  capturedResumeCallbacks = [];
+  mockFetchPoolStatusDeduped.mockReset();
+  mockIsDocumentVisible.mockReset();
+  mockIsDocumentVisible.mockReturnValue(true);
+  mockRegisterResumeCallback.mockReset();
+  mockRegisterResumeCallback.mockImplementation((cb: () => void) => {
+    capturedResumeCallbacks.push(cb);
+    return () => {
+      capturedResumeCallbacks = capturedResumeCallbacks.filter((c) => c !== cb);
+    };
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Test 5: fresh mount reports loading:true then loading:false
+// ---------------------------------------------------------------------------
+
+describe("initial mount behavior", () => {
+  it("reports loading:true immediately, then loading:false after fetch resolves", async () => {
+    mockFetchPoolStatusDeduped.mockReturnValue(makeOkFetch());
+
+    const { result } = renderHook(() =>
+      usePoolStatus("my-slug", true)
+    );
+
+    // loading starts true
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.poolStatus).toEqual(makeStatus());
+  });
+
+  it("sets error and loading:false when fetch throws", async () => {
+    mockFetchPoolStatusDeduped.mockRejectedValue(new Error("Network error"));
+
+    const { result } = renderHook(() =>
+      usePoolStatus("my-slug", true)
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBe("Network error");
+    expect(result.current.poolStatus).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 7: empty/undefined slug issues no request
+// ---------------------------------------------------------------------------
+
+describe("slug gating", () => {
+  it("issues no fetch and sets loading:false when slug is empty string", async () => {
+    const { result } = renderHook(() =>
+      usePoolStatus("", true)
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockFetchPoolStatusDeduped).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("issues no fetch and sets loading:false when slug is undefined", async () => {
+    const { result } = renderHook(() =>
+      usePoolStatus(undefined, true)
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockFetchPoolStatusDeduped).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 6: interval-0 caller with isPoolActive:false performs no fetch
+// ---------------------------------------------------------------------------
+
+describe("isPoolActive gating", () => {
+  it("issues no fetch when isPoolActive is false (interval=0)", async () => {
+    const { result } = renderHook(() =>
+      usePoolStatus("my-slug", false)
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockFetchPoolStatusDeduped).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("does not start a poller or register a resume callback when isPoolActive is false", async () => {
+    renderHook(() =>
+      usePoolStatus("my-slug", false, { pollingInterval: 30000 })
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(60000);
+      await Promise.resolve();
+    });
+
+    expect(mockFetchPoolStatusDeduped).not.toHaveBeenCalled();
+    expect(mockRegisterResumeCallback).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 4: pollingInterval:0 — one fetch on mount, no timer, no resume callback
+// ---------------------------------------------------------------------------
+
+describe("pollingInterval:0 (CapacityPage / TaskChatPage callers)", () => {
+  it("performs exactly one fetch on mount and never schedules a timer", async () => {
+    mockFetchPoolStatusDeduped.mockReturnValue(makeOkFetch());
+
+    renderHook(() => usePoolStatus("cap-slug", true)); // no pollingInterval
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockFetchPoolStatusDeduped).toHaveBeenCalledTimes(1);
+
+    // Advance time — no extra calls
+    await act(async () => {
+      vi.advanceTimersByTime(120_000);
+      await Promise.resolve();
+    });
+
+    expect(mockFetchPoolStatusDeduped).toHaveBeenCalledTimes(1);
+  });
+
+  it("never registers a resume callback", async () => {
+    mockFetchPoolStatusDeduped.mockReturnValue(makeOkFetch());
+
+    renderHook(() => usePoolStatus("cap-slug", true));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockRegisterResumeCallback).not.toHaveBeenCalled();
+  });
+
+  it("refetch triggers a new fetch unconditionally", async () => {
+    mockFetchPoolStatusDeduped.mockReturnValue(makeOkFetch());
+
+    const { result } = renderHook(() => usePoolStatus("cap-slug", true));
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockFetchPoolStatusDeduped).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    expect(mockFetchPoolStatusDeduped).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 3: initial fetch and refetch fire even while tab is hidden
+// ---------------------------------------------------------------------------
+
+describe("initial fetch and refetch are not visibility-gated", () => {
+  it("performs initial fetch even when document is hidden", async () => {
+    mockIsDocumentVisible.mockReturnValue(false); // tab is hidden
+    mockFetchPoolStatusDeduped.mockReturnValue(makeOkFetch());
+
+    renderHook(() => usePoolStatus("hidden-slug", true));
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // The initial fetch must have fired despite the tab being hidden
+    expect(mockFetchPoolStatusDeduped).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetch fires even when document is hidden", async () => {
+    mockIsDocumentVisible.mockReturnValue(false);
+    mockFetchPoolStatusDeduped.mockReturnValue(makeOkFetch());
+
+    const { result } = renderHook(() => usePoolStatus("hidden-slug", true));
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    expect(mockFetchPoolStatusDeduped).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 2: background poll is skipped when hidden; resumes on visible transition
+// ---------------------------------------------------------------------------
+
+describe("visibility-aware polling (pollingInterval > 0)", () => {
+  it("registers a resume callback and starts a polling timer", async () => {
+    mockFetchPoolStatusDeduped.mockReturnValue(makeOkFetch());
+    mockIsDocumentVisible.mockReturnValue(true);
+
+    renderHook(() =>
+      usePoolStatus("poll-slug", true, { pollingInterval: 1000 })
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockRegisterResumeCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips the poll tick when document is hidden", async () => {
+    mockFetchPoolStatusDeduped.mockReturnValue(makeOkFetch());
+    // Initial fetch fires (visible doesn't matter for initial)
+    // Polling ticks: hidden
+    mockIsDocumentVisible.mockReturnValue(false);
+
+    renderHook(() =>
+      usePoolStatus("poll-slug", true, { pollingInterval: 1000 })
+    );
+
+    // Initial fetch (not gated)
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const afterInitial = mockFetchPoolStatusDeduped.mock.calls.length;
+
+    // Advance past several polling intervals — all ticks should be skipped
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+      await Promise.resolve();
+    });
+
+    // No extra fetches because tab was hidden
+    expect(mockFetchPoolStatusDeduped.mock.calls.length).toBe(afterInitial);
+  });
+
+  it("fires an immediate refresh and reschedules on resume (visible transition)", async () => {
+    mockFetchPoolStatusDeduped.mockReturnValue(makeOkFetch());
+    mockIsDocumentVisible.mockReturnValue(false); // start hidden
+
+    renderHook(() =>
+      usePoolStatus("poll-slug", true, { pollingInterval: 1000 })
+    );
+
+    // Initial fetch
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const afterInitial = mockFetchPoolStatusDeduped.mock.calls.length;
+
+    // Advance timers while hidden — tick fires but skips fetch, doesn't reschedule
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+      await Promise.resolve();
+    });
+
+    expect(mockFetchPoolStatusDeduped.mock.calls.length).toBe(afterInitial);
+
+    // Simulate tab becoming visible — the resume callback fires
+    mockIsDocumentVisible.mockReturnValue(true);
+    await act(async () => {
+      capturedResumeCallbacks.forEach((cb) => cb());
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Immediate refresh fired
+    expect(mockFetchPoolStatusDeduped.mock.calls.length).toBe(
+      afterInitial + 1
+    );
+
+    // New polling loop started — advance one interval
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockFetchPoolStatusDeduped.mock.calls.length).toBeGreaterThanOrEqual(
+      afterInitial + 2
+    );
+  });
+
+  it("unregisters the resume callback on unmount", async () => {
+    const mockUnregister = vi.fn();
+    mockRegisterResumeCallback.mockReturnValue(mockUnregister);
+    mockFetchPoolStatusDeduped.mockReturnValue(makeOkFetch());
+
+    const { unmount } = renderHook(() =>
+      usePoolStatus("poll-slug", true, { pollingInterval: 1000 })
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    unmount();
+
+    expect(mockUnregister).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 5 (independence): fresh mount has its own loading:true regardless of
+// another mount already fetching the same slug
+// ---------------------------------------------------------------------------
+
+describe("per-mount loading independence", () => {
+  it("each new mount starts with loading:true independent of other mounts", async () => {
+    // First mount fetches and resolves
+    let resolveFirst!: (v: unknown) => void;
+    const blocker = new Promise((res) => {
+      resolveFirst = res;
+    });
+    const statusValue = makeStatus();
+    mockFetchPoolStatusDeduped.mockReturnValue(
+      blocker.then(() => statusValue)
+    );
+
+    const { result: r1 } = renderHook(() =>
+      usePoolStatus("shared-slug", true)
+    );
+
+    // Both start as loading
+    expect(r1.current.loading).toBe(true);
+
+    const { result: r2 } = renderHook(() =>
+      usePoolStatus("shared-slug", true)
+    );
+
+    expect(r2.current.loading).toBe(true);
+
+    // Now resolve
+    resolveFirst(undefined);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(r1.current.loading).toBe(false);
+    expect(r2.current.loading).toBe(false);
+    expect(r1.current.poolStatus).toEqual(statusValue);
+    expect(r2.current.poolStatus).toEqual(statusValue);
+  });
+});

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -452,11 +452,11 @@ export function Sidebar({ user }: SidebarProps) {
     slug: workspaceSlug,
   });
 
-  // Fetch pool status for capacity count with real-time polling (every 10 seconds).
+  // Fetch pool status for capacity count with real-time polling (every 30 seconds).
   // Skip polling entirely for public viewers — the pool status endpoint is auth-only.
   const isPoolActive = workspace?.poolState === "COMPLETE" && !isPublicViewer;
   const { poolStatus } = usePoolStatus(workspaceSlug || "", isPoolActive, {
-    pollingInterval: 10000 // Poll every 10 seconds
+    pollingInterval: 30000 // Poll every 30 seconds
   });
 
   // Calculate pool capacity count (in use / total)

--- a/src/hooks/poolStatusStore.ts
+++ b/src/hooks/poolStatusStore.ts
@@ -1,0 +1,110 @@
+/**
+ * poolStatusStore.ts — module-level coordinator for usePoolStatus.
+ *
+ * Provides two client-only helpers (never executed during SSR):
+ *  1. fetchPoolStatusDeduped — deduplicates concurrent in-flight requests for
+ *     the same workspace slug so N mounts share one network call.
+ *  2. Shared visibility manager — a single `visibilitychange` listener that
+ *     notifies all registered "resume" callbacks when the tab becomes visible,
+ *     enabling the polling loop to pause while hidden and resume immediately.
+ */
+
+import { PoolStatusResponse } from "@/types/pool-manager";
+
+// ---------------------------------------------------------------------------
+// 1. In-flight request dedupe
+// ---------------------------------------------------------------------------
+
+const inFlightRequests = new Map<
+  string,
+  Promise<PoolStatusResponse["status"]>
+>();
+
+/**
+ * Fetch pool status for `slug`, deduplicating concurrent calls.
+ * Returns `null` (and issues no request) when `slug` is falsy/empty.
+ */
+export async function fetchPoolStatusDeduped(
+  slug: string | undefined
+): Promise<PoolStatusResponse["status"] | null> {
+  if (!slug) return null;
+
+  const existing = inFlightRequests.get(slug);
+  if (existing) return existing;
+
+  const promise = (async (): Promise<PoolStatusResponse["status"]> => {
+    const response = await fetch(`/api/w/${slug}/pool/status`);
+    const result = await response.json();
+
+    if (!response.ok) {
+      throw new Error(result.error || "Failed to fetch pool status");
+    }
+    if (!result.success) {
+      throw new Error(result.error || "Failed to fetch pool status");
+    }
+
+    return result.data.status as PoolStatusResponse["status"];
+  })();
+
+  // Attach cleanup before storing so the map entry is removed on settle.
+  // The `.catch(() => {})` on the cleanup chain prevents a second unhandled-
+  // rejection warning; callers that await `promise` directly still receive
+  // the real rejection because they hold a reference to the original promise.
+  promise.finally(() => inFlightRequests.delete(slug)).catch(() => {});
+
+  inFlightRequests.set(slug, promise);
+
+  return promise;
+}
+
+// ---------------------------------------------------------------------------
+// 2. Shared visibility manager
+// ---------------------------------------------------------------------------
+
+type ResumeCallback = () => void;
+
+const resumeCallbacks = new Set<ResumeCallback>();
+let listenerAttached = false;
+
+function handleVisibilityChange() {
+  if (typeof document === "undefined") return;
+  if (document.visibilityState === "visible") {
+    resumeCallbacks.forEach((cb) => cb());
+  }
+}
+
+/**
+ * Register a callback to be invoked when the tab transitions to visible.
+ * Returns an unregister function; call it on unmount.
+ * Safe to call during SSR — guards on `typeof document`.
+ */
+export function registerResumeCallback(cb: ResumeCallback): () => void {
+  if (typeof document === "undefined") {
+    // SSR: no-op; return a no-op unregister
+    return () => {};
+  }
+
+  resumeCallbacks.add(cb);
+
+  if (!listenerAttached) {
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    listenerAttached = true;
+  }
+
+  return () => {
+    resumeCallbacks.delete(cb);
+    if (resumeCallbacks.size === 0 && listenerAttached) {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      listenerAttached = false;
+    }
+  };
+}
+
+/**
+ * Returns `true` when the document is visible (or when running in SSR, where
+ * there is no tab concept — treat as visible so initial fetches still fire).
+ */
+export function isDocumentVisible(): boolean {
+  if (typeof document === "undefined") return true;
+  return document.visibilityState === "visible";
+}

--- a/src/hooks/usePoolStatus.ts
+++ b/src/hooks/usePoolStatus.ts
@@ -1,5 +1,10 @@
 import { useCallback, useEffect, useState, useRef } from "react";
 import { PoolStatusResponse } from "@/types/pool-manager";
+import {
+  fetchPoolStatusDeduped,
+  registerResumeCallback,
+  isDocumentVisible,
+} from "./poolStatusStore";
 
 interface UsePoolStatusResult {
   poolStatus: PoolStatusResponse["status"] | null;
@@ -13,56 +18,60 @@ interface UsePoolStatusOptions {
 }
 
 export function usePoolStatus(
-  slug: string | undefined, 
+  slug: string | undefined,
   isPoolActive: boolean,
   options: UsePoolStatusOptions = {}
 ): UsePoolStatusResult {
   const { pollingInterval = 0 } = options;
-  const [poolStatus, setPoolStatus] = useState<PoolStatusResponse["status"] | null>(null);
+  const [poolStatus, setPoolStatus] = useState<
+    PoolStatusResponse["status"] | null
+  >(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const pollingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  // Keep latest values accessible inside callbacks without re-creating them
+  const slugRef = useRef(slug);
+  const isPoolActiveRef = useRef(isPoolActive);
+  slugRef.current = slug;
+  isPoolActiveRef.current = isPoolActive;
 
-  const fetchPoolStatus = useCallback(async (showLoading = true) => {
-    if (!slug || !isPoolActive) {
-      setLoading(false);
-      return;
-    }
-
-    if (showLoading) {
-      setLoading(true);
-    }
-    setError(null);
-
-    try {
-      const response = await fetch(`/api/w/${slug}/pool/status`);
-      const result = await response.json();
-
-      if (!response.ok) {
-        throw new Error(result.error || "Failed to fetch pool status");
-      }
-
-      if (result.success) {
-        setPoolStatus(result.data.status);
-      } else {
-        throw new Error(result.error || "Failed to fetch pool status");
-      }
-    } catch (err) {
-      console.error("Error fetching pool status:", err);
-      setError(err instanceof Error ? err.message : "Failed to load pool status");
-    } finally {
-      if (showLoading) {
+  const fetchPoolStatus = useCallback(
+    async (showLoading = true) => {
+      if (!slug || !isPoolActive) {
         setLoading(false);
+        return;
       }
-    }
-  }, [slug, isPoolActive]);
 
-  // Initial fetch
+      if (showLoading) {
+        setLoading(true);
+      }
+      setError(null);
+
+      try {
+        const status = await fetchPoolStatusDeduped(slug);
+        if (status !== null) {
+          setPoolStatus(status);
+        }
+      } catch (err) {
+        console.error("Error fetching pool status:", err);
+        setError(
+          err instanceof Error ? err.message : "Failed to load pool status"
+        );
+      } finally {
+        if (showLoading) {
+          setLoading(false);
+        }
+      }
+    },
+    [slug, isPoolActive]
+  );
+
+  // Initial fetch — unconditional, not visibility-gated
   useEffect(() => {
     fetchPoolStatus(true);
   }, [fetchPoolStatus]);
 
-  // Polling effect
+  // Polling effect — visibility-aware
   useEffect(() => {
     // Clear any existing timeout
     if (pollingTimeoutRef.current) {
@@ -70,23 +79,40 @@ export function usePoolStatus(
       pollingTimeoutRef.current = null;
     }
 
-    // Set up polling if enabled
-    if (pollingInterval > 0 && slug && isPoolActive) {
-      const schedulePoll = () => {
-        pollingTimeoutRef.current = setTimeout(async () => {
-          await fetchPoolStatus(false); // Don't show loading on background polls
-          schedulePoll(); // Schedule next poll
-        }, pollingInterval);
-      };
-
-      schedulePoll();
+    if (!(pollingInterval > 0 && slug && isPoolActive)) {
+      // No polling for interval-0 callers or when gates are closed
+      return;
     }
 
-    // Cleanup
+    let unregisterResume: (() => void) | null = null;
+
+    const schedulePoll = () => {
+      pollingTimeoutRef.current = setTimeout(async () => {
+        // Visibility check: if hidden, stop here — resume callback will restart
+        if (!isDocumentVisible()) return;
+
+        await fetchPoolStatus(false); // background poll — no loading spinner
+        schedulePoll(); // reschedule next tick
+      }, pollingInterval);
+    };
+
+    const onResume = () => {
+      // Tab became visible: do an immediate refresh then restart the loop
+      fetchPoolStatus(false);
+      schedulePoll();
+    };
+
+    unregisterResume = registerResumeCallback(onResume);
+    schedulePoll();
+
     return () => {
       if (pollingTimeoutRef.current) {
         clearTimeout(pollingTimeoutRef.current);
         pollingTimeoutRef.current = null;
+      }
+      if (unregisterResume) {
+        unregisterResume();
+        unregisterResume = null;
       }
     };
   }, [pollingInterval, slug, isPoolActive, fetchPoolStatus]);


### PR DESCRIPTION
Generated with Hive: Fix pool-status polling leak with visibility guard, deduplication, and 30s interval