### PR TITLE
Run report: render deterministic agent roster when no LLM summaries exist

### DIFF
--- a/src/__tests__/unit/components/RunReportView.test.tsx
+++ b/src/__tests__/unit/components/RunReportView.test.tsx
@@ -102,6 +102,25 @@ describe("RunReportView — empty shapes are not errors", () => {
     expect(screen.queryByTestId("run-report-state-absent")).toBeNull();
   });
 
+  it("renders the deterministic agent roster when summaries are empty but agents exist", () => {
+    render(<RunReportView payload={payload({ projection: projectionFor("deterministic") })} />);
+    const section = screen.getByTestId("run-report-section-agents");
+    expect(section).toHaveTextContent(/agent activity/i);
+    expect(section).toHaveTextContent(/deterministic run/i);
+    expect(screen.getAllByTestId("run-report-deterministic-agent").length).toBeGreaterThan(0);
+    // record-form tools render a fold; the roster is metadata, never an error state
+    expect(section).toHaveTextContent(/tools used \(2\)/i);
+    expect(screen.queryByTestId("run-report-state-absent")).toBeNull();
+  });
+
+  it("keeps the plain empty state when both summaries and agents are empty", () => {
+    render(<RunReportView payload={payload({ projection: projectionFor("no-analysis") })} />);
+    expect(screen.getByTestId("run-report-section-agents")).toHaveTextContent(
+      /no agent summaries/i,
+    );
+    expect(screen.queryByTestId("run-report-deterministic-agent")).toBeNull();
+  });
+
   it("renders an all-pass run with no failures panel content", () => {
     render(<RunReportView payload={payload({ projection: projectionFor("all-pass") })} />);
     expect(screen.getByTestId("run-report-section-failures")).toHaveTextContent(/no failures/i);

--- a/src/app/api/mock/run-report/fixtures/index.ts
+++ b/src/app/api/mock/run-report/fixtures/index.ts
@@ -169,6 +169,24 @@ const UNKNOWN_KEYS: Bundle = (() => {
   return b;
 })();
 
+/**
+ * Deterministic run: real page_data (agents included) with the analysis
+ * phases deliberately skipped (run_llm=false). The agents section must render
+ * the roster from page_data.agents[] — not an empty state. The first agent's
+ * `tools` uses the producer's current record form ({toolName: count}); the
+ * remaining agents keep the legacy array form, which renders without a tools
+ * fold (tolerated, never an error).
+ */
+const DETERMINISTIC: Bundle = (() => {
+  const b = clone(FULL_BUNDLE) as Bundle;
+  const pageData = b.page_data as Record<string, unknown>;
+  const agents = pageData.agents as Array<Record<string, unknown>>;
+  agents[0].tools = { graph_search: 5, bash: 3 };
+  b.analysis = { summaries: [], traces: [] };
+  b.concepts = {};
+  return b;
+})();
+
 // ── Export map ───────────────────────────────────────────────────────────────
 
 /** Hardcoded literal record — the only way a variant name resolves. */
@@ -177,6 +195,7 @@ export const RUN_REPORT_FIXTURES = {
   "no-concepts": NO_CONCEPTS,
   "all-pass": ALL_PASS,
   "no-analysis": NO_ANALYSIS,
+  deterministic: DETERMINISTIC,
   "bumped-schema": BUMPED_SCHEMA,
   "split-token": SPLIT_TOKEN,
   "strings-only": STRINGS_ONLY,

--- a/src/components/run-report/sections.tsx
+++ b/src/components/run-report/sections.tsx
@@ -506,9 +506,62 @@ function AgentSummaryCard({
   );
 }
 
+/**
+ * Deterministic agent card — rendered from `page_data.agents[]` when the run
+ * has no LLM summaries (deterministic mode, or every summary phase failed).
+ * The producer contract for an entry: name, step, start/end, duration_s,
+ * n_messages, tools as a {toolName: count} record, final_answer prose.
+ * Everything renders as escaped React text per this directory's rule.
+ */
+function DeterministicAgentCard({ agent }: { agent: Record<string, unknown> }) {
+  const name = asString(agent.name) ?? asString(agent.agent_label) ?? "(unnamed agent)";
+  const step = asString(agent.step);
+  const durationS = typeof agent.duration_s === "number" ? agent.duration_s : null;
+  const nMessages = typeof agent.n_messages === "number" ? agent.n_messages : null;
+  const tools = isRecord(agent.tools)
+    ? Object.entries(agent.tools).filter(
+        (e): e is [string, number] => typeof e[1] === "number",
+      )
+    : [];
+  const finalAnswer = asString(agent.final_answer);
+
+  return (
+    <Panel className="mt-4">
+      <div className="flex flex-wrap items-baseline gap-3" data-testid="run-report-deterministic-agent">
+        <h3 className="text-[17px] font-semibold">{name}</h3>
+        {step && <Chip label="step" value={step} />}
+        {durationS != null && <Chip label="ran" value={formatDuration(durationS * 1000)} />}
+        {nMessages != null && <Chip label="messages" value={nMessages} />}
+      </div>
+
+      {tools.length > 0 && (
+        <Fold summary={`Tools used (${tools.length})`}>
+          <ul className="space-y-1">
+            {tools.map(([toolName, count]) => (
+              <li key={toolName} className="flex items-baseline gap-2 text-[12.5px]">
+                <span className="font-mono text-[11px] text-muted-foreground/70 min-w-[80px]">
+                  {toolName}
+                </span>
+                <span className="text-muted-foreground/60 tabular-nums">×{count}</span>
+              </li>
+            ))}
+          </ul>
+        </Fold>
+      )}
+
+      {finalAnswer && (
+        <Fold summary="Final answer">
+          <p className="text-[13px] text-muted-foreground whitespace-pre-wrap">{finalAnswer}</p>
+        </Fold>
+      )}
+    </Panel>
+  );
+}
+
 export function TracesSection({ projection }: { projection: RunReportProjection }) {
   const traces = readTraces(projection.analysis);
   const summaries = readSummaries(projection.analysis);
+  const deterministicAgents = projection.pageData.agents.filter(isRecord);
 
   // Build a quick rubric-id → title map for joining traces to rubric labels.
   const rubricTitleById = new Map(projection.rubricRows.map((r) => [r.id, r.title]));
@@ -533,13 +586,30 @@ export function TracesSection({ projection }: { projection: RunReportProjection 
       )}
 
       {/* ── Agent summaries ─────────────────────────────────────────────── */}
-      <MiniHeading className="mt-8">Agent summaries ({summaries.length})</MiniHeading>
-      {summaries.length === 0 ? (
-        <EmptyPanel label="No agent summaries for this run." />
+      {summaries.length > 0 ? (
+        <>
+          <MiniHeading className="mt-8">Agent summaries ({summaries.length})</MiniHeading>
+          {summaries.map((summary, i) => (
+            <AgentSummaryCard key={summary.agent_name} summary={summary} index={i} />
+          ))}
+        </>
+      ) : deterministicAgents.length > 0 ? (
+        <>
+          {/* Deterministic runs (run_llm=false) carry no LLM summaries, but
+              page_data.agents still has the roster — show it rather than an
+              empty state, flagged as activity metadata rather than analysis. */}
+          <MiniHeading className="mt-8">
+            Agent activity ({deterministicAgents.length}) — deterministic run, no LLM summaries
+          </MiniHeading>
+          {deterministicAgents.map((agent, i) => (
+            <DeterministicAgentCard key={asString(agent.name) ?? String(i)} agent={agent} />
+          ))}
+        </>
       ) : (
-        summaries.map((summary, i) => (
-          <AgentSummaryCard key={summary.agent_name} summary={summary} index={i} />
-        ))
+        <>
+          <MiniHeading className="mt-8">Agent summaries (0)</MiniHeading>
+          <EmptyPanel label="No agent summaries for this run." />
+        </>
       )}
     </Section>
   );


### PR DESCRIPTION
## Problem

The Agent roster section renders `analysis.summaries` / `analysis.traces` — the LLM phases. A deterministic run (`run_llm=false`, or a run whose summary phase failed) has real agent activity in `page_data.agents[]` but shows only an empty state, which reads as a broken report.

## Change

- `TracesSection` now falls back to rendering `page_data.agents[]` as deterministic agent cards (name, launching step, duration, message count, tool-call counts, final answer in a fold) when there are no summaries. The heading labels it explicitly as a deterministic run so it can't be mistaken for LLM analysis.
- Cards tolerate both producer tool shapes: the current `{toolName: count}` record renders the tools fold; the legacy string-array form renders without it.
- Both-empty keeps the existing empty state.
- New `deterministic` mock fixture (real agents, empty analysis, first agent on record-form tools) + two unit tests covering the fallback and the both-empty state.

All prose renders as escaped React text per the run-report directory rule.

## Testing

- `npx vitest run src/__tests__/unit/components/RunReportView.test.tsx src/__tests__/unit/lib/run-report/project.test.ts` — 53/53 pass (2 new)
- eslint clean on touched files (one pre-existing warning in `AgentSummaryCard` untouched)