### PR TITLE
Dedup 1:1 launch agents from the run-report gantt

### DIFF
--- a/src/__tests__/unit/lib/run-report/derive.test.ts
+++ b/src/__tests__/unit/lib/run-report/derive.test.ts
@@ -252,10 +252,36 @@ describe("buildTimeline", () => {
     }
   });
 
-  it("includes agent entries alongside timeline steps", () => {
-    const entries = buildTimeline(TIMELINE, AGENTS);
-    // timeline steps + agent entries
-    expect(entries.length).toBe(TIMELINE.length + AGENTS.length);
+  it("dedups 1:1 launch agents and keeps fan-out agents as extra rows", () => {
+    // full fixture: both agents are 1:1 with steps already on the timeline —
+    // their rows would duplicate the step bars (run_draft / draft, twice)
+    const deduped = buildTimeline(TIMELINE, AGENTS);
+    expect(deduped.length).toBe(TIMELINE.length);
+    expect(deduped.some((e) => e.name === "cross_check_agent")).toBe(false);
+
+    // a fan-out step (several agents per step) adds one row per agent
+    const fanout = [
+      { name: "ingest: a.docx", step: "foreach_ingest", start: "2026-08-10 14:28:12.000", end: "2026-08-10 14:28:20.000" },
+      { name: "ingest: b.docx", step: "foreach_ingest", start: "2026-08-10 14:28:13.000", end: "2026-08-10 14:28:25.000" },
+    ];
+    expect(buildTimeline(TIMELINE, fanout).length).toBe(TIMELINE.length + 2);
+
+    // an agent whose step is unknown to the timeline keeps its row too
+    const stray = [{ name: "judge", step: "not_on_timeline", start: null, end: null }];
+    expect(buildTimeline(TIMELINE, stray).length).toBe(TIMELINE.length + 1);
+  });
+
+  it("interleaves rows chronologically by start time", () => {
+    const fanout = [
+      { name: "ingest: a.docx", step: "foreach_ingest", start: "2026-08-10 14:28:12.000", end: "2026-08-10 14:28:20.000" },
+    ];
+    const entries = buildTimeline(TIMELINE, fanout);
+    const timed = entries.filter((e) => e.startMs != null);
+    for (let i = 1; i < timed.length; i++) {
+      expect(timed[i - 1].startMs! <= timed[i].startMs!).toBe(true);
+    }
+    // the fan-out row lands right after check_documents, not appended at the end
+    expect(entries[1].name).toBe("ingest: a.docx");
   });
 
   it("feeds buildGantt with at least one non-other phase for the full fixture", () => {
@@ -267,8 +293,12 @@ describe("buildTimeline", () => {
     expect(nonOther.length).toBeGreaterThan(0);
   });
 
-  it("produces at least one pair of overlapping spans for the full fixture", () => {
-    const entries = buildTimeline(TIMELINE, AGENTS);
+  it("produces at least one pair of overlapping spans when a step fans out", () => {
+    const fanout = [
+      { name: "ingest: a.docx", step: "foreach_ingest", start: "2026-08-10 14:28:12.000", end: "2026-08-10 14:28:20.000" },
+      { name: "ingest: b.docx", step: "foreach_ingest", start: "2026-08-10 14:28:13.000", end: "2026-08-10 14:28:25.000" },
+    ];
+    const entries = buildTimeline(TIMELINE, fanout);
     const valid = entries.filter(
       (e): e is { name: string; startMs: number; endMs: number } =>
         e.startMs != null && e.endMs != null,

--- a/src/lib/run-report/derive.ts
+++ b/src/lib/run-report/derive.ts
@@ -199,6 +199,18 @@ export function buildTimeline(
   agents: unknown[],
 ): Array<{ name: string; startMs: number | null; endMs: number | null }> {
   const entries: Array<{ name: string; startMs: number | null; endMs: number | null }> = [];
+  const stepNames = new Set(timeline.map((s) => s.step));
+
+  // Agents per launching step. A step that launched exactly ONE agent is a
+  // 1:1 launch — its agent row would duplicate the step's own window (the
+  // "run_draft"/"draft" double bar). Only fan-out steps (foreach_ingest_doc
+  // → one agent per document) add per-agent rows.
+  const perStep = new Map<string, number>();
+  for (const agent of agents) {
+    if (!isRecord(agent)) continue;
+    const step = asString(agent.step);
+    if (step) perStep.set(step, (perStep.get(step) ?? 0) + 1);
+  }
 
   for (const step of timeline) {
     entries.push({
@@ -212,6 +224,8 @@ export function buildTimeline(
     if (!isRecord(agent)) continue;
     const name = asString(agent.name) ?? asString(agent.agent_label);
     if (!name) continue;
+    const step = asString(agent.step);
+    if (step && stepNames.has(step) && (perStep.get(step) ?? 0) === 1) continue;
     entries.push({
       name,
       startMs: toEpochMs(agent.start),
@@ -219,7 +233,19 @@ export function buildTimeline(
     });
   }
 
-  return entries;
+  // Chronological interleave: timed rows sort by start (stable); untimed
+  // rows keep their relative order at the end.
+  return entries
+    .map((entry, i) => ({ entry, i }))
+    .sort((a, b) => {
+      const as = a.entry.startMs;
+      const bs = b.entry.startMs;
+      if (as == null && bs == null) return a.i - b.i;
+      if (as == null) return 1;
+      if (bs == null) return -1;
+      return as - bs || a.i - b.i;
+    })
+    .map(({ entry }) => entry);
 }
 
 /** Human-readable duration. Returns "—" for unknown. */


### PR DESCRIPTION
The pipeline gantt rendered every `page_data.agents[]` entry as its own row after the steps, so each 1:1 launch step appeared twice with identical windows (`run_draft` colored + `draft` grey), and fan-out agent rows sat in a block at the bottom.

`buildTimeline` now:
- folds an agent into its launching step's row when that step launched exactly one agent (the duplicate pairs disappear)
- keeps one row per agent for fan-out steps (per-document ingestion workers) and for agents whose step isn't on the timeline
- sorts all rows chronologically by start, so fan-out rows interleave at their actual time

On the current production bundle this reduces 32 rows to 21 — every bar drawn once. Derive + RunReportView suites 68/68.