### PR TITLE
Add Graph Agent Chat: sidebar chat over repo/agent graph mode with concept proposal chips

### DIFF
--- a/docs/plans/graph-agent-chat.md
+++ b/docs/plans/graph-agent-chat.md
@@ -1,0 +1,170 @@
+# Graph Agent Chat
+
+Chat with a swarm `repo/agent` (in `mode: "graph"`) from the Graph Explorer page (`/w/[slug]/context/graph`), using the existing `AgentRun` table + webhook fan-back. Optionally let the agent file Concept change proposals (`propose_concept_change`), surfaced in the chat as read-only cards that deep-link to the review UI on `/learn`.
+
+## Goals
+
+- **Chat button** on the graph page opens a right sidebar with past chat threads and a thread view.
+- **New button** opens a modal: a prompt textarea plus a **"Allow concept change proposals" checkbox** decided at chat creation. The checkbox is a per-thread setting — it controls whether `propose_concept_change` / `list_concept_proposals` are enabled in the agent's `toolsConfig` for every message in that thread.
+- Each message is a one-shot `POST /repo/agent` dispatch with a `webhookUrl`; the terminal result lands via webhook, is stored on the `AgentRun` row, and a Pusher nudge refreshes the UI.
+- When a completed run filed proposals, show compact proposal cards (action badge, concept, rationale, read-only diff) linking to `/w/{slug}/learn` for review. **No approve/reject in this surface** — deciding lives on `/learn` (separate work in progress; see [Coordination](#coordination-with-the-learn-proposals-ui)).
+
+## Why this shape
+
+- `repo/agent` already supports everything server-side: `mode: "graph"` is a declared param (`parseAgentBody`, stakgraph `mcp/src/repo/index.ts:159`), `webhookUrl` gets a terminal POST of `{ request_id, status: "completed", result }` / `{ ..., status: "failed", error, retryable }` with retries and an orphan sweep after restarts.
+- The webhook path is **one-shot, not streaming** — so the sidebar is a run thread that *feels* like chat. Session continuity is server-side: `repo/agent` persists session history keyed by `sessionId`, so follow-up messages just re-POST with the same `sessionId`. Hive stores only prompt/result pairs for display.
+- Proposals filed by the agent carry `sessionIds` (see `stakgraph/mcp/src/gitree/PROPOSALS_API.md`), so the chat can correlate "this thread filed these proposals" with a filtered list call — no new plumbing.
+
+## Current state (what we reuse, what's missing)
+
+**Reuse as-is:**
+- `AgentRun` row + 256-bit callback token pattern (`prisma/schema.prisma` `AgentRun`, producer in `src/lib/ai/workflowExplorerTools.ts` `setupFanBack()`).
+- `/api/agent-runs/webhook` hardening: middleware allowlist (`src/config/middleware.ts`), per-run+IP rate limit, SHA-256 + `timingSafeEqual` token check with dummy compare on 404, atomic `updateMany` PENDING→terminal claim, 128KB `hardenContent` cap, 500-on-unexpected-error so the swarm retries.
+- Dispatch helper `dispatchRepoAgent` (`src/lib/ai/askTools.ts`) and the `mode?: "graph" | "workflow"` request type — nothing passes `"graph"` yet; this is the first caller.
+
+**Gaps to close:**
+1. Result content is never stored on the row — the webhook fans out into a canvas `SharedConversation` and **warns-and-drops when `conversationId` is null**. Graph runs have no canvas conversation.
+2. No `workspaceId`, no run-type discriminator (`agentKind: "workflow_explorer"` is hardcoded in the webhook fan-out), no stored prompt, no `sessionId`.
+
+## Schema changes
+
+Migration: `npx prisma migrate dev --name agent_run_graph_chat`.
+
+```prisma
+model AgentRun {
+  // existing: id, tokenHash, conversationId?, orgId, userId, title,
+  //           requestId?, status, error?, createdAt, updatedAt
+
+  agentKind   String  @default("workflow_explorer") @map("agent_kind") // "workflow_explorer" | "graph_chat"
+  workspaceId String? @map("workspace_id")   // set for graph_chat runs; null for canvas runs
+  sessionId   String? @map("session_id")     // repo/agent session — groups runs into a thread
+  prompt      String? @db.Text               // the user message for this run (display only)
+  result      String? @db.Text               // terminal content, capped at 128KB by hardenContent
+  proposalsEnabled Boolean @default(false) @map("proposals_enabled") // checkbox snapshot for this run
+
+  @@index([workspaceId, sessionId])
+}
+```
+
+Notes:
+- **No new thread table.** A thread *is* a `sessionId`: thread list = `AgentRun` rows for the workspace grouped by `sessionId` (title from the first run's `title`, which we set from the prompt's first line). The per-thread checkbox is snapshotted onto every run (`proposalsEnabled`); on reload the client derives the thread setting from the latest run in the session. If threads later need renaming/archiving, promote to a `GraphChatThread` model then — not now.
+- Keep `conversationId`, `orgId` nullable-string semantics as today (no FKs on this table currently; stay consistent).
+- `status` enum unchanged: `PENDING | DELIVERED_INLINE | DELIVERED_WEBHOOK | FAILED`. Graph runs terminal at `DELIVERED_WEBHOOK`/`FAILED`.
+
+## API
+
+### `POST /api/workspaces/[slug]/graph/agent`
+
+Body: `{ prompt: string, sessionId?: string, proposalsEnabled?: boolean }`.
+
+- Auth: `validateWorkspaceAccess(slug, userId, true)` + **`canAdmin`** — same gate as the existing graph query route (`src/app/api/workspaces/[slug]/graph/query/route.ts`) and the page itself.
+- New thread: no `sessionId` → mint `randomUUID()`; `proposalsEnabled` comes from the modal checkbox. Follow-up: client passes the thread's `sessionId` and its stored `proposalsEnabled` (server re-snapshots it onto the run row; server does **not** trust the client to flip it mid-thread — reject if it differs from the latest run in the session).
+- Flow (mirrors `setupFanBack()` in `workflowExplorerTools.ts`):
+  1. Mint 256-bit token, `tokenHash = sha256(token)`.
+  2. `db.agentRun.create({ agentKind: "graph_chat", workspaceId, orgId, userId, sessionId, prompt, proposalsEnabled, title, status: PENDING })`.
+  3. Resolve the **workspace's own swarm** via `getSwarmConfig(workspaceId)` (the `learnings/utils.ts` helper) — *not* the hardcoded Stakwork workflow-library swarm the explorer tool uses.
+  4. `dispatchRepoAgent(swarmUrl, swarmApiKey, { prompt, mode: "graph", sessionId, toolsConfig: proposalsEnabled ? { propose_concept_change: true, list_concept_proposals: true } : undefined, webhookUrl })` where `webhookUrl = ${publicBaseUrl}/api/agent-runs/webhook?id=${run.id}&token=${rawToken}`.
+  5. Best-effort `update({ requestId })`; on dispatch throw, `markAgentRunFailed()` (guarded `updateMany` on PENDING, as today).
+- Response: `{ runId, sessionId }`. UI renders the pending bubble optimistically.
+- `USE_MOCKS`: short-circuit dispatch to a mock endpoint (see [Mocks & tests](#mocks--tests)).
+
+### `GET /api/workspaces/[slug]/graph/agent/runs`
+
+- `?sessionId=` → runs in that thread, oldest first: `{ runs: [{ id, prompt, result, status, error, createdAt }] }`.
+- No `sessionId` → thread list: latest run per `sessionId` (`{ sessionId, title, proposalsEnabled, lastStatus, updatedAt }`), newest first.
+- Same admin gate. Scope every query by `workspaceId` **and** `agentKind: "graph_chat"`.
+
+### Webhook: branch in `/api/agent-runs/webhook`
+
+Token check, rate limit, payload parse, and the atomic claim are unchanged. After the claim, branch on the row:
+
+- `agentKind === "graph_chat"` (or simply `workspaceId != null`): store `result` (success) / `error` (failure) on the row in the same `updateMany` that claims it, then Pusher-nudge (below). No canvas fan-out.
+- Else: existing canvas fan-out path, untouched.
+
+This also fixes the current warn-and-drop for null-conversation runs by giving them a real destination.
+
+### Pusher
+
+Add to `src/lib/pusher.ts`:
+
+- Event: `PUSHER_EVENTS.GRAPH_AGENT_RUN_UPDATED = "graph-agent-run-updated"` (hyphenated, matching existing convention).
+- Channel: reuse `getWorkspaceChannelName(slug)` — no new channel type. Payload is a nudge only: `{ runId, sessionId, status, at }`; the client refetches the thread. (Requires the webhook handler to resolve the workspace slug from `workspaceId` — one indexed lookup; alternatively store `workspaceSlug` on the run row at create time to keep the webhook handler DB-light. Prefer storing the slug: the webhook path should stay cheap and retry-safe.)
+
+## UI
+
+All new components under `src/components/graph-explorer/chat/` (directory with `index.tsx`, per project convention). Follow the **`LogsChat` / `DashboardChat` precedent: local component state (or a small dedicated Zustand store), NOT the org canvas chat store** — `CANVAS_CHAT.md` explicitly says not to unify with it, and this surface is workspace-scoped while the canvas is org-scoped.
+
+### Entry points on `GraphExplorer`
+
+- Header gains two buttons next to the existing controls:
+  - **Chat** — toggles the right sidebar (thread list → thread view). Implement as a fixed right panel (like `LearnSidebar`) rather than a `Sheet`, so it can stay open while interacting with the graph; the node-properties `Sheet` already occupies the overlay pattern.
+  - **New** — opens `NewGraphChatModal`.
+
+### `NewGraphChatModal`
+
+- Prompt `Textarea` (autofocus, Cmd+Enter submits).
+- Checkbox: **"Allow concept change proposals"** — helper text: "The agent may propose edits, merges, or deletions of Concept nodes. Proposals are reviewed on the Learn page before anything changes." Default **off**.
+- Submit → `POST .../graph/agent` (no `sessionId`) → open the sidebar on the new thread with the pending run showing.
+
+### `GraphChatSidebar`
+
+- **Thread list**: title, relative time, status dot; a small icon/badge on threads created with proposals enabled. Click → thread view.
+- **Thread view**: alternating user prompt / agent result bubbles from `GET .../runs?sessionId=`. States:
+  - `PENDING` → spinner bubble ("Agent is working…"). Subscribe to `workspace-${slug}` / `graph-agent-run-updated`, refetch on matching `sessionId`. Also poll-fallback every ~20s while any run is PENDING (webhooks can be delayed).
+  - `DELIVERED_WEBHOOK` → render `result` as markdown.
+  - `FAILED` → error bubble with `error`; if the webhook payload said `retryable: true`, offer a "Retry" that re-POSTs the same prompt (same `sessionId`).
+- **Composer** at the bottom for follow-ups (`POST` with the thread's `sessionId`). Disable while a run in the thread is PENDING — `repo/agent` sessions are serial.
+- The thread header shows the proposals setting as a read-only badge ("Proposals on/off") — it is not editable after creation.
+
+### Proposal cards in the thread
+
+After a completed run in a proposals-enabled thread:
+
+1. Fetch `GET /api/learnings/concepts/proposals?workspace={slug}&status=pending` (the proxy added on branch `feature/CMSTAKT2-add-concept-proposals-proxy-and-mocks-*`).
+2. Filter to proposals whose `sessionIds` includes the thread's `sessionId`.
+3. Render `ConceptProposalChip` per match, appended under the run bubble:
+   - Action badge (`create` / `update` / `delete` / `merge`), concept name/id, `rationale`.
+   - "View diff" expands a **read-only** unified diff: `computeUnifiedDiff` (`src/lib/diff/unifiedLineDiff.ts`) with `oldStr = baseDocs`, `newStr = documentation` (per `PROPOSALS_API.md`); for `merge` also show `absorbedDocs` as removed. Reuse the `UnifiedDiffView` rendering from `ProposalCard.tsx`.
+   - **"Review on Learn →"** linking to `/w/{slug}/learn?proposal={id}` (see Coordination). No approve/reject buttons here in v1.
+4. Also fetch with `status=accepted|rejected` filtered by session on subsequent views so decided proposals show their outcome instead of vanishing.
+
+## Coordination with the /learn proposals UI
+
+A parallel effort is building the review queue on `/learn` on top of the same proxies. Two contracts to agree on:
+
+1. **Deep link**: `/w/{slug}/learn?proposal={id}` should open that proposal in the review UI (the page already deep-links via `?concept=` / `?doc=`; add `?proposal=`). Until it exists, link to plain `/w/{slug}/learn`.
+2. **Shared types**: promote the proposal interface out of `src/app/api/mock/stakgraph/gitree/proposals/fixtures.ts` (current de-facto source) into e.g. `src/types/concept-proposals.ts` — `ProposalAction`, `ProposalStatus`, `ConceptProposal`. Both UIs import it. Do **not** reuse the canvas `ProposalOutput` union (`src/lib/proposals/types.ts`) — that's the older, separate `conceptCreate`/`conceptUpdate` pipeline with different semantics (direct-apply on approve, no delete/merge, no `stale_base`).
+
+## Security notes
+
+- Page + all new routes gated `canAdmin` (matches existing graph query route). Proposal *listing* via the proxy is `requireReadAccess`, which admin satisfies.
+- Webhook token flow unchanged (query-string token, hash-only at rest, constant-time compare, atomic single-claim). The new branch stores content on the row — keep the existing `hardenContent` 128KB cap and the demote-to-FAILED-on-oversize behavior.
+- Swarm credentials (`swarmApiKey`) stay server-side; the client only ever sees run rows.
+- `proposalsEnabled` is enforced server-side per dispatch (`toolsConfig` omitted unless true) and immutable per thread; the checkbox is not a client-trusted flag at message time.
+- The agent can only *file* proposals — accept/reject is human-only upstream (agents never get those tools) and DEVELOPER-role-gated in the Hive proxy.
+
+## Mocks & tests
+
+- **Mock dispatch**: under `USE_MOCKS`, `POST .../graph/agent` skips the swarm and schedules a fake webhook: a mock route (e.g. `/api/mock/stakgraph/repo/agent`) that immediately (or after a short delay) POSTs a canned terminal payload to the run's `webhookUrl`. Add a canned proposals-enabled variant that also inserts a `MockProposal` with the run's `sessionId` into the existing stateful mock fixtures so the chip flow is testable end-to-end.
+- **Integration tests** (`src/__tests__/integration/api/`):
+  - `graph/agent` route: admin gate, thread creation, follow-up sessionId reuse, `proposalsEnabled` immutability, dispatch-failure → FAILED.
+  - Webhook branch: graph_chat run stores `result` on row + no canvas fan-out; canvas run behavior unchanged (extend `agent-runs/webhook.test.ts`).
+- **Unit tests**: thread grouping in the runs GET; proposal `sessionIds` filtering; `ConceptProposalChip` diff rendering states (create/update/delete/merge).
+- **E2E** (optional v1): mock-auth flow — new chat with checkbox on → pending → mock webhook → response + proposal chip → link href check. Add `data-testid`s via `selectors.ts` first per E2E guidelines.
+
+## Implementation order
+
+1. **Migration** — new `AgentRun` columns.
+2. **Webhook branch** — store-on-row path + Pusher event (safe: dead code until a graph_chat run exists).
+3. **Dispatch + runs routes** — `POST/GET /api/workspaces/[slug]/graph/agent[...]`, with mocks.
+4. **Sidebar + modal UI** — threads, pending/complete/failed states, composer.
+5. **Proposal chips** — list proxy + `sessionIds` filter + read-only diff + Learn link.
+6. **Tests** throughout; E2E last.
+
+Steps 1–3 are shippable without UI (curl-testable). Step 5 depends on the proposals proxy branch landing (or its mocks).
+
+## Open questions
+
+- Does the graph agent need repo context (`repo_url`/`pat`) for graph mode, or is the swarm graph alone sufficient? The workflow explorer sends neither; assume none until proven otherwise.
+- `DELIVERED_INLINE` status remains unused by this flow — fine, but worth a cleanup note.
+- Thread deletion/archival: out of scope v1 (threads are cheap rows); revisit if the list gets noisy.

--- a/prisma/migrations/20260814210134_agent_run_graph_chat/migration.sql
+++ b/prisma/migrations/20260814210134_agent_run_graph_chat/migration.sql
@@ -1,0 +1,12 @@
+-- AlterTable
+ALTER TABLE "agent_runs" ADD COLUMN     "agent_kind" TEXT NOT NULL DEFAULT 'workflow_explorer',
+ADD COLUMN     "prompt" TEXT,
+ADD COLUMN     "proposals_enabled" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "result" TEXT,
+ADD COLUMN     "session_id" TEXT,
+ADD COLUMN     "workspace_id" TEXT,
+ADD COLUMN     "workspace_slug" TEXT,
+ALTER COLUMN "org_id" DROP NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "agent_runs_workspace_id_session_id_idx" ON "agent_runs"("workspace_id", "session_id");

--- a/prisma/migrations/20260814210134_agent_run_graph_chat/migration.sql
+++ b/prisma/migrations/20260814210134_agent_run_graph_chat/migration.sql
@@ -2,6 +2,7 @@
 ALTER TABLE "agent_runs" ADD COLUMN     "agent_kind" TEXT NOT NULL DEFAULT 'workflow_explorer',
 ADD COLUMN     "prompt" TEXT,
 ADD COLUMN     "proposals_enabled" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "reflection" JSONB,
 ADD COLUMN     "result" TEXT,
 ADD COLUMN     "session_id" TEXT,
 ADD COLUMN     "workspace_id" TEXT,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2298,19 +2298,42 @@ model AgentRun {
   /// SHA-256 hash of the high-entropy callback bearer token. Never stored plaintext.
   tokenHash      String        @map("token_hash")
   /// Delivery target for canvas-linked runs (SharedConversation id). Null for
-  /// future non-canvas run types, whose webhook endpoints deliver elsewhere.
+  /// non-canvas run types (e.g. graph_chat), whose results are stored on the row.
   conversationId String?       @map("conversation_id")
-  orgId          String        @map("org_id")
+  /// SourceControlOrg id for canvas-linked runs. Null for graph_chat runs on
+  /// workspaces without a linked source-control org. No FK (consistent with
+  /// the rest of this table).
+  orgId          String?       @map("org_id")
   userId         String        @map("user_id")
   title          String
   /// Swarm request_id — observability / log-correlation only. NOT part of the arbitration key.
   requestId      String?       @map("request_id")
   status         AgentRunStatus @default(PENDING)
   error          String?       @db.Text
+
+  /// Run-type discriminator: "workflow_explorer" (canvas fan-out) | "graph_chat"
+  /// (result stored on the row, surfaced in the Graph Explorer chat sidebar).
+  agentKind      String        @default("workflow_explorer") @map("agent_kind")
+  /// Set for graph_chat runs; null for canvas runs.
+  workspaceId    String?       @map("workspace_id")
+  /// Denormalized workspace slug snapshotted at create time so the webhook
+  /// handler can Pusher-nudge the workspace channel without a lookup.
+  workspaceSlug  String?       @map("workspace_slug")
+  /// repo/agent session id — groups graph_chat runs into a chat thread.
+  sessionId      String?       @map("session_id")
+  /// The user message for this run (display only).
+  prompt         String?       @db.Text
+  /// Terminal result content, capped at 128KB by hardenContent.
+  result         String?       @db.Text
+  /// Per-thread "Allow concept change proposals" checkbox, snapshotted onto
+  /// every run in the session. Immutable per thread (enforced at dispatch).
+  proposalsEnabled Boolean     @default(false) @map("proposals_enabled")
+
   createdAt      DateTime      @default(now()) @map("created_at")
   updatedAt      DateTime      @updatedAt @map("updated_at")
 
   @@index([conversationId])
+  @@index([workspaceId, sessionId])
   @@map("agent_runs")
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2325,6 +2325,10 @@ model AgentRun {
   prompt         String?       @db.Text
   /// Terminal result content, capped at 128KB by hardenContent.
   result         String?       @db.Text
+  /// stakgraph SessionReflection sidecar delivered on the terminal webhook
+  /// (graph_chat runs): { session_id, updated_at, concepts[], gap?, raw? }.
+  /// Session-cumulative — the latest run's snapshot supersedes earlier ones.
+  reflection     Json?
   /// Per-thread "Allow concept change proposals" checkbox, snapshotted onto
   /// every run in the session. Immutable per thread (enforced at dispatch).
   proposalsEnabled Boolean     @default(false) @map("proposals_enabled")

--- a/src/__tests__/integration/api/agent-runs/webhook.test.ts
+++ b/src/__tests__/integration/api/agent-runs/webhook.test.ts
@@ -27,8 +27,13 @@ import crypto from "crypto";
 vi.mock("@/lib/pusher", () => ({
   pusherServer: { trigger: vi.fn().mockResolvedValue({}) },
   getCanvasConversationChannelName: vi.fn((id: string) => `canvas-conversation-${id}`),
-  PUSHER_EVENTS: { CANVAS_CONVERSATION_UPDATED: "canvas-conversation-updated" },
+  getWorkspaceChannelName: vi.fn((slug: string) => `workspace-${slug}`),
+  PUSHER_EVENTS: {
+    CANVAS_CONVERSATION_UPDATED: "canvas-conversation-updated",
+    GRAPH_AGENT_RUN_UPDATED: "graph-agent-run-updated",
+  },
   notifyCanvasConversationUpdated: vi.fn(),
+  notifyGraphAgentRunUpdated: vi.fn(),
 }));
 
 // Rate limit: default allow — specific tests override
@@ -38,7 +43,10 @@ vi.mock("@/lib/rate-limit", () => ({
 }));
 
 import { checkRateLimit } from "@/lib/rate-limit";
-import { notifyCanvasConversationUpdated } from "@/lib/pusher";
+import {
+  notifyCanvasConversationUpdated,
+  notifyGraphAgentRunUpdated,
+} from "@/lib/pusher";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -465,6 +473,166 @@ describe("POST /api/agent-runs/webhook", () => {
     const row = await db.agentRun.findUnique({ where: { id: agentRun.id } });
     expect(row?.status).toBe("DELIVERED_WEBHOOK");
     expect(notifyCanvasConversationUpdated).not.toHaveBeenCalled();
+  });
+
+  // ── graph_chat branch ─────────────────────────────────────────────────────
+
+  describe("graph_chat runs (result stored on row, workspace nudge, no canvas fan-out)", () => {
+    let workspace: { id: string; slug: string };
+
+    beforeEach(async () => {
+      const ts = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      workspace = await db.workspace.create({
+        data: {
+          name: "Graph Chat WS",
+          slug: `graph-chat-ws-${ts}`,
+          ownerId: user.id,
+        },
+        select: { id: true, slug: true },
+      });
+    });
+
+    async function createGraphChatRun(overrides: Record<string, unknown> = {}) {
+      return db.agentRun.create({
+        data: {
+          tokenHash: hashToken(rawToken),
+          conversationId: null,
+          orgId: null,
+          userId: user.id,
+          title: "What does the auth module do?",
+          agentKind: "graph_chat",
+          workspaceId: workspace.id,
+          workspaceSlug: workspace.slug,
+          sessionId: "session-abc",
+          prompt: "What does the auth module do?",
+          proposalsEnabled: false,
+          ...overrides,
+        },
+      });
+    }
+
+    it("stores the result on the row, nudges the workspace channel, and skips canvas fan-out", async () => {
+      const agentRun = await createGraphChatRun();
+      const req = makeWebhookRequest({
+        runId: agentRun.id,
+        token: rawToken,
+        body: {
+          request_id: "req-g1",
+          status: "completed",
+          result: { success: true, content: "## Graph answer\n\nAuth handles JWT." },
+        },
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+
+      const row = await db.agentRun.findUnique({ where: { id: agentRun.id } });
+      expect(row?.status).toBe("DELIVERED_WEBHOOK");
+      expect(row?.result).toBe("## Graph answer\n\nAuth handles JWT.");
+      expect(row?.error).toBeNull();
+
+      // Workspace nudge fired with the run's identifiers
+      expect(notifyGraphAgentRunUpdated).toHaveBeenCalledWith(workspace.slug, {
+        runId: agentRun.id,
+        sessionId: "session-abc",
+        status: "DELIVERED_WEBHOOK",
+      });
+
+      // No canvas fan-out of any kind
+      expect(notifyCanvasConversationUpdated).not.toHaveBeenCalled();
+      const conv = await db.sharedConversation.findUnique({ where: { id: conversation.id } });
+      expect(conv?.messages as unknown[]).toHaveLength(0);
+    });
+
+    it("stores the error (not result) and nudges FAILED on a failure payload", async () => {
+      const agentRun = await createGraphChatRun();
+      const req = makeWebhookRequest({
+        runId: agentRun.id,
+        token: rawToken,
+        body: { request_id: "req-g2", status: "failed", error: "graph agent exploded" },
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+
+      const row = await db.agentRun.findUnique({ where: { id: agentRun.id } });
+      expect(row?.status).toBe("FAILED");
+      expect(row?.error).toBe("graph agent exploded");
+      expect(row?.result).toBeNull();
+
+      expect(notifyGraphAgentRunUpdated).toHaveBeenCalledWith(workspace.slug, {
+        runId: agentRun.id,
+        sessionId: "session-abc",
+        status: "FAILED",
+      });
+      expect(notifyCanvasConversationUpdated).not.toHaveBeenCalled();
+    });
+
+    it("demotes oversized content to FAILED without storing a result", async () => {
+      const agentRun = await createGraphChatRun();
+      const oversized = "x".repeat(128 * 1024 + 1);
+      const req = makeWebhookRequest({
+        runId: agentRun.id,
+        token: rawToken,
+        body: { request_id: "req-g3", status: "completed", result: { content: oversized } },
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+
+      const row = await db.agentRun.findUnique({ where: { id: agentRun.id } });
+      expect(row?.status).toBe("FAILED");
+      expect(row?.result).toBeNull();
+    });
+
+    it("resolves the slug by workspaceId lookup when workspaceSlug is not snapshotted", async () => {
+      const agentRun = await createGraphChatRun({ workspaceSlug: null });
+      const req = makeWebhookRequest({ runId: agentRun.id, token: rawToken });
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+
+      expect(notifyGraphAgentRunUpdated).toHaveBeenCalledWith(
+        workspace.slug,
+        expect.objectContaining({ runId: agentRun.id }),
+      );
+    });
+
+    it("a second webhook call is a no-op — the first result wins", async () => {
+      const agentRun = await createGraphChatRun();
+      const req1 = makeWebhookRequest({
+        runId: agentRun.id,
+        token: rawToken,
+        body: { status: "completed", result: { content: "Result A" } },
+      });
+      const req2 = makeWebhookRequest({
+        runId: agentRun.id,
+        token: rawToken,
+        body: { status: "completed", result: { content: "Result B" } },
+      });
+      await POST(req1);
+      const res2 = await POST(req2);
+      expect(res2.status).toBe(200);
+
+      const row = await db.agentRun.findUnique({ where: { id: agentRun.id } });
+      expect(row?.result).toBe("Result A");
+      expect(notifyGraphAgentRunUpdated).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("canvas (workflow_explorer) runs never trigger the graph workspace nudge", async () => {
+    const agentRun = await createAgentRun({ conversationId: conversation.id, orgId: org.id, userId: user.id, rawToken });
+    const req = makeWebhookRequest({
+      runId: agentRun.id,
+      token: rawToken,
+      body: { status: "completed", result: { content: "Canvas result" } },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    // Result is NOT stored on the row for canvas runs (fan-out only — path unchanged)
+    const row = await db.agentRun.findUnique({ where: { id: agentRun.id } });
+    expect(row?.status).toBe("DELIVERED_WEBHOOK");
+    expect(row?.result).toBeNull();
+
+    expect(notifyGraphAgentRunUpdated).not.toHaveBeenCalled();
+    expect(notifyCanvasConversationUpdated).toHaveBeenCalledWith(conversation.id, "agent_run");
   });
 
   // ── tokenHash gating of the claim ─────────────────────────────────────────

--- a/src/__tests__/integration/api/agent-runs/webhook.test.ts
+++ b/src/__tests__/integration/api/agent-runs/webhook.test.ts
@@ -566,6 +566,72 @@ describe("POST /api/agent-runs/webhook", () => {
       expect(notifyCanvasConversationUpdated).not.toHaveBeenCalled();
     });
 
+    it("stores the reflection sidecar alongside the result when the payload carries one", async () => {
+      const agentRun = await createGraphChatRun();
+      const reflection = {
+        session_id: "session-abc",
+        updated_at: "2026-08-14T12:00:00.000Z",
+        concepts: [
+          { id: "stakwork/hive/auth", name: "Authentication", read_order: 1, rank: null },
+        ],
+      };
+      const req = makeWebhookRequest({
+        runId: agentRun.id,
+        token: rawToken,
+        body: {
+          status: "completed",
+          result: { content: "Answer", reflection },
+        },
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+
+      const row = await db.agentRun.findUnique({ where: { id: agentRun.id } });
+      expect(row?.result).toBe("Answer");
+      expect(row?.reflection).toEqual(reflection);
+    });
+
+    it("drops a malformed reflection but still delivers the result", async () => {
+      const agentRun = await createGraphChatRun();
+      const req = makeWebhookRequest({
+        runId: agentRun.id,
+        token: rawToken,
+        body: {
+          status: "completed",
+          result: { content: "Answer", reflection: ["not", "an", "object"] },
+        },
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+
+      const row = await db.agentRun.findUnique({ where: { id: agentRun.id } });
+      expect(row?.status).toBe("DELIVERED_WEBHOOK");
+      expect(row?.result).toBe("Answer");
+      expect(row?.reflection).toBeNull();
+    });
+
+    it("drops an oversized reflection but still delivers the result", async () => {
+      const agentRun = await createGraphChatRun();
+      const req = makeWebhookRequest({
+        runId: agentRun.id,
+        token: rawToken,
+        body: {
+          status: "completed",
+          result: {
+            content: "Answer",
+            reflection: { gap: "x".repeat(128 * 1024 + 1) },
+          },
+        },
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+
+      const row = await db.agentRun.findUnique({ where: { id: agentRun.id } });
+      expect(row?.status).toBe("DELIVERED_WEBHOOK");
+      expect(row?.result).toBe("Answer");
+      expect(row?.reflection).toBeNull();
+    });
+
     it("demotes oversized content to FAILED without storing a result", async () => {
       const agentRun = await createGraphChatRun();
       const oversized = "x".repeat(128 * 1024 + 1);
@@ -621,15 +687,23 @@ describe("POST /api/agent-runs/webhook", () => {
     const req = makeWebhookRequest({
       runId: agentRun.id,
       token: rawToken,
-      body: { status: "completed", result: { content: "Canvas result" } },
+      body: {
+        status: "completed",
+        result: {
+          content: "Canvas result",
+          reflection: { session_id: "s", concepts: [] },
+        },
+      },
     });
     const res = await POST(req);
     expect(res.status).toBe(200);
 
-    // Result is NOT stored on the row for canvas runs (fan-out only — path unchanged)
+    // Result/reflection are NOT stored on the row for canvas runs (fan-out
+    // only — path unchanged)
     const row = await db.agentRun.findUnique({ where: { id: agentRun.id } });
     expect(row?.status).toBe("DELIVERED_WEBHOOK");
     expect(row?.result).toBeNull();
+    expect(row?.reflection).toBeNull();
 
     expect(notifyGraphAgentRunUpdated).not.toHaveBeenCalled();
     expect(notifyCanvasConversationUpdated).toHaveBeenCalledWith(conversation.id, "agent_run");

--- a/src/__tests__/integration/api/graph-agent-chat.test.ts
+++ b/src/__tests__/integration/api/graph-agent-chat.test.ts
@@ -288,7 +288,11 @@ describe("Graph Agent Chat routes", () => {
     }
 
     it("returns runs for a session oldest-first with display fields", async () => {
-      await seedRun({ createdAt: new Date("2026-08-01T10:00:00Z") });
+      const reflection = {
+        session_id: "session-1",
+        concepts: [{ id: "stakwork/hive/auth", name: "Authentication", read_order: 1, rank: null }],
+      };
+      await seedRun({ reflection, createdAt: new Date("2026-08-01T10:00:00Z") });
       await seedRun({
         prompt: "second prompt",
         status: "PENDING",
@@ -304,8 +308,9 @@ describe("Graph Agent Chat routes", () => {
         prompt: "first prompt",
         result: "the answer",
         status: "DELIVERED_WEBHOOK",
+        reflection: reflection,
       });
-      expect(body.runs[1]).toMatchObject({ prompt: "second prompt", status: "PENDING" });
+      expect(body.runs[1]).toMatchObject({ prompt: "second prompt", status: "PENDING", reflection: null });
       // No token material in the payload
       expect(JSON.stringify(body)).not.toContain("tokenHash");
     });

--- a/src/__tests__/integration/api/graph-agent-chat.test.ts
+++ b/src/__tests__/integration/api/graph-agent-chat.test.ts
@@ -1,0 +1,370 @@
+/**
+ * Integration tests for the Graph Agent Chat routes:
+ *   - POST /api/workspaces/[slug]/graph/agent (dispatch)
+ *   - GET  /api/workspaces/[slug]/graph/agent/runs (thread list / thread runs)
+ *
+ * Covers: admin gate, thread creation, follow-up sessionId reuse,
+ * proposalsEnabled immutability, dispatch-failure → FAILED, and
+ * workspace/agentKind scoping of the history reads.
+ *
+ * The swarm is mocked at the `dispatchRepoAgent` seam (the route's only
+ * outbound call) and swarm credential resolution at `getSwarmConfig`.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { db } from "@/lib/db";
+import { createTestUser, createTestWorkspace, createTestMembership } from "@/__tests__/support/fixtures";
+import { createAuthenticatedSession, mockSessionAs } from "@/__tests__/support/helpers/auth";
+
+vi.mock("next-auth/next", async () => {
+  const actual = await vi.importActual("next-auth/next");
+  return { ...actual, getServerSession: vi.fn() };
+});
+
+vi.mock("@/lib/ai/askTools", () => ({
+  dispatchRepoAgent: vi.fn(),
+}));
+
+vi.mock("@/app/api/learnings/utils", () => ({
+  getSwarmConfig: vi.fn(),
+}));
+
+// Import routes after mocks
+import { POST } from "@/app/api/workspaces/[slug]/graph/agent/route";
+import { GET } from "@/app/api/workspaces/[slug]/graph/agent/runs/route";
+import { dispatchRepoAgent } from "@/lib/ai/askTools";
+import { getSwarmConfig } from "@/app/api/learnings/utils";
+
+const mockDispatch = vi.mocked(dispatchRepoAgent);
+const mockGetSwarmConfig = vi.mocked(getSwarmConfig);
+
+function postRequest(slug: string, body: object): [NextRequest, { params: Promise<{ slug: string }> }] {
+  return [
+    new NextRequest(`http://localhost:3000/api/workspaces/${slug}/graph/agent`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    { params: Promise.resolve({ slug }) },
+  ];
+}
+
+function getRequest(slug: string, sessionId?: string): [NextRequest, { params: Promise<{ slug: string }> }] {
+  const qs = sessionId ? `?sessionId=${encodeURIComponent(sessionId)}` : "";
+  return [
+    new NextRequest(`http://localhost:3000/api/workspaces/${slug}/graph/agent/runs${qs}`),
+    { params: Promise.resolve({ slug }) },
+  ];
+}
+
+describe("Graph Agent Chat routes", () => {
+  let owner: Awaited<ReturnType<typeof createTestUser>>;
+  let workspace: Awaited<ReturnType<typeof createTestWorkspace>>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockDispatch.mockResolvedValue("mock-request-id-1");
+    mockGetSwarmConfig.mockResolvedValue({
+      baseSwarmUrl: "https://swarm.test:3355",
+      decryptedSwarmApiKey: "decrypted-key",
+    } as never);
+
+    owner = await createTestUser({ name: "Graph Owner" });
+    workspace = await createTestWorkspace({ ownerId: owner.id });
+    mockSessionAs(createAuthenticatedSession(owner));
+  });
+
+  // ── Auth gates ─────────────────────────────────────────────────────────────
+
+  it("POST returns 401 when unauthenticated", async () => {
+    mockSessionAs(null);
+    const res = await POST(...postRequest(workspace.slug, { prompt: "hi" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("POST returns 403 for a non-admin member (DEVELOPER)", async () => {
+    const dev = await createTestUser({ name: "Dev" });
+    await createTestMembership({
+      workspaceId: workspace.id,
+      userId: dev.id,
+      role: "DEVELOPER",
+    });
+    mockSessionAs(createAuthenticatedSession(dev));
+
+    const res = await POST(...postRequest(workspace.slug, { prompt: "hi" }));
+    expect(res.status).toBe(403);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it("POST returns 404 for a non-member", async () => {
+    const outsider = await createTestUser({ name: "Outsider" });
+    mockSessionAs(createAuthenticatedSession(outsider));
+
+    const res = await POST(...postRequest(workspace.slug, { prompt: "hi" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("GET returns 401 when unauthenticated and 403 for non-admin", async () => {
+    mockSessionAs(null);
+    const res1 = await GET(...getRequest(workspace.slug));
+    expect(res1.status).toBe(401);
+
+    const viewer = await createTestUser({ name: "Viewer" });
+    await createTestMembership({
+      workspaceId: workspace.id,
+      userId: viewer.id,
+      role: "VIEWER",
+    });
+    mockSessionAs(createAuthenticatedSession(viewer));
+    const res2 = await GET(...getRequest(workspace.slug));
+    expect(res2.status).toBe(403);
+  });
+
+  // ── Validation ─────────────────────────────────────────────────────────────
+
+  it("POST returns 400 when prompt is missing or blank", async () => {
+    const res1 = await POST(...postRequest(workspace.slug, {}));
+    expect(res1.status).toBe(400);
+    const res2 = await POST(...postRequest(workspace.slug, { prompt: "   " }));
+    expect(res2.status).toBe(400);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  // ── Thread creation ────────────────────────────────────────────────────────
+
+  it("creates a new thread: mints a sessionId, snapshots proposalsEnabled, dispatches with graph mode + tools", async () => {
+    const res = await POST(
+      ...postRequest(workspace.slug, {
+        prompt: "Map the auth module\nplease include edges",
+        proposalsEnabled: true,
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.runId).toBeTruthy();
+    expect(body.sessionId).toBeTruthy();
+
+    const row = await db.agentRun.findUnique({ where: { id: body.runId } });
+    expect(row).toMatchObject({
+      agentKind: "graph_chat",
+      workspaceId: workspace.id,
+      workspaceSlug: workspace.slug,
+      sessionId: body.sessionId,
+      prompt: "Map the auth module\nplease include edges",
+      proposalsEnabled: true,
+      status: "PENDING",
+      requestId: "mock-request-id-1",
+      title: "Map the auth module", // first line of the prompt
+      conversationId: null,
+    });
+    // Token stored only as a hash
+    expect(row?.tokenHash).toMatch(/^[0-9a-f]{64}$/);
+
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    const [swarmUrl, apiKey, params] = mockDispatch.mock.calls[0];
+    expect(swarmUrl).toBe("https://swarm.test:3355");
+    expect(apiKey).toBe("decrypted-key");
+    expect(params).toMatchObject({
+      prompt: "Map the auth module\nplease include edges",
+      mode: "graph",
+      sessionId: body.sessionId,
+      toolsConfig: { propose_concept_change: true, list_concept_proposals: true },
+    });
+    expect(params.webhookUrl).toContain(`/api/agent-runs/webhook?id=${body.runId}&token=`);
+    // The raw token in the webhookUrl hashes to the stored tokenHash's format
+    // but is never echoed back to the client.
+    expect(JSON.stringify(body)).not.toContain("token");
+  });
+
+  it("omits toolsConfig entirely when proposals are off", async () => {
+    const res = await POST(...postRequest(workspace.slug, { prompt: "hello graph" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    const row = await db.agentRun.findUnique({ where: { id: body.runId } });
+    expect(row?.proposalsEnabled).toBe(false);
+
+    const [, , params] = mockDispatch.mock.calls[0];
+    expect(params).not.toHaveProperty("toolsConfig");
+  });
+
+  // ── Follow-ups & immutability ──────────────────────────────────────────────
+
+  it("reuses the sessionId on follow-up and re-snapshots the thread's proposalsEnabled", async () => {
+    const first = await POST(...postRequest(workspace.slug, { prompt: "start", proposalsEnabled: true }));
+    const { runId: firstRunId, sessionId } = await first.json();
+
+    // Follow-up does not send proposalsEnabled at all — the server derives it
+    const res = await POST(...postRequest(workspace.slug, { prompt: "follow up", sessionId }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sessionId).toBe(sessionId);
+    expect(body.runId).not.toBe(firstRunId); // distinct row per message
+
+    const rows = await db.agentRun.findMany({
+      where: { sessionId, agentKind: "graph_chat" },
+      orderBy: { createdAt: "asc" },
+    });
+    expect(rows).toHaveLength(2);
+    expect(rows[1].prompt).toBe("follow up");
+    expect(rows[1].proposalsEnabled).toBe(true); // re-snapshotted from the thread
+
+    // Both dispatches used the same swarm session
+    expect(mockDispatch.mock.calls[1][2]).toMatchObject({ sessionId, mode: "graph" });
+  });
+
+  it("rejects an attempt to flip proposalsEnabled mid-thread (409, no row created)", async () => {
+    const first = await POST(...postRequest(workspace.slug, { prompt: "start", proposalsEnabled: true }));
+    const { sessionId } = await first.json();
+
+    const res = await POST(
+      ...postRequest(workspace.slug, {
+        prompt: "sneaky flip",
+        sessionId,
+        proposalsEnabled: false,
+      }),
+    );
+    expect(res.status).toBe(409);
+
+    const rows = await db.agentRun.findMany({ where: { sessionId } });
+    expect(rows).toHaveLength(1);
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 404 for a follow-up on an unknown sessionId", async () => {
+    const res = await POST(...postRequest(workspace.slug, { prompt: "hi", sessionId: "no-such-session" }));
+    expect(res.status).toBe(404);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  // ── Dispatch failure ───────────────────────────────────────────────────────
+
+  it("marks the run FAILED and returns 502 when dispatch throws", async () => {
+    mockDispatch.mockRejectedValue(new Error("swarm unreachable"));
+
+    const res = await POST(...postRequest(workspace.slug, { prompt: "doomed" }));
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.runId).toBeTruthy();
+
+    const row = await db.agentRun.findUnique({ where: { id: body.runId } });
+    expect(row?.status).toBe("FAILED");
+    expect(row?.error).toBe("swarm unreachable");
+  });
+
+  it("does not create a run row when the swarm is not configured", async () => {
+    mockGetSwarmConfig.mockResolvedValue({
+      error: "Swarm not found for this workspace",
+      status: 404,
+    } as never);
+
+    const res = await POST(...postRequest(workspace.slug, { prompt: "hi" }));
+    expect(res.status).toBe(404);
+    expect(await db.agentRun.count({ where: { workspaceId: workspace.id } })).toBe(0);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  // ── Runs GET ───────────────────────────────────────────────────────────────
+
+  describe("GET /runs", () => {
+    async function seedRun(overrides: Record<string, unknown> = {}) {
+      return db.agentRun.create({
+        data: {
+          tokenHash: "0".repeat(64),
+          agentKind: "graph_chat",
+          workspaceId: workspace.id,
+          workspaceSlug: workspace.slug,
+          orgId: null,
+          userId: owner.id,
+          sessionId: "session-1",
+          title: "Thread one",
+          prompt: "first prompt",
+          status: "DELIVERED_WEBHOOK",
+          result: "the answer",
+          ...overrides,
+        },
+      });
+    }
+
+    it("returns runs for a session oldest-first with display fields", async () => {
+      await seedRun({ createdAt: new Date("2026-08-01T10:00:00Z") });
+      await seedRun({
+        prompt: "second prompt",
+        status: "PENDING",
+        result: null,
+        createdAt: new Date("2026-08-01T11:00:00Z"),
+      });
+
+      const res = await GET(...getRequest(workspace.slug, "session-1"));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.runs).toHaveLength(2);
+      expect(body.runs[0]).toMatchObject({
+        prompt: "first prompt",
+        result: "the answer",
+        status: "DELIVERED_WEBHOOK",
+      });
+      expect(body.runs[1]).toMatchObject({ prompt: "second prompt", status: "PENDING" });
+      // No token material in the payload
+      expect(JSON.stringify(body)).not.toContain("tokenHash");
+    });
+
+    it("returns the thread list grouped by session, newest-first, title from the first run", async () => {
+      await seedRun({
+        sessionId: "session-1",
+        title: "Thread one",
+        createdAt: new Date("2026-08-01T10:00:00Z"),
+        updatedAt: new Date("2026-08-01T10:05:00Z"),
+      });
+      await seedRun({
+        sessionId: "session-1",
+        title: "Follow-up title (ignored)",
+        status: "PENDING",
+        proposalsEnabled: true,
+        createdAt: new Date("2026-08-02T10:00:00Z"),
+        updatedAt: new Date("2026-08-02T10:00:00Z"),
+      });
+      await seedRun({
+        sessionId: "session-2",
+        title: "Thread two",
+        createdAt: new Date("2026-08-01T12:00:00Z"),
+        updatedAt: new Date("2026-08-01T12:30:00Z"),
+      });
+
+      const res = await GET(...getRequest(workspace.slug));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.threads).toHaveLength(2);
+      // Newest activity first
+      expect(body.threads[0]).toMatchObject({
+        sessionId: "session-1",
+        title: "Thread one", // first run's title wins
+        lastStatus: "PENDING", // latest run's status
+        proposalsEnabled: true, // latest run's snapshot
+      });
+      expect(body.threads[1]).toMatchObject({ sessionId: "session-2", title: "Thread two" });
+    });
+
+    it("scopes reads to the workspace and agentKind graph_chat", async () => {
+      // Foreign workspace graph run
+      const otherOwner = await createTestUser({ name: "Other" });
+      const otherWs = await createTestWorkspace({ ownerId: otherOwner.id });
+      await seedRun({ workspaceId: otherWs.id, workspaceSlug: otherWs.slug, sessionId: "foreign" });
+      // Canvas run in THIS workspace's org scope (different kind)
+      await db.agentRun.create({
+        data: {
+          tokenHash: "1".repeat(64),
+          agentKind: "workflow_explorer",
+          orgId: "some-org",
+          userId: owner.id,
+          title: "Canvas run",
+        },
+      });
+
+      const res = await GET(...getRequest(workspace.slug));
+      const body = await res.json();
+      expect(body.threads).toHaveLength(0);
+    });
+  });
+});

--- a/src/__tests__/unit/components/graph-chat/ConceptProposalChip.test.tsx
+++ b/src/__tests__/unit/components/graph-chat/ConceptProposalChip.test.tsx
@@ -1,0 +1,114 @@
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ConceptProposalChip } from "@/components/graph-explorer/chat/ConceptProposalChip";
+import type { ConceptProposal } from "@/types/concept-proposals";
+
+function proposal(overrides: Partial<ConceptProposal>): ConceptProposal {
+  return {
+    id: "p1",
+    action: "update",
+    status: "pending",
+    rationale: "Because the docs drifted.",
+    source: "graph_chat",
+    prNumbers: [],
+    createdAt: "2026-08-01T10:00:00.000Z",
+    repo: "stakwork/hive",
+    ...overrides,
+  };
+}
+
+describe("ConceptProposalChip", () => {
+  it("renders the action badge, rationale, and the Learn deep link", () => {
+    render(
+      <ConceptProposalChip workspaceSlug="acme" proposal={proposal({ id: "prop-9", conceptId: "acme/repo/auth" })} />,
+    );
+    expect(screen.getByTestId("proposal-chip-action")).toHaveTextContent("update");
+    expect(screen.getByText("Because the docs drifted.")).toBeInTheDocument();
+    expect(screen.getByTestId("proposal-chip-learn-link")).toHaveAttribute("href", "/w/acme/learn?proposal=prop-9");
+    // Pending proposals show no status badge
+    expect(screen.queryByTestId("proposal-chip-status")).toBeNull();
+  });
+
+  it("shows the decided status badge for accepted/rejected proposals", () => {
+    render(
+      <ConceptProposalChip
+        workspaceSlug="acme"
+        proposal={proposal({ status: "accepted", conceptId: "acme/repo/auth" })}
+      />,
+    );
+    expect(screen.getByTestId("proposal-chip-status")).toHaveTextContent("accepted");
+  });
+
+  it("update: labels with the conceptId and diffs baseDocs → documentation", () => {
+    render(
+      <ConceptProposalChip
+        workspaceSlug="acme"
+        proposal={proposal({
+          conceptId: "acme/repo/auth",
+          baseDocs: "old line",
+          documentation: "new line",
+        })}
+      />,
+    );
+    expect(screen.getByText("acme/repo/auth")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("proposal-chip-diff-toggle"));
+    expect(screen.getByText("old line")).toBeInTheDocument();
+    expect(screen.getByText("new line")).toBeInTheDocument();
+  });
+
+  it("create: labels with the proposed name and shows the docs as added", () => {
+    render(
+      <ConceptProposalChip
+        workspaceSlug="acme"
+        proposal={proposal({
+          action: "create",
+          name: "Encryption Service",
+          documentation: "brand new docs",
+        })}
+      />,
+    );
+    expect(screen.getByText("Encryption Service")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("proposal-chip-diff-toggle"));
+    expect(screen.getByText("brand new docs")).toBeInTheDocument();
+  });
+
+  it("delete: shows the base docs as removed", () => {
+    render(
+      <ConceptProposalChip
+        workspaceSlug="acme"
+        proposal={proposal({
+          action: "delete",
+          conceptId: "acme/repo/janitors",
+          baseDocs: "docs being deleted",
+        })}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("proposal-chip-diff-toggle"));
+    expect(screen.getByText("docs being deleted")).toBeInTheDocument();
+  });
+
+  it("merge: labels absorbed → survivor and shows both the survivor diff and the absorbed docs", () => {
+    render(
+      <ConceptProposalChip
+        workspaceSlug="acme"
+        proposal={proposal({
+          action: "merge",
+          conceptId: "acme/repo/janitors",
+          mergeIntoConceptId: "acme/repo/swarm",
+          baseDocs: "survivor docs",
+          documentation: "survivor docs plus janitors",
+          absorbedDocs: "absorbed janitor docs",
+        })}
+      />,
+    );
+    expect(screen.getByText("acme/repo/janitors → acme/repo/swarm")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("proposal-chip-diff-toggle"));
+    expect(screen.getByText("survivor docs plus janitors")).toBeInTheDocument();
+    expect(screen.getByText("absorbed janitor docs")).toBeInTheDocument();
+    expect(screen.getByText(/Absorbed concept/)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/unit/lib/graph-chat/threads.test.ts
+++ b/src/__tests__/unit/lib/graph-chat/threads.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { groupRunsIntoThreads, filterProposalsForSession, type ThreadSourceRun } from "@/lib/graph-chat/threads";
+import type { ConceptProposal } from "@/types/concept-proposals";
+
+function run(overrides: Partial<ThreadSourceRun>): ThreadSourceRun {
+  return {
+    sessionId: "s1",
+    title: "Title",
+    proposalsEnabled: false,
+    status: "DELIVERED_WEBHOOK",
+    createdAt: "2026-08-01T10:00:00.000Z",
+    updatedAt: "2026-08-01T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("groupRunsIntoThreads", () => {
+  it("groups runs by sessionId with title from the FIRST run and status/setting from the LATEST", () => {
+    const threads = groupRunsIntoThreads([
+      run({ title: "Opening prompt", updatedAt: "2026-08-01T10:00:00.000Z" }),
+      run({
+        title: "Follow-up (ignored)",
+        status: "PENDING",
+        proposalsEnabled: true,
+        updatedAt: "2026-08-01T11:00:00.000Z",
+      }),
+    ]);
+    expect(threads).toHaveLength(1);
+    expect(threads[0]).toEqual({
+      sessionId: "s1",
+      title: "Opening prompt",
+      proposalsEnabled: true,
+      lastStatus: "PENDING",
+      updatedAt: "2026-08-01T11:00:00.000Z",
+    });
+  });
+
+  it("orders threads newest activity first", () => {
+    const threads = groupRunsIntoThreads([
+      run({ sessionId: "old", updatedAt: "2026-08-01T09:00:00.000Z" }),
+      run({ sessionId: "new", updatedAt: "2026-08-02T09:00:00.000Z" }),
+      run({ sessionId: "mid", updatedAt: "2026-08-01T15:00:00.000Z" }),
+    ]);
+    expect(threads.map((t) => t.sessionId)).toEqual(["new", "mid", "old"]);
+  });
+
+  it("skips rows without a sessionId and accepts Date objects", () => {
+    const threads = groupRunsIntoThreads([
+      run({ sessionId: null }),
+      run({
+        sessionId: "s2",
+        createdAt: new Date("2026-08-01T10:00:00.000Z"),
+        updatedAt: new Date("2026-08-01T10:00:00.000Z"),
+      }),
+    ]);
+    expect(threads).toHaveLength(1);
+    expect(threads[0].sessionId).toBe("s2");
+    expect(threads[0].updatedAt).toBe("2026-08-01T10:00:00.000Z");
+  });
+
+  it("returns an empty list for no runs", () => {
+    expect(groupRunsIntoThreads([])).toEqual([]);
+  });
+});
+
+describe("filterProposalsForSession", () => {
+  function proposal(overrides: Partial<ConceptProposal>): ConceptProposal {
+    return {
+      id: "p1",
+      action: "update",
+      status: "pending",
+      rationale: "why",
+      source: "graph_chat",
+      prNumbers: [],
+      createdAt: "2026-08-01T10:00:00.000Z",
+      repo: "stakwork/hive",
+      ...overrides,
+    };
+  }
+
+  it("keeps only proposals whose sessionIds include the thread's session", () => {
+    const matched = proposal({ id: "match", sessionIds: ["other", "s1"] });
+    const unmatched = proposal({ id: "nope", sessionIds: ["other"] });
+    expect(filterProposalsForSession([matched, unmatched], "s1")).toEqual([matched]);
+  });
+
+  it("treats missing or empty sessionIds as no match", () => {
+    const none = proposal({ id: "none", sessionIds: undefined });
+    const empty = proposal({ id: "empty", sessionIds: [] });
+    expect(filterProposalsForSession([none, empty], "s1")).toEqual([]);
+  });
+});

--- a/src/__tests__/unit/lib/graph-chat/threads.test.ts
+++ b/src/__tests__/unit/lib/graph-chat/threads.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { groupRunsIntoThreads, filterProposalsForSession, type ThreadSourceRun } from "@/lib/graph-chat/threads";
+import {
+  groupRunsIntoThreads,
+  filterProposalsForSession,
+  latestReflection,
+  type ThreadSourceRun,
+} from "@/lib/graph-chat/threads";
 import type { ConceptProposal } from "@/types/concept-proposals";
 
 function run(overrides: Partial<ThreadSourceRun>): ThreadSourceRun {
@@ -88,5 +93,25 @@ describe("filterProposalsForSession", () => {
     const none = proposal({ id: "none", sessionIds: undefined });
     const empty = proposal({ id: "empty", sessionIds: [] });
     expect(filterProposalsForSession([none, empty], "s1")).toEqual([]);
+  });
+});
+
+describe("latestReflection", () => {
+  it("returns the reflection from the LATEST run carrying one (runs are oldest-first)", () => {
+    const early = { session_id: "s1", concepts: [{ id: "a", rank: null }] };
+    const late = {
+      session_id: "s1",
+      concepts: [
+        { id: "a", rank: null },
+        { id: "b", rank: null },
+      ],
+    };
+    const runs = [{ reflection: early }, { reflection: null }, { reflection: late }, { reflection: undefined }];
+    expect(latestReflection(runs)).toBe(late);
+  });
+
+  it("returns null when no run carries a reflection", () => {
+    expect(latestReflection([{ reflection: null }, {}])).toBeNull();
+    expect(latestReflection([])).toBeNull();
   });
 });

--- a/src/__tests__/unit/lib/pusher.test.ts
+++ b/src/__tests__/unit/lib/pusher.test.ts
@@ -300,6 +300,7 @@ describe("pusher.ts", () => {
         CANVAS_USER_LEAVE: "canvas-user-leave",
         CANVAS_SELECTION_UPDATE: "canvas-selection-update",
         CANVAS_RUN_ACTIVE: "canvas-run-active",
+        GRAPH_AGENT_RUN_UPDATED: "graph-agent-run-updated",
         RESEARCH_UPDATED: "research-updated",
         AGENT_LOG_UPDATED: "agent-log-updated",
         CANVAS_CONVERSATION_UPDATED: "canvas-conversation-updated",

--- a/src/app/api/agent-runs/webhook/route.ts
+++ b/src/app/api/agent-runs/webhook/route.ts
@@ -45,7 +45,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import crypto from "crypto";
 import { db } from "@/lib/db";
-import { AgentRunStatus } from "@prisma/client";
+import { AgentRunStatus, Prisma } from "@prisma/client";
 import { timingSafeEqual } from "@/lib/encryption";
 import { checkRateLimit, getClientIp } from "@/lib/rate-limit";
 import {
@@ -73,6 +73,13 @@ interface WebhookPayload {
   result?: {
     content?: unknown;
     final_answer?: unknown;
+    /**
+     * stakgraph SessionReflection sidecar — present when the run read any
+     * gitree Concepts (reads are always recorded; rank/evidence/gap only
+     * when the dispatch opted into the reflect pass). Stored on graph_chat
+     * rows; ignored for canvas runs.
+     */
+    reflection?: unknown;
   } | null;
   /** Error detail on failure (e.g. "aborted", or an exception message). */
   error?: unknown;
@@ -81,6 +88,24 @@ interface WebhookPayload {
 /** Hash a raw token with SHA-256 (hex digest). */
 function hashToken(token: string): string {
   return crypto.createHash("sha256").update(token).digest("hex");
+}
+
+/** Max serialized size accepted for the reflection sidecar (same cap as content). */
+const MAX_REFLECTION_LENGTH = 128 * 1024;
+
+/**
+ * Harden the external reflection payload: must be a plain object and fit the
+ * size cap. Returns null when missing/malformed/oversized — the run is still
+ * delivered normally; reflection is a best-effort sidecar, never load-bearing.
+ */
+function hardenReflection(raw: unknown): Prisma.InputJsonObject | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  try {
+    if (JSON.stringify(raw).length > MAX_REFLECTION_LENGTH) return null;
+  } catch {
+    return null;
+  }
+  return raw as Prisma.InputJsonObject;
 }
 
 export async function POST(request: NextRequest) {
@@ -200,9 +225,13 @@ export async function POST(request: NextRequest) {
       : (isSuccess ? "oversized or malformed result payload" : errorDetail);
 
   // graph_chat runs have no canvas conversation — the row itself is the
-  // delivery destination: the terminal result is stored on it in the same
-  // updateMany that claims it, and the workspace channel gets a nudge.
+  // delivery destination: the terminal result (and the Concept-reads
+  // reflection sidecar, when present) is stored on it in the same updateMany
+  // that claims it, and the workspace channel gets a nudge.
   const isGraphChat = row.agentKind === "graph_chat";
+  const reflection = isGraphChat
+    ? hardenReflection(payload.result?.reflection)
+    : null;
 
   // ── Atomic, token-gated claim ─────────────────────────────────────────────
   // `tokenHash` in the where-clause makes the claim itself credential-gated —
@@ -219,7 +248,7 @@ export async function POST(request: NextRequest) {
         status: effectiveStatus,
         ...(errorField ? { error: errorField } : {}),
         ...(isGraphChat && effectiveStatus === AgentRunStatus.DELIVERED_WEBHOOK
-          ? { result: content! }
+          ? { result: content!, ...(reflection ? { reflection } : {}) }
           : {}),
       },
     });

--- a/src/app/api/agent-runs/webhook/route.ts
+++ b/src/app/api/agent-runs/webhook/route.ts
@@ -1,11 +1,15 @@
 /**
  * POST /api/agent-runs/webhook?id=<runId>&token=<rawToken>
  *
- * Session-less callback for canvas-linked workflow-explorer runs that outlive
- * the Vercel lambda that kicked them off (the "webhook fan-back safety net").
- * The swarm POSTs here when a run reaches a terminal state; Hive claims the
- * `AgentRun` arbitration row exactly once and fans the result into the owning
- * canvas conversation.
+ * Session-less callback for agent runs that outlive the Vercel lambda that
+ * kicked them off (the "webhook fan-back safety net"). The swarm POSTs here
+ * when a run reaches a terminal state; Hive claims the `AgentRun` arbitration
+ * row exactly once and delivers by `agentKind`:
+ *   - "workflow_explorer" (canvas-linked): fans the result into the owning
+ *     canvas conversation.
+ *   - "graph_chat": stores the result on the row itself (in the same
+ *     updateMany that claims it) and Pusher-nudges the workspace channel so
+ *     the Graph Explorer chat sidebar refetches.
  *
  * The payload is what stakgraph's `postTerminalWebhook` actually sends
  * (stakgraph `mcp/src/repo/index.ts`) — the swarm POSTs the registered
@@ -48,6 +52,7 @@ import {
   fanOutAgentRunToCanvas,
   hardenContent,
 } from "@/services/canvas-agent-run-fanout";
+import { notifyGraphAgentRunUpdated } from "@/lib/pusher";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -120,6 +125,10 @@ export async function POST(request: NextRequest) {
       userId: true,
       title: true,
       status: true,
+      agentKind: true,
+      workspaceId: true,
+      workspaceSlug: true,
+      sessionId: true,
     },
   });
 
@@ -190,6 +199,11 @@ export async function POST(request: NextRequest) {
       ? content!
       : (isSuccess ? "oversized or malformed result payload" : errorDetail);
 
+  // graph_chat runs have no canvas conversation — the row itself is the
+  // delivery destination: the terminal result is stored on it in the same
+  // updateMany that claims it, and the workspace channel gets a nudge.
+  const isGraphChat = row.agentKind === "graph_chat";
+
   // ── Atomic, token-gated claim ─────────────────────────────────────────────
   // `tokenHash` in the where-clause makes the claim itself credential-gated —
   // not only the preceding compare — so a race with a concurrent webhook call
@@ -204,6 +218,9 @@ export async function POST(request: NextRequest) {
       data: {
         status: effectiveStatus,
         ...(errorField ? { error: errorField } : {}),
+        ...(isGraphChat && effectiveStatus === AgentRunStatus.DELIVERED_WEBHOOK
+          ? { result: content! }
+          : {}),
       },
     });
 
@@ -221,12 +238,41 @@ export async function POST(request: NextRequest) {
       parsedStatus: effectiveStatus,
     });
 
+    // ── graph_chat delivery: result is on the row — nudge the workspace ───
+    // No canvas fan-out. The slug is snapshotted on the row at create time
+    // (webhook path stays DB-light); fall back to one indexed lookup for
+    // rows created before the snapshot existed.
+    if (isGraphChat) {
+      let slug = row.workspaceSlug;
+      if (!slug && row.workspaceId) {
+        const ws = await db.workspace.findUnique({
+          where: { id: row.workspaceId },
+          select: { slug: true },
+        });
+        slug = ws?.slug ?? null;
+      }
+      if (slug) {
+        notifyGraphAgentRunUpdated(slug, {
+          runId,
+          sessionId: row.sessionId,
+          status: effectiveStatus,
+        });
+      } else {
+        console.warn("[graph-agent-chat] webhook: no workspace slug for run — skipping nudge", {
+          runId,
+        });
+      }
+      return NextResponse.json({ ok: true });
+    }
+
     // ── Fan out to canvas conversation ────────────────────────────────────
     // AgentRun is generalized: conversationId is null for non-canvas run
     // types, which have their own webhook endpoints. A null here means the
     // row was misrouted to this canvas-specific endpoint — the claim above
     // still recorded the terminal state; there is just nowhere to deliver.
-    if (!row.conversationId) {
+    // (`orgId` joined the guard when it became nullable for graph_chat rows;
+    // canvas rows always carry it, so behavior for them is unchanged.)
+    if (!row.conversationId || !row.orgId) {
       console.warn("[canvas-agent-run-fanout] webhook: row has no conversationId — claimed without fan-out", {
         runId,
       });

--- a/src/app/api/mock/stakgraph/repo/agent/route.ts
+++ b/src/app/api/mock/stakgraph/repo/agent/route.ts
@@ -120,6 +120,31 @@ export async function POST(request: NextRequest) {
         const successContent = isGraphMode
           ? graphContent
           : "Mock workflow explorer result: found 3 matching workflows with video-to-transcript skills.";
+        // Graph runs also carry the Concept-reads reflection sidecar, exactly
+        // as stakgraph's terminal payload does (reads recorded, rank null —
+        // graph chat does not opt into the reflect ranking pass).
+        const reflection = isGraphMode
+          ? {
+              session_id: sessionId,
+              updated_at: new Date().toISOString(),
+              concepts: [
+                {
+                  id: "stakwork/hive/tasks",
+                  name: "Tasks",
+                  repo: "stakwork/hive",
+                  read_order: 1,
+                  rank: null,
+                },
+                {
+                  id: "stakwork/hive/auth",
+                  name: "Authentication",
+                  repo: "stakwork/hive",
+                  read_order: 2,
+                  rank: null,
+                },
+              ],
+            }
+          : undefined;
         const callbackBody: Record<string, unknown> = isSuccess
           ? {
               request_id: "mock-diagram-req-001",
@@ -129,6 +154,7 @@ export async function POST(request: NextRequest) {
                 final_answer: successContent,
                 content: successContent,
                 sessionId,
+                ...(reflection ? { reflection } : {}),
               },
             }
           : {

--- a/src/app/api/mock/stakgraph/repo/agent/route.ts
+++ b/src/app/api/mock/stakgraph/repo/agent/route.ts
@@ -1,4 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+import crypto from "crypto";
+import { mockProposals } from "@/app/api/mock/stakgraph/gitree/proposals/fixtures";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -34,6 +36,17 @@ export const dynamic = "force-dynamic";
  *
  * The poll path continues to be exercised by the existing mock progress
  * route (`/api/mock/stakgraph/progress/route.ts`).
+ *
+ * ## Graph Agent Chat simulation
+ *
+ * When `mode: "graph"` is sent (the Graph Explorer chat dispatch), the
+ * success callback carries a graph-flavored markdown answer echoing the
+ * prompt. If the dispatch also enabled the proposal tools
+ * (`toolsConfig.propose_concept_change`) and carries a `sessionId`, a canned
+ * pending `MockProposal` tagged with that `sessionId` is inserted into the
+ * stateful gitree proposal fixtures BEFORE the callback fires — so the chip
+ * flow (webhook nudge → proposals fetch → sessionIds filter) is testable
+ * end-to-end against the mocks.
  */
 export async function POST(request: NextRequest) {
   try {
@@ -51,11 +64,49 @@ export async function POST(request: NextRequest) {
 
     const webhookUrl = body.webhookUrl as string | undefined;
     const webhookMode = (body.webhookMode as string | undefined) ?? "success";
+    const isGraphMode = body.mode === "graph";
+    const sessionId = typeof body.sessionId === "string" ? body.sessionId : undefined;
+    const toolsConfig = (body.toolsConfig ?? {}) as Record<string, unknown>;
+    const proposalsEnabled = toolsConfig.propose_concept_change === true;
 
     console.log("[StakgraphMock] POST /repo/agent - returning mock request_id", {
       hasWebhookUrl: !!webhookUrl,
       webhookMode,
+      isGraphMode,
+      proposalsEnabled,
     });
+
+    // Graph chat with proposals on: file a canned pending proposal tagged
+    // with this session BEFORE the terminal callback fires, so the chip flow
+    // finds it as soon as the run completes.
+    if (isGraphMode && proposalsEnabled && sessionId && webhookMode === "success") {
+      mockProposals.push({
+        id: `proposal-graph-chat-${crypto.randomUUID()}`,
+        action: "update",
+        status: "pending",
+        conceptId: "stakwork/hive/tasks",
+        documentation:
+          "Core task CRUD with dual status system (user vs workflow). The graph agent noted that task threads now group agent runs by sessionId.",
+        baseDocs: "Core task CRUD with dual status system (user vs workflow).",
+        rationale: "Filed by the mock graph agent from a proposals-enabled chat thread.",
+        source: "graph_chat",
+        prNumbers: [],
+        sessionIds: [sessionId],
+        createdAt: new Date().toISOString(),
+        repo: "stakwork/hive",
+      });
+    }
+
+    const graphContent = [
+      "## Mock graph agent answer",
+      "",
+      `You asked: ${typeof body.prompt === "string" ? body.prompt.slice(0, 200) : "(no prompt)"}`,
+      "",
+      "The workspace graph contains **5 concepts**; `stakwork/hive/tasks` is the most connected node.",
+      ...(proposalsEnabled
+        ? ["", "I filed one concept change proposal for review on the Learn page."]
+        : []),
+    ].join("\n");
 
     // Schedule a simulated terminal callback when webhookUrl is present and
     // webhookMode is not "inline" (inline mode is exercised by the poll route).
@@ -66,16 +117,18 @@ export async function POST(request: NextRequest) {
       setTimeout(() => {
         // Mirror stakgraph's TerminalWebhookPayload shape exactly.
         const callbackStatus = isSuccess ? "completed" : "failed";
+        const successContent = isGraphMode
+          ? graphContent
+          : "Mock workflow explorer result: found 3 matching workflows with video-to-transcript skills.";
         const callbackBody: Record<string, unknown> = isSuccess
           ? {
               request_id: "mock-diagram-req-001",
               status: "completed",
               result: {
                 success: true,
-                final_answer:
-                  "Mock workflow explorer result: found 3 matching workflows with video-to-transcript skills.",
-                content:
-                  "Mock workflow explorer result: found 3 matching workflows with video-to-transcript skills.",
+                final_answer: successContent,
+                content: successContent,
+                sessionId,
               },
             }
           : {

--- a/src/app/api/workspaces/[slug]/graph/agent/route.ts
+++ b/src/app/api/workspaces/[slug]/graph/agent/route.ts
@@ -1,0 +1,228 @@
+/**
+ * POST /api/workspaces/[slug]/graph/agent — Graph Agent Chat dispatch.
+ *
+ * One user message = one one-shot `repo/agent` dispatch (mode: "graph")
+ * against the workspace's own swarm, with a webhook fan-back URL. The
+ * terminal result lands on the `AgentRun` row via /api/agent-runs/webhook
+ * and a Pusher nudge refreshes the sidebar. Session continuity is
+ * server-side on the swarm (history keyed by `sessionId`) — Hive stores
+ * only prompt/result pairs for display.
+ *
+ * Body: `{ prompt, sessionId?, proposalsEnabled? }`.
+ *   - No sessionId → new thread: mint a UUID; `proposalsEnabled` comes from
+ *     the modal checkbox and is snapshotted onto the run.
+ *   - sessionId → follow-up: the per-thread proposals setting is IMMUTABLE —
+ *     the server re-snapshots it from the latest run in the session and
+ *     rejects a client attempt to flip it mid-thread (409).
+ *
+ * Auth: admin/owner only — same gate as the graph query route and the page.
+ *
+ * NEVER log the raw token or the full webhookUrl.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import crypto from "crypto";
+import { authOptions } from "@/lib/auth/nextauth";
+import { db } from "@/lib/db";
+import { config } from "@/config/env";
+import { validateWorkspaceAccess } from "@/services/workspace";
+import { getSwarmConfig } from "@/app/api/learnings/utils";
+import { dispatchRepoAgent } from "@/lib/ai/askTools";
+import { getPublicBaseUrl } from "@/lib/url";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const MAX_PROMPT_LENGTH = 20_000;
+const TITLE_MAX = 120;
+
+/** Thread title from the opening prompt: first line, length-capped. */
+function titleFromPrompt(prompt: string): string {
+  const firstLine = prompt.split("\n", 1)[0].trim() || "Graph chat";
+  return firstLine.length > TITLE_MAX ? `${firstLine.slice(0, TITLE_MAX)}…` : firstLine;
+}
+
+export async function POST(request: NextRequest, { params }: { params: Promise<{ slug: string }> }) {
+  try {
+    const session = await getServerSession(authOptions);
+    const { slug } = await params;
+
+    if (!session?.user) {
+      return NextResponse.json({ success: false, message: "Unauthorized" }, { status: 401 });
+    }
+    const userId = (session.user as { id?: string })?.id;
+    if (!userId) {
+      return NextResponse.json({ success: false, message: "Invalid user session" }, { status: 401 });
+    }
+
+    const access = await validateWorkspaceAccess(slug, userId, true);
+    if (!access.hasAccess || !access.workspace) {
+      return NextResponse.json({ success: false, message: "Workspace not found or access denied" }, { status: 404 });
+    }
+    if (!access.canAdmin) {
+      return NextResponse.json({ success: false, message: "Forbidden: admin access required" }, { status: 403 });
+    }
+    const workspaceId = access.workspace.id;
+
+    let body: {
+      prompt?: unknown;
+      sessionId?: unknown;
+      proposalsEnabled?: unknown;
+    };
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ success: false, message: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const prompt = typeof body.prompt === "string" ? body.prompt.trim() : "";
+    if (!prompt) {
+      return NextResponse.json({ success: false, message: "prompt is required" }, { status: 400 });
+    }
+    if (prompt.length > MAX_PROMPT_LENGTH) {
+      return NextResponse.json({ success: false, message: "prompt is too long" }, { status: 400 });
+    }
+    if (body.sessionId !== undefined && typeof body.sessionId !== "string") {
+      return NextResponse.json({ success: false, message: "sessionId must be a string" }, { status: 400 });
+    }
+    if (body.proposalsEnabled !== undefined && typeof body.proposalsEnabled !== "boolean") {
+      return NextResponse.json({ success: false, message: "proposalsEnabled must be a boolean" }, { status: 400 });
+    }
+
+    // ── Thread resolution ───────────────────────────────────────────────────
+    // The per-thread proposals setting is decided at creation and snapshotted
+    // onto every run. On follow-ups the server derives it from the latest run
+    // — the client-sent flag is only cross-checked, never trusted.
+    let sessionId: string;
+    let proposalsEnabled: boolean;
+    if (body.sessionId) {
+      const latest = await db.agentRun.findFirst({
+        where: { workspaceId, agentKind: "graph_chat", sessionId: body.sessionId },
+        orderBy: { createdAt: "desc" },
+        select: { proposalsEnabled: true },
+      });
+      if (!latest) {
+        return NextResponse.json({ success: false, message: "Unknown chat thread" }, { status: 404 });
+      }
+      if (body.proposalsEnabled !== undefined && body.proposalsEnabled !== latest.proposalsEnabled) {
+        return NextResponse.json(
+          {
+            success: false,
+            message: "proposalsEnabled cannot change after thread creation",
+          },
+          { status: 409 },
+        );
+      }
+      sessionId = body.sessionId;
+      proposalsEnabled = latest.proposalsEnabled;
+    } else {
+      sessionId = crypto.randomUUID();
+      proposalsEnabled = body.proposalsEnabled === true;
+    }
+
+    // ── Swarm resolution (before creating any row — no orphans on config
+    //    errors). Mocks short-circuit to the mock stakgraph repo/agent. ─────
+    let swarmUrl: string;
+    let swarmApiKey: string;
+    if (config.USE_MOCKS) {
+      swarmUrl = `${config.MOCK_BASE}/api/mock/stakgraph`;
+      swarmApiKey = "mock";
+    } else {
+      const swarmConfig = await getSwarmConfig(workspaceId);
+      if ("error" in swarmConfig) {
+        return NextResponse.json({ success: false, message: swarmConfig.error }, { status: swarmConfig.status });
+      }
+      swarmUrl = swarmConfig.baseSwarmUrl;
+      swarmApiKey = swarmConfig.decryptedSwarmApiKey;
+    }
+
+    const workspace = await db.workspace.findFirst({
+      where: { id: workspaceId },
+      select: { slug: true, sourceControlOrgId: true },
+    });
+
+    // ── Fan-back arbitration row (mirrors setupFanBack) ────────────────────
+    // High-entropy token — stored hashed, carried raw in the webhookUrl the
+    // swarm POSTs back to. NEVER log rawToken or the full webhookUrl.
+    const rawToken = crypto.randomBytes(32).toString("hex");
+    const tokenHash = crypto.createHash("sha256").update(rawToken).digest("hex");
+
+    const run = await db.agentRun.create({
+      data: {
+        tokenHash,
+        agentKind: "graph_chat",
+        workspaceId,
+        workspaceSlug: workspace?.slug ?? slug,
+        orgId: workspace?.sourceControlOrgId ?? null,
+        userId,
+        sessionId,
+        prompt,
+        proposalsEnabled,
+        title: titleFromPrompt(prompt),
+      },
+      select: { id: true },
+    });
+
+    const webhookUrl = `${getPublicBaseUrl(request)}/api/agent-runs/webhook?id=${run.id}&token=${rawToken}`;
+
+    try {
+      // `proposalsEnabled` is enforced server-side per dispatch: toolsConfig
+      // is omitted entirely unless the thread was created with it on.
+      const requestId = await dispatchRepoAgent(swarmUrl, swarmApiKey, {
+        prompt,
+        mode: "graph",
+        sessionId,
+        ...(proposalsEnabled
+          ? {
+              toolsConfig: {
+                propose_concept_change: true,
+                list_concept_proposals: true,
+              },
+            }
+          : {}),
+        webhookUrl,
+      });
+      console.log("[graph-agent-chat] dispatched", { runId: run.id, requestId });
+
+      // Save requestId for observability — best-effort, NOT part of the
+      // arbitration key.
+      await db.agentRun.update({ where: { id: run.id }, data: { requestId } }).catch((e) =>
+        console.warn("[graph-agent-chat] requestId save failed (non-fatal)", {
+          runId: run.id,
+          error: e instanceof Error ? e.message : String(e),
+        }),
+      );
+    } catch (e) {
+      // Initiation failure: the swarm never accepted the run, so no callback
+      // can ever arrive. Claim PENDING → FAILED (guarded, as the webhook may
+      // never race us but a cancel could).
+      await db.agentRun.updateMany({
+        where: { id: run.id, status: "PENDING" },
+        data: {
+          status: "FAILED",
+          error: e instanceof Error ? e.message : "initiation_failed",
+        },
+      });
+      console.error("[graph-agent-chat] dispatch failed — run FAILED", {
+        runId: run.id,
+      });
+      return NextResponse.json(
+        {
+          success: false,
+          message: "Failed to dispatch graph agent",
+          runId: run.id,
+          sessionId,
+        },
+        { status: 502 },
+      );
+    }
+
+    return NextResponse.json({ runId: run.id, sessionId });
+  } catch (e) {
+    console.error("[graph-agent-chat] unexpected error", {
+      error: e instanceof Error ? e.message : String(e),
+    });
+    return NextResponse.json({ success: false, message: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/workspaces/[slug]/graph/agent/route.ts
+++ b/src/app/api/workspaces/[slug]/graph/agent/route.ts
@@ -169,6 +169,10 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     try {
       // `proposalsEnabled` is enforced server-side per dispatch: toolsConfig
       // is omitted entirely unless the thread was created with it on.
+      // `reflect` is deliberately NOT sent: Concept READS are recorded to the
+      // session sidecar (and delivered on the terminal webhook) regardless;
+      // the opt-in only adds a post-run ranking pass that would hold the run
+      // open for an extra agent call on every message.
       const requestId = await dispatchRepoAgent(swarmUrl, swarmApiKey, {
         prompt,
         mode: "graph",

--- a/src/app/api/workspaces/[slug]/graph/agent/runs/route.ts
+++ b/src/app/api/workspaces/[slug]/graph/agent/runs/route.ts
@@ -60,6 +60,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
           status: true,
           error: true,
           proposalsEnabled: true,
+          reflection: true,
           createdAt: true,
         },
       });

--- a/src/app/api/workspaces/[slug]/graph/agent/runs/route.ts
+++ b/src/app/api/workspaces/[slug]/graph/agent/runs/route.ts
@@ -1,0 +1,92 @@
+/**
+ * GET /api/workspaces/[slug]/graph/agent/runs — Graph Agent Chat history.
+ *
+ *   - `?sessionId=` → runs in that thread, oldest first:
+ *     `{ runs: [{ id, prompt, result, status, error, proposalsEnabled, createdAt }] }`
+ *   - no sessionId → thread list (latest run per session), newest first:
+ *     `{ threads: [{ sessionId, title, proposalsEnabled, lastStatus, updatedAt }] }`
+ *
+ * Admin/owner only (same gate as the dispatch route and the page). Every
+ * query is scoped by `workspaceId` AND `agentKind: "graph_chat"` — canvas
+ * workflow-explorer rows are never visible here.
+ *
+ * NOTE: middleware marks GET /api/workspaces/* as public, so this handler
+ * does its own session check (same as the other graph GET routes).
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/lib/auth/nextauth";
+import { db } from "@/lib/db";
+import { validateWorkspaceAccess } from "@/services/workspace";
+import { groupRunsIntoThreads } from "@/lib/graph-chat/threads";
+import type { GraphChatRunStatus } from "@/types/graph-chat";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest, { params }: { params: Promise<{ slug: string }> }) {
+  try {
+    const session = await getServerSession(authOptions);
+    const { slug } = await params;
+
+    if (!session?.user) {
+      return NextResponse.json({ success: false, message: "Unauthorized" }, { status: 401 });
+    }
+    const userId = (session.user as { id?: string })?.id;
+    if (!userId) {
+      return NextResponse.json({ success: false, message: "Invalid user session" }, { status: 401 });
+    }
+
+    const access = await validateWorkspaceAccess(slug, userId, true);
+    if (!access.hasAccess || !access.workspace) {
+      return NextResponse.json({ success: false, message: "Workspace not found or access denied" }, { status: 404 });
+    }
+    if (!access.canAdmin) {
+      return NextResponse.json({ success: false, message: "Forbidden: admin access required" }, { status: 403 });
+    }
+    const workspaceId = access.workspace.id;
+
+    const sessionId = request.nextUrl.searchParams.get("sessionId");
+
+    if (sessionId) {
+      const runs = await db.agentRun.findMany({
+        where: { workspaceId, agentKind: "graph_chat", sessionId },
+        orderBy: { createdAt: "asc" },
+        select: {
+          id: true,
+          prompt: true,
+          result: true,
+          status: true,
+          error: true,
+          proposalsEnabled: true,
+          createdAt: true,
+        },
+      });
+      return NextResponse.json({
+        runs: runs.map((r) => ({ ...r, createdAt: r.createdAt.toISOString() })),
+      });
+    }
+
+    const rows = await db.agentRun.findMany({
+      where: { workspaceId, agentKind: "graph_chat" },
+      orderBy: { createdAt: "asc" },
+      select: {
+        sessionId: true,
+        title: true,
+        proposalsEnabled: true,
+        status: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+    return NextResponse.json({
+      threads: groupRunsIntoThreads(rows.map((r) => ({ ...r, status: r.status as GraphChatRunStatus }))),
+    });
+  } catch (e) {
+    console.error("[graph-agent-chat] runs GET error", {
+      error: e instanceof Error ? e.message : String(e),
+    });
+    return NextResponse.json({ success: false, message: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/components/graph-explorer/GraphExplorer.tsx
+++ b/src/components/graph-explorer/GraphExplorer.tsx
@@ -9,6 +9,8 @@ import {
   DatabaseZap,
   Search,
   ChevronRight,
+  MessageSquare,
+  Plus,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -33,6 +35,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 
 import { stakgraphToRawGraph } from "./stakgraphToRawGraph";
 import { useKGGraph } from "./useKGGraph";
+import { GraphChatSidebar, NewGraphChatModal } from "./chat";
 import type { RawNode, RawEdge } from "@/graph-viz-kit";
 
 // Dynamically import the 3D canvas — Three.js is browser-only
@@ -181,6 +184,11 @@ export function GraphExplorer({ workspaceSlug }: GraphExplorerProps) {
   const [searchResults, setSearchResults] = useState<SearchResultItem[]>([]);
   const [searchLoading, setSearchLoading] = useState(false);
   const [searchError, setSearchError] = useState<string | null>(null);
+
+  // ── Graph agent chat state ────────────────────────────────────────────────
+  const [chatOpen, setChatOpen] = useState(false);
+  const [chatSessionId, setChatSessionId] = useState<string | null>(null);
+  const [newChatOpen, setNewChatOpen] = useState(false);
 
   // ── Update raw graph whenever query result changes ────────────────────────
   useEffect(() => {
@@ -362,185 +370,222 @@ export function GraphExplorer({ workspaceSlug }: GraphExplorerProps) {
 
   // ── Render ────────────────────────────────────────────────────────────────
   return (
-    <div className="flex flex-col gap-4 flex-1 min-h-0">
-      {/* ── Search panel ── */}
-      <div className="flex gap-2 items-center" data-testid="search-panel">
-        <Input
-          data-testid="search-input"
-          placeholder="Keyword / semantic search…"
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-          onKeyDown={handleSearchKeyDown}
-          className="flex-1"
-        />
-        <Button
-          data-testid="search-button"
-          variant="secondary"
-          onClick={runSearch}
-          disabled={searchLoading || !searchQuery.trim()}
-        >
-          {searchLoading ? (
-            <Loader2 className="h-4 w-4 animate-spin mr-2" />
-          ) : (
-            <Search className="h-4 w-4 mr-2" />
-          )}
-          Search
-        </Button>
-      </div>
-
-      {/* Search results */}
-      {searchError && (
-        <p className="text-xs text-destructive" data-testid="search-error">
-          {searchError}
-        </p>
-      )}
-      {searchResults.length > 0 && (
-        <div
-          className="flex flex-wrap gap-2 p-2 border rounded-md bg-muted/40"
-          data-testid="search-results"
-        >
-          {searchResults.map((item) => (
-            <button
-              key={item.ref_id}
-              data-testid={`search-result-${item.ref_id}`}
-              onClick={() => handleSearchResultClick(item)}
-              className="flex items-center gap-1 px-2 py-1 rounded border bg-background hover:bg-accent text-xs transition-colors"
-            >
-              <span className="font-medium">{item.name}</span>
-              <ChevronRight className="h-3 w-3 text-muted-foreground" />
-              <span className="text-muted-foreground truncate max-w-[140px]">{item.file}</span>
-            </button>
-          ))}
+    <div className="flex flex-1 min-h-0 gap-4">
+      <div className="flex flex-col gap-4 flex-1 min-h-0 min-w-0">
+        {/* ── Search panel ── */}
+        <div className="flex gap-2 items-center" data-testid="search-panel">
+          <Input
+            data-testid="search-input"
+            placeholder="Keyword / semantic search…"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            onKeyDown={handleSearchKeyDown}
+            className="flex-1"
+          />
+          <Button
+            data-testid="search-button"
+            variant="secondary"
+            onClick={runSearch}
+            disabled={searchLoading || !searchQuery.trim()}
+          >
+            {searchLoading ? (
+              <Loader2 className="h-4 w-4 animate-spin mr-2" />
+            ) : (
+              <Search className="h-4 w-4 mr-2" />
+            )}
+            Search
+          </Button>
+          <Button
+            data-testid="graph-chat-toggle-button"
+            variant={chatOpen ? "secondary" : "outline"}
+            onClick={() => setChatOpen((open) => !open)}
+          >
+            <MessageSquare className="h-4 w-4 mr-2" />
+            Chat
+          </Button>
+          <Button
+            data-testid="graph-chat-new-button"
+            variant="outline"
+            onClick={() => setNewChatOpen(true)}
+          >
+            <Plus className="h-4 w-4 mr-2" />
+            New
+          </Button>
         </div>
-      )}
 
-      {/* ── Cypher query bar ── */}
-      <div className="flex gap-2 items-start" data-testid="query-bar">
-        <Textarea
-          data-testid="cypher-input"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          onKeyDown={handleKeyDown}
-          rows={3}
-          placeholder="MATCH (n) RETURN n LIMIT 25"
-          className="font-mono text-sm resize-none flex-1"
-          spellCheck={false}
-        />
-        <Button
-          data-testid="run-query-button"
-          onClick={() => runQuery()}
-          disabled={loading || !query.trim()}
-          className="shrink-0"
-        >
-          {loading ? (
-            <Loader2 className="h-4 w-4 animate-spin mr-2" />
-          ) : (
-            <Play className="h-4 w-4 mr-2" />
-          )}
-          Run
-        </Button>
-      </div>
-
-      <p className="text-xs text-muted-foreground -mt-2">
-        Press{" "}
-        <kbd className="px-1 py-0.5 rounded border text-xs font-mono">Ctrl+Enter</kbd> to run
-      </p>
-
-      {/* ── Status states ── */}
-      {notConfigured && (
-        <div
-          data-testid="not-configured-state"
-          className="flex flex-col items-center justify-center py-16 text-center gap-3"
-        >
-          <DatabaseZap className="h-10 w-10 text-muted-foreground" />
-          <p className="font-medium text-foreground">Graph DB not configured for this workspace</p>
-          <p className="text-sm text-muted-foreground max-w-sm">
-            Attach a swarm with a graph endpoint to start exploring.
+        {/* Search results */}
+        {searchError && (
+          <p className="text-xs text-destructive" data-testid="search-error">
+            {searchError}
           </p>
-        </div>
-      )}
-
-      {error && (
-        <Alert variant="destructive" data-testid="error-state">
-          <AlertCircle className="h-4 w-4" />
-          <AlertDescription>{error}</AlertDescription>
-        </Alert>
-      )}
-
-      {loading && (
-        <div
-          data-testid="loading-state"
-          className="flex items-center justify-center py-16 gap-2 text-muted-foreground"
-        >
-          <Loader2 className="h-5 w-5 animate-spin" />
-          <span>Running query…</span>
-        </div>
-      )}
-
-      {/* ── Results ── */}
-      {!loading && queryResult !== null && !error && !notConfigured && (
-        <>
-          {queryResult.rows.length === 0 ? (
-            <div
-              data-testid="empty-state"
-              className="flex flex-col items-center justify-center py-16 gap-2 text-muted-foreground"
-            >
-              <Search className="h-8 w-8" />
-              <p>No results returned.</p>
-            </div>
-          ) : (
-            <Tabs value={tab} onValueChange={setTab} className="flex flex-col flex-1 min-h-0">
-              <div className="flex items-center gap-3">
-                <TabsList>
-                  <TabsTrigger value="table" data-testid="tab-table">
-                    Table
-                  </TabsTrigger>
-                  <TabsTrigger value="graph" data-testid="tab-graph">
-                    Graph
-                  </TabsTrigger>
-                </TabsList>
-                <span className="text-xs text-muted-foreground">
-                  {queryResult.rows.length} record{queryResult.rows.length !== 1 ? "s" : ""}
-                </span>
-                {viewState.mode === "subgraph" && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={goOverview}
-                    data-testid="go-overview-button"
-                    className="text-xs"
-                  >
-                    ← Overview
-                  </Button>
-                )}
-              </div>
-
-              <TabsContent value="table" className="flex-1 min-h-0 mt-2 overflow-auto">
-                <ResultTable columns={queryResult.columns} rows={queryResult.rows} />
-              </TabsContent>
-
-              <TabsContent
-                value="graph"
-                className="flex-1 min-h-0 mt-2 border rounded-md overflow-hidden"
-                style={{ minHeight: 400 }}
+        )}
+        {searchResults.length > 0 && (
+          <div
+            className="flex flex-wrap gap-2 p-2 border rounded-md bg-muted/40"
+            data-testid="search-results"
+          >
+            {searchResults.map((item) => (
+              <button
+                key={item.ref_id}
+                data-testid={`search-result-${item.ref_id}`}
+                onClick={() => handleSearchResultClick(item)}
+                className="flex items-center gap-1 px-2 py-1 rounded border bg-background hover:bg-accent text-xs transition-colors"
               >
-                {graph.nodes.length > 0 ? (
-                  <KGCanvas
-                    graph={graph}
-                    viewState={viewState}
-                    onNodeClick={handleCanvasNodeClick}
-                    searchMatches={searchMatches}
-                  />
-                ) : (
-                  <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
-                    No graph nodes found in these results.
-                  </div>
-                )}
-              </TabsContent>
-            </Tabs>
-          )}
-        </>
+                <span className="font-medium">{item.name}</span>
+                <ChevronRight className="h-3 w-3 text-muted-foreground" />
+                <span className="text-muted-foreground truncate max-w-[140px]">{item.file}</span>
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* ── Cypher query bar ── */}
+        <div className="flex gap-2 items-start" data-testid="query-bar">
+          <Textarea
+            data-testid="cypher-input"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            rows={3}
+            placeholder="MATCH (n) RETURN n LIMIT 25"
+            className="font-mono text-sm resize-none flex-1"
+            spellCheck={false}
+          />
+          <Button
+            data-testid="run-query-button"
+            onClick={() => runQuery()}
+            disabled={loading || !query.trim()}
+            className="shrink-0"
+          >
+            {loading ? (
+              <Loader2 className="h-4 w-4 animate-spin mr-2" />
+            ) : (
+              <Play className="h-4 w-4 mr-2" />
+            )}
+            Run
+          </Button>
+        </div>
+
+        <p className="text-xs text-muted-foreground -mt-2">
+          Press{" "}
+          <kbd className="px-1 py-0.5 rounded border text-xs font-mono">Ctrl+Enter</kbd> to run
+        </p>
+
+        {/* ── Status states ── */}
+        {notConfigured && (
+          <div
+            data-testid="not-configured-state"
+            className="flex flex-col items-center justify-center py-16 text-center gap-3"
+          >
+            <DatabaseZap className="h-10 w-10 text-muted-foreground" />
+            <p className="font-medium text-foreground">Graph DB not configured for this workspace</p>
+            <p className="text-sm text-muted-foreground max-w-sm">
+              Attach a swarm with a graph endpoint to start exploring.
+            </p>
+          </div>
+        )}
+
+        {error && (
+          <Alert variant="destructive" data-testid="error-state">
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        {loading && (
+          <div
+            data-testid="loading-state"
+            className="flex items-center justify-center py-16 gap-2 text-muted-foreground"
+          >
+            <Loader2 className="h-5 w-5 animate-spin" />
+            <span>Running query…</span>
+          </div>
+        )}
+
+        {/* ── Results ── */}
+        {!loading && queryResult !== null && !error && !notConfigured && (
+          <>
+            {queryResult.rows.length === 0 ? (
+              <div
+                data-testid="empty-state"
+                className="flex flex-col items-center justify-center py-16 gap-2 text-muted-foreground"
+              >
+                <Search className="h-8 w-8" />
+                <p>No results returned.</p>
+              </div>
+            ) : (
+              <Tabs value={tab} onValueChange={setTab} className="flex flex-col flex-1 min-h-0">
+                <div className="flex items-center gap-3">
+                  <TabsList>
+                    <TabsTrigger value="table" data-testid="tab-table">
+                      Table
+                    </TabsTrigger>
+                    <TabsTrigger value="graph" data-testid="tab-graph">
+                      Graph
+                    </TabsTrigger>
+                  </TabsList>
+                  <span className="text-xs text-muted-foreground">
+                    {queryResult.rows.length} record{queryResult.rows.length !== 1 ? "s" : ""}
+                  </span>
+                  {viewState.mode === "subgraph" && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={goOverview}
+                      data-testid="go-overview-button"
+                      className="text-xs"
+                    >
+                      ← Overview
+                    </Button>
+                  )}
+                </div>
+
+                <TabsContent value="table" className="flex-1 min-h-0 mt-2 overflow-auto">
+                  <ResultTable columns={queryResult.columns} rows={queryResult.rows} />
+                </TabsContent>
+
+                <TabsContent
+                  value="graph"
+                  className="flex-1 min-h-0 mt-2 border rounded-md overflow-hidden"
+                  style={{ minHeight: 400 }}
+                >
+                  {graph.nodes.length > 0 ? (
+                    <KGCanvas
+                      graph={graph}
+                      viewState={viewState}
+                      onNodeClick={handleCanvasNodeClick}
+                      searchMatches={searchMatches}
+                    />
+                  ) : (
+                    <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
+                      No graph nodes found in these results.
+                    </div>
+                  )}
+                </TabsContent>
+              </Tabs>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* ── Graph agent chat sidebar + new-chat modal ── */}
+      {chatOpen && (
+        <GraphChatSidebar
+          workspaceSlug={workspaceSlug}
+          activeSessionId={chatSessionId}
+          onSelectThread={setChatSessionId}
+          onClose={() => setChatOpen(false)}
+        />
       )}
+      <NewGraphChatModal
+        workspaceSlug={workspaceSlug}
+        open={newChatOpen}
+        onOpenChange={setNewChatOpen}
+        onCreated={(sessionId) => {
+          setChatSessionId(sessionId);
+          setChatOpen(true);
+        }}
+      />
 
       {/* ── Node properties / path-tracing sheet ── */}
       <Sheet open={!!selectedNode} onOpenChange={(open) => !open && setSelectedNode(null)}>

--- a/src/components/graph-explorer/chat/ConceptProposalChip.tsx
+++ b/src/components/graph-explorer/chat/ConceptProposalChip.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import Link from "next/link";
+import { ChevronDown, ChevronRight, ExternalLink } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { computeUnifiedDiff } from "@/lib/diff/unifiedLineDiff";
+import { UnifiedDiffView, SECTION_LABEL_CLASS } from "@/components/diff/UnifiedDiffView";
+import {
+  conceptProposalLabel,
+  type ConceptProposal,
+  type ProposalAction,
+  type ProposalStatus,
+} from "@/types/concept-proposals";
+
+/**
+ * Read-only proposal card shown under a completed run in a proposals-enabled
+ * graph chat thread. No accept/reject here — deciding lives on /learn, so the
+ * chip only badges the action/status, shows the rationale, expands a
+ * read-only diff, and deep-links to the review UI.
+ */
+
+const ACTION_BADGE_CLASS: Record<ProposalAction, string> = {
+  create: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300",
+  update: "bg-blue-500/15 text-blue-700 dark:text-blue-300",
+  delete: "bg-rose-500/15 text-rose-700 dark:text-rose-300",
+  merge: "bg-violet-500/15 text-violet-700 dark:text-violet-300",
+};
+
+const STATUS_BADGE_CLASS: Record<ProposalStatus, string> = {
+  pending: "bg-amber-500/15 text-amber-700 dark:text-amber-300",
+  accepted: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300",
+  rejected: "bg-rose-500/15 text-rose-700 dark:text-rose-300",
+};
+
+export function ConceptProposalChip({ proposal, workspaceSlug }: { proposal: ConceptProposal; workspaceSlug: string }) {
+  const [expanded, setExpanded] = useState(false);
+
+  // Per-action diff shapes (per PROPOSALS_API): create is all-added docs,
+  // update is baseDocs → documentation, delete removes baseDocs, merge is the
+  // survivor's diff plus the absorbed concept's docs shown removed.
+  // Note: diffing to "" yields one blank "added" line — expected lib behavior.
+  const diffs = useMemo(() => {
+    if (!expanded) return null;
+    switch (proposal.action) {
+      case "create":
+        return { main: computeUnifiedDiff("", proposal.documentation ?? "") };
+      case "update":
+        return {
+          main: computeUnifiedDiff(proposal.baseDocs ?? "", proposal.documentation ?? ""),
+        };
+      case "delete":
+        return { main: computeUnifiedDiff(proposal.baseDocs ?? "", "") };
+      case "merge":
+        return {
+          main: computeUnifiedDiff(proposal.baseDocs ?? "", proposal.documentation ?? ""),
+          absorbed: computeUnifiedDiff(proposal.absorbedDocs ?? "", ""),
+        };
+    }
+  }, [expanded, proposal]);
+
+  return (
+    <div className="rounded-md border bg-muted/30 p-2.5 space-y-1.5" data-testid={`proposal-chip-${proposal.id}`}>
+      <div className="flex items-center gap-2 min-w-0">
+        <Badge
+          variant="secondary"
+          className={`uppercase text-[10px] ${ACTION_BADGE_CLASS[proposal.action]}`}
+          data-testid="proposal-chip-action"
+        >
+          {proposal.action}
+        </Badge>
+        {proposal.status !== "pending" && (
+          <Badge
+            variant="secondary"
+            className={`text-[10px] ${STATUS_BADGE_CLASS[proposal.status]}`}
+            data-testid="proposal-chip-status"
+          >
+            {proposal.status}
+          </Badge>
+        )}
+        <span className="text-xs font-medium truncate" title={conceptProposalLabel(proposal)}>
+          {conceptProposalLabel(proposal)}
+        </span>
+      </div>
+
+      <p className="text-xs text-muted-foreground">{proposal.rationale}</p>
+
+      <div className="flex items-center gap-3">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 px-1.5 text-xs"
+          onClick={() => setExpanded((v) => !v)}
+          data-testid="proposal-chip-diff-toggle"
+        >
+          {expanded ? <ChevronDown className="h-3 w-3 mr-1" /> : <ChevronRight className="h-3 w-3 mr-1" />}
+          View diff
+        </Button>
+        <Link
+          href={`/w/${workspaceSlug}/learn?proposal=${proposal.id}`}
+          className="text-xs text-primary hover:underline inline-flex items-center gap-1"
+          data-testid="proposal-chip-learn-link"
+        >
+          Review on Learn
+          <ExternalLink className="h-3 w-3" />
+        </Link>
+      </div>
+
+      {expanded && diffs && (
+        <div className="space-y-2 pt-1">
+          <UnifiedDiffView diff={diffs.main} emptyText="No documentation changes." />
+          {"absorbed" in diffs && diffs.absorbed && (
+            <div className="space-y-1">
+              <div className={SECTION_LABEL_CLASS}>Absorbed concept ({proposal.conceptId ?? "?"})</div>
+              <UnifiedDiffView diff={diffs.absorbed} emptyText="No absorbed documentation." />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/graph-explorer/chat/GraphChatSidebar.tsx
+++ b/src/components/graph-explorer/chat/GraphChatSidebar.tsx
@@ -1,0 +1,392 @@
+"use client";
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ArrowLeft, Loader2, MessageSquare, Send, Sparkles, X } from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Textarea } from "@/components/ui/textarea";
+import { MarkdownRenderer } from "@/components/MarkdownRenderer";
+import { usePusherChannel } from "@/hooks/usePusherChannel";
+import { getWorkspaceChannelName, PUSHER_EVENTS } from "@/lib/pusher";
+import { filterProposalsForSession } from "@/lib/graph-chat/threads";
+import type { ConceptProposal, ConceptProposalListResponse } from "@/types/concept-proposals";
+import type {
+  GraphChatRun,
+  GraphChatThread,
+  GraphChatRunsResponse,
+  GraphChatThreadsResponse,
+} from "@/types/graph-chat";
+import { ConceptProposalChip } from "./ConceptProposalChip";
+
+/**
+ * Right chat panel for the Graph Explorer — thread list plus thread view over
+ * `AgentRun` rows (one row per prompt/result pair; a thread IS a sessionId).
+ *
+ * Fixed panel (not a Sheet) so it can stay open while interacting with the
+ * graph — the node-properties Sheet already occupies the overlay pattern.
+ * Local component state per the LogsChat/DashboardChat precedent — NOT the
+ * org canvas chat store (CANVAS_CHAT.md forbids unifying with it).
+ *
+ * Live updates: subscribes to the workspace channel's
+ * `graph-agent-run-updated` nudge and refetches; also poll-falls-back every
+ * 20s while any run is PENDING (webhooks can be delayed).
+ */
+
+const POLL_INTERVAL_MS = 20_000;
+
+/** Pusher nudge payload for a terminal graph run (see notifyGraphAgentRunUpdated). */
+interface GraphRunNudge {
+  runId: string;
+  sessionId: string | null;
+  status: string;
+}
+
+function StatusDot({ status }: { status: GraphChatThread["lastStatus"] }) {
+  const cls =
+    status === "PENDING" ? "bg-amber-500 animate-pulse" : status === "FAILED" ? "bg-rose-500" : "bg-emerald-500";
+  return <span className={`inline-block h-2 w-2 rounded-full shrink-0 ${cls}`} />;
+}
+
+export function GraphChatSidebar({
+  workspaceSlug,
+  activeSessionId,
+  onSelectThread,
+  onClose,
+}: {
+  workspaceSlug: string;
+  /** null → thread list view */
+  activeSessionId: string | null;
+  onSelectThread: (sessionId: string | null) => void;
+  onClose: () => void;
+}) {
+  const [threads, setThreads] = useState<GraphChatThread[]>([]);
+  const [threadsLoading, setThreadsLoading] = useState(false);
+  const [runs, setRuns] = useState<GraphChatRun[]>([]);
+  const [runsLoading, setRunsLoading] = useState(false);
+  const [proposals, setProposals] = useState<ConceptProposal[]>([]);
+  const [composerText, setComposerText] = useState("");
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const fetchThreads = useCallback(async () => {
+    setThreadsLoading(true);
+    try {
+      const res = await fetch(`/api/workspaces/${workspaceSlug}/graph/agent/runs`);
+      if (res.ok) {
+        const data: GraphChatThreadsResponse = await res.json();
+        setThreads(data.threads ?? []);
+      }
+    } catch {
+      // Non-fatal; the poll/nudge will retry.
+    } finally {
+      setThreadsLoading(false);
+    }
+  }, [workspaceSlug]);
+
+  const fetchRuns = useCallback(
+    async (sessionId: string) => {
+      try {
+        const res = await fetch(
+          `/api/workspaces/${workspaceSlug}/graph/agent/runs?sessionId=${encodeURIComponent(sessionId)}`,
+        );
+        if (res.ok) {
+          const data: GraphChatRunsResponse = await res.json();
+          setRuns(data.runs ?? []);
+        }
+      } catch {
+        // Non-fatal; the poll/nudge will retry.
+      } finally {
+        setRunsLoading(false);
+      }
+    },
+    [workspaceSlug],
+  );
+
+  // Thread-level proposals setting: snapshotted onto every run — derive from
+  // the latest one (server enforces immutability anyway).
+  const proposalsEnabled = runs.length > 0 && runs[runs.length - 1].proposalsEnabled;
+  const anyPending = runs.some((r) => r.status === "PENDING");
+  const anyCompleted = runs.some((r) => r.status === "DELIVERED_WEBHOOK");
+
+  // Proposals filed from this thread's session. One unfiltered-status call —
+  // decided proposals keep showing their outcome instead of vanishing.
+  const fetchProposals = useCallback(
+    async (sessionId: string) => {
+      try {
+        const res = await fetch(`/api/learnings/concepts/proposals?workspace=${encodeURIComponent(workspaceSlug)}`);
+        if (res.ok) {
+          const data: ConceptProposalListResponse = await res.json();
+          setProposals(filterProposalsForSession(data.proposals ?? [], sessionId));
+        }
+      } catch {
+        // Non-fatal.
+      }
+    },
+    [workspaceSlug],
+  );
+
+  // ── Initial + per-view fetches ────────────────────────────────────────────
+  useEffect(() => {
+    fetchThreads();
+  }, [fetchThreads]);
+
+  useEffect(() => {
+    setRuns([]);
+    setProposals([]);
+    setError(null);
+    if (activeSessionId) {
+      setRunsLoading(true);
+      fetchRuns(activeSessionId);
+    }
+  }, [activeSessionId, fetchRuns]);
+
+  useEffect(() => {
+    if (activeSessionId && proposalsEnabled && anyCompleted) {
+      fetchProposals(activeSessionId);
+    }
+  }, [activeSessionId, proposalsEnabled, anyCompleted, fetchProposals]);
+
+  // Keep the newest bubble in view.
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+  }, [runs.length]);
+
+  // ── Live updates: Pusher nudge + poll fallback while PENDING ─────────────
+  const channel = usePusherChannel(getWorkspaceChannelName(workspaceSlug));
+  const activeSessionRef = useRef(activeSessionId);
+  activeSessionRef.current = activeSessionId;
+
+  useEffect(() => {
+    if (!channel) return;
+    const handler = (payload: GraphRunNudge) => {
+      fetchThreads();
+      if (payload.sessionId && payload.sessionId === activeSessionRef.current) {
+        fetchRuns(payload.sessionId);
+      }
+    };
+    channel.bind(PUSHER_EVENTS.GRAPH_AGENT_RUN_UPDATED, handler);
+    return () => {
+      channel.unbind(PUSHER_EVENTS.GRAPH_AGENT_RUN_UPDATED, handler);
+    };
+  }, [channel, fetchThreads, fetchRuns]);
+
+  const hasPendingSomewhere = anyPending || threads.some((t) => t.lastStatus === "PENDING");
+  useEffect(() => {
+    if (!hasPendingSomewhere) return;
+    const interval = setInterval(() => {
+      fetchThreads();
+      if (activeSessionRef.current) fetchRuns(activeSessionRef.current);
+    }, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [hasPendingSomewhere, fetchThreads, fetchRuns]);
+
+  // ── Follow-up composer ────────────────────────────────────────────────────
+  const send = useCallback(
+    async (prompt: string) => {
+      if (!activeSessionId || !prompt.trim() || sending) return;
+      setSending(true);
+      setError(null);
+      try {
+        const res = await fetch(`/api/workspaces/${workspaceSlug}/graph/agent`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            prompt: prompt.trim(),
+            sessionId: activeSessionId,
+            proposalsEnabled,
+          }),
+        });
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          setError((data as { message?: string }).message || `Request failed (${res.status})`);
+          return;
+        }
+        setComposerText("");
+        await fetchRuns(activeSessionId);
+        fetchThreads();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Request failed");
+      } finally {
+        setSending(false);
+      }
+    },
+    [activeSessionId, sending, workspaceSlug, proposalsEnabled, fetchRuns, fetchThreads],
+  );
+
+  const activeThread = useMemo(
+    () => threads.find((t) => t.sessionId === activeSessionId) ?? null,
+    [threads, activeSessionId],
+  );
+
+  return (
+    <aside className="flex w-[360px] shrink-0 flex-col border-l bg-background min-h-0" data-testid="graph-chat-sidebar">
+      {/* ── Header ── */}
+      <div className="flex items-center gap-2 border-b px-3 py-2">
+        {activeSessionId ? (
+          <>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              onClick={() => onSelectThread(null)}
+              data-testid="graph-chat-back-button"
+            >
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+            <span className="text-sm font-medium truncate flex-1">{activeThread?.title ?? "Chat"}</span>
+            {runs.length > 0 && (
+              <Badge variant="secondary" className="text-[10px] shrink-0" data-testid="graph-chat-proposals-badge">
+                <Sparkles className="h-3 w-3 mr-1" />
+                Proposals {proposalsEnabled ? "on" : "off"}
+              </Badge>
+            )}
+          </>
+        ) : (
+          <>
+            <MessageSquare className="h-4 w-4 text-muted-foreground" />
+            <span className="text-sm font-medium flex-1">Graph chats</span>
+          </>
+        )}
+        <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onClose} data-testid="graph-chat-close-button">
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {/* ── Body ── */}
+      {activeSessionId ? (
+        <>
+          <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto p-3 space-y-3">
+            {runsLoading && runs.length === 0 && (
+              <div className="flex justify-center py-8 text-muted-foreground">
+                <Loader2 className="h-5 w-5 animate-spin" />
+              </div>
+            )}
+            {runs.map((run) => (
+              <div key={run.id} className="space-y-2" data-testid={`graph-chat-run-${run.id}`}>
+                {run.prompt && (
+                  <div className="ml-8 rounded-lg bg-primary text-primary-foreground px-3 py-2 text-sm whitespace-pre-wrap break-words">
+                    {run.prompt}
+                  </div>
+                )}
+                {run.status === "PENDING" && (
+                  <div
+                    className="mr-8 flex items-center gap-2 rounded-lg bg-muted px-3 py-2 text-sm text-muted-foreground"
+                    data-testid="graph-chat-pending-bubble"
+                  >
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    Agent is working…
+                  </div>
+                )}
+                {run.status === "DELIVERED_WEBHOOK" && run.result && (
+                  <div className="mr-8 rounded-lg bg-muted px-3 py-2 text-sm">
+                    <MarkdownRenderer size="compact">{run.result}</MarkdownRenderer>
+                  </div>
+                )}
+                {run.status === "FAILED" && (
+                  <div
+                    className="mr-8 rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive space-y-1"
+                    data-testid="graph-chat-failed-bubble"
+                  >
+                    <p>Run failed{run.error ? `: ${run.error}` : "."}</p>
+                    {run.prompt && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-6 text-xs"
+                        disabled={sending || anyPending}
+                        onClick={() => send(run.prompt!)}
+                        data-testid="graph-chat-retry-button"
+                      >
+                        Retry
+                      </Button>
+                    )}
+                  </div>
+                )}
+              </div>
+            ))}
+
+            {proposals.length > 0 && (
+              <div className="space-y-2 pt-1" data-testid="graph-chat-proposals">
+                <p className="text-[10px] uppercase tracking-wide text-muted-foreground font-medium">
+                  Concept proposals from this chat
+                </p>
+                {proposals.map((p) => (
+                  <ConceptProposalChip key={p.id} proposal={p} workspaceSlug={workspaceSlug} />
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* ── Composer ── */}
+          <div className="border-t p-3 space-y-2">
+            {error && <p className="text-xs text-destructive">{error}</p>}
+            <div className="flex gap-2 items-end">
+              <Textarea
+                rows={2}
+                placeholder={anyPending ? "Waiting for the agent…" : "Ask a follow-up…"}
+                value={composerText}
+                onChange={(e) => setComposerText(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                    e.preventDefault();
+                    send(composerText);
+                  }
+                }}
+                disabled={anyPending || sending}
+                className="resize-none text-sm"
+                data-testid="graph-chat-composer"
+              />
+              <Button
+                size="icon"
+                className="shrink-0"
+                onClick={() => send(composerText)}
+                disabled={anyPending || sending || !composerText.trim()}
+                data-testid="graph-chat-send-button"
+              >
+                {sending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+              </Button>
+            </div>
+          </div>
+        </>
+      ) : (
+        <div className="flex-1 min-h-0 overflow-y-auto" data-testid="graph-chat-thread-list">
+          {threadsLoading && threads.length === 0 ? (
+            <div className="flex justify-center py-8 text-muted-foreground">
+              <Loader2 className="h-5 w-5 animate-spin" />
+            </div>
+          ) : threads.length === 0 ? (
+            <div className="flex flex-col items-center gap-2 py-12 text-center text-muted-foreground px-4">
+              <MessageSquare className="h-8 w-8" />
+              <p className="text-sm">No graph chats yet.</p>
+              <p className="text-xs">Use the New button to start a conversation with the graph agent.</p>
+            </div>
+          ) : (
+            threads.map((thread) => (
+              <button
+                key={thread.sessionId}
+                onClick={() => onSelectThread(thread.sessionId)}
+                className="flex w-full items-center gap-2 border-b px-3 py-2.5 text-left hover:bg-accent transition-colors"
+                data-testid={`graph-chat-thread-${thread.sessionId}`}
+              >
+                <StatusDot status={thread.lastStatus} />
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm truncate">{thread.title}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {formatDistanceToNow(new Date(thread.updatedAt), {
+                      addSuffix: true,
+                    })}
+                  </p>
+                </div>
+                {thread.proposalsEnabled && (
+                  <Sparkles className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-label="Proposals enabled" />
+                )}
+              </button>
+            ))
+          )}
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/src/components/graph-explorer/chat/GraphChatSidebar.tsx
+++ b/src/components/graph-explorer/chat/GraphChatSidebar.tsx
@@ -9,7 +9,8 @@ import { Textarea } from "@/components/ui/textarea";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
 import { usePusherChannel } from "@/hooks/usePusherChannel";
 import { getWorkspaceChannelName, PUSHER_EVENTS } from "@/lib/pusher";
-import { filterProposalsForSession } from "@/lib/graph-chat/threads";
+import { filterProposalsForSession, latestReflection } from "@/lib/graph-chat/threads";
+import { ConceptsPanel } from "@/components/agent-logs/LogDetailContent";
 import type { ConceptProposal, ConceptProposalListResponse } from "@/types/concept-proposals";
 import type {
   GraphChatRun,
@@ -109,6 +110,10 @@ export function GraphChatSidebar({
   const proposalsEnabled = runs.length > 0 && runs[runs.length - 1].proposalsEnabled;
   const anyPending = runs.some((r) => r.status === "PENDING");
   const anyCompleted = runs.some((r) => r.status === "DELIVERED_WEBHOOK");
+
+  // Concepts the session read (stakgraph reflection sidecar) — cumulative,
+  // so the latest run carrying a snapshot represents the whole thread.
+  const reflection = useMemo(() => latestReflection(runs), [runs]);
 
   // Proposals filed from this thread's session. One unfiltered-status call —
   // decided proposals keep showing their outcome instead of vanishing.
@@ -306,6 +311,12 @@ export function GraphChatSidebar({
                 )}
               </div>
             ))}
+
+            {reflection && (
+              <div className="pt-1" data-testid="graph-chat-concepts">
+                <ConceptsPanel reflection={reflection} workspaceSlug={workspaceSlug} />
+              </div>
+            )}
 
             {proposals.length > 0 && (
               <div className="space-y-2 pt-1" data-testid="graph-chat-proposals">

--- a/src/components/graph-explorer/chat/NewGraphChatModal.tsx
+++ b/src/components/graph-explorer/chat/NewGraphChatModal.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import React, { useState } from "react";
+import { Loader2 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import type { GraphChatDispatchResponse } from "@/types/graph-chat";
+
+/**
+ * "New chat" modal for the Graph Agent Chat: prompt textarea plus the
+ * per-thread "Allow concept change proposals" checkbox. The checkbox is
+ * decided HERE, at chat creation, and is immutable for the life of the
+ * thread (the server snapshots it onto every run and rejects flips).
+ */
+export function NewGraphChatModal({
+  workspaceSlug,
+  open,
+  onOpenChange,
+  onCreated,
+}: {
+  workspaceSlug: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreated: (sessionId: string) => void;
+}) {
+  const [prompt, setPrompt] = useState("");
+  const [proposalsEnabled, setProposalsEnabled] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async () => {
+    if (!prompt.trim() || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/workspaces/${workspaceSlug}/graph/agent`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt: prompt.trim(), proposalsEnabled }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError((data as { message?: string }).message || `Request failed (${res.status})`);
+        return;
+      }
+      const { sessionId } = data as GraphChatDispatchResponse;
+      setPrompt("");
+      setProposalsEnabled(false);
+      onOpenChange(false);
+      onCreated(sessionId);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Request failed");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      submit();
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg" data-testid="new-graph-chat-modal">
+        <DialogHeader>
+          <DialogTitle>New graph chat</DialogTitle>
+          <DialogDescription>Ask the graph agent about this workspace&apos;s knowledge graph.</DialogDescription>
+        </DialogHeader>
+
+        <Textarea
+          autoFocus
+          rows={5}
+          placeholder="What would you like to know about the graph?"
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          onKeyDown={handleKeyDown}
+          data-testid="new-graph-chat-prompt"
+        />
+
+        <div className="flex items-start gap-2">
+          <Checkbox
+            id="graph-chat-proposals"
+            checked={proposalsEnabled}
+            onCheckedChange={(v) => setProposalsEnabled(v === true)}
+            data-testid="new-graph-chat-proposals-checkbox"
+          />
+          <div className="grid gap-1 leading-none">
+            <Label htmlFor="graph-chat-proposals" className="text-sm">
+              Allow concept change proposals
+            </Label>
+            <p className="text-xs text-muted-foreground">
+              The agent may propose edits, merges, or deletions of Concept nodes. Proposals are reviewed on the Learn
+              page before anything changes.
+            </p>
+          </div>
+        </div>
+
+        {error && <p className="text-xs text-destructive">{error}</p>}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button onClick={submit} disabled={submitting || !prompt.trim()} data-testid="new-graph-chat-submit">
+            {submitting && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+            Start chat
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/graph-explorer/chat/index.tsx
+++ b/src/components/graph-explorer/chat/index.tsx
@@ -1,0 +1,3 @@
+export { GraphChatSidebar } from "./GraphChatSidebar";
+export { NewGraphChatModal } from "./NewGraphChatModal";
+export { ConceptProposalChip } from "./ConceptProposalChip";

--- a/src/lib/graph-chat/threads.ts
+++ b/src/lib/graph-chat/threads.ts
@@ -1,0 +1,66 @@
+/**
+ * Pure helpers for the Graph Agent Chat surface.
+ *
+ * A chat thread has no table of its own — it IS a `sessionId`: the thread
+ * list is `AgentRun` rows for the workspace grouped by session. Pure and
+ * dependency-free so both the runs GET route and unit tests can share them.
+ */
+
+import type { GraphChatRunStatus, GraphChatThread } from "@/types/graph-chat";
+import type { ConceptProposal } from "@/types/concept-proposals";
+
+/** Row shape the grouping needs (subset of an AgentRun row). */
+export interface ThreadSourceRun {
+  sessionId: string | null;
+  title: string;
+  proposalsEnabled: boolean;
+  status: GraphChatRunStatus;
+  createdAt: Date | string;
+  updatedAt: Date | string;
+}
+
+function toIso(d: Date | string): string {
+  return typeof d === "string" ? d : d.toISOString();
+}
+
+/**
+ * Group graph_chat runs into thread-list entries.
+ *
+ * Expects `runs` ordered oldest-first (createdAt asc). Per session:
+ * title from the FIRST run (set from the opening prompt), proposals setting
+ * and last status from the LATEST run, `updatedAt` from the latest update.
+ * Rows without a sessionId are skipped. Result is newest-first.
+ */
+export function groupRunsIntoThreads(runs: ThreadSourceRun[]): GraphChatThread[] {
+  const bySession = new Map<string, GraphChatThread>();
+  for (const run of runs) {
+    if (!run.sessionId) continue;
+    const existing = bySession.get(run.sessionId);
+    if (!existing) {
+      bySession.set(run.sessionId, {
+        sessionId: run.sessionId,
+        title: run.title,
+        proposalsEnabled: run.proposalsEnabled,
+        lastStatus: run.status,
+        updatedAt: toIso(run.updatedAt),
+      });
+      continue;
+    }
+    // Later run in the same session: keep the first title, refresh the rest.
+    existing.proposalsEnabled = run.proposalsEnabled;
+    existing.lastStatus = run.status;
+    if (toIso(run.updatedAt) > existing.updatedAt) {
+      existing.updatedAt = toIso(run.updatedAt);
+    }
+  }
+  return [...bySession.values()].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+}
+
+/**
+ * Proposals filed from a given repo/agent session — the correlation between
+ * a chat thread and the proposals its runs filed (`sessionIds` per
+ * stakgraph's PROPOSALS_API).
+ */
+export function filterProposalsForSession(proposals: ConceptProposal[], sessionId: string): ConceptProposal[] {
+  return proposals.filter((p) => p.sessionIds?.includes(sessionId) ?? false);
+}

--- a/src/lib/graph-chat/threads.ts
+++ b/src/lib/graph-chat/threads.ts
@@ -64,3 +64,16 @@ export function groupRunsIntoThreads(runs: ThreadSourceRun[]): GraphChatThread[]
 export function filterProposalsForSession(proposals: ConceptProposal[], sessionId: string): ConceptProposal[] {
   return proposals.filter((p) => p.sessionIds?.includes(sessionId) ?? false);
 }
+
+/**
+ * The thread's current Concept-reads reflection: the sidecar is
+ * session-cumulative on the swarm (each terminal webhook delivers the merged
+ * session state), so the LATEST run carrying one supersedes earlier
+ * snapshots. Expects runs oldest-first, as the runs GET returns them.
+ */
+export function latestReflection<R extends { reflection?: unknown }>(runs: R[]): R["reflection"] | null {
+  for (let i = runs.length - 1; i >= 0; i--) {
+    if (runs[i].reflection) return runs[i].reflection;
+  }
+  return null;
+}

--- a/src/lib/pusher.ts
+++ b/src/lib/pusher.ts
@@ -109,6 +109,10 @@ export const PUSHER_EVENTS = {
   // Canvas chat: a repo_agent run started or ended in this conversation.
   // Payload is ONLY `{ active: boolean }` — no request_id or workspace identifiers.
   CANVAS_RUN_ACTIVE: "canvas-run-active",
+  // A graph_chat AgentRun reached a terminal state (webhook claimed it).
+  // Fired on the workspace channel; payload is a nudge only
+  // `{ runId, sessionId, status, at }` — the client refetches the thread.
+  GRAPH_AGENT_RUN_UPDATED: "graph-agent-run-updated",
 } as const;
 
 /**
@@ -187,6 +191,35 @@ export function notifyCanvasConversationUpdated(
       "[pusher] notifyCanvasConversationUpdated threw (non-fatal):",
       err,
     );
+  }
+}
+
+/**
+ * Fire-and-forget broadcast that a graph_chat AgentRun reached a terminal
+ * state. The webhook handler calls this AFTER the atomic claim commits so an
+ * open Graph Explorer chat sidebar refetches the thread. Never throws — a
+ * Pusher outage must not break the webhook claim (the swarm would retry a
+ * 5xx against an already-claimed row).
+ */
+export function notifyGraphAgentRunUpdated(
+  workspaceSlug: string,
+  payload: { runId: string; sessionId: string | null; status: string },
+): void {
+  try {
+    void pusherServer
+      .trigger(
+        getWorkspaceChannelName(workspaceSlug),
+        PUSHER_EVENTS.GRAPH_AGENT_RUN_UPDATED,
+        { ...payload, at: Date.now() },
+      )
+      .catch((err) => {
+        console.error(
+          "[pusher] notifyGraphAgentRunUpdated failed (non-fatal):",
+          err,
+        );
+      });
+  } catch (err) {
+    console.error("[pusher] notifyGraphAgentRunUpdated threw (non-fatal):", err);
   }
 }
 

--- a/src/types/graph-chat.ts
+++ b/src/types/graph-chat.ts
@@ -7,6 +7,8 @@
  * DELIVERED_WEBHOOK / FAILED; DELIVERED_INLINE is unused by this flow.
  */
 
+import type { SessionReflection } from "@/types/agent-logs";
+
 export type GraphChatRunStatus = "PENDING" | "DELIVERED_INLINE" | "DELIVERED_WEBHOOK" | "FAILED";
 
 /** One prompt/result pair in a thread (a single AgentRun row). */
@@ -17,6 +19,13 @@ export interface GraphChatRun {
   status: GraphChatRunStatus;
   error: string | null;
   proposalsEnabled: boolean;
+  /**
+   * stakgraph SessionReflection sidecar from the terminal webhook — which
+   * gitree Concepts the session read (always recorded; ranked only when the
+   * dispatch opts into the reflect pass, which graph chat does not).
+   * Session-cumulative: the latest run's snapshot supersedes earlier ones.
+   */
+  reflection?: SessionReflection | null;
   createdAt: string;
 }
 

--- a/src/types/graph-chat.ts
+++ b/src/types/graph-chat.ts
@@ -1,0 +1,48 @@
+/**
+ * Graph Agent Chat types — the contract of the
+ * /api/workspaces/[slug]/graph/agent[/runs] routes.
+ *
+ * Client-safe (no @prisma/client import): `GraphChatRunStatus` mirrors the
+ * `AgentRunStatus` enum as a string union. Graph runs terminal at
+ * DELIVERED_WEBHOOK / FAILED; DELIVERED_INLINE is unused by this flow.
+ */
+
+export type GraphChatRunStatus = "PENDING" | "DELIVERED_INLINE" | "DELIVERED_WEBHOOK" | "FAILED";
+
+/** One prompt/result pair in a thread (a single AgentRun row). */
+export interface GraphChatRun {
+  id: string;
+  prompt: string | null;
+  result: string | null;
+  status: GraphChatRunStatus;
+  error: string | null;
+  proposalsEnabled: boolean;
+  createdAt: string;
+}
+
+/** Thread-list entry — a thread IS a sessionId (no dedicated table). */
+export interface GraphChatThread {
+  sessionId: string;
+  /** First run's title (derived from the opening prompt's first line). */
+  title: string;
+  /** Per-thread proposals setting, derived from the latest run's snapshot. */
+  proposalsEnabled: boolean;
+  lastStatus: GraphChatRunStatus;
+  updatedAt: string;
+}
+
+/** Response of GET /api/workspaces/[slug]/graph/agent/runs?sessionId= */
+export interface GraphChatRunsResponse {
+  runs: GraphChatRun[];
+}
+
+/** Response of GET /api/workspaces/[slug]/graph/agent/runs (no sessionId) */
+export interface GraphChatThreadsResponse {
+  threads: GraphChatThread[];
+}
+
+/** Response of POST /api/workspaces/[slug]/graph/agent */
+export interface GraphChatDispatchResponse {
+  runId: string;
+  sessionId: string;
+}


### PR DESCRIPTION
## What

Implements the Graph Agent Chat feature per [docs/plans/graph-agent-chat.md](https://github.com/stakwork/hive/blob/feature/graph-agent-chat/docs/plans/graph-agent-chat.md) (included in this PR): chat with the workspace swarm's `repo/agent` in `mode: "graph"` from the Graph Explorer page, using the existing `AgentRun` table + webhook fan-back. Threads are `sessionId` groups of runs — no new thread table. Optionally the agent can file concept change proposals, surfaced as read-only chips that deep-link to the `/learn` review UI.

### Schema (`agent_run_graph_chat` migration)
- `AgentRun` gains `agentKind` (`"workflow_explorer" | "graph_chat"`), `workspaceId`, `workspaceSlug` (snapshotted so the webhook stays DB-light), `sessionId`, `prompt`, `result`, `proposalsEnabled`, plus a `[workspaceId, sessionId]` index.
- `orgId` became nullable — the plan assumed it already was, but graph-chat workspaces may have no `sourceControlOrgId`. Canvas rows always set it; the canvas fan-out guard now also checks it (type-level only, unreachable for real canvas rows).

### Webhook branch (`/api/agent-runs/webhook`)
- After the existing atomic token-gated claim, `agentKind === "graph_chat"` rows store the (128KB-capped) result **in the same `updateMany` that claims the row**, then fire the new `graph-agent-run-updated` Pusher nudge on the workspace channel. No canvas fan-out.
- The existing canvas path is behaviorally unchanged — extended tests prove both branches (canvas runs don't get the graph nudge and don't store results on the row; graph runs don't touch conversations).

### Routes
- `POST /api/workspaces/[slug]/graph/agent` — admin/owner-gated (same as the graph query route). New thread mints a UUID session; follow-ups reuse it. `proposalsEnabled` is **immutable per thread**: the server re-snapshots it from the latest run and 409s a mid-thread flip; `toolsConfig` (`propose_concept_change`, `list_concept_proposals`) is only sent when it's on. Dispatch throw → guarded PENDING→FAILED claim, 502.
- `GET /api/workspaces/[slug]/graph/agent/runs` — thread list (grouped via pure `groupRunsIntoThreads`, title from the first run, status/setting from the latest) or per-session runs oldest-first. All queries scoped by `workspaceId` + `agentKind`.
- `USE_MOCKS` short-circuits dispatch to the extended mock `repo/agent`, which returns a graph-flavored answer and — when proposals are on — inserts a session-tagged `MockProposal` into the stateful gitree fixtures before the callback fires, so the whole flow (steps 1–3 and the chip flow) is testable without a swarm.

### UI (`src/components/graph-explorer/chat/`, local state — not the canvas chat store)
- **Chat / New** buttons on the Graph Explorer header; the sidebar is a fixed right panel (the node-properties `Sheet` keeps the overlay pattern).
- `GraphChatSidebar`: thread list → thread view with pending/markdown/failed bubbles, Pusher nudge subscription + 20s poll fallback while PENDING, composer disabled during a pending run (sessions are serial), Retry on failed runs.
- `NewGraphChatModal`: prompt + "Allow concept change proposals" checkbox (default off, decided at creation).
- `ConceptProposalChip`: imports the shared `ConceptProposal` types / `conceptProposalLabel` / `UnifiedDiffView` (no forks), per-action diffs (merge shows the survivor diff plus absorbed docs removed), decided proposals show their accepted/rejected outcome, "Review on Learn" links to `/w/{slug}/learn?proposal={id}`. Read-only — no accept/reject in this surface.

## Why

`repo/agent` already supports graph mode, session continuity, and terminal webhooks server-side; this is the first caller to pass `mode: "graph"`. Storing the result on the run row also fixes the existing warn-and-drop for null-conversation runs by giving them a real destination.

## Notes for reviewers

- Proposal fetch is one unfiltered proxy call filtered client-side by `sessionIds` — the proxy validates single `status` values, so the plan's `status=accepted|rejected` literal would 400; fetching all statuses covers pending + decided in one request.
- Chips render as a "Concept proposals from this chat" section at the bottom of the thread: proposals correlate to sessions, not individual runs.
- `retryable` from the webhook payload isn't persisted, so Retry is offered on any failed run.
- E2E was skipped (optional v1 per the plan). Verified: 40 integration tests (webhook both branches + dispatch/runs routes) and 12 unit tests pass; `tsc --noEmit` and eslint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)