### PR TITLE
Show recorded tool calls and final answer on summarized agent cards

### DIFF
--- a/src/__tests__/unit/components/RunReportView.test.tsx
+++ b/src/__tests__/unit/components/RunReportView.test.tsx
@@ -109,7 +109,7 @@ describe("RunReportView — empty shapes are not errors", () => {
     expect(section).toHaveTextContent(/deterministic run/i);
     expect(screen.getAllByTestId("run-report-deterministic-agent").length).toBeGreaterThan(0);
     // record-form tools render a fold; the roster is metadata, never an error state
-    expect(section).toHaveTextContent(/tools used \(2\)/i);
+    expect(section).toHaveTextContent(/tool calls \(2\)/i);
     expect(screen.queryByTestId("run-report-state-absent")).toBeNull();
   });
 
@@ -122,6 +122,14 @@ describe("RunReportView — empty shapes are not errors", () => {
     expect(section).toHaveTextContent(/ingest: appointment-chronology\.xlsx/);
     // summaries still render in full
     expect(section).toHaveTextContent(/agent summaries/i);
+  });
+
+  it("shows the recorded final answer on summarized agent cards", () => {
+    render(<RunReportView payload={payload({ projection: projectionFor("full") })} />);
+    const section = screen.getByTestId("run-report-section-agents");
+    // both summarized agents carry page_data.agents[].final_answer - each
+    // summary card now folds it in alongside the LLM summary
+    expect(section.textContent?.match(/final answer/gi)?.length ?? 0).toBeGreaterThanOrEqual(2);
   });
 
   it("keeps the plain empty state when both summaries and agents are empty", () => {

--- a/src/components/run-report/sections.tsx
+++ b/src/components/run-report/sections.tsx
@@ -422,17 +422,58 @@ function TraceCard({
   );
 }
 
+/** page_data.agents[].tools is a {toolName: count} record from send_agent_logs. */
+function toolEntries(value: unknown): [string, number][] {
+  return isRecord(value)
+    ? Object.entries(value).filter((e): e is [string, number] => typeof e[1] === "number")
+    : [];
+}
+
+function ToolCountsFold({ tools }: { tools: [string, number][] }) {
+  return (
+    <Fold summary={`Tool calls (${tools.length})`}>
+      <ul className="space-y-1">
+        {tools.map(([toolName, count]) => (
+          <li key={toolName} className="flex items-baseline gap-2 text-[12.5px]">
+            <span className="font-mono text-[11px] text-muted-foreground/70 min-w-[80px]">
+              {toolName}
+            </span>
+            <span className="text-muted-foreground/60 tabular-nums">×{count}</span>
+          </li>
+        ))}
+      </ul>
+    </Fold>
+  );
+}
+
+function FinalAnswerFold({ text }: { text: string }) {
+  return (
+    <Fold summary="Final answer">
+      <p className="text-[13px] text-muted-foreground whitespace-pre-wrap">{text}</p>
+    </Fold>
+  );
+}
+
 function AgentSummaryCard({
   summary,
   index,
+  agent,
 }: {
   summary: AgentSummary;
   index: number;
+  agent?: Record<string, unknown>;
 }) {
+  const durationS = agent && typeof agent.duration_s === "number" ? agent.duration_s : null;
+  const nMessages = agent && typeof agent.n_messages === "number" ? agent.n_messages : null;
+  const recordedTools = agent ? toolEntries(agent.tools) : [];
+  const finalAnswer = agent ? asString(agent.final_answer) : null;
+
   return (
     <Panel className="mt-4">
       <div className="flex flex-wrap items-baseline gap-3">
         <h3 className="text-[17px] font-semibold">{summary.agent_name}</h3>
+        {durationS != null && <Chip label="ran" value={formatDuration(durationS * 1000)} />}
+        {nMessages != null && <Chip label="messages" value={nMessages} />}
         {summary.mission && (
           <span className="text-[13px] text-muted-foreground truncate max-w-[40ch]">
             {summary.mission}
@@ -502,6 +543,13 @@ function AgentSummaryCard({
           </ul>
         </Fold>
       )}
+
+      {/* Recorded activity from page_data.agents — ground truth regardless of
+          what the LLM summary chose to mention. */}
+      {summary.tools.length === 0 && recordedTools.length > 0 && (
+        <ToolCountsFold tools={recordedTools} />
+      )}
+      {finalAnswer && <FinalAnswerFold text={finalAnswer} />}
     </Panel>
   );
 }
@@ -518,11 +566,7 @@ function DeterministicAgentCard({ agent }: { agent: Record<string, unknown> }) {
   const step = asString(agent.step);
   const durationS = typeof agent.duration_s === "number" ? agent.duration_s : null;
   const nMessages = typeof agent.n_messages === "number" ? agent.n_messages : null;
-  const tools = isRecord(agent.tools)
-    ? Object.entries(agent.tools).filter(
-        (e): e is [string, number] => typeof e[1] === "number",
-      )
-    : [];
+  const tools = toolEntries(agent.tools);
   const finalAnswer = asString(agent.final_answer);
 
   return (
@@ -534,26 +578,8 @@ function DeterministicAgentCard({ agent }: { agent: Record<string, unknown> }) {
         {nMessages != null && <Chip label="messages" value={nMessages} />}
       </div>
 
-      {tools.length > 0 && (
-        <Fold summary={`Tools used (${tools.length})`}>
-          <ul className="space-y-1">
-            {tools.map(([toolName, count]) => (
-              <li key={toolName} className="flex items-baseline gap-2 text-[12.5px]">
-                <span className="font-mono text-[11px] text-muted-foreground/70 min-w-[80px]">
-                  {toolName}
-                </span>
-                <span className="text-muted-foreground/60 tabular-nums">×{count}</span>
-              </li>
-            ))}
-          </ul>
-        </Fold>
-      )}
-
-      {finalAnswer && (
-        <Fold summary="Final answer">
-          <p className="text-[13px] text-muted-foreground whitespace-pre-wrap">{finalAnswer}</p>
-        </Fold>
-      )}
+      {tools.length > 0 && <ToolCountsFold tools={tools} />}
+      {finalAnswer && <FinalAnswerFold text={finalAnswer} />}
     </Panel>
   );
 }
@@ -565,6 +591,11 @@ export function TracesSection({ projection }: { projection: RunReportProjection 
   const summarizedNames = new Set(summaries.map((s) => s.agent_name));
   const unsummarizedAgents = deterministicAgents.filter(
     (a) => !summarizedNames.has(asString(a.name) ?? ""),
+  );
+  // Recorded activity per agent (tool counts, final answer) joins the LLM
+  // summary card by name so every card carries ground truth.
+  const agentByName = new Map(
+    deterministicAgents.map((a) => [asString(a.name) ?? "", a]),
   );
 
   // Build a quick rubric-id → title map for joining traces to rubric labels.
@@ -594,7 +625,12 @@ export function TracesSection({ projection }: { projection: RunReportProjection 
         <>
           <MiniHeading className="mt-8">Agent summaries ({summaries.length})</MiniHeading>
           {summaries.map((summary, i) => (
-            <AgentSummaryCard key={summary.agent_name} summary={summary} index={i} />
+            <AgentSummaryCard
+              key={summary.agent_name}
+              summary={summary}
+              index={i}
+              agent={agentByName.get(summary.agent_name)}
+            />
           ))}
           {/* Workers without an LLM summary (e.g. per-document ingestion
               agents) still render as deterministic cards so the roster shows


### PR DESCRIPTION
The agent roster's LLM summary cards only rendered what the model chose to mention — no per-agent final answer, no ground-truth tool counts.

Each summary card now joins its `page_data.agents` record by name and renders:
- a "Tool calls (N)" fold from the recorded `{toolName: count}` map, when the LLM summary reports no tools
- a "Final answer" fold with the agent's recovered final answer
- duration / message-count chips

Shared fold components between the summary card and the deterministic card (which previously duplicated this markup). RunReportView suite 19/19.