### PR TITLE
List failed rubrics and every agent in the report section rail

### DIFF
--- a/src/__tests__/unit/components/RunReportView.test.tsx
+++ b/src/__tests__/unit/components/RunReportView.test.tsx
@@ -132,6 +132,29 @@ describe("RunReportView — empty shapes are not errors", () => {
     expect(section.textContent?.match(/final answer/gi)?.length ?? 0).toBeGreaterThanOrEqual(2);
   });
 
+  it("lists failed rubrics and every agent in the section rail with matching anchors", () => {
+    const { container } = render(
+      <RunReportView payload={payload({ projection: projectionFor("full") })} />,
+    );
+    // failed rubric R2 gets a rail link and an anchored investigation panel
+    const failLink = container.querySelector('nav a[href="#failure-r2"]');
+    expect(failLink).not.toBeNull();
+    expect(container.querySelector("#failure-r2")).not.toBeNull();
+    // both summarized agents get rail links and anchored cards
+    const agentLink = container.querySelector('nav a[href="#agent-cross-check-agent"]');
+    expect(agentLink).not.toBeNull();
+    expect(container.querySelector("#agent-cross-check-agent")).not.toBeNull();
+    expect(container.querySelector("#agent-drafter")).not.toBeNull();
+  });
+
+  it("rail lists deterministic-only agents too", () => {
+    const { container } = render(
+      <RunReportView payload={payload({ projection: projectionFor("deterministic") })} />,
+    );
+    expect(container.querySelector('nav a[href="#agent-cross-check-agent"]')).not.toBeNull();
+    expect(container.querySelector("#agent-cross-check-agent")).not.toBeNull();
+  });
+
   it("keeps the plain empty state when both summaries and agents are empty", () => {
     render(<RunReportView payload={payload({ projection: projectionFor("no-analysis") })} />);
     expect(screen.getByTestId("run-report-section-agents")).toHaveTextContent(

--- a/src/components/run-report/RunReportView.tsx
+++ b/src/components/run-report/RunReportView.tsx
@@ -15,7 +15,8 @@ import {
   SourcesSection,
   HealthSection,
 } from "./sections";
-import { SectionErrorBoundary } from "./chrome";
+import { SectionErrorBoundary, anchorId } from "./chrome";
+import { readSummaries, isRecord, asString } from "@/lib/run-report/derive";
 
 /**
  * Run report renderer.
@@ -115,11 +116,45 @@ export function RunReportView({ payload, taskTitle = "Run report" }: Props) {
     ? projection.sourceDocs.find((d) => d.id === openDoc.docId) ?? null
     : null;
 
+  // The rail lists every failed rubric and every agent, mirroring the
+  // generator's own viewer: tap C-038 → its investigation, tap an agent →
+  // its roster card. Names join the same way TracesSection renders them.
+  const summaryNames = readSummaries(projection.analysis).map((s) => s.agent_name);
+  const rosterNames = [
+    ...new Set([
+      ...summaryNames,
+      ...projection.pageData.agents
+        .filter(isRecord)
+        .map((a) => asString(a.name) ?? "")
+        .filter(Boolean),
+    ]),
+  ];
+  const navGroups = NAV_GROUPS.map((group) => {
+    if (group.group === "Failures") {
+      return {
+        ...group,
+        items: [
+          ...group.items,
+          ...rubricRows
+            .filter((r) => !r.passed)
+            .map((r) => ({ id: anchorId("failure", r.id), label: r.id })),
+        ],
+      };
+    }
+    if (group.group === "Agents") {
+      return {
+        ...group,
+        items: [...group.items, ...rosterNames.map((n) => ({ id: anchorId("agent", n), label: n }))],
+      };
+    }
+    return group;
+  });
+
   return (
     <div className="grid grid-cols-1 lg:grid-cols-[200px_minmax(0,1fr)] gap-8 max-w-[1180px]" data-testid="run-report-view">
       {/* Sticky section rail */}
       <nav className="hidden lg:block sticky top-4 self-start max-h-[calc(100vh-2rem)] overflow-y-auto font-mono text-[11px] border-r border-border pr-4">
-        {NAV_GROUPS.map((group) => (
+        {navGroups.map((group) => (
           <div key={group.group}>
             <div className="text-[9px] uppercase tracking-[0.14em] text-muted-foreground/50 mt-4 mb-1.5 first:mt-0">
               {group.group}
@@ -128,7 +163,8 @@ export function RunReportView({ payload, taskTitle = "Run report" }: Props) {
               <a
                 key={item.id}
                 href={`#${item.id}`}
-                className="block text-muted-foreground hover:text-foreground hover:bg-muted/50 rounded px-2 -ml-2 py-0.5 transition-colors"
+                title={item.label}
+                className="block truncate text-muted-foreground hover:text-foreground hover:bg-muted/50 rounded px-2 -ml-2 py-0.5 transition-colors"
               >
                 {item.label}
               </a>

--- a/src/components/run-report/chrome.tsx
+++ b/src/components/run-report/chrome.tsx
@@ -44,6 +44,14 @@ export function Section({
   );
 }
 
+/**
+ * Stable DOM id for sidebar deep links (agent cards, failure panels).
+ * Names can carry spaces/colons/dots ("ingest: protocol-v3.docx").
+ */
+export function anchorId(prefix: string, name: string): string {
+  return `${prefix}-${name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "")}`;
+}
+
 /** Bordered surface — the viewer's `.panel`. */
 export function Panel({
   children,

--- a/src/components/run-report/sections.tsx
+++ b/src/components/run-report/sections.tsx
@@ -15,6 +15,7 @@ import {
 import type { RunReportProjection, RubricRow, TraceRow, AgentSummary } from "@/lib/run-report/types";
 import { formatInUserTz } from "@/lib/date-utils";
 import {
+  anchorId,
   Section,
   Panel,
   EmptyPanel,
@@ -242,7 +243,8 @@ export function FailuresSection({
             // deep link; without it that pathway has no wiring.
             const links = projection.rubricLinks[row.id] ?? [];
             return (
-              <Panel key={row.id} tone="fail" className="mt-4">
+              <div key={row.id} id={anchorId("failure", row.id)} className="scroll-mt-4">
+              <Panel tone="fail" className="mt-4">
                 <div className="flex items-baseline gap-3">
                   <span className="font-mono text-[11px] text-muted-foreground/70">{row.id}</span>
                   <h3 className="text-[17px] font-semibold flex-1">{row.title}</h3>
@@ -274,6 +276,7 @@ export function FailuresSection({
                   </>
                 )}
               </Panel>
+              </div>
             );
           })}
 
@@ -469,6 +472,7 @@ function AgentSummaryCard({
   const finalAnswer = agent ? asString(agent.final_answer) : null;
 
   return (
+    <div id={anchorId("agent", summary.agent_name)} className="scroll-mt-4">
     <Panel className="mt-4">
       <div className="flex flex-wrap items-baseline gap-3">
         <h3 className="text-[17px] font-semibold">{summary.agent_name}</h3>
@@ -551,6 +555,7 @@ function AgentSummaryCard({
       )}
       {finalAnswer && <FinalAnswerFold text={finalAnswer} />}
     </Panel>
+    </div>
   );
 }
 
@@ -570,6 +575,7 @@ function DeterministicAgentCard({ agent }: { agent: Record<string, unknown> }) {
   const finalAnswer = asString(agent.final_answer);
 
   return (
+    <div id={anchorId("agent", name)} className="scroll-mt-4">
     <Panel className="mt-4">
       <div className="flex flex-wrap items-baseline gap-3" data-testid="run-report-deterministic-agent">
         <h3 className="text-[17px] font-semibold">{name}</h3>
@@ -581,6 +587,7 @@ function DeterministicAgentCard({ agent }: { agent: Record<string, unknown> }) {
       {tools.length > 0 && <ToolCountsFold tools={tools} />}
       {finalAnswer && <FinalAnswerFold text={finalAnswer} />}
     </Panel>
+    </div>
   );
 }
 


### PR DESCRIPTION
The run-report rail only carried static section links — no way to jump to a specific failure or agent.

It now mirrors the generator viewer's navigation:
- **Failures**: one link per failed rubric (e.g. `C-038`) jumping to its anchored investigation panel
- **Agents**: one link per agent (LLM-summarized and deterministic/ingest workers alike) jumping to its anchored roster card

Anchor ids are shared between the rail and the cards via a single `anchorId()` helper in chrome. Long agent names truncate with a title tooltip. RunReportView suite 21/21.