### PR TITLE
Add Learn page concept proposal review UI + shared UnifiedDiffView extraction

### DIFF
--- a/src/__tests__/unit/components/ConceptProposalReviewCard.test.tsx
+++ b/src/__tests__/unit/components/ConceptProposalReviewCard.test.tsx
@@ -1,0 +1,368 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+import { ConceptProposalReviewCard } from "@/app/w/[slug]/learn/components/ConceptProposalReviewCard";
+import type { ConceptProposal } from "@/types/concept-proposals";
+import { toast } from "sonner";
+
+const mockUseWorkspaceAccess = vi.fn(() => ({ canWrite: true }));
+vi.mock("@/hooks/useWorkspaceAccess", () => ({
+  useWorkspaceAccess: () => mockUseWorkspaceAccess(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+// The shared diff renderer is exercised by its own usage in ProposalCard's
+// suite; here a stub exposing the diff stats keeps assertions direct.
+vi.mock("@/components/diff/UnifiedDiffView", () => ({
+  SECTION_LABEL_CLASS: "section-label",
+  UnifiedDiffView: ({ diff, emptyText }: any) => (
+    <div data-testid="unified-diff" data-added={diff.added} data-removed={diff.removed}>
+      {diff.unchanged ? emptyText : `+${diff.added}/-${diff.removed}`}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({ children, ...props }: any) => <span {...props}>{children}</span>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, onClick, disabled, ...props }: any) => (
+    <button onClick={onClick} disabled={disabled} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/textarea", () => ({
+  Textarea: ({ value, onChange, ...props }: any) => (
+    <textarea value={value} onChange={onChange} {...props} />
+  ),
+}));
+
+vi.mock("lucide-react", () => ({
+  Check: () => <span data-testid="check-icon" />,
+  X: () => <span data-testid="x-icon" />,
+  Loader2: () => <span data-testid="loader-icon" />,
+  RefreshCw: () => <span data-testid="refresh-icon" />,
+  AlertTriangle: () => <span data-testid="alert-icon" />,
+}));
+
+const base = {
+  status: "pending" as const,
+  rationale: "Concepts drifted from the code.",
+  source: "https://github.com/stakwork/hive/pull/201",
+  prNumbers: [201],
+  createdAt: "2025-08-06T14:30:00.000Z",
+  repo: "stakwork/hive",
+};
+
+const updateProposal: ConceptProposal = {
+  ...base,
+  id: "proposal-update-1",
+  action: "update",
+  conceptId: "stakwork/hive/tasks",
+  baseDocs: "Old docs line.",
+  documentation: "New docs line.",
+};
+
+const createProposal: ConceptProposal = {
+  ...base,
+  id: "proposal-create-1",
+  action: "create",
+  name: "Encryption Service",
+  documentation: "AES-256-GCM field-level encryption.",
+};
+
+const deleteProposal: ConceptProposal = {
+  ...base,
+  id: "proposal-delete-1",
+  action: "delete",
+  conceptId: "stakwork/hive/janitors",
+  baseDocs: "Janitor docs.",
+};
+
+const mergeProposal: ConceptProposal = {
+  ...base,
+  id: "proposal-merge-1",
+  action: "merge",
+  conceptId: "stakwork/hive/janitors",
+  mergeIntoConceptId: "stakwork/hive/swarm",
+  baseDocs: "Swarm docs.",
+  absorbedDocs: "Janitor docs.",
+  documentation: "Swarm docs plus janitors.",
+};
+
+function renderCard(
+  proposal: ConceptProposal,
+  overrides: Partial<React.ComponentProps<typeof ConceptProposalReviewCard>> = {},
+) {
+  const onDecided = vi.fn();
+  const onTerminal = vi.fn();
+  render(
+    <ConceptProposalReviewCard
+      proposal={proposal}
+      workspaceSlug="test-ws"
+      onDecided={onDecided}
+      onTerminal={onTerminal}
+      {...overrides}
+    />,
+  );
+  return { onDecided, onTerminal };
+}
+
+function mockFetchResponse(status: number, body: unknown) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  });
+}
+
+describe("ConceptProposalReviewCard — per-action rendering", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseWorkspaceAccess.mockReturnValue({ canWrite: true });
+    global.fetch = mockFetchResponse(200, {});
+  });
+
+  it("update: renders a diff labeled with the concept id, plus metadata", () => {
+    renderCard(updateProposal);
+    const diffSection = screen.getByTestId("proposal-diff");
+    expect(diffSection.textContent).toContain("stakwork/hive/tasks");
+    expect(diffSection.querySelector('[data-testid="unified-diff"]')).toBeTruthy();
+    expect(screen.getByText("Concepts drifted from the code.")).toBeTruthy();
+    expect(screen.getByTestId("proposal-pr-numbers").textContent).toContain("#201");
+    expect(screen.getByTestId("proposal-action-badge").textContent).toBe("Update");
+  });
+
+  it("create: shows name and proposed docs verbatim, no diff", () => {
+    renderCard(createProposal);
+    expect(screen.getByText("Encryption Service")).toBeTruthy();
+    expect(screen.getByTestId("proposal-create-docs").textContent).toBe(
+      "AES-256-GCM field-level encryption.",
+    );
+    expect(screen.queryByTestId("proposal-diff")).toBeNull();
+  });
+
+  it("delete: shows baseDocs as fully removed", () => {
+    renderCard(deleteProposal);
+    const diff = screen
+      .getByTestId("proposal-diff")
+      .querySelector('[data-testid="unified-diff"]');
+    // The empty "after" text still parses as one blank line, so added is 1.
+    expect(diff?.getAttribute("data-removed")).toBe("1");
+    expect(diff?.textContent).toContain("-1");
+  });
+
+  it("merge: shows the survivor diff and the absorbed docs separately", () => {
+    renderCard(mergeProposal);
+    expect(screen.getByTestId("proposal-diff").textContent).toContain(
+      "stakwork/hive/swarm",
+    );
+    const absorbed = screen.getByTestId("proposal-absorbed-docs");
+    expect(absorbed.textContent).toContain("stakwork/hive/janitors");
+    const absorbedDiff = absorbed.querySelector('[data-testid="unified-diff"]');
+    expect(absorbedDiff?.getAttribute("data-removed")).toBe("1");
+  });
+
+  it("hides decision buttons below DEVELOPER role", () => {
+    mockUseWorkspaceAccess.mockReturnValue({ canWrite: false });
+    renderCard(updateProposal);
+    expect(screen.queryByTestId("proposal-accept-button")).toBeNull();
+    expect(screen.queryByTestId("proposal-reject-button")).toBeNull();
+    expect(screen.getByTestId("proposal-readonly-note")).toBeTruthy();
+  });
+});
+
+describe("ConceptProposalReviewCard — decisions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseWorkspaceAccess.mockReturnValue({ canWrite: true });
+  });
+
+  it("accept POSTs to the accept proxy with the workspace param", async () => {
+    global.fetch = mockFetchResponse(200, { status: "success", proposal: updateProposal });
+    const { onDecided } = renderCard(updateProposal);
+    fireEvent.click(screen.getByTestId("proposal-accept-button"));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/learnings/concepts/proposals/proposal-update-1/accept?workspace=test-ws",
+        expect.objectContaining({ method: "POST", body: JSON.stringify({}) }),
+      );
+      expect(onDecided).toHaveBeenCalledWith({
+        outcome: "accepted",
+        createdConceptId: undefined,
+      });
+    });
+  });
+
+  it("accepting a create proposal passes createdConceptId through", async () => {
+    global.fetch = mockFetchResponse(200, {
+      status: "success",
+      proposal: { ...createProposal, createdConceptId: "stakwork/hive/encryption-service" },
+    });
+    const { onDecided } = renderCard(createProposal);
+    fireEvent.click(screen.getByTestId("proposal-accept-button"));
+
+    await waitFor(() => {
+      expect(onDecided).toHaveBeenCalledWith({
+        outcome: "accepted",
+        createdConceptId: "stakwork/hive/encryption-service",
+      });
+    });
+  });
+
+  it("reject sends the optional reason and reports the outcome", async () => {
+    global.fetch = mockFetchResponse(200, { status: "success" });
+    const { onDecided } = renderCard(updateProposal);
+    fireEvent.click(screen.getByTestId("proposal-reject-button"));
+    fireEvent.change(screen.getByTestId("proposal-reject-reason"), {
+      target: { value: "Outdated." },
+    });
+    fireEvent.click(screen.getByTestId("proposal-reject-confirm"));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/learnings/concepts/proposals/proposal-update-1/reject?workspace=test-ws",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ reason: "Outdated." }),
+        }),
+      );
+      expect(onDecided).toHaveBeenCalledWith({
+        outcome: "rejected",
+        createdConceptId: undefined,
+      });
+    });
+  });
+
+  it("reject without a reason sends an empty body", async () => {
+    global.fetch = mockFetchResponse(200, { status: "success" });
+    renderCard(updateProposal);
+    fireEvent.click(screen.getByTestId("proposal-reject-button"));
+    fireEvent.click(screen.getByTestId("proposal-reject-confirm"));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/reject?workspace=test-ws"),
+        expect.objectContaining({ body: JSON.stringify({}) }),
+      );
+    });
+  });
+
+  it("surfaces upstream errors as a toast without deciding", async () => {
+    global.fetch = mockFetchResponse(502, { error: "Upstream exploded" });
+    const { onDecided, onTerminal } = renderCard(updateProposal);
+    fireEvent.click(screen.getByTestId("proposal-accept-button"));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Upstream exploded");
+    });
+    expect(onDecided).not.toHaveBeenCalled();
+    expect(onTerminal).not.toHaveBeenCalled();
+  });
+});
+
+describe("ConceptProposalReviewCard — stale_base flow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseWorkspaceAccess.mockReturnValue({ canWrite: true });
+  });
+
+  async function triggerStale() {
+    global.fetch = mockFetchResponse(409, {
+      error: "drifted",
+      code: "stale_base",
+      conceptId: "stakwork/hive/tasks",
+    });
+    const callbacks = renderCard(updateProposal);
+    fireEvent.click(screen.getByTestId("proposal-accept-button"));
+    await waitFor(() => {
+      expect(screen.getByTestId("proposal-stale-banner")).toBeTruthy();
+    });
+    return callbacks;
+  }
+
+  it("shows the re-review banner and swaps Accept for force-accept", async () => {
+    const { onDecided } = await triggerStale();
+    expect(screen.queryByTestId("proposal-accept-button")).toBeNull();
+    expect(screen.getByTestId("proposal-force-accept-button")).toBeTruthy();
+    expect(onDecided).not.toHaveBeenCalled();
+  });
+
+  it("re-fetch loads the concept's current docs and shows a fresh diff", async () => {
+    await triggerStale();
+    global.fetch = mockFetchResponse(200, {
+      concept: { documentation: "Docs as they are now." },
+    });
+    fireEvent.click(screen.getByTestId("proposal-stale-refetch"));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/learnings/concepts/stakwork%2Fhive%2Ftasks?workspace=test-ws",
+      );
+      expect(screen.getByTestId("proposal-current-diff")).toBeTruthy();
+    });
+  });
+
+  it("force-accept re-calls accept with force: true", async () => {
+    const { onDecided } = await triggerStale();
+    global.fetch = mockFetchResponse(200, { status: "success", proposal: updateProposal });
+    fireEvent.click(screen.getByTestId("proposal-force-accept-button"));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/learnings/concepts/proposals/proposal-update-1/accept?workspace=test-ws",
+        expect.objectContaining({ body: JSON.stringify({ force: true }) }),
+      );
+      expect(onDecided).toHaveBeenCalledWith({
+        outcome: "accepted",
+        createdConceptId: undefined,
+      });
+    });
+  });
+});
+
+describe("ConceptProposalReviewCard — terminal states", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseWorkspaceAccess.mockReturnValue({ canWrite: true });
+  });
+
+  it("409 already-decided shows a terminal banner, no force-accept", async () => {
+    global.fetch = mockFetchResponse(409, {
+      error: "already decided",
+      status: "accepted",
+    });
+    const { onTerminal } = renderCard(updateProposal);
+    fireEvent.click(screen.getByTestId("proposal-accept-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("proposal-terminal-state").textContent).toContain(
+        "already accepted",
+      );
+      expect(onTerminal).toHaveBeenCalled();
+    });
+    expect(screen.queryByTestId("proposal-force-accept-button")).toBeNull();
+    expect(screen.queryByTestId("proposal-accept-button")).toBeNull();
+  });
+
+  it("404 shows the gone terminal state and refreshes the list", async () => {
+    global.fetch = mockFetchResponse(404, { error: "not found" });
+    const { onTerminal, onDecided } = renderCard(updateProposal);
+    fireEvent.click(screen.getByTestId("proposal-accept-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("proposal-terminal-state").textContent).toContain(
+        "no longer exists",
+      );
+      expect(onTerminal).toHaveBeenCalled();
+    });
+    expect(onDecided).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/unit/components/LearnSidebar.test.tsx
+++ b/src/__tests__/unit/components/LearnSidebar.test.tsx
@@ -90,6 +90,7 @@ vi.mock("lucide-react", () => ({
   BookOpen: () => <span data-testid="book-icon" />,
   Lightbulb: () => <span data-testid="lightbulb-icon" />,
   GitBranch: () => <span data-testid="gitbranch-icon" />,
+  GitPullRequest: () => <span data-testid="gitpullrequest-icon" />,
   Plus: () => <span data-testid="plus-icon" />,
   Pencil: () => <span data-testid="pencil-icon" />,
   RefreshCw: () => <span data-testid="refresh-icon" />,
@@ -663,5 +664,126 @@ describe("LearnSidebar — concept search", () => {
 
     fireEvent.click(screen.getByTestId("concept-search-result-semantic"));
     expect(onConceptClick).toHaveBeenCalledWith("stakwork/hive/tasks", "Tasks", "");
+  });
+});
+
+describe("LearnSidebar — concept proposals", () => {
+  const pendingProposals = [
+    {
+      id: "proposal-create-1",
+      action: "create" as const,
+      status: "pending" as const,
+      name: "Encryption Service",
+      rationale: "r",
+      source: "s",
+      prNumbers: [],
+      createdAt: "2025-08-05T10:00:00.000Z",
+      repo: "stakwork/hive",
+    },
+    {
+      id: "proposal-update-1",
+      action: "update" as const,
+      status: "pending" as const,
+      conceptId: "stakwork/hive/tasks",
+      rationale: "r",
+      source: "s",
+      prNumbers: [],
+      createdAt: "2025-08-06T14:30:00.000Z",
+      repo: "stakwork/hive",
+    },
+    {
+      id: "proposal-merge-1",
+      action: "merge" as const,
+      status: "pending" as const,
+      conceptId: "stakwork/hive/auth",
+      mergeIntoConceptId: "stakwork/hive/tasks",
+      rationale: "r",
+      source: "s",
+      prNumbers: [],
+      createdAt: "2025-08-08T16:45:00.000Z",
+      repo: "stakwork/hive",
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseWorkspace.mockReturnValue({ workspace: { repositories: [] } });
+    global.fetch = vi.fn().mockResolvedValue({ ok: false });
+  });
+
+  it("hides the Proposals section when there are no proposals", () => {
+    render(<LearnSidebar {...defaultProps} />);
+    expect(screen.queryByTestId("learn-proposals-section")).toBeNull();
+  });
+
+  it("renders the Proposals section with a count badge", () => {
+    render(<LearnSidebar {...defaultProps} proposals={pendingProposals} />);
+    const header = screen.getByTestId("learn-proposals-header");
+    expect(header.textContent).toContain("Proposals");
+    expect(header.textContent).toContain("3");
+  });
+
+  it("lists every proposal, including create proposals with no concept row", () => {
+    render(<LearnSidebar {...defaultProps} proposals={pendingProposals} />);
+    const items = screen.getAllByTestId("learn-proposal-item");
+    expect(items).toHaveLength(3);
+    expect(items[0].textContent).toContain("Encryption Service");
+    expect(items[1].textContent).toContain("stakwork/hive/tasks");
+    expect(items[2].textContent).toContain(
+      "stakwork/hive/auth → stakwork/hive/tasks"
+    );
+  });
+
+  it("collapses and re-expands on header click", () => {
+    render(<LearnSidebar {...defaultProps} proposals={pendingProposals} />);
+    expect(screen.getAllByTestId("learn-proposal-item")).toHaveLength(3);
+    fireEvent.click(screen.getByTestId("learn-proposals-header"));
+    expect(screen.queryAllByTestId("learn-proposal-item")).toHaveLength(0);
+    fireEvent.click(screen.getByTestId("learn-proposals-header"));
+    expect(screen.getAllByTestId("learn-proposal-item")).toHaveLength(3);
+  });
+
+  it("clicking a proposal row calls onProposalClick with the proposal", () => {
+    const onProposalClick = vi.fn();
+    render(
+      <LearnSidebar
+        {...defaultProps}
+        proposals={pendingProposals}
+        onProposalClick={onProposalClick}
+      />
+    );
+    fireEvent.click(screen.getAllByTestId("learn-proposal-item")[1]);
+    expect(onProposalClick).toHaveBeenCalledWith(pendingProposals[1]);
+  });
+
+  it("marks concept rows on both sides of a merge, and not unflagged rows", () => {
+    render(
+      <LearnSidebar
+        {...defaultProps}
+        concepts={multiRepoConcepts}
+        proposals={pendingProposals}
+        pendingProposalConceptIds={
+          new Set(["stakwork/hive/auth", "stakwork/hive/tasks"])
+        }
+      />
+    );
+    const items = screen.getAllByTestId("learn-concept-item");
+    const flagged = items.filter(
+      (el) => el.querySelector('[data-testid="concept-pending-marker"]') !== null
+    );
+    expect(flagged.map((el) => el.textContent)).toEqual(["Auth", "Tasks"]);
+  });
+
+  it("highlights the active proposal row via activeItemKey", () => {
+    render(
+      <LearnSidebar
+        {...defaultProps}
+        proposals={pendingProposals}
+        activeItemKey="proposal-proposal-update-1"
+      />
+    );
+    const items = screen.getAllByTestId("learn-proposal-item");
+    expect(items[1].className).toContain("bg-muted/60");
+    expect(items[0].className).not.toContain("bg-muted/60");
   });
 });

--- a/src/__tests__/unit/types/concept-proposals.test.ts
+++ b/src/__tests__/unit/types/concept-proposals.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import {
+  derivePendingProposalConceptIds,
+  conceptProposalLabel,
+  type ConceptProposal,
+} from "@/types/concept-proposals";
+
+const base = {
+  rationale: "r",
+  source: "s",
+  prNumbers: [],
+  createdAt: "2025-08-01T00:00:00.000Z",
+  repo: "stakwork/hive",
+};
+
+const mixedProposals: ConceptProposal[] = [
+  {
+    ...base,
+    id: "p-create",
+    action: "create",
+    status: "pending",
+    name: "Encryption Service",
+  },
+  {
+    ...base,
+    id: "p-update",
+    action: "update",
+    status: "pending",
+    conceptId: "stakwork/hive/tasks",
+  },
+  {
+    ...base,
+    id: "p-delete",
+    action: "delete",
+    status: "pending",
+    conceptId: "stakwork/hive/janitors",
+  },
+  {
+    ...base,
+    id: "p-merge",
+    action: "merge",
+    status: "pending",
+    conceptId: "stakwork/hive/auth",
+    mergeIntoConceptId: "stakwork/hive/workspace",
+  },
+  {
+    ...base,
+    id: "p-decided",
+    action: "update",
+    status: "accepted",
+    conceptId: "stakwork/hive/swarm",
+  },
+];
+
+describe("derivePendingProposalConceptIds", () => {
+  it("flags update/delete targets and BOTH sides of a merge, skips create", () => {
+    const ids = derivePendingProposalConceptIds(mixedProposals);
+    expect(ids).toEqual(
+      new Set([
+        "stakwork/hive/tasks",
+        "stakwork/hive/janitors",
+        "stakwork/hive/auth",
+        "stakwork/hive/workspace",
+      ]),
+    );
+  });
+
+  it("ignores proposals that are no longer pending", () => {
+    const ids = derivePendingProposalConceptIds(mixedProposals);
+    expect(ids.has("stakwork/hive/swarm")).toBe(false);
+  });
+
+  it("returns an empty set for no proposals", () => {
+    expect(derivePendingProposalConceptIds([]).size).toBe(0);
+  });
+});
+
+describe("conceptProposalLabel", () => {
+  it("labels create proposals by name", () => {
+    expect(conceptProposalLabel(mixedProposals[0])).toBe("Encryption Service");
+  });
+
+  it("labels update/delete proposals by concept id", () => {
+    expect(conceptProposalLabel(mixedProposals[1])).toBe("stakwork/hive/tasks");
+    expect(conceptProposalLabel(mixedProposals[2])).toBe("stakwork/hive/janitors");
+  });
+
+  it("labels merges as absorbed → survivor", () => {
+    expect(conceptProposalLabel(mixedProposals[3])).toBe(
+      "stakwork/hive/auth → stakwork/hive/workspace",
+    );
+  });
+});

--- a/src/app/api/mock/stakgraph/gitree/proposals/fixtures.ts
+++ b/src/app/api/mock/stakgraph/gitree/proposals/fixtures.ts
@@ -14,55 +14,17 @@
  * must reset as a unit or tests become order-dependent.
  */
 
-export type ProposalAction = "create" | "update" | "delete" | "merge";
-export type ProposalStatus = "pending" | "accepted" | "rejected";
+import type {
+  ConceptProposal,
+  ProposalAction,
+  ProposalStatus,
+} from "@/types/concept-proposals";
 
-export interface MockProposal {
-  id: string;
-  action: ProposalAction;
-  status: ProposalStatus;
-  /** For update/delete/merge — the concept being changed or absorbed */
-  conceptId?: string;
-  /** For merge — the survivor concept that absorbs the deleted one */
-  mergeIntoConceptId?: string;
-  /** Proposed new name (create) */
-  name?: string;
-  /** Optional one-line description (create/update) */
-  description?: string;
-  /** Proposed documentation (create / update / merge result) */
-  documentation?: string;
-  /**
-   * Docs snapshot of the concept being EDITED, captured at proposal-creation
-   * time. For update/delete this is the target concept; for merge it is the
-   * SURVIVING concept (mergeIntoConceptId) — the stale_base check runs against
-   * the survivor, matching the real swarm.
-   */
-  baseDocs?: string;
-  /** Docs of the absorbed concept (merge only) */
-  absorbedDocs?: string;
-  /** Optional parent concept id (create only) */
-  parent?: string;
-  /** Human-readable rationale for the proposal */
-  rationale: string;
-  /** Source of the proposal (e.g. PR url or tool name) */
-  source: string;
-  /** Related PR numbers */
-  prNumbers: number[];
-  /** Agent sessions that motivated this proposal */
-  sessionIds?: string[];
-  /** Set to the new concept id on accepted create proposals */
-  createdConceptId?: string;
-  /** User id that accepted/rejected this proposal */
-  decidedBy?: string;
-  /** Optional rejection reason */
-  decisionReason?: string;
-  /** ISO timestamp of the decision */
-  decidedAt?: string;
-  /** ISO timestamp of proposal creation */
-  createdAt: string;
-  /** Repository this proposal belongs to */
-  repo: string;
-}
+// Canonical proposal types live in src/types/concept-proposals.ts (shared
+// with the /learn review UI). Re-exported here so the mock routes and their
+// tests keep importing from the fixtures module.
+export type { ProposalAction, ProposalStatus };
+export type MockProposal = ConceptProposal;
 
 /**
  * Current documentation for mock concepts (mirrors the concepts/[id] mock).

--- a/src/app/org/[githubLogin]/_components/ProposalCard.tsx
+++ b/src/app/org/[githubLogin]/_components/ProposalCard.tsx
@@ -12,6 +12,11 @@ import {
   Code2,
 } from "lucide-react";
 import { computeUnifiedDiff, type UnifiedDiff } from "@/lib/diff/unifiedLineDiff";
+import {
+  UnifiedDiffView,
+  ConceptDiffDialog,
+  SECTION_LABEL_CLASS,
+} from "@/components/diff/UnifiedDiffView";
 import { Switch } from "@/components/ui/switch";
 import ReactMarkdown from "react-markdown";
 import {
@@ -653,10 +658,6 @@ interface ProposalDetailsDialogProps {
   onOpenChange: (open: boolean) => void;
 }
 
-/** Section header style — consistent with "Features to attach" label in MilestoneMeta. */
-const SECTION_LABEL_CLASS =
-  "text-[10px] uppercase tracking-wide text-muted-foreground font-medium";
-
 function ProposalDetailsDialog({
   proposal,
   open,
@@ -1237,7 +1238,7 @@ function PromptDiffDialog({
         </DialogHeader>
 
         <ScrollArea className="max-h-[65vh] min-w-0">
-          <UnifiedDiffView diff={diff} />
+          <UnifiedDiffView diff={diff} emptyText="No prompt-text changes." />
         </ScrollArea>
         {promptId && (
           <div className="flex justify-start pt-1">
@@ -1253,50 +1254,6 @@ function PromptDiffDialog({
         )}
       </DialogContent>
     </Dialog>
-  );
-}
-
-/** Renders a {@link UnifiedDiff} as red/green rows with collapsed gaps. */
-function UnifiedDiffView({ diff }: { diff: UnifiedDiff }) {
-  if (diff.unchanged || diff.hunks.length === 0) {
-    return (
-      <div className="px-1 py-2 text-xs text-muted-foreground italic">
-        No prompt-text changes.
-      </div>
-    );
-  }
-  return (
-    <div className="overflow-hidden rounded border font-mono text-[11px] leading-relaxed">
-      {diff.hunks.map((hunk, hi) => (
-        <React.Fragment key={hi}>
-          {hunk.gapBefore > 0 && (
-            <div className="bg-muted/40 px-3 py-0.5 text-[10px] text-muted-foreground">
-              ⋯ {hunk.gapBefore} unchanged line{hunk.gapBefore === 1 ? "" : "s"}
-            </div>
-          )}
-          {hunk.rows.map((row, ri) => {
-            const sign =
-              row.type === "add" ? "+" : row.type === "del" ? "−" : " ";
-            const rowClass =
-              row.type === "add"
-                ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
-                : row.type === "del"
-                  ? "bg-rose-500/10 text-rose-700 dark:text-rose-300"
-                  : "text-muted-foreground";
-            return (
-              <div key={ri} className={`flex ${rowClass}`}>
-                <span className="w-4 flex-shrink-0 select-none px-1 text-center opacity-60">
-                  {sign}
-                </span>
-                <pre className="min-w-0 flex-1 whitespace-pre-wrap break-words py-0.5 pr-2">
-                  {row.text === "" ? " " : row.text}
-                </pre>
-              </div>
-            );
-          })}
-        </React.Fragment>
-      ))}
-    </div>
   );
 }
 
@@ -1382,44 +1339,6 @@ function ConceptUpdateMeta({
         </>
       )}
     </div>
-  );
-}
-
-/** Diff modal for a concept documentation update (mirrors PromptDiffDialog). */
-function ConceptDiffDialog({
-  open,
-  onOpenChange,
-  conceptName,
-  diff,
-}: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  conceptName?: string;
-  diff: UnifiedDiff;
-}) {
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-3xl">
-        <DialogHeader className="min-w-0">
-          <div className={SECTION_LABEL_CLASS}>Documentation changes</div>
-          <DialogTitle className="text-base min-w-0 break-words [overflow-wrap:anywhere]">
-            {conceptName ?? "Concept update"}
-          </DialogTitle>
-          <div className="mt-0.5 font-mono text-xs">
-            <span className="text-emerald-600 dark:text-emerald-400">
-              +{diff.added}
-            </span>{" "}
-            <span className="text-rose-600 dark:text-rose-400">
-              −{diff.removed}
-            </span>
-          </div>
-        </DialogHeader>
-
-        <ScrollArea className="max-h-[65vh] min-w-0">
-          <UnifiedDiffView diff={diff} />
-        </ScrollArea>
-      </DialogContent>
-    </Dialog>
   );
 }
 

--- a/src/app/w/[slug]/learn/components/ConceptProposalReviewCard.tsx
+++ b/src/app/w/[slug]/learn/components/ConceptProposalReviewCard.tsx
@@ -1,0 +1,443 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import { Check, X, Loader2, RefreshCw, AlertTriangle } from "lucide-react";
+import { toast } from "sonner";
+import { computeUnifiedDiff } from "@/lib/diff/unifiedLineDiff";
+import {
+  UnifiedDiffView,
+  SECTION_LABEL_CLASS,
+} from "@/components/diff/UnifiedDiffView";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { useWorkspaceAccess } from "@/hooks/useWorkspaceAccess";
+import {
+  conceptProposalLabel,
+  type ConceptProposal,
+  type ProposalStatus,
+} from "@/types/concept-proposals";
+
+/**
+ * Review surface for a single concept change proposal on /learn.
+ *
+ * Deliberately NOT the org-canvas ProposalCard — that component is coupled
+ * to the canvas chat store and applies decisions through chat messages.
+ * Here decisions go straight to the proposal proxy routes:
+ *   POST /api/learnings/concepts/proposals/[id]/accept?workspace=<slug>
+ *   POST /api/learnings/concepts/proposals/[id]/reject?workspace=<slug>
+ *
+ * 409 handling mirrors the swarm contract:
+ *   { code: "stale_base", conceptId } → concept drifted since the proposal
+ *     was filed; offer re-review against current docs and explicit force.
+ *   { status } → already decided elsewhere; terminal, no force.
+ *   404 → proposal or target gone; terminal, no force.
+ */
+
+const ACTION_LABEL: Record<ConceptProposal["action"], string> = {
+  create: "Create",
+  update: "Update",
+  delete: "Delete",
+  merge: "Merge",
+};
+
+type TerminalState =
+  | { kind: "decided"; status: ProposalStatus }
+  | { kind: "gone" };
+
+interface StaleBaseState {
+  conceptId: string;
+  /** Current docs of the drifted concept, once re-fetched (null = not yet). */
+  currentDocs: string | null;
+  isRefetching: boolean;
+}
+
+export interface ConceptProposalReviewCardProps {
+  proposal: ConceptProposal;
+  workspaceSlug: string;
+  /**
+   * A decision landed here (accepted/rejected). Parent should refresh
+   * proposals + concepts; `createdConceptId` is set when accepting a
+   * create proposal so the parent can open the new concept.
+   */
+  onDecided: (result: {
+    outcome: "accepted" | "rejected";
+    createdConceptId?: string;
+  }) => void;
+  /**
+   * The proposal turned out to be already decided or gone (409/404).
+   * Parent should refresh the proposals list; the card keeps showing
+   * its terminal banner.
+   */
+  onTerminal: () => void;
+}
+
+export function ConceptProposalReviewCard({
+  proposal,
+  workspaceSlug,
+  onDecided,
+  onTerminal,
+}: ConceptProposalReviewCardProps) {
+  // canWrite = DEVELOPER and above — same threshold the accept/reject
+  // proxy routes enforce server-side.
+  const { canWrite } = useWorkspaceAccess();
+
+  const [submitting, setSubmitting] = useState<"accept" | "reject" | null>(null);
+  const [staleBase, setStaleBase] = useState<StaleBaseState | null>(null);
+  const [terminal, setTerminal] = useState<TerminalState | null>(null);
+  const [isRejectOpen, setIsRejectOpen] = useState(false);
+  const [rejectReason, setRejectReason] = useState("");
+
+  const baseDocs = proposal.baseDocs ?? "";
+  const proposedDocs = proposal.documentation ?? "";
+
+  // Primary diff per action: update/merge propose new docs over the edited
+  // concept's snapshot; delete shows the docs fully removed; create has no
+  // base and renders the proposed docs verbatim instead of a diff.
+  const diff = useMemo(() => {
+    if (proposal.action === "create") return null;
+    if (proposal.action === "delete") return computeUnifiedDiff(baseDocs, "");
+    return computeUnifiedDiff(baseDocs, proposedDocs);
+  }, [proposal.action, baseDocs, proposedDocs]);
+
+  // Merge only: the absorbed concept's docs, shown as removed so the two
+  // sides of the merge aren't conflated in one diff.
+  const absorbedDiff = useMemo(
+    () =>
+      proposal.action === "merge"
+        ? computeUnifiedDiff(proposal.absorbedDocs ?? "", "")
+        : null,
+    [proposal.action, proposal.absorbedDocs],
+  );
+
+  // After a stale_base 409 + re-fetch: diff against the concept's CURRENT
+  // docs so the reviewer sees what force-accept would actually overwrite.
+  const currentDiff = useMemo(
+    () =>
+      staleBase?.currentDocs != null
+        ? computeUnifiedDiff(staleBase.currentDocs, proposedDocs)
+        : null,
+    [staleBase?.currentDocs, proposedDocs],
+  );
+
+  const decide = async (
+    kind: "accept" | "reject",
+    opts?: { force?: boolean },
+  ) => {
+    if (submitting) return;
+    setSubmitting(kind);
+    try {
+      const url = `/api/learnings/concepts/proposals/${encodeURIComponent(
+        proposal.id,
+      )}/${kind}?workspace=${encodeURIComponent(workspaceSlug)}`;
+      const body =
+        kind === "accept"
+          ? opts?.force
+            ? { force: true }
+            : {}
+          : rejectReason.trim()
+            ? { reason: rejectReason.trim() }
+            : {};
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const data = await response.json().catch(() => ({}));
+
+      if (response.ok) {
+        toast.success(
+          kind === "accept" ? "Proposal accepted" : "Proposal rejected",
+        );
+        onDecided({
+          outcome: kind === "accept" ? "accepted" : "rejected",
+          createdConceptId:
+            kind === "accept" && proposal.action === "create"
+              ? (data?.proposal?.createdConceptId ?? undefined)
+              : undefined,
+        });
+        return;
+      }
+
+      if (response.status === 409 && data?.code === "stale_base") {
+        setStaleBase({
+          conceptId: data.conceptId ?? proposal.conceptId ?? "",
+          currentDocs: null,
+          isRefetching: false,
+        });
+        return;
+      }
+
+      if (response.status === 409 && data?.status) {
+        setTerminal({ kind: "decided", status: data.status });
+        onTerminal();
+        return;
+      }
+
+      if (response.status === 404) {
+        setTerminal({ kind: "gone" });
+        onTerminal();
+        return;
+      }
+
+      toast.error(data?.error ?? `Failed to ${kind} proposal`);
+    } catch (error) {
+      console.error(`Failed to ${kind} proposal:`, error);
+      toast.error(`Failed to ${kind} proposal`);
+    } finally {
+      setSubmitting(null);
+    }
+  };
+
+  const refetchCurrentDocs = async () => {
+    if (!staleBase || staleBase.isRefetching) return;
+    setStaleBase({ ...staleBase, isRefetching: true });
+    try {
+      const response = await fetch(
+        `/api/learnings/concepts/${encodeURIComponent(
+          staleBase.conceptId,
+        )}?workspace=${encodeURIComponent(workspaceSlug)}`,
+      );
+      if (!response.ok) throw new Error(`status ${response.status}`);
+      const data = await response.json();
+      const documentation =
+        data?.concept?.documentation ?? data?.feature?.documentation ?? "";
+      setStaleBase({
+        conceptId: staleBase.conceptId,
+        currentDocs: documentation,
+        isRefetching: false,
+      });
+    } catch (error) {
+      console.error("Failed to re-fetch concept docs:", error);
+      toast.error("Failed to load the concept's current documentation");
+      setStaleBase({ ...staleBase, isRefetching: false });
+    }
+  };
+
+  const isBusy = submitting !== null;
+
+  return (
+    <div
+      className="mx-auto max-w-3xl p-6 space-y-4"
+      data-testid="proposal-review-card"
+    >
+      {/* Header */}
+      <div className="space-y-1">
+        <div className="flex items-center gap-2">
+          <Badge variant="secondary" data-testid="proposal-action-badge">
+            {ACTION_LABEL[proposal.action]}
+          </Badge>
+          <h2 className="text-lg font-semibold break-words [overflow-wrap:anywhere]">
+            {conceptProposalLabel(proposal)}
+          </h2>
+        </div>
+        {proposal.description && (
+          <p className="text-sm text-muted-foreground">{proposal.description}</p>
+        )}
+      </div>
+
+      {/* Metadata */}
+      <div className="space-y-2 rounded-md border p-3">
+        <div>
+          <div className={SECTION_LABEL_CLASS}>Rationale</div>
+          <p className="text-sm">{proposal.rationale}</p>
+        </div>
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+          <span>
+            <span className={SECTION_LABEL_CLASS}>Source&nbsp;</span>
+            {/^https?:\/\//.test(proposal.source) ? (
+              <a
+                href={proposal.source}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline hover:text-foreground"
+              >
+                {proposal.source}
+              </a>
+            ) : (
+              proposal.source
+            )}
+          </span>
+          {proposal.prNumbers.length > 0 && (
+            <span data-testid="proposal-pr-numbers">
+              <span className={SECTION_LABEL_CLASS}>PRs&nbsp;</span>
+              {proposal.prNumbers.map((n) => `#${n}`).join(", ")}
+            </span>
+          )}
+          <span className="font-mono">{proposal.repo}</span>
+        </div>
+      </div>
+
+      {/* Terminal state: decided elsewhere or gone. */}
+      {terminal && (
+        <div
+          className="rounded-md border border-muted bg-muted/30 p-3 text-sm"
+          data-testid="proposal-terminal-state"
+        >
+          {terminal.kind === "decided"
+            ? `This proposal was already ${terminal.status}.`
+            : "This proposal no longer exists — it may have been decided or its concept removed."}
+        </div>
+      )}
+
+      {/* Stale base: concept drifted since the proposal was filed. */}
+      {!terminal && staleBase && (
+        <div
+          className="space-y-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-3"
+          data-testid="proposal-stale-banner"
+        >
+          <div className="flex items-start gap-2 text-sm">
+            <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-600 dark:text-amber-400" />
+            <span>
+              <span className="font-mono">{staleBase.conceptId}</span> has
+              changed since this was proposed — re-review before accepting.
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={refetchCurrentDocs}
+              disabled={staleBase.isRefetching || isBusy}
+              data-testid="proposal-stale-refetch"
+            >
+              {staleBase.isRefetching ? (
+                <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+              ) : (
+                <RefreshCw className="mr-1 h-3 w-3" />
+              )}
+              Compare with current docs
+            </Button>
+            {canWrite && (
+              <Button
+                size="sm"
+                variant="destructive"
+                onClick={() => decide("accept", { force: true })}
+                disabled={isBusy}
+                data-testid="proposal-force-accept-button"
+              >
+                {submitting === "accept" && (
+                  <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                )}
+                Accept anyway
+              </Button>
+            )}
+          </div>
+          {currentDiff && (
+            <div className="space-y-1" data-testid="proposal-current-diff">
+              <div className={SECTION_LABEL_CLASS}>
+                Proposed change vs current documentation
+              </div>
+              <UnifiedDiffView
+                diff={currentDiff}
+                emptyText="The concept's current documentation already matches this proposal."
+              />
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Proposal body per action */}
+      {proposal.action === "create" ? (
+        <div className="space-y-1">
+          <div className={SECTION_LABEL_CLASS}>Proposed documentation</div>
+          <pre
+            className="whitespace-pre-wrap break-words rounded border bg-muted/20 p-3 font-mono text-[11px] leading-relaxed"
+            data-testid="proposal-create-docs"
+          >
+            {proposedDocs}
+          </pre>
+        </div>
+      ) : (
+        diff && (
+          <div className="space-y-1" data-testid="proposal-diff">
+            <div className={SECTION_LABEL_CLASS}>
+              {proposal.action === "delete"
+                ? "Documentation to remove"
+                : proposal.action === "merge"
+                  ? `Surviving concept — ${proposal.mergeIntoConceptId}`
+                  : `Documentation change — ${proposal.conceptId}`}
+            </div>
+            <UnifiedDiffView diff={diff} emptyText="No documentation change." />
+          </div>
+        )
+      )}
+
+      {absorbedDiff && (
+        <div className="space-y-1" data-testid="proposal-absorbed-docs">
+          <div className={SECTION_LABEL_CLASS}>
+            Absorbed concept (removed) — {proposal.conceptId}
+          </div>
+          <UnifiedDiffView
+            diff={absorbedDiff}
+            emptyText="The absorbed concept has no documentation."
+          />
+        </div>
+      )}
+
+      {/* Decision controls */}
+      {!terminal &&
+        (canWrite ? (
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              {!staleBase && (
+                <Button
+                  size="sm"
+                  onClick={() => decide("accept")}
+                  disabled={isBusy}
+                  data-testid="proposal-accept-button"
+                >
+                  {submitting === "accept" ? (
+                    <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                  ) : (
+                    <Check className="mr-1 h-3 w-3" />
+                  )}
+                  Accept
+                </Button>
+              )}
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setIsRejectOpen((open) => !open)}
+                disabled={isBusy}
+                data-testid="proposal-reject-button"
+              >
+                <X className="mr-1 h-3 w-3" />
+                Reject
+              </Button>
+            </div>
+            {isRejectOpen && (
+              <div className="space-y-2">
+                <Textarea
+                  value={rejectReason}
+                  onChange={(e) => setRejectReason(e.target.value)}
+                  placeholder="Reason (optional)"
+                  className="min-h-16 text-sm"
+                  data-testid="proposal-reject-reason"
+                />
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  onClick={() => decide("reject")}
+                  disabled={isBusy}
+                  data-testid="proposal-reject-confirm"
+                >
+                  {submitting === "reject" && (
+                    <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                  )}
+                  Confirm reject
+                </Button>
+              </div>
+            )}
+          </div>
+        ) : (
+          <p
+            className="text-xs text-muted-foreground"
+            data-testid="proposal-readonly-note"
+          >
+            Reviewing proposals requires developer access.
+          </p>
+        ))}
+    </div>
+  );
+}

--- a/src/app/w/[slug]/learn/components/LearnSidebar.tsx
+++ b/src/app/w/[slug]/learn/components/LearnSidebar.tsx
@@ -6,6 +6,7 @@ import {
   BookOpen,
   Lightbulb,
   GitBranch,
+  GitPullRequest,
   Plus,
   Pencil,
   RefreshCw,
@@ -39,6 +40,10 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { toast } from "sonner";
+import {
+  conceptProposalLabel,
+  type ConceptProposal,
+} from "@/types/concept-proposals";
 
 interface Doc {
   repoName: string;
@@ -80,7 +85,15 @@ interface LearnSidebarProps {
   isDocsLoading: boolean;
   isConceptsLoading: boolean;
   isDiagramsLoading: boolean;
+  /** Pending concept change proposals (member-only; empty for public viewers). */
+  proposals?: ConceptProposal[];
+  /** Concept ids that should carry a pending-proposal marker. */
+  pendingProposalConceptIds?: Set<string>;
+  onProposalClick?: (proposal: ConceptProposal) => void;
+  isProposalsLoading?: boolean;
 }
+
+const EMPTY_CONCEPT_ID_SET: Set<string> = new Set();
 
 function getRepoFromConceptId(id: string): string {
   const parts = id.split("/");
@@ -102,6 +115,10 @@ export function LearnSidebar({
   isDocsLoading,
   isConceptsLoading,
   isDiagramsLoading,
+  proposals = [],
+  pendingProposalConceptIds = EMPTY_CONCEPT_ID_SET,
+  onProposalClick,
+  isProposalsLoading = false,
 }: LearnSidebarProps) {
   const { timezone } = useUserTimezone();
   const { workspace, isPublicViewer } = useWorkspace();
@@ -110,6 +127,7 @@ export function LearnSidebar({
   const [isDocsExpanded, setIsDocsExpanded] = useState(true);
   const [isConceptsExpanded, setIsConceptsExpanded] = useState(true);
   const [isDiagramsExpanded, setIsDiagramsExpanded] = useState(true);
+  const [isProposalsExpanded, setIsProposalsExpanded] = useState(true);
   const [expandedRepoGroups, setExpandedRepoGroups] = useState<Record<string, boolean>>({});
 
   // Process Repository state
@@ -679,13 +697,20 @@ export function LearnSidebar({
                                           onConceptClick(concept.id, concept.name, concept.content || "")
                                         }
                                         className={cn(
-                                          "w-full text-left p-2 rounded-md text-sm transition-colors",
+                                          "w-full text-left p-2 rounded-md text-sm transition-colors flex items-center justify-between gap-2",
                                           isActive
                                             ? "bg-muted/60 font-medium"
                                             : "bg-muted/30 hover:bg-muted/50"
                                         )}
                                       >
-                                        {concept.name}
+                                        <span className="truncate">{concept.name}</span>
+                                        {pendingProposalConceptIds.has(concept.id) && (
+                                          <span
+                                            data-testid="concept-pending-marker"
+                                            title="Pending proposal"
+                                            className="h-2 w-2 flex-shrink-0 rounded-full bg-amber-500"
+                                          />
+                                        )}
                                       </button>
                                     );
                                   })}
@@ -702,6 +727,84 @@ export function LearnSidebar({
             )}
           </AnimatePresence>
         </div>
+
+        {/* Proposals Section — pending concept change proposals awaiting review.
+            Hidden entirely when there's nothing pending (public viewers never
+            receive proposals, so it's hidden for them too). */}
+        {(isProposalsLoading || proposals.length > 0) && (
+          <div data-testid="learn-proposals-section">
+            <Button
+              variant="ghost"
+              className="w-full justify-between p-2 h-auto"
+              onClick={() => setIsProposalsExpanded(!isProposalsExpanded)}
+              data-testid="learn-proposals-header"
+            >
+              <div className="flex items-center gap-2">
+                <GitPullRequest className="h-4 w-4" />
+                <span className="font-medium">Proposals</span>
+                <Badge variant="secondary" className="ml-1">
+                  {proposals.length}
+                </Badge>
+              </div>
+              <ChevronDown
+                className={cn(
+                  "h-4 w-4 transition-transform",
+                  isProposalsExpanded && "rotate-180"
+                )}
+              />
+            </Button>
+
+            <AnimatePresence>
+              {isProposalsExpanded && (
+                <motion.div
+                  initial={{ height: 0, opacity: 0 }}
+                  animate={{ height: "auto", opacity: 1 }}
+                  exit={{ height: 0, opacity: 0 }}
+                  transition={{ duration: 0.2 }}
+                  className="overflow-hidden"
+                >
+                  <div className="mt-2 space-y-1">
+                    {isProposalsLoading ? (
+                      <div className="space-y-2 p-2">
+                        {[1, 2, 3].map((i) => (
+                          <div key={i} className="h-8 bg-muted/30 rounded animate-pulse" />
+                        ))}
+                      </div>
+                    ) : (
+                      proposals.map((proposal) => {
+                        const itemKey = `proposal-${proposal.id}`;
+                        const isActive = activeItemKey === itemKey;
+                        return (
+                          <button
+                            key={proposal.id}
+                            data-testid="learn-proposal-item"
+                            onClick={() => onProposalClick?.(proposal)}
+                            className={cn(
+                              "w-full text-left p-2 rounded-md text-sm transition-colors flex items-center gap-2",
+                              isActive
+                                ? "bg-muted/60 font-medium"
+                                : "bg-muted/30 hover:bg-muted/50"
+                            )}
+                          >
+                            <Badge
+                              variant="outline"
+                              className="flex-shrink-0 text-[10px] uppercase"
+                            >
+                              {proposal.action}
+                            </Badge>
+                            <span className="truncate">
+                              {conceptProposalLabel(proposal)}
+                            </span>
+                          </button>
+                        );
+                      })
+                    )}
+                  </div>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
+        )}
       </div>
 
       {/* Process Repository Section - pinned to bottom (hidden for public viewers; the underlying actions require write access) */}

--- a/src/app/w/[slug]/learn/components/LearnViewer.tsx
+++ b/src/app/w/[slug]/learn/components/LearnViewer.tsx
@@ -1,12 +1,17 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { LearnSidebar } from "./LearnSidebar";
 import { LearnDocViewer } from "./LearnDocViewer";
 import { DiagramViewer } from "./DiagramViewer";
 import { CreateDiagramModal } from "./CreateDiagramModal";
+import { ConceptProposalReviewCard } from "./ConceptProposalReviewCard";
+import {
+  derivePendingProposalConceptIds,
+  type ConceptProposal,
+} from "@/types/concept-proposals";
 import { toast } from "sonner";
 
 interface Doc {
@@ -51,15 +56,21 @@ export function LearnViewer({ workspaceSlug }: LearnViewerProps) {
   const [docs, setDocs] = useState<Doc[]>([]);
   const [concepts, setConcepts] = useState<Concept[]>([]);
   const [diagrams, setDiagrams] = useState<Diagram[]>([]);
+  const [proposals, setProposals] = useState<ConceptProposal[]>([]);
   const [activeItem, setActiveItem] = useState<ActiveItem | null>(null);
+  const [selectedProposal, setSelectedProposal] = useState<ConceptProposal | null>(null);
   const [isDocsLoading, setIsDocsLoading] = useState(true);
   const [isConceptsLoading, setIsConceptsLoading] = useState(true);
   const [isDiagramsLoading, setIsDiagramsLoading] = useState(true);
+  const [isProposalsLoading, setIsProposalsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
   const [isCreateDiagramOpen, setIsCreateDiagramOpen] = useState(false);
   const [editingDiagram, setEditingDiagram] = useState<Diagram | null>(null);
 
-  const setUrlParam = (key: "doc" | "concept" | "diagram", value: string) => {
+  const setUrlParam = (
+    key: "doc" | "concept" | "diagram" | "proposal",
+    value: string
+  ) => {
     const p = new URLSearchParams();
     p.set(key, encodeURIComponent(value));
     router.replace(`${pathname}?${p.toString()}`, { scroll: false });
@@ -81,6 +92,36 @@ export function LearnViewer({ workspaceSlug }: LearnViewerProps) {
     }
     return [];
   };
+
+  const refreshProposals = async () => {
+    if (isPublicViewer) return;
+    try {
+      const response = await fetch(
+        `/api/learnings/concepts/proposals?workspace=${encodeURIComponent(workspaceSlug)}&status=pending`
+      );
+      if (response.ok) {
+        const data = await response.json();
+        setProposals(Array.isArray(data?.proposals) ? data.proposals : []);
+      }
+    } catch (error) {
+      console.error("Failed to fetch proposals:", error);
+    } finally {
+      setIsProposalsLoading(false);
+    }
+  };
+
+  // Proposals are member-only (the proxy rejects public viewers), so don't
+  // even fetch for them — just resolve the loading flag.
+  useEffect(() => {
+    if (isPublicViewer) {
+      setProposals([]);
+      setIsProposalsLoading(false);
+      return;
+    }
+    setIsProposalsLoading(true);
+    refreshProposals();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspaceSlug, isPublicViewer]);
 
   useEffect(() => {
     async function fetchData() {
@@ -151,13 +192,19 @@ export function LearnViewer({ workspaceSlug }: LearnViewerProps) {
 
   // Restore active item from URL params once all data has loaded
   useEffect(() => {
-    if (isDocsLoading || isConceptsLoading || isDiagramsLoading) return;
+    if (isDocsLoading || isConceptsLoading || isDiagramsLoading || isProposalsLoading)
+      return;
 
     const docParam = searchParams.get("doc");
     const conceptParam = searchParams.get("concept");
     const diagramParam = searchParams.get("diagram");
+    const proposalParam = searchParams.get("proposal");
 
-    if (docParam) {
+    if (proposalParam) {
+      const id = decodeURIComponent(proposalParam);
+      const match = proposals.find((p) => p.id === id);
+      if (match) setSelectedProposal(match);
+    } else if (docParam) {
       const repoName = decodeURIComponent(docParam);
       const match = docs.find((d) => d.repoName === repoName);
       if (match) {
@@ -177,7 +224,7 @@ export function LearnViewer({ workspaceSlug }: LearnViewerProps) {
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isDocsLoading, isConceptsLoading, isDiagramsLoading]);
+  }, [isDocsLoading, isConceptsLoading, isDiagramsLoading, isProposalsLoading]);
 
   const refreshConcepts = async () => {
     try {
@@ -194,6 +241,7 @@ export function LearnViewer({ workspaceSlug }: LearnViewerProps) {
   };
 
   const handleDocClick = (repoName: string, content: string) => {
+    setSelectedProposal(null);
     setActiveItem({
       type: "doc",
       repoName,
@@ -205,6 +253,7 @@ export function LearnViewer({ workspaceSlug }: LearnViewerProps) {
 
   const handleConceptClick = async (id: string, name: string, content: string) => {
     const cachedDescription = concepts.find((c) => c.id === id)?.description ?? null;
+    setSelectedProposal(null);
     setActiveItem({ type: "concept", id, name, content, description: cachedDescription });
     setUrlParam("concept", id);
 
@@ -235,8 +284,44 @@ export function LearnViewer({ workspaceSlug }: LearnViewerProps) {
     body: string,
     description?: string | null
   ) => {
+    setSelectedProposal(null);
     setActiveItem({ type: "diagram", id, name, content: "", body, description });
     setUrlParam("diagram", id);
+  };
+
+  const handleProposalClick = (proposal: ConceptProposal) => {
+    setSelectedProposal(proposal);
+    setUrlParam("proposal", proposal.id);
+  };
+
+  const handleProposalDecided = async (result: {
+    outcome: "accepted" | "rejected";
+    createdConceptId?: string;
+  }) => {
+    const proposalName = selectedProposal?.name;
+    setSelectedProposal(null);
+    await Promise.all([refreshProposals(), refreshConcepts()]);
+    if (result.createdConceptId) {
+      // Select the new concept directly — the URL-restore effect only runs
+      // on initial load, so navigating to ?concept= alone wouldn't do it.
+      handleConceptClick(
+        result.createdConceptId,
+        proposalName ?? result.createdConceptId,
+        ""
+      );
+    } else if (activeItem?.type === "doc" && activeItem.repoName) {
+      setUrlParam("doc", activeItem.repoName);
+    } else if (activeItem && activeItem.type !== "doc" && activeItem.id) {
+      setUrlParam(activeItem.type, activeItem.id);
+    } else {
+      router.replace(pathname, { scroll: false });
+    }
+  };
+
+  // The proposal turned out to be already decided (or gone): keep the card's
+  // terminal banner on screen, just refresh the pending list and markers.
+  const handleProposalTerminal = () => {
+    refreshProposals();
   };
 
   const handleDiagramCreated = async () => {
@@ -316,17 +401,31 @@ export function LearnViewer({ workspaceSlug }: LearnViewerProps) {
   };
 
   const getActiveItemKey = () => {
+    if (selectedProposal) return `proposal-${selectedProposal.id}`;
     if (!activeItem) return null;
     if (activeItem.type === "doc") return `doc-${activeItem.repoName}`;
     if (activeItem.type === "concept") return `concept-${activeItem.id}`;
     return `diagram-${activeItem.id}`;
   };
 
+  const pendingProposalConceptIds = useMemo(
+    () => derivePendingProposalConceptIds(proposals),
+    [proposals]
+  );
+
   return (
     <div className="flex h-full w-full">
       {/* Main content area */}
       <div className="flex-1 pr-80">
-        {activeItem?.type === "diagram" ? (
+        {selectedProposal ? (
+          <ConceptProposalReviewCard
+            key={selectedProposal.id}
+            proposal={selectedProposal}
+            workspaceSlug={workspaceSlug}
+            onDecided={handleProposalDecided}
+            onTerminal={handleProposalTerminal}
+          />
+        ) : activeItem?.type === "diagram" ? (
           <DiagramViewer
             name={activeItem.name}
             body={activeItem.body ?? ""}
@@ -358,6 +457,10 @@ export function LearnViewer({ workspaceSlug }: LearnViewerProps) {
         isDocsLoading={isDocsLoading}
         isConceptsLoading={isConceptsLoading}
         isDiagramsLoading={isDiagramsLoading}
+        proposals={proposals}
+        pendingProposalConceptIds={pendingProposalConceptIds}
+        onProposalClick={handleProposalClick}
+        isProposalsLoading={isProposalsLoading}
       />
 
       <CreateDiagramModal

--- a/src/components/diff/UnifiedDiffView.tsx
+++ b/src/components/diff/UnifiedDiffView.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import React from "react";
+import { type UnifiedDiff } from "@/lib/diff/unifiedLineDiff";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
+
+/** Section header style — consistent with "Features to attach" label in MilestoneMeta. */
+export const SECTION_LABEL_CLASS =
+  "text-[10px] uppercase tracking-wide text-muted-foreground font-medium";
+
+/** Renders a {@link UnifiedDiff} as red/green rows with collapsed gaps. */
+export function UnifiedDiffView({
+  diff,
+  emptyText = "No changes.",
+}: {
+  diff: UnifiedDiff;
+  emptyText?: string;
+}) {
+  if (diff.unchanged || diff.hunks.length === 0) {
+    return (
+      <div className="px-1 py-2 text-xs text-muted-foreground italic">
+        {emptyText}
+      </div>
+    );
+  }
+  return (
+    <div className="overflow-hidden rounded border font-mono text-[11px] leading-relaxed">
+      {diff.hunks.map((hunk, hi) => (
+        <React.Fragment key={hi}>
+          {hunk.gapBefore > 0 && (
+            <div className="bg-muted/40 px-3 py-0.5 text-[10px] text-muted-foreground">
+              ⋯ {hunk.gapBefore} unchanged line{hunk.gapBefore === 1 ? "" : "s"}
+            </div>
+          )}
+          {hunk.rows.map((row, ri) => {
+            const sign =
+              row.type === "add" ? "+" : row.type === "del" ? "−" : " ";
+            const rowClass =
+              row.type === "add"
+                ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+                : row.type === "del"
+                  ? "bg-rose-500/10 text-rose-700 dark:text-rose-300"
+                  : "text-muted-foreground";
+            return (
+              <div key={ri} className={`flex ${rowClass}`}>
+                <span className="w-4 flex-shrink-0 select-none px-1 text-center opacity-60">
+                  {sign}
+                </span>
+                <pre className="min-w-0 flex-1 whitespace-pre-wrap break-words py-0.5 pr-2">
+                  {row.text === "" ? " " : row.text}
+                </pre>
+              </div>
+            );
+          })}
+        </React.Fragment>
+      ))}
+    </div>
+  );
+}
+
+/** Diff modal for a concept documentation update (mirrors PromptDiffDialog). */
+export function ConceptDiffDialog({
+  open,
+  onOpenChange,
+  conceptName,
+  diff,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  conceptName?: string;
+  diff: UnifiedDiff;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-3xl">
+        <DialogHeader className="min-w-0">
+          <div className={SECTION_LABEL_CLASS}>Documentation changes</div>
+          <DialogTitle className="text-base min-w-0 break-words [overflow-wrap:anywhere]">
+            {conceptName ?? "Concept update"}
+          </DialogTitle>
+          <div className="mt-0.5 font-mono text-xs">
+            <span className="text-emerald-600 dark:text-emerald-400">
+              +{diff.added}
+            </span>{" "}
+            <span className="text-rose-600 dark:text-rose-400">
+              −{diff.removed}
+            </span>
+          </div>
+        </DialogHeader>
+
+        <ScrollArea className="max-h-[65vh] min-w-0">
+          <UnifiedDiffView diff={diff} />
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/types/concept-proposals.ts
+++ b/src/types/concept-proposals.ts
@@ -1,0 +1,101 @@
+/**
+ * Concept change proposal types — the contract of the swarm's
+ * /gitree/proposals API as proxied by /api/learnings/concepts/proposals.
+ *
+ * Shared by the /learn review UI, the graph-chat proposal chips, and the
+ * mock stakgraph fixtures (the mocks import these so the mock world and
+ * the UI can never drift apart).
+ *
+ * NOT the same thing as the canvas `ProposalOutput` union in
+ * src/lib/proposals/types.ts — that is the older chat-metadata pipeline
+ * (direct-apply on approve, no delete/merge, no stale_base handling).
+ */
+
+export type ProposalAction = "create" | "update" | "delete" | "merge";
+export type ProposalStatus = "pending" | "accepted" | "rejected";
+
+export interface ConceptProposal {
+  id: string;
+  action: ProposalAction;
+  status: ProposalStatus;
+  /** For update/delete/merge — the concept being changed or absorbed */
+  conceptId?: string;
+  /** For merge — the survivor concept that absorbs the deleted one */
+  mergeIntoConceptId?: string;
+  /** Proposed new name (create) */
+  name?: string;
+  /** Optional one-line description (create/update) */
+  description?: string;
+  /** Proposed documentation (create / update / merge result) */
+  documentation?: string;
+  /**
+   * Docs snapshot of the concept being EDITED, captured at proposal-creation
+   * time. For update/delete this is the target concept; for merge it is the
+   * SURVIVING concept (mergeIntoConceptId) — the stale_base check runs against
+   * the survivor.
+   */
+  baseDocs?: string;
+  /** Docs of the absorbed concept (merge only) */
+  absorbedDocs?: string;
+  /** Optional parent concept id (create only) */
+  parent?: string;
+  /** Human-readable rationale for the proposal */
+  rationale: string;
+  /** Source of the proposal (e.g. PR url or tool name) */
+  source: string;
+  /** Related PR numbers */
+  prNumbers: number[];
+  /** Agent sessions that motivated this proposal */
+  sessionIds?: string[];
+  /** Set to the new concept id on accepted create proposals */
+  createdConceptId?: string;
+  /** User id that accepted/rejected this proposal */
+  decidedBy?: string;
+  /** Optional rejection reason */
+  decisionReason?: string;
+  /** ISO timestamp of the decision */
+  decidedAt?: string;
+  /** ISO timestamp of proposal creation */
+  createdAt: string;
+  /** Repository this proposal belongs to */
+  repo: string;
+}
+
+/** Response shape of GET /api/learnings/concepts/proposals */
+export interface ConceptProposalListResponse {
+  proposals: ConceptProposal[];
+  count: number;
+  repo: string;
+}
+
+/**
+ * Concept ids that should carry a pending-proposal marker in the UI:
+ * the target concept for update/delete, and BOTH sides of a merge
+ * (the absorbed concept and the survivor). Create proposals have no
+ * existing concept to flag.
+ */
+export function derivePendingProposalConceptIds(
+  proposals: ConceptProposal[],
+): Set<string> {
+  const ids = new Set<string>();
+  for (const proposal of proposals) {
+    if (proposal.status !== "pending") continue;
+    if (proposal.conceptId) ids.add(proposal.conceptId);
+    if (proposal.action === "merge" && proposal.mergeIntoConceptId) {
+      ids.add(proposal.mergeIntoConceptId);
+    }
+  }
+  return ids;
+}
+
+/** Short human label for a proposal row (sidebar list, chips). */
+export function conceptProposalLabel(proposal: ConceptProposal): string {
+  switch (proposal.action) {
+    case "create":
+      return proposal.name ?? "New concept";
+    case "merge":
+      return `${proposal.conceptId ?? "?"} → ${proposal.mergeIntoConceptId ?? "?"}`;
+    default:
+      return proposal.conceptId ?? proposal.id;
+  }
+}


### PR DESCRIPTION
## What

Builds the review surface for concept change proposals on `/w/[slug]/learn`, on top of the proxy routes and stateful mocks added in #5019.

- **Shared types** — `ProposalAction`/`ProposalStatus`/`ConceptProposal` promoted from the mock fixtures into `src/types/concept-proposals.ts` (the mocks import them, so mock world and UI can't drift), plus `derivePendingProposalConceptIds()` which flags update/delete targets and **both** sides of a merge, and `conceptProposalLabel()`.
- **Shared diff renderer** — `UnifiedDiffView`, `ConceptDiffDialog`, and `SECTION_LABEL_CLASS` extracted out of the org-canvas `ProposalCard.tsx` into `src/components/diff/UnifiedDiffView.tsx`. The empty-state message is now a prop (the org card passes "No prompt-text changes."). No fork — both surfaces import the same renderer.
- **`ConceptProposalReviewCard`** (new, purpose-built — the org ProposalCard is coupled to canvas chat):
  - `update`: diff `baseDocs` → `documentation`; `merge`: survivor diff plus the absorbed concept's docs shown separately; `delete`: docs shown fully removed; `create`: name + proposed docs verbatim.
  - Accept/Reject call the proxy routes directly with the required `?workspace=` param; reject supports an optional reason.
  - 409 `{ code: "stale_base" }`: re-review banner with a "Compare with current docs" re-fetch (diffs the proposal against the concept's *current* docs) and an explicit force-accept (`force: true`). Accept is hidden while stale.
  - 409 `{ status }` (already decided) and 404: distinct terminal banners, proposals list refreshed, no force-accept offered.
  - Decision buttons gated on `canWrite` (DEVELOPER+), matching the server-side gate.
- **`LearnViewer`** — member-only proposals fetch (public viewers never hit the member-only proxy), `?proposal={id}` deep-link support in the URL-restore effect (the contract the graph-chat effort links to), and on a successful create-accept the new concept is selected directly via `handleConceptClick` (the restore effect only runs on initial load, so URL navigation alone wouldn't select it).
- **`LearnSidebar`** — pending-proposal marker dots on flagged concept rows, and a collapsible Proposals section (count badge, per-row action badge, `absorbed → survivor` merge labels) copying the existing Docs/Diagrams/Concepts section pattern. New props are optional; the section hides when nothing is pending, which also covers public viewers.

## Why

Proposals filed by agents (and soon by graph-chat sessions) need a human review queue. Deciding lives here on /learn; the parallel graph-chat work renders read-only chips that deep-link to this UI via `?proposal=`.

## Tests

28 new tests; all affected suites green (166 tests across the six touched suites). Full `npm run test:unit` matches master exactly plus the new tests — the 27 failing files are pre-existing Prisma-env collection errors, identical on master.

- `ConceptProposalReviewCard`: per-action rendering, accept/reject request shapes, stale_base re-review + force-accept, already-decided/404 terminal states, role gating.
- `LearnSidebar`: section render/hide, count badge, expand/collapse, item click, markers on both sides of a merge, active-row highlight.
- Type helpers: derivation from a mixed create/update/delete/merge fixture, non-pending exclusion, labels.
- `ProposalCard.test.tsx` + `repo-selector` suites still pass after the extraction.

## Notes for review

- For `delete` proposals the diff lib counts the empty "after" text as one blank added line, so the stat reads `+1/−N` — cosmetic, asserted in the test.
- Not exercised in a browser against `USE_MOCKS` yet; the mock endpoints from #5019 (including the intentionally-stale `proposal-stale-1`) make that flow walkable if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)