### PR TITLE
Render judge review and match criteria in the rubric ledger; drop the rail

### DIFF
--- a/src/__tests__/unit/components/RunReportView.test.tsx
+++ b/src/__tests__/unit/components/RunReportView.test.tsx
@@ -46,15 +46,9 @@ describe("RunReportView — render states", () => {
     }
   });
 
-  it("renders the section rail with a link per section", () => {
+  it("renders no section rail — the ledger is the navigation", () => {
     const { container } = render(<RunReportView payload={payload()} />);
-    const railLinks = [...container.querySelectorAll('nav a[href^="#"]')].map((a) =>
-      a.getAttribute("href"),
-    );
-    expect(railLinks).toContain("#run-report-header");
-    expect(railLinks).toContain("#rubrics");
-    expect(railLinks).toContain("#checklist-map");
-    expect(railLinks).toContain("#system");
+    expect(container.querySelector("nav")).toBeNull();
   });
 
   it("renders the rubric ledger: failed and unscored listed, passes folded", () => {
@@ -67,6 +61,21 @@ describe("RunReportView — render states", () => {
     // failed-first ordering selects R2 by default; its chain renders hops
     expect(screen.getAllByText(/The deliverable/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Did the checklist represent what the rubric expected/i).length).toBeGreaterThan(0);
+  });
+
+  it("renders match criteria and the judge review on the selected failed rubric", () => {
+    render(<RunReportView payload={payload()} />);
+    // R2 (fail) is selected by default; its criteria text and judge-review
+    // block (flagged + prose + excerpt from the fixture) render
+    expect(screen.getByText(/identifies section 12\.4 as unilateral/i)).toBeInTheDocument();
+    const dispute = screen.getByTestId("run-report-judge-dispute");
+    expect(dispute).toHaveTextContent(/may be too strict/i);
+    expect(dispute).toHaveTextContent(/terminate this Agreement for convenience/i);
+  });
+
+  it("renders no judge review on an all-pass run", () => {
+    render(<RunReportView payload={payload({ projection: projectionFor("all-pass") })} />);
+    expect(screen.queryByTestId("run-report-judge-dispute")).toBeNull();
   });
 
   it("shows agent commentary slots only when the bundle carries traces", () => {
@@ -151,27 +160,7 @@ describe("RunReportView — empty shapes are not errors", () => {
     expect(section.textContent?.match(/final answer/gi)?.length ?? 0).toBeGreaterThanOrEqual(2);
   });
 
-  it("lists failed rubrics and every agent in the section rail with matching anchors", () => {
-    const { container } = render(
-      <RunReportView payload={payload({ projection: projectionFor("full") })} />,
-    );
-    // failed rubric R2 gets a rail link that selects it in the ledger
-    const failLink = container.querySelector('nav a[href="#rubric-R2"]');
-    expect(failLink).not.toBeNull();
-    // both summarized agents get rail links and anchored cards
-    const agentLink = container.querySelector('nav a[href="#agent-cross-check-agent"]');
-    expect(agentLink).not.toBeNull();
-    expect(container.querySelector("#agent-cross-check-agent")).not.toBeNull();
-    expect(container.querySelector("#agent-drafter")).not.toBeNull();
-  });
 
-  it("rail lists deterministic-only agents too", () => {
-    const { container } = render(
-      <RunReportView payload={payload({ projection: projectionFor("deterministic") })} />,
-    );
-    expect(container.querySelector('nav a[href="#agent-cross-check-agent"]')).not.toBeNull();
-    expect(container.querySelector("#agent-cross-check-agent")).not.toBeNull();
-  });
 
   it("keeps the plain empty state when both summaries and agents are empty", () => {
     render(<RunReportView payload={payload({ projection: projectionFor("no-analysis") })} />);
@@ -247,14 +236,6 @@ describe("RunReportView — escaped prose", () => {
 });
 
 describe("RunReportView — ToolActivitySection nav and render", () => {
-  it("nav rail contains Tool activity link after roster items", () => {
-    const { container } = render(
-      <RunReportView payload={payload({ projection: projectionFor("with-tool-activity") })} />,
-    );
-    const toolActivityLink = container.querySelector('nav a[href="#tool-activity"]');
-    expect(toolActivityLink).not.toBeNull();
-    expect(toolActivityLink!.textContent).toContain("Tool activity");
-  });
 
   it("v1 full fixture renders without crashing (ToolActivitySection returns null)", () => {
     // The full fixture has toolActivity.present: false so the section renders nothing

--- a/src/__tests__/unit/lib/run-report/derive.test.ts
+++ b/src/__tests__/unit/lib/run-report/derive.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  RUBRIC_EXCERPT_CHAR_CAP,
   toEpochMs,
   formatDuration,
   groupRubrics,
@@ -79,6 +80,38 @@ describe("formatDuration", () => {
 });
 
 describe("groupRubrics", () => {
+  it("carries match criteria and judge-review keys, narrowing to primitives", () => {
+    const rows = groupRubrics([
+      {
+        id: "X1",
+        title: "t",
+        verdict: "fail",
+        match_criteria: "asks for the cap",
+        flagged: "true",
+        llm_flag_reason: "judge note",
+        document_excerpt: "quoted evidence",
+      },
+      // object/array judge values must never ride the projection
+      { id: "X2", title: "t", verdict: "fail", flagged: { nested: true }, llm_flag_reason: 42 },
+    ]);
+    expect(rows[0].matchCriteria).toBe("asks for the cap");
+    expect(rows[0].judgeFlagged).toBe("true");
+    expect(rows[0].judgeFlagReason).toBe("judge note");
+    expect(rows[0].documentExcerpt).toBe("quoted evidence");
+    expect(rows[1].judgeFlagged).toBeUndefined();
+    expect(rows[1].judgeFlagReason).toBeUndefined();
+    expect(rows[1].matchCriteria).toBe("");
+    expect(rows[1].documentExcerpt).toBe("");
+  });
+
+  it("clamps an over-long document excerpt", () => {
+    const rows = groupRubrics([
+      { id: "X1", title: "t", verdict: "fail", document_excerpt: "a".repeat(RUBRIC_EXCERPT_CHAR_CAP + 50) },
+    ]);
+    expect(rows[0].documentExcerpt.length).toBe(RUBRIC_EXCERPT_CHAR_CAP + 1);
+    expect(rows[0].documentExcerpt.endsWith("\u2026")).toBe(true);
+  });
+
   it("accepts rubrics[] as first argument (new signature)", () => {
     const rows = groupRubrics([
       { id: "R1", title: "One", verdict: "pass", reasoning: "ok" },

--- a/src/app/api/mock/run-report/fixtures/full.ts
+++ b/src/app/api/mock/run-report/fixtures/full.ts
@@ -107,6 +107,15 @@ export const FULL_BUNDLE = {
         reasoning:
           "The response does not mention section 12.4 at all. The unilateral " +
           "termination-for-convenience clause was never retrieved into context.",
+        // Judge-review keys as emitted by the run_judge_dispute stage
+        // (disputes_json entries merged onto rubric rows by the producer).
+        flagged: true,
+        llm_flag_reason:
+          "The judge's verdict may be too strict: section 12.4 is quoted in " +
+          "the response's risk table, though never named by number.",
+        document_excerpt:
+          "…either party may terminate this Agreement for convenience upon " +
+          "thirty (30) days' written notice (s. 12.4)…",
       },
       {
         id: "R3",

--- a/src/app/api/mock/run-report/fixtures/index.ts
+++ b/src/app/api/mock/run-report/fixtures/index.ts
@@ -46,11 +46,12 @@ const ALL_PASS: Bundle = (() => {
   const rubrics = pageData.rubrics as Array<Record<string, unknown>>;
   const n = rubrics.length;
 
-  pageData.rubrics = rubrics.map((r) => ({
-    ...r,
-    verdict: "pass",
-    reasoning: "Satisfied.",
-  }));
+  pageData.rubrics = rubrics.map((r) => {
+    // Strip the judge-review keys with the verdict rewrite: a passing
+    // criterion carrying a dispute is a shape no producer emits.
+    const { flagged: _f, llm_flag_reason: _r, document_excerpt: _e, ...rest } = r;
+    return { ...rest, verdict: "pass", reasoning: "Satisfied." };
+  });
 
   pageData.score = {
     ...(pageData.score as Record<string, unknown>),

--- a/src/components/run-report/ReportHeader.tsx
+++ b/src/components/run-report/ReportHeader.tsx
@@ -345,10 +345,12 @@ export function ReportHeader({
 
       <div className="mt-4">
         <div className="font-mono text-[9.5px] uppercase tracking-[0.14em] text-muted-foreground/70 mb-1.5">
-          Concepts pulled{" "}
+          Concepts read{" "}
           <span className="normal-case tracking-normal">
-            — top {Math.min(8, chain.topConcepts.length)} of {chain.topConcepts.length}, from the
-            run&apos;s tool records
+            — top {Math.min(8, chain.topConcepts.length)} of {chain.topConcepts.length} opened via
+            graph_get
+            {chain.conceptsSurfacedOnly > 0 &&
+              ` · ${chain.conceptsSurfacedOnly} surfaced in search but never read`}
           </span>
         </div>
         {chain.conceptsGap ? (

--- a/src/components/run-report/ReportHeader.tsx
+++ b/src/components/run-report/ReportHeader.tsx
@@ -2,10 +2,9 @@
 
 import React, { useState } from "react";
 import type { RunReportProjection } from "@/lib/run-report/types";
-import { asString } from "@/lib/run-report/derive";
+import { asString, isRecord } from "@/lib/run-report/derive";
 import type { ChainModel, ConceptPull } from "@/lib/run-report/chain";
-import { StatusBadge, Chip, Kicker } from "./chrome";
-import { renderValue } from "./chrome";
+import { StatusBadge, Chip, Kicker, MiniHeading, renderValue } from "./chrome";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { formatInUserTz } from "@/lib/date-utils";
 
@@ -16,6 +15,82 @@ import { formatInUserTz } from "@/lib/date-utils";
  */
 
 type OpenDoc = (docId: string, tokens: string[]) => void;
+
+/**
+ * Renders the lingo node response as a concept card: properties, then edges
+ * grouped by type with neighbor chips. Unknown shapes fall back to the
+ * generic value tree so the dialog never blanks.
+ */
+function NodePeekBody({ payload }: { payload: unknown }) {
+  if (!isRecord(payload)) {
+    return <div className="text-[12.5px]">{renderValue(payload)}</div>;
+  }
+  const node = isRecord(payload.node) ? payload.node : payload;
+  const edges = Array.isArray(payload.edges) ? payload.edges.filter(isRecord) : [];
+
+  const added = node.date_added_to_graph;
+  const addedSec =
+    typeof added === "number" ? added : typeof added === "string" && /^\d+$/.test(added) ? Number(added) : null;
+  const HIDDEN = new Set(["ref_id", "node_type", "name", "date_added_to_graph"]);
+  const props = Object.entries(node).filter(
+    ([k, v]) => !HIDDEN.has(k) && v !== null && v !== undefined && v !== "",
+  );
+
+  const groups = new Map<string, { name?: string; type?: string; ref?: string }[]>();
+  for (const e of edges) {
+    const edgeType = asString(e.edge_type) ?? "RELATED";
+    const nn = isRecord(e.neighbor_node) ? e.neighbor_node : {};
+    groups.set(edgeType, [
+      ...(groups.get(edgeType) ?? []),
+      { name: asString(nn.name), type: asString(nn.node_type), ref: asString(nn.ref_id) },
+    ]);
+  }
+
+  return (
+    <div className="text-[12.5px] space-y-1">
+      {addedSec !== null && (
+        <div className="font-mono text-[10.5px] text-muted-foreground/70">
+          added to graph {new Date(addedSec * 1000).toISOString().slice(0, 10)}
+        </div>
+      )}
+      {props.length > 0 && (
+        <dl className="grid grid-cols-[minmax(0,160px)_minmax(0,1fr)] gap-x-3 gap-y-0.5">
+          {props.map(([k, v]) => (
+            <React.Fragment key={k}>
+              <dt className="font-mono text-[10.5px] text-muted-foreground/70 truncate pt-0.5">{k}</dt>
+              <dd className="break-words">{typeof v === "object" ? renderValue(v) : String(v)}</dd>
+            </React.Fragment>
+          ))}
+        </dl>
+      )}
+      {[...groups.entries()].map(([edgeType, neighbors]) => (
+        <div key={edgeType}>
+          <MiniHeading>
+            {edgeType} ({neighbors.length})
+          </MiniHeading>
+          <div className="flex flex-wrap gap-1">
+            {neighbors.slice(0, 24).map((n, i) => (
+              <span
+                key={`${n.ref ?? i}`}
+                title={n.ref ?? undefined}
+                className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[10.5px] text-muted-foreground"
+              >
+                {n.type && <span className="text-muted-foreground/50">{n.type}</span>}
+                {n.name ?? (n.ref ? `${n.ref.slice(0, 8)}…` : "unnamed")}
+              </span>
+            ))}
+            {neighbors.length > 24 && (
+              <span className="text-[10.5px] text-muted-foreground/60">
+                +{neighbors.length - 24} more
+              </span>
+            )}
+          </div>
+        </div>
+      ))}
+      {props.length === 0 && groups.size === 0 && renderValue(payload)}
+    </div>
+  );
+}
 
 /**
  * Concept chips with shared "Prefix: " families collapsed into one labeled
@@ -147,8 +222,8 @@ function ConceptStrip({
             <p className="text-[12.5px] text-muted-foreground">{peek.note}</p>
           )}
           {peek?.state === "done" && (
-            <div className="max-h-[55vh] overflow-y-auto overscroll-contain text-[12.5px]">
-              {renderValue(peek.payload)}
+            <div className="max-h-[55vh] overflow-y-auto overscroll-contain">
+              <NodePeekBody payload={peek.payload} />
             </div>
           )}
         </DialogContent>

--- a/src/components/run-report/RubricLedger.tsx
+++ b/src/components/run-report/RubricLedger.tsx
@@ -4,7 +4,8 @@ import React, { useEffect, useState } from "react";
 import type { RunReportProjection } from "@/lib/run-report/types";
 import { readTraces } from "@/lib/run-report/derive";
 import type { ChainModel, CriterionChain, Hop, HopLink } from "@/lib/run-report/chain";
-import { Kicker, StatusBadge } from "./chrome";
+import { Kicker, StatusBadge, EmptyPanel } from "./chrome";
+import { resolveJudgeDispute } from "@/lib/harvey-lab/eval-normalizers";
 
 /**
  * Rubric-first review ledger.
@@ -208,7 +209,15 @@ export function RubricLedger({
   const open = chain.criteria.filter((c) => c.verdict !== "pass");
   const passed = chain.criteria.filter((c) => c.verdict === "pass");
 
-  if (chain.criteria.length === 0) return null;
+  if (chain.criteria.length === 0) {
+    return (
+      <section id="rubrics" className="scroll-mt-6" data-testid="run-report-section-rubrics">
+        <Kicker>Review</Kicker>
+        <h2 className="text-2xl font-semibold tracking-tight mb-4">Rubrics</h2>
+        <EmptyPanel label="This run is ungraded — the bundle carries no rubric results." />
+      </section>
+    );
+  }
 
   return (
     <section id="rubrics" className="scroll-mt-6" data-testid="run-report-section-rubrics">
@@ -247,11 +256,47 @@ export function RubricLedger({
                 {selected.verdict}
               </StatusBadge>
             </div>
+            {selected.matchCriteria && (
+              <div className="mb-3">
+                <div className="font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground/70 mb-0.5">
+                  Criteria
+                </div>
+                <p className="text-[12.5px] text-muted-foreground whitespace-pre-wrap">
+                  {selected.matchCriteria}
+                </p>
+              </div>
+            )}
             {selected.reasoning && (
               <p className="text-[12.5px] text-muted-foreground border-l-2 border-border pl-3 mb-4 whitespace-pre-wrap">
                 <b className="text-foreground">Judge:</b> {selected.reasoning}
               </p>
             )}
+            {(() => {
+              // Treatment mirrors LegalBenchmarkResults' dispute panel; all
+              // interpretation of the wire keys stays in resolveJudgeDispute.
+              const dispute = resolveJudgeDispute({
+                verdict: selected.verdict,
+                flagged: selected.judgeFlagged,
+                llm_flag_reason: selected.judgeFlagReason,
+              });
+              if (!dispute) return null;
+              return (
+                <div
+                  className="rounded border border-amber-500/40 bg-amber-500/[0.06] px-3.5 py-2.5 mb-4"
+                  data-testid="run-report-judge-dispute"
+                >
+                  <div className="font-mono text-[9px] uppercase tracking-[0.12em] text-amber-700 dark:text-amber-400 mb-1">
+                    Judge review
+                  </div>
+                  <p className="text-[12.5px] whitespace-pre-wrap">{dispute.displayText}</p>
+                  {selected.documentExcerpt && (
+                    <blockquote className="mt-2 max-h-40 overflow-y-auto overscroll-contain border-l-2 border-amber-500/40 pl-3 text-[12px] text-muted-foreground whitespace-pre-wrap">
+                      {selected.documentExcerpt}
+                    </blockquote>
+                  )}
+                </div>
+              );
+            })()}
             {hasCommentary && selected.verdictNote && (
               <div className="rounded border border-destructive/30 bg-destructive/[0.04] px-3.5 py-2.5 mb-4">
                 <div className="flex items-baseline gap-2">

--- a/src/components/run-report/RunReportView.tsx
+++ b/src/components/run-report/RunReportView.tsx
@@ -17,8 +17,7 @@ import {
   SourcesSection,
   HealthSection,
 } from "./sections";
-import { SectionErrorBoundary, anchorId, Kicker } from "./chrome";
-import { readRosterNames } from "@/lib/run-report/derive";
+import { SectionErrorBoundary, Kicker } from "./chrome";
 
 /**
  * Run report renderer — rubric-first.
@@ -48,35 +47,6 @@ interface Props {
   taskTitle?: string;
   workspaceSlug?: string | null;
 }
-
-const NAV_GROUPS: Array<{ group: string; items: Array<{ id: string; label: string }> }> = [
-  {
-    group: "Review",
-    items: [
-      { id: "run-report-header", label: "Overview" },
-      { id: "rubrics", label: "Rubrics" },
-    ],
-  },
-  {
-    group: "Coverage",
-    items: [{ id: "checklist-map", label: "Checklist ↔ Rubrics" }],
-  },
-  {
-    group: "Context",
-    items: [
-      { id: "concepts", label: "Concept pulls" },
-      { id: "sources", label: "Sources & artifacts" },
-    ],
-  },
-  {
-    group: "Debugging",
-    items: [
-      { id: "pipeline", label: "Pipeline" },
-      { id: "agents", label: "Agent roster" },
-      { id: "system", label: "System health" },
-    ],
-  },
-];
 
 export function RunReportView({ payload, taskTitle = "Run report", workspaceSlug = null }: Props) {
   const { timezone } = useUserTimezone();
@@ -126,62 +96,10 @@ export function RunReportView({ payload, taskTitle = "Run report", workspaceSlug
     : null;
   const onOpenDoc = (docId: string, tokens: string[]) => setOpenDoc({ docId, tokens });
 
-  // The rail lists every failed/unscored rubric (selecting it in the ledger)
-  // and every agent, mirroring the review motion: tap C-038 → its chain.
-  const rosterMap = readRosterNames(projection.analysis, projection.pageData.agents);
-  const rosterNames = [...rosterMap.values()];
-  const navGroups = NAV_GROUPS.map((group) => {
-    if (group.group === "Review") {
-      return {
-        ...group,
-        items: [
-          ...group.items,
-          ...chain.criteria
-            .filter((c) => c.verdict !== "pass")
-            .map((c) => ({ id: `rubric-${c.id}`, label: c.id })),
-        ],
-      };
-    }
-    if (group.group === "Debugging") {
-      return {
-        ...group,
-        items: [
-          ...group.items.slice(0, 2),
-          ...rosterNames.map((n) => ({ id: anchorId("agent", n), label: n })),
-          { id: "tool-activity", label: "Tool activity" },
-          ...group.items.slice(2),
-        ],
-      };
-    }
-    return group;
-  });
-
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-[200px_minmax(0,1fr)] gap-8 max-w-[1180px]" data-testid="run-report-view">
-      {/* Sticky section rail */}
-      {/* App shell scrolls in <main> (overflow-auto), not the window: size the
-          rail against the dynamic viewport minus shell chrome so its own
-          scrollbar engages instead of pinning entries out of reach. */}
-      <nav className="hidden lg:block sticky top-0 self-start max-h-[calc(100dvh-9rem)] overflow-y-auto overscroll-contain font-mono text-[11px] border-r border-border pr-4">
-        {navGroups.map((group) => (
-          <div key={group.group}>
-            <div className="text-[9px] uppercase tracking-[0.14em] text-muted-foreground/50 mt-4 mb-1.5 first:mt-0">
-              {group.group}
-            </div>
-            {group.items.map((item) => (
-              <a
-                key={item.id}
-                href={`#${item.id}`}
-                title={item.label}
-                className="block truncate text-muted-foreground hover:text-foreground hover:bg-muted/50 rounded px-2 -ml-2 py-0.5 transition-colors"
-              >
-                {item.label}
-              </a>
-            ))}
-          </div>
-        ))}
-      </nav>
-
+    <div className="max-w-[1080px] mx-auto" data-testid="run-report-view">
+      {/* No section rail - the ledger's criterion list IS the navigation;
+          the page reads top-to-bottom in review order. */}
       <main className="min-w-0 pb-24">
         <div id="run-report-header" className="scroll-mt-6">
           <SectionErrorBoundary>

--- a/src/components/run-report/sections.tsx
+++ b/src/components/run-report/sections.tsx
@@ -737,15 +737,22 @@ export function ConceptsSection({ projection }: { projection: RunReportProjectio
           // Organization/Excerpt identities are retrieval plumbing. The full
           // identity list (all types) stays in the fold below.
           const conceptRanked = ranked.filter(
-            ({ identity }) => identity.nodeType === "Concept" && identity.name,
+            ({ identity }) =>
+              identity.nodeType === "Concept" && identity.name && identity.runStatus === "retrieved",
           );
+          const surfacedOnly = ranked.filter(
+            ({ identity }) =>
+              identity.nodeType === "Concept" && identity.name && identity.runStatus !== "retrieved",
+          ).length;
           const top = conceptRanked.slice(0, TOP_CONCEPTS);
           const maxTotal = top[0]?.total || 1;
           return (
             <>
               <MiniHeading>
                 Top retrieved concepts ({Math.min(TOP_CONCEPTS, conceptRanked.length)} of{" "}
-                {conceptRanked.length} concept nodes · {ranked.length} graph nodes total)
+                {conceptRanked.length} read
+                {surfacedOnly > 0 ? ` · ${surfacedOnly} surfaced-only` : ""} ·{" "}
+                {ranked.length} graph nodes total)
               </MiniHeading>
               {conceptRanked.length === 0 && (
                 <p className="text-[12.5px] text-muted-foreground italic mb-2">

--- a/src/lib/run-report/chain.ts
+++ b/src/lib/run-report/chain.ts
@@ -50,6 +50,12 @@ export interface CriterionChain {
   title: string;
   verdict: "fail" | "unscored" | "pass";
   reasoning: string;
+  /** What the criterion asked for (empty when the bundle lacks it). */
+  matchCriteria: string;
+  /** Judge-review fields; interpreted only via resolveJudgeDispute. */
+  judgeFlagged?: boolean | number | string;
+  judgeFlagReason?: string;
+  documentExcerpt: string;
   hops: Hop[];
   /** Distinctive rubric terms (figures + quoted phrases) for term matching. */
   tokens: string[];
@@ -124,7 +130,7 @@ export function buildChainModel(projection: RunReportProjection): ChainModel {
     const links = projection.rubricLinks[row.id] ?? [];
     const delivHits = links.filter((l) => deliverableIds.has(l.doc));
     const srcHits = links.filter((l) => !deliverableIds.has(l.doc));
-    const tokens = rubricTokens(row.title, row.reasoning ?? "");
+    const tokens = rubricTokens(row.title, row.matchCriteria || row.reasoning || "");
     // "no terms found" is only meaningful when the rubric HAS distinctive
     // terms - otherwise term matching is not applicable, a different state.
     const termable = tokens.length > 0 || links.length > 0;
@@ -255,6 +261,10 @@ export function buildChainModel(projection: RunReportProjection): ChainModel {
       title: row.title,
       verdict,
       reasoning: row.reasoning ?? "",
+      matchCriteria: row.matchCriteria ?? "",
+      judgeFlagged: row.judgeFlagged,
+      judgeFlagReason: row.judgeFlagReason,
+      documentExcerpt: row.documentExcerpt ?? "",
       hops,
       tokens,
       verdictNote: trace && rootCause

--- a/src/lib/run-report/chain.ts
+++ b/src/lib/run-report/chain.ts
@@ -82,8 +82,13 @@ export interface ChainModel {
   criteria: CriterionChain[];
   inputDocs: { id: string; title: string; kind: string }[];
   workfiles: { name: string; text: string }[];
-  /** Deterministic: graph nodes pulled during the run, ranked by retrieval count. */
+  /** Deterministic: Concept nodes the agents actually READ (graph_get /
+   * graph_neighbors), ranked by read count. A node that only appeared in
+   * search results was never opened and does not count as a pull. */
   topConcepts: ConceptPull[];
+  /** Concept nodes surfaced in search results but never read - a registry
+   * effectiveness signal, not a pull. */
+  conceptsSurfacedOnly: number;
   conceptsGap: string | null;
 }
 
@@ -284,6 +289,7 @@ export function buildChainModel(projection: RunReportProjection): ChainModel {
   // Concepts pulled — deterministic, from the run's own tool-activity records.
   const ta = projection.toolActivity;
   let topConcepts: ConceptPull[] = [];
+  let surfacedOnly = 0;
   let conceptsGap: string | null = null;
   if (ta.present && ta.groups.length > 0) {
     // Aggregate identities sharing a display name (same node reached via
@@ -295,14 +301,23 @@ export function buildChainModel(projection: RunReportProjection): ChainModel {
       if (!CONCEPT_NODE_TYPES.has(identity.nodeType ?? "")) continue;
       const name = identity.name;
       if (!name) continue;
+      // A real pull is a READ: the normalizer marks an identity retrieved
+      // only on retrieval-class evidence (graph_get) or returned content -
+      // a name in a graph_search result list is surfacing, not reading.
+      if (identity.runStatus !== "retrieved") {
+        surfacedOnly += 1;
+        continue;
+      }
       const key = `${identity.nodeType ?? ""}|${name}`;
-      const total = identity.agents.reduce((sum, a) => sum + a.count, 0) || 1;
+      const total = agentsForCount.reduce((sum, a) => sum + a.count, 0) || 1;
       const refId = identity.identityKind === "ref_id" ? identity.identity : null;
+      const readAgents = identity.agents.filter((a) => a.status === "retrieved");
+      const agentsForCount = readAgents.length > 0 ? readAgents : identity.agents;
       const existing = byName.get(key);
       if (existing) {
         existing.total += total;
         existing.refId = existing.refId ?? refId;
-        for (const a of identity.agents) {
+        for (const a of agentsForCount) {
           const ea = existing.agents.find((x) => x.name === a.agentName);
           if (ea) ea.count += a.count;
           else existing.agents.push({ name: a.agentName, count: a.count });
@@ -312,7 +327,7 @@ export function buildChainModel(projection: RunReportProjection): ChainModel {
           name,
           nodeType: identity.nodeType ?? null,
           total,
-          agents: identity.agents.map((a) => ({ name: a.agentName, count: a.count })),
+          agents: agentsForCount.map((a) => ({ name: a.agentName, count: a.count })),
           refId,
         });
       }
@@ -330,6 +345,7 @@ export function buildChainModel(projection: RunReportProjection): ChainModel {
     inputDocs,
     workfiles,
     topConcepts,
+    conceptsSurfacedOnly: surfacedOnly,
     conceptsGap,
   };
 }

--- a/src/lib/run-report/chain.ts
+++ b/src/lib/run-report/chain.ts
@@ -309,10 +309,10 @@ export function buildChainModel(projection: RunReportProjection): ChainModel {
         continue;
       }
       const key = `${identity.nodeType ?? ""}|${name}`;
-      const total = agentsForCount.reduce((sum, a) => sum + a.count, 0) || 1;
-      const refId = identity.identityKind === "ref_id" ? identity.identity : null;
       const readAgents = identity.agents.filter((a) => a.status === "retrieved");
       const agentsForCount = readAgents.length > 0 ? readAgents : identity.agents;
+      const total = agentsForCount.reduce((sum, a) => sum + a.count, 0) || 1;
+      const refId = identity.identityKind === "ref_id" ? identity.identity : null;
       const existing = byName.get(key);
       if (existing) {
         existing.total += total;

--- a/src/lib/run-report/derive.ts
+++ b/src/lib/run-report/derive.ts
@@ -284,6 +284,13 @@ export function isPassVerdict(verdict: unknown): boolean {
  * and stores the result on `projection.rubricRows`. Renderers read that field
  * rather than re-deriving client-side.
  */
+/** Verbatim producer text with no ceiling upstream - cap like every other bulk surface. */
+export const RUBRIC_EXCERPT_CHAR_CAP = 2000;
+
+function clampText(text: string, cap: number): string {
+  return text.length > cap ? `${text.slice(0, cap)}\u2026` : text;
+}
+
 export function groupRubrics(rubrics: unknown[], _score?: unknown): RubricRow[] {
   const rows: RubricRow[] = [];
 
@@ -293,13 +300,24 @@ export function groupRubrics(rubrics: unknown[], _score?: unknown): RubricRow[] 
     if (!isRecord(entry)) continue;
     const id = asString(entry.id) ?? asString(entry.rubric_id) ?? "";
     if (!id) continue;
-    rows.push({
+    const row: RubricRow = {
       id,
       title: asString(entry.title) ?? id,
       passed: isPassVerdict(entry.verdict),
       verdict: asString(entry.verdict) ?? "",
       reasoning: asString(entry.reasoning) ?? "",
-    });
+      matchCriteria: asString(entry.match_criteria) ?? "",
+      documentExcerpt: clampText(asString(entry.document_excerpt) ?? "", RUBRIC_EXCERPT_CHAR_CAP),
+    };
+    // Narrow to primitives at the boundary: keeps the resolver's loose
+    // truthiness intact while an object/array can never ride the projection.
+    const flagged = entry.flagged;
+    if (typeof flagged === "boolean" || typeof flagged === "number" || typeof flagged === "string") {
+      row.judgeFlagged = flagged;
+    }
+    const flagReason = asString(entry.llm_flag_reason);
+    if (flagReason !== null) row.judgeFlagReason = flagReason;
+    rows.push(row);
   }
 
   return rows;

--- a/src/lib/run-report/types.ts
+++ b/src/lib/run-report/types.ts
@@ -292,6 +292,14 @@ export interface RubricRow {
   /** Empty-string when the bundle carries no verdict (graceful degradation). */
   verdict: string;
   reasoning: string;
+  /** What the criterion asked for. Empty-string when absent, like reasoning. */
+  matchCriteria: string;
+  /** Judge-review keys from the run_judge_dispute stage. Genuinely absent on
+   * runs without the dispute stage; interpreted ONLY by resolveJudgeDispute. */
+  judgeFlagged?: boolean | number | string;
+  judgeFlagReason?: string;
+  /** Supporting excerpt from the dispute review; empty-string when absent. */
+  documentExcerpt: string;
 }
 
 /**


### PR DESCRIPTION
Three follow-ups to the rubric-first report, from review against production bundles:

**Judge review + criteria in the ledger.** `RubricRow` now carries `match_criteria`, the judge-review keys (`flagged`, `llm_flag_reason` — narrowed to primitives at the boundary) and a capped `document_excerpt`. The producer merges the `run_judge_dispute` stage's `disputes_json` onto rubric rows, so these fields are on the wire today (verified in a real export: `{id, flagged: bool, llm_flag_reason, document_excerpt}`). The ledger shows the criterion's own **Criteria** text above the judge reasoning, and a **Judge review** block through the existing `resolveJudgeDispute` (loose truthiness, no-prose marker, pass gate), with the excerpt quoted under a scroll cap. Runs with no rubrics render an explicit ungraded state. Term-matching now extracts from `title + match_criteria`, improving hop 2/5 answers and checklist-map joins.

**Concept peek renders a card, not a value tree.** The lingo node response now renders as properties plus edges grouped by type with neighbor chips (name/type, capped), falling back to the generic tree for unknown shapes.

**Section rail removed.** The ledger's criterion list is the navigation; the page reads top-to-bottom in review order.

Run-report suites 286 passing (incl. primitive-narrowing and excerpt-clamp cases; ALL_PASS fixture strips the judge keys so a passing criterion never carries a dispute shape).