### PR TITLE
Remove unused hast-util-to-jsx-runtime and cut run-report comment volume

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,6 @@
         "gsap": "^3.13.0",
         "hast-util-from-html": "^2.0.3",
         "hast-util-sanitize": "^5.0.2",
-        "hast-util-to-jsx-runtime": "^2.3.6",
         "ioredis": "^5.10.1",
         "jsonwebtoken": "^9.0.3",
         "jspdf": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
     "gsap": "^3.13.0",
     "hast-util-from-html": "^2.0.3",
     "hast-util-sanitize": "^5.0.2",
-    "hast-util-to-jsx-runtime": "^2.3.6",
     "ioredis": "^5.10.1",
     "jsonwebtoken": "^9.0.3",
     "jspdf": "^3.0.4",

--- a/src/components/run-report/SanitizedContent.tsx
+++ b/src/components/run-report/SanitizedContent.tsx
@@ -4,18 +4,13 @@ import React, { createElement, Fragment, type ReactNode } from "react";
 import type { SanitizedNode } from "@/lib/run-report/types";
 
 /**
- * Render the pipeline's closed sanitized-node shape as React elements.
+ * Render the closed sanitized-node shape as React elements.
  *
- * There is NO `dangerouslySetInnerHTML` in this directory — greppable and
- * absolute. The nodes arrive already sanitized server-side, and this renderer
- * only ever calls `createElement` with a tag name and an attribute bag, so the
- * no-HTML-sink guarantee is structural rather than conventional.
+ * There is NO `dangerouslySetInnerHTML` in this directory — this only ever
+ * calls `createElement` with a tag name and an allowlisted attribute bag.
  *
- * `highlights` are character ranges into the document's flattened text index
- * (see `flattenText` in src/lib/run-report/derive.ts). They are applied by
- * walking the same tree in the same order, so a range can span several nodes —
- * which is the normal case, because the generator's tokens are matched against
- * a plain-text rendition it strips before shipping.
+ * `highlights` are character ranges into the flattened text index, applied by
+ * walking the tree in the same order, so a range can span several nodes.
  */
 
 interface Props {
@@ -63,11 +58,7 @@ function renderNode(
   return createElement(node.t, { key, ...(node.a ?? {}) }, children);
 }
 
-/**
- * Split one text node against the highlight ranges, emitting `<mark>` for the
- * overlapping slices. Returns the bare string when nothing overlaps, so the
- * common case allocates nothing.
- */
+/** Split a text node against overlapping ranges; bare string if none overlap. */
 function applyHighlights(
   text: string,
   nodeStart: number,

--- a/src/lib/run-report/fetch-bundle.ts
+++ b/src/lib/run-report/fetch-bundle.ts
@@ -1,24 +1,15 @@
 /**
- * SSRF-guarded fetch of a run report bundle from S3.
+ * SSRF-guarded fetch of a report bundle from S3, at view time — the JSON lives
+ * in S3 and is never copied into the database.
  *
- * Runs at VIEW time: the bundle JSON lives in S3 and is never copied into the
- * database. Only the URL is stored. That is possible because the object is
- * stable and public rather than a short-lived presigned URL.
+ * `report_url` arrives on an unauthenticated webhook, so it is attacker
+ * influenced: the URL is validated before the request and the URL actually
+ * landed on is re-validated after redirects, so a redirect cannot escape the
+ * allowlist. Body size is capped mid-stream, before any parse. Errors are
+ * opaque and URL-free.
  *
- * Deliberately NOT built on `fetchBlobContent` (src/lib/utils/blob-fetch.ts):
- * that helper is Vercel-Blob-only, does a bare `fetch(url)` with no validation,
- * and embeds the target URL in the messages it throws.
- *
- * Controls:
- *   1. Full URL validation through the shared guard (protocol, userinfo, port,
- *      host allowlist) — `report_url` arrives on an unauthenticated webhook, so
- *      it is attacker-influenced input.
- *   2. Redirects followed by the platform, then the FINAL URL re-validated
- *      through the same guard, so a redirect cannot escape the allowlist.
- *   3. Timeout, Content-Length pre-check, and a streaming byte-count abort that
- *      fires before parsing.
- *
- * Every error thrown here is opaque and URL-free.
+ * Not built on `fetchBlobContent` — that helper is Vercel-Blob-only, does a
+ * bare `fetch(url)` with no validation, and puts the URL in thrown messages.
  */
 
 import { validateReportUrl } from "./url-guard";
@@ -121,11 +112,7 @@ export async function fetchReportBundle(rawUrl: string): Promise<FetchedBundle> 
   return { text: new TextDecoder().decode(body) };
 }
 
-/**
- * Read the body with a running byte counter, aborting as soon as the cap is
- * exceeded — before any JSON parsing, so an oversized body is never buffered
- * whole and never reaches the parser.
- */
+/** Read with a running byte count, aborting over the cap before any parse. */
 async function readCapped(response: Response): Promise<Uint8Array> {
   const reader = response.body?.getReader();
   if (!reader) throw new BundleFetchError("network_error");

--- a/src/lib/run-report/safe-url-log.ts
+++ b/src/lib/run-report/safe-url-log.ts
@@ -1,28 +1,16 @@
-/**
- * Log-safe rendering of a URL.
- *
- * Never log a bundle URL. The report bundle is a public, unsigned S3 object, so
- * its URL is a non-expiring bearer capability over converted legal source
- * documents and agent transcripts — anything that reaches a log line, an error
- * body, or a trace grants permanent access to those documents.
- *
- * The query string is excluded unconditionally: it is where presigned
- * credentials (`X-Amz-Signature`) would live if the producer ever switches to
- * signed URLs, and it is where the `run_token` HMAC lives on webhook URLs.
- */
-
 import { createHash } from "crypto";
 
 export interface SafeUrlParts {
   host: string;
-  /** SHA-256 of the path, first 12 hex chars. Correlates without disclosing. */
   pathHash: string;
 }
 
 /**
- * Reduce a URL to `{ host, pathHash }`. Returns `{ host: "<unparseable>" }` for
- * input that does not parse, so a malformed URL can never fall through to being
- * logged verbatim by a caller's error path.
+ * Reduce a URL to `{ host, pathHash }` for logging.
+ *
+ * Never log a bundle URL: the S3 object is public and unsigned, so the URL is a
+ * permanent read capability over legal documents. The query string is dropped
+ * unconditionally — that is where a signature or `run_token` would sit.
  */
 export function safeUrlParts(raw: string): SafeUrlParts {
   try {
@@ -32,6 +20,7 @@ export function safeUrlParts(raw: string): SafeUrlParts {
       pathHash: createHash("sha256").update(parsed.pathname).digest("hex").slice(0, 12),
     };
   } catch {
+    // Never fall through to a caller logging the raw value.
     return { host: "<unparseable>", pathHash: "" };
   }
 }

--- a/src/lib/run-report/sanitize-schema.ts
+++ b/src/lib/run-report/sanitize-schema.ts
@@ -1,18 +1,14 @@
 /**
- * Pinned hast-util-sanitize schema for run report source documents.
+ * Pinned sanitize schema for source documents.
  *
- * Pinned rather than derived from `defaultSchema`, so an upstream change can
- * never silently widen what we accept. `source_docs[].html` is arbitrary
- * third-party markup (converted .docx/.eml/.xlsx) arriving via an
- * unauthenticated webhook.
+ * Pinned rather than derived from `defaultSchema` so an upstream change cannot
+ * silently widen what we accept — this is arbitrary third-party markup arriving
+ * through an unauthenticated webhook.
  *
- * Dropped: `img` (beacon channel), `svg`/`math` (foreign-content mXSS),
- * script/style/iframe/object/embed, every `on*`, and class/style/id/target.
- * `a[href]` is http(s)-only with a forced `rel`.
- *
- * Regex tag-stripping is forbidden (bypassable via malformed tags), and
- * `rehype-raw` must never enter this pipeline — it re-parses raw HTML AFTER
- * sanitization and would undo it.
+ * `img` is dropped as a beacon channel; `svg`/`math` because foreign content is
+ * the classic mXSS vector. `rehype-raw` must never enter this pipeline — it
+ * re-parses raw HTML after sanitization and would undo it. Regex tag-stripping
+ * is not an acceptable substitute (bypassable via malformed tags).
  */
 
 import type { Schema } from "hast-util-sanitize";
@@ -71,11 +67,8 @@ export const RUN_REPORT_SANITIZE_SCHEMA: Schema = {
 };
 
 /**
- * Attributes serialized into the projection, per tag.
- *
- * Keys are hast PROPERTY names (`colSpan`), values are the HTML attribute names
- * the renderer emits (`colspan`). These differ — hast normalizes attributes to
- * DOM property spelling — and conflating them silently drops the attribute.
+ * Keys are hast PROPERTY names (`colSpan`), values the HTML attribute names we
+ * emit (`colspan`). Conflating the two silently drops the attribute.
  */
 export const PROJECTED_ATTRIBUTES: Record<string, Readonly<Record<string, string>>> = {
   a: { href: "href", title: "title", rel: "rel" },

--- a/src/lib/run-report/sanitize.ts
+++ b/src/lib/run-report/sanitize.ts
@@ -2,12 +2,10 @@
  * HTML → sanitized closed-node-shape projection. Server-side only; components
  * never sanitize.
  *
- * parse (document mode) → discard doctype/html/head → hast-util-sanitize with
- * the pinned schema → project to `SanitizedNode`.
- *
- * Document mode because the upstream converters emit whole documents, not
- * fragments; parsing those as fragments yields node types the pinned schema was
- * never written for.
+ * Parsed in document mode because the upstream converters emit whole documents
+ * (`<!doctype><html><head>…`), not fragments — the pinned schema was never
+ * written for those wrapper node types, so `<body>` children are extracted
+ * explicitly.
  */
 
 import { fromHtml } from "hast-util-from-html";
@@ -22,12 +20,7 @@ export interface SanitizeResult {
   droppedCount: number;
 }
 
-/**
- * Sanitize one source document's HTML into the closed node shape.
- *
- * Returns an empty node list (not a throw) for unparseable input, so one bad
- * document can never fail the whole bundle.
- */
+/** Returns [] for unparseable input so one bad document cannot fail a bundle. */
 export function sanitizeDocumentHtml(html: string): SanitizeResult {
   if (typeof html !== "string" || html.length === 0) {
     return { nodes: [], droppedCount: 0 };
@@ -61,10 +54,7 @@ export function sanitizeDocumentHtml(html: string): SanitizeResult {
   return { nodes, droppedCount: Math.max(0, beforeCount - afterCount) };
 }
 
-/**
- * Pull the children of `<body>` out of a parsed document, discarding the
- * doctype / html / head wrapper nodes explicitly.
- */
+/** Extract `<body>` children, discarding the doctype/html/head wrapper. */
 function extractBodyChildren(tree: Nodes): RootContent[] {
   if (tree.type === "element" && tree.tagName === "body") {
     return tree.children;
@@ -94,13 +84,10 @@ function extractBodyChildren(tree: Nodes): RootContent[] {
 }
 
 /**
- * Project a sanitized hast node into the closed wire shape.
- *
- * Anything that is not a text node or an element is dropped — comments,
- * doctypes and raw nodes never reach the client. Attribute values are coerced
- * to strings and filtered through the per-tag projection allowlist, so an
- * attribute the sanitize schema permitted but the renderer does not understand
- * cannot ride along.
+ * Project into the closed wire shape. Anything not text or an element is
+ * dropped, and attributes are filtered through the per-tag allowlist — so an
+ * attribute the schema permitted but the renderer does not understand cannot
+ * ride along.
  */
 function projectNode(node: RootContent): SanitizedNode | null {
   if (node.type === "text") {


### PR DESCRIPTION
Follow-up to #4988. No behaviour change — dependency removal and comments only.

## Drops a dependency that was never imported

`hast-util-to-jsx-runtime` was installed but has zero imports: `SanitizedContent`
renders the sanitized node shape with `createElement` directly. Removing it
leaves two hast packages, and only one of them is genuinely new to the tree:

| package | why |
|---|---|
| `hast-util-from-html` | parses the HTML string into a tree — net new |
| `hast-util-sanitize` | sanitizes that tree against the pinned schema — already present via `rehype-sanitize@6`, now a direct dep |

They can't collapse into one: `rehype-sanitize` is a unified *plugin* and can't
sanitize a standalone string.

## Cuts comment volume

`src/lib/run-report` 31% → 20%, `src/components/run-report` → 7%. 223 lines
removed, 84 added.

Removed: restatements of what the code already says, and the promotion history
of helpers moved from elsewhere.

Kept: the rationale a future edit would otherwise undo by accident — why `img`
and `svg`/`math` are dropped from the sanitize schema, why `rehype-raw` must
never enter the pipeline, why the token-shape pass is scoped away from document
bodies, and why the report route uses a role gate rather than the sibling
routes' swarm gate.

## Verification

14,064 unit tests pass, production build clean, cherry-picked onto current
master with no conflicts.