### PR TITLE
Render unsummarized workers alongside LLM summaries in the agent roster

### DIFF
--- a/src/__tests__/unit/components/RunReportView.test.tsx
+++ b/src/__tests__/unit/components/RunReportView.test.tsx
@@ -113,6 +113,17 @@ describe("RunReportView — empty shapes are not errors", () => {
     expect(screen.queryByTestId("run-report-state-absent")).toBeNull();
   });
 
+  it("renders unsummarized workers alongside LLM summaries", () => {
+    render(
+      <RunReportView payload={payload({ projection: projectionFor("with-ingest-worker") })} />,
+    );
+    const section = screen.getByTestId("run-report-section-agents");
+    expect(section).toHaveTextContent(/other agent activity \(1\)/i);
+    expect(section).toHaveTextContent(/ingest: appointment-chronology\.xlsx/);
+    // summaries still render in full
+    expect(section).toHaveTextContent(/agent summaries/i);
+  });
+
   it("keeps the plain empty state when both summaries and agents are empty", () => {
     render(<RunReportView payload={payload({ projection: projectionFor("no-analysis") })} />);
     expect(screen.getByTestId("run-report-section-agents")).toHaveTextContent(

--- a/src/app/api/mock/run-report/fixtures/index.ts
+++ b/src/app/api/mock/run-report/fixtures/index.ts
@@ -177,6 +177,30 @@ const UNKNOWN_KEYS: Bundle = (() => {
  * remaining agents keep the legacy array form, which renders without a tools
  * fold (tolerated, never an error).
  */
+/**
+ * Full run whose page_data.agents includes a worker with no matching LLM
+ * summary (a per-document ingestion agent) - exercises the "Other agent
+ * activity" sub-list that renders alongside summaries.
+ */
+const WITH_INGEST_WORKER: Bundle = (() => {
+  const b = clone(FULL_BUNDLE) as Bundle;
+  const pageData = b.page_data as Record<string, unknown>;
+  const agents = pageData.agents as Array<Record<string, unknown>>;
+  agents.push({
+    name: "ingest: appointment-chronology.xlsx",
+    step: "foreach_ingest_doc",
+    kind: "ingest",
+    start: "2026-08-10 14:26:11.000",
+    end: "2026-08-10 14:26:27.000",
+    duration_s: 16.0,
+    n_messages: 0,
+    tools: {},
+    final_answer:
+      "Parsed appointment-chronology.xlsx with strategy auto into 3 element(s); graph node b41a... already existed (create skipped).",
+  });
+  return b;
+})();
+
 const DETERMINISTIC: Bundle = (() => {
   const b = clone(FULL_BUNDLE) as Bundle;
   const pageData = b.page_data as Record<string, unknown>;
@@ -196,6 +220,7 @@ export const RUN_REPORT_FIXTURES = {
   "all-pass": ALL_PASS,
   "no-analysis": NO_ANALYSIS,
   deterministic: DETERMINISTIC,
+  "with-ingest-worker": WITH_INGEST_WORKER,
   "bumped-schema": BUMPED_SCHEMA,
   "split-token": SPLIT_TOKEN,
   "strings-only": STRINGS_ONLY,

--- a/src/components/run-report/sections.tsx
+++ b/src/components/run-report/sections.tsx
@@ -562,6 +562,10 @@ export function TracesSection({ projection }: { projection: RunReportProjection 
   const traces = readTraces(projection.analysis);
   const summaries = readSummaries(projection.analysis);
   const deterministicAgents = projection.pageData.agents.filter(isRecord);
+  const summarizedNames = new Set(summaries.map((s) => s.agent_name));
+  const unsummarizedAgents = deterministicAgents.filter(
+    (a) => !summarizedNames.has(asString(a.name) ?? ""),
+  );
 
   // Build a quick rubric-id → title map for joining traces to rubric labels.
   const rubricTitleById = new Map(projection.rubricRows.map((r) => [r.id, r.title]));
@@ -592,6 +596,19 @@ export function TracesSection({ projection }: { projection: RunReportProjection 
           {summaries.map((summary, i) => (
             <AgentSummaryCard key={summary.agent_name} summary={summary} index={i} />
           ))}
+          {/* Workers without an LLM summary (e.g. per-document ingestion
+              agents) still render as deterministic cards so the roster shows
+              every child project that did work. */}
+          {unsummarizedAgents.length > 0 && (
+            <>
+              <MiniHeading className="mt-8">
+                Other agent activity ({unsummarizedAgents.length})
+              </MiniHeading>
+              {unsummarizedAgents.map((agent, i) => (
+                <DeterministicAgentCard key={asString(agent.name) ?? String(i)} agent={agent} />
+              ))}
+            </>
+          )}
         </>
       ) : deterministicAgents.length > 0 ? (
         <>


### PR DESCRIPTION
Follow-up to #4998 — that PR was squash-merged before its second commit landed, so this carries the remainder.

When a run has LLM summaries, workers without one (document-ingestion workers, late-added agents) were invisible in the roster. They now render as deterministic cards under "Other agent activity (N)" below the summarized agents.

- `TracesSection` splits `page_data.agents` into summarized / unsummarized and renders both
- `with-ingest-worker` mock fixture + unit test (RunReportView suite, 54/54 locally)